### PR TITLE
Update to Rust 1.11. Bump version for rules_rust in README to 0.0.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ external repositories for the Rust toolchain:
 git_repository(
     name = "io_bazel_rules_rust",
     remote = "https://github.com/bazelbuild/rules_rust.git",
-    tag = "0.0.2",
+    tag = "0.0.3",
 )
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_repositories")
 

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -752,16 +752,16 @@ filegroup(
 def rust_repositories():
   native.new_http_archive(
       name = "rust_linux_x86_64",
-      url = "http://bazel-mirror.storage.googleapis.com/static.rust-lang.org/dist/rust-1.9.0-x86_64-unknown-linux-gnu.tar.gz",
-      strip_prefix = "rust-1.9.0-x86_64-unknown-linux-gnu",
-      sha256 = "288ff13efa2577e81c77fc2cb6e2b49b1ed0ceab51b4fa12f7efb87039ac49b7",
+      url = "http://bazel-mirror.storage.googleapis.com/static.rust-lang.org/dist/rust-1.11.0-x86_64-unknown-linux-gnu.tar.gz",
+      strip_prefix = "rust-1.11.0-x86_64-unknown-linux-gnu",
+      sha256 = "f4ebbd6d9494cb8fa6c410cb58954e1913546c2bca8963faebc424591547d83f",
       build_file_content = RUST_BUILD_FILE,
   )
 
   native.new_http_archive(
       name = "rust_darwin_x86_64",
-      url = "http://bazel-mirror.storage.googleapis.com/static.rust-lang.org/dist/rust-1.9.0-x86_64-apple-darwin.tar.gz",
-      strip_prefix = "rust-1.9.0-x86_64-apple-darwin",
-      sha256 = "d59b5509e69c1cace20a57072e3b3ecefdbfd8c7e95657b0ff2ac10aa1dfebe6",
+      url = "http://bazel-mirror.storage.googleapis.com/static.rust-lang.org/dist/rust-1.11.0-x86_64-apple-darwin.tar.gz",
+      strip_prefix = "rust-1.11.0-x86_64-apple-darwin",
+      sha256 = "2cdbc47438dc86ecaf35298317b77d735956eb160862e3f6d0fda0da656ecc35",
       build_file_content = RUST_BUILD_FILE,
   )


### PR DESCRIPTION
I have mirrored the Rust 1.11 releases on `gs://bazel-mirror/static.rust-lang.org/dist`.