### PR TITLE
Mark experimental benchmark features manual-only

### DIFF
--- a/examples/fibonacci/BUILD
+++ b/examples/fibonacci/BUILD
@@ -22,6 +22,7 @@ rust_test(
 rust_bench_test(
     name = "fibonacci_bench",
     srcs = ["benches/fibonacci_bench.rs"],
+    tags = ["manual"],
     deps = [":fibonacci"],
 )
 


### PR DESCRIPTION
...to unbreak continuous integration, see http://ci.bazel.io/job/rules_rust/BAZEL_VERSION=HEAD,PLATFORM_NAME=linux-x86_64/1/console.