### PR TITLE
Update tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ external repositories for the Rust toolchain:
 git_repository(
     name = "io_bazel_rules_rust",
     remote = "https://github.com/bazelbuild/rules_rust.git",
-    tag = "0.0.1",
+    tag = "0.0.2",
 )
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_repositories")
 


### PR DESCRIPTION
tag = 0.0.1 does not work for the latest bazel (version 0.3.0)