### PR TITLE
Make rust rules use workspace root as-is if it's in the correct form

### DIFF
--- a/test/test_rules.bzl
+++ b/test/test_rules.bzl
@@ -188,8 +188,12 @@ def _rule_test_impl(ctx):
     prefix_parts = []
 
     if rule_.label.workspace_root:
-      # Create a prefix that is correctly relative to the output of this rule.
-      prefix_parts = ["..", strip_prefix("external/", rule_.label.workspace_root)]
+      if rule_.label.workspace_root.startswith("external/"):
+        # Create a prefix that is correctly relative to the output of this rule.
+        prefix_parts = ["..", strip_prefix("external/", rule_.label.workspace_root)]
+      else:
+        # New-style: ../repo.
+        prefix_parts = [rule_.label.workspace_root]
 
     if rule_.label.package:
       prefix_parts.append(rule_.label.package)


### PR DESCRIPTION
I'm working on updating the execution root structure (see https://github.com/bazelbuild/bazel/issues/1681), which makes manually building the prefix unnecessary. I've left the strip_prefix("external/" code for backwards compatibility,
but it should be able to be removed in the future.