### PR TITLE
Use Bazel mirror to download externals

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,3 +18,4 @@ Kamal Marhubi <kamal@marhubi.com>
 Kristina Chodorow <kchodorow@google.com>
 Philipp Wollermann <philwo@google.com>
 Ulf Adams <ulfjack@google.com>
+Justine Alexandra Roberts Tunney <jart@google.com>

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -746,7 +746,7 @@ filegroup(
 def rust_repositories():
   native.new_http_archive(
       name = "rust_linux_x86_64",
-      url = "https://static.rust-lang.org/dist/rust-1.9.0-x86_64-unknown-linux-gnu.tar.gz",
+      url = "http://bazel-mirror.storage.googleapis.com/static.rust-lang.org/dist/rust-1.9.0-x86_64-unknown-linux-gnu.tar.gz",
       strip_prefix = "rust-1.9.0-x86_64-unknown-linux-gnu",
       sha256 = "288ff13efa2577e81c77fc2cb6e2b49b1ed0ceab51b4fa12f7efb87039ac49b7",
       build_file_content = RUST_BUILD_FILE,
@@ -754,7 +754,7 @@ def rust_repositories():
 
   native.new_http_archive(
       name = "rust_darwin_x86_64",
-      url = "https://static.rust-lang.org/dist/rust-1.9.0-x86_64-apple-darwin.tar.gz",
+      url = "http://bazel-mirror.storage.googleapis.com/static.rust-lang.org/dist/rust-1.9.0-x86_64-apple-darwin.tar.gz",
       strip_prefix = "rust-1.9.0-x86_64-apple-darwin",
       sha256 = "d59b5509e69c1cace20a57072e3b3ecefdbfd8c7e95657b0ff2ac10aa1dfebe6",
       build_file_content = RUST_BUILD_FILE,


### PR DESCRIPTION
I've mirrored your files for guaranteed reliability, courtesy of Google Cloud Storage.

In the future, you can mirror these files too with the following command. Although you need to ask @damienmg for write access to the bucket. Or just email me the URL you want mirrored and I'll happily do it.

```bash
bzmirror() {
  local url="${1:?url}"
  if [[ "${url}" =~ ^([^:]+):([^:]+):([^:]+)$ ]]; then
    url="http://repo1.maven.org/maven2/${BASH_REMATCH[1]//.//}/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.jar"
  fi
  local dest="gs://bazel-mirror/${url#http*//}"
  local desturl="http://bazel-mirror.storage.googleapis.com/${url#http*//}"
  local name="$(basename "${dest}")"
  wget -O "/tmp/${name}" "${url}" || return 1
  gsutil cp -a public-read "/tmp/${name}" "${dest}" || return 1
  gsutil setmeta -h 'Cache-Control:public, max-age=31536000' "${dest}" || return 1
  curl -I "${desturl}"
  echo
  sha256sum "/tmp/${name}"
  echo "${desturl}"
  rm "/tmp/${name}" || return 1
}
```