### PR TITLE
Add a dependency on the cc_wrapper, so it's present when rust_binary …

### DIFF
--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -617,6 +617,9 @@ _rust_toolchain_attrs = {
         executable = True,
         single_file = True,
     ),
+    "_cc_wrapper": attr.label(
+        default = Label("@local_config_cc//:cc_wrapper")
+    ),
 }
 
 _rust_library_attrs = _rust_common_attrs + {


### PR DESCRIPTION
…is executed

Otherwise, the local_config_cc isn't written to the execroot on OS X because it
isn't a dependency of the build rule.

Fixes https://github.com/bazelbuild/bazel/issues/1556.