### PR TITLE
Support crate_type file extensions more fully

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The master branch should always be current with the latest bazel, as such you ca
 ## rust_library
 
 ```python
-rust_library(name, srcs, crate_root, deps, data, crate_features, rustc_flags)
+rust_library(name, srcs, crate_root, crate_type, deps, data, crate_features, rustc_flags)
 ```
 
 <table class="table table-condensed table-bordered table-params">
@@ -112,7 +112,24 @@ rust_library(name, srcs, crate_root, deps, data, crate_features, rustc_flags)
           if <code>srcs</code> contains only one file.
         </p>
       </td>
-    </td>
+    </tr>
+    <tr>
+      <td><code>crate_type</code></td>
+      <td>
+        <code>String, optional</code>
+        <p>
+          The type of crate to be produced during library compilation. This
+          list closely matches Cargo's own notion of crate-type, and the
+          available options are "lib", "rlib", "dylib", "cdylib", "staticlib",
+          and "proc-macro".
+        </p>
+        <p>
+          The exact output depends on the selected toolchain but generally will
+          match what Cargo would do. If binary compilation is desired, use
+          <code>rust_binary</code> instead of the "bin" crate type.
+        </p>
+      </td>
+    </tr>
     <tr>
       <td><code>deps</code></td>
       <td>

--- a/examples/hello_lib/BUILD
+++ b/examples/hello_lib/BUILD
@@ -16,6 +16,15 @@ rust_library(
     ],
 )
 
+rust_library(
+    name = "hello_dylib",
+    srcs = [
+        "src/greeter.rs",
+        "src/lib.rs",
+    ],
+    crate_type = "dylib",
+)
+
 rust_test(
     name = "hello_lib_test",
     deps = [":hello_lib"],

--- a/examples/hello_lib/BUILD
+++ b/examples/hello_lib/BUILD
@@ -25,6 +25,24 @@ rust_library(
     crate_type = "dylib",
 )
 
+rust_library(
+    name = "hello_cdylib",
+    srcs = [
+        "src/greeter.rs",
+        "src/lib.rs",
+    ],
+    crate_type = "cdylib",
+)
+
+rust_library(
+    name = "hello_staticlib",
+    srcs = [
+        "src/greeter.rs",
+        "src/lib.rs",
+    ],
+    crate_type = "staticlib",
+)
+
 rust_test(
     name = "hello_lib_test",
     deps = [":hello_lib"],

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -91,7 +91,6 @@ rust_toolchain(
     rustc_lib = ["@rust_linux_x86_64//:rustc_lib"],
     staticlib_ext = ".a",
     dylib_ext = ".so",
-    binary_ext = "",
     visibility = ["//visibility:public"],
 )
 
@@ -117,7 +116,6 @@ rust_toolchain(
     rustc_lib = ["@rust_darwin_x86_64//:rustc_lib"],
     staticlib_ext = ".a",
     dylib_ext = ".dylib",
-    binary_ext = "",
     visibility = ["//visibility:public"],
 )
 """

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -89,6 +89,9 @@ rust_toolchain(
     rust_lib = ["@rust_linux_x86_64//:rust_lib"],
     rustc = "@rust_linux_x86_64//:rustc",
     rustc_lib = ["@rust_linux_x86_64//:rustc_lib"],
+    staticlib_ext = ".a",
+    dylib_ext = ".so",
+    binary_ext = "",
     visibility = ["//visibility:public"],
 )
 
@@ -112,6 +115,9 @@ rust_toolchain(
     rust_lib = ["@rust_darwin_x86_64//:rust_lib"],
     rustc = "@rust_darwin_x86_64//:rustc",
     rustc_lib = ["@rust_darwin_x86_64//:rustc_lib"],
+    staticlib_ext = ".a",
+    dylib_ext = ".dylib",
+    binary_ext = "",
     visibility = ["//visibility:public"],
 )
 """

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -208,8 +208,8 @@ def _determine_lib_name(name, crate_type, toolchain):
     # All platforms produce 'rlib' here
     extension = ".rlib"
   elif crate_type == "bin":
-    fail("crate_type of 'bin' was detected. Please compile this crate as a " +
-         "rust_binary.")
+    fail("crate_type of 'bin' was detected in a rust_library. Please compile "
+         + "this crate as a rust_binary instead.")
 
   if not extension:
     fail(("Unknown crate_type: %s. If this is a cargo-supported crate type, "
@@ -570,6 +570,10 @@ Args:
 
     If `crate_root` is not set, then this rule will look for a `lib.rs` file or
     the single file in `srcs` if `srcs` contains only one file.
+  crate_type: The type of linkage to use for building this library. Options
+    include "lib", "rlib", "dylib", "cdylib", "staticlib", and "proc-macro"
+
+    The exact output file will depend on the toolchain used.
   deps: List of other libraries to be linked to this library target.
 
     These can be either other `rust_library` targets or `cc_library` targets if

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -204,7 +204,7 @@ def _determine_lib_name(name, crate_type, toolchain):
     extension = toolchain.dylib_ext
   elif crate_type == "staticlib":
     extension = toolchain.staticlib_ext
-  elif crate_type in ("rlib", "lib"):
+  elif crate_type in ("lib", "rlib"):
     # All platforms produce 'rlib' here
     extension = ".rlib"
   elif crate_type == "bin":

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -55,13 +55,6 @@ RUST_FILETYPE = FileType([".rs"])
 
 A_FILETYPE = FileType([".a"])
 
-LIBRARY_CRATE_TYPES = [
-    "lib",
-    "rlib",
-    "dylib",
-    "staticlib",
-]
-
 # Used by rust_doc
 HTML_MD_FILETYPE = FileType([
     ".html",
@@ -205,6 +198,27 @@ def _find_crate_root_src(srcs, file_names=["lib.rs"]):
       return src
   fail("No %s source file found." % " or ".join(file_names), "srcs")
 
+def _determine_lib_name(name, crate_type, toolchain):
+  extension = None
+  if crate_type in ("dylib", "cdylib"):
+    extension = toolchain.dylib_ext
+  elif crate_type == "staticlib":
+    extension = toolchain.staticlib_ext
+  elif crate_type in ("rlib", "lib", "proc-macro"):
+    # All platforms produce 'rlib' here
+    extension = ".rlib"
+  elif crate_type == "bin":
+    fail("crate_type of 'bin' was detected. Please compile this crate as a " +
+         "rust_binary.")
+
+  if not extension:
+    fail(("Unknown crate_type: %s. If this is a cargo-supported crate type, "
+         + "please file an issue!") % crate_type)
+
+
+  return "lib{name}{extension}".format(name=name,
+                                       extension=extension)
+
 def _crate_root_src(ctx, file_names=["lib.rs"]):
   if ctx.file.crate_root == None:
     return _find_crate_root_src(ctx.files.srcs, file_names)
@@ -219,28 +233,14 @@ def _rust_library_impl(ctx):
   # Find lib.rs
   lib_rs = _crate_root_src(ctx)
 
-  # Validate crate_type
-  crate_type = ""
-  if ctx.attr.crate_type != "":
-    if ctx.attr.crate_type not in LIBRARY_CRATE_TYPES:
-      fail("Invalid crate_type for rust_library. Allowed crate types are: %s"
-           % " ".join(LIBRARY_CRATE_TYPES), "crate_type")
-    crate_type += ctx.attr.crate_type
-  else:
-    crate_type += "lib"
-
+  # Find toolchain
   toolchain = _find_toolchain(ctx)
 
-  crate_type = ctx.attr.crate_type or "rlib"
-
-  extension = ".rlib"
-  if crate_type == "dylib" or crate_type == "cdylib":
-    extension = toolchain.dylib_ext
-  elif crate_type == "staticlib":
-    extension = toolchain.staticlib_ext
-
   # Output library
-  rust_lib = ctx.actions.declare_file("lib{name}{extension}".format(name=ctx.label.name, extension=extension))
+  rust_lib_name = _determine_lib_name(ctx.attr.name,
+                                      ctx.attr.crate_type,
+                                      toolchain);
+  rust_lib = ctx.actions.declare_file(rust_lib_name)
   output_dir = rust_lib.dirname
 
   # Dependencies
@@ -254,7 +254,7 @@ def _rust_library_impl(ctx):
       ctx = ctx,
       toolchain = toolchain,
       crate_name = ctx.label.name,
-      crate_type = crate_type,
+      crate_type = ctx.attr.crate_type,
       src = lib_rs,
       output_dir = output_dir,
       depinfo = depinfo)
@@ -281,7 +281,7 @@ def _rust_library_impl(ctx):
 
   return struct(
       files = depset([rust_lib]),
-      crate_type = crate_type,
+      crate_type = ctx.attr.crate_type,
       crate_root = lib_rs,
       rust_srcs = ctx.files.srcs,
       rust_deps = ctx.attr.deps,
@@ -544,7 +544,7 @@ _rust_common_attrs = {
 }
 
 _rust_library_attrs = {
-    "crate_type": attr.string(),
+    "crate_type": attr.string(default = "rlib"),
 }
 
 rust_library = rule(

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -60,6 +60,8 @@ LIBRARY_CRATE_TYPES = [
     "staticlib",
 ]
 
+# TODO: Consider supporting platform via alternative Bazel mechanisms
+# e.g. config_setting
 LIBRARY_AND_PLATFORM_TO_EXTENSION = {
     ("dylib", "linux"): ".so",
     ("dylib", "darwin"): ".dylib",

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -200,11 +200,11 @@ def _find_crate_root_src(srcs, file_names=["lib.rs"]):
 
 def _determine_lib_name(name, crate_type, toolchain):
   extension = None
-  if crate_type in ("dylib", "cdylib"):
+  if crate_type in ("dylib", "cdylib", "proc-macro"):
     extension = toolchain.dylib_ext
   elif crate_type == "staticlib":
     extension = toolchain.staticlib_ext
-  elif crate_type in ("rlib", "lib", "proc-macro"):
+  elif crate_type in ("rlib", "lib"):
     # All platforms produce 'rlib' here
     extension = ".rlib"
   elif crate_type == "bin":

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -141,6 +141,9 @@ def _rust_toolchain_impl(ctx):
       rust_doc = _get_first_file(ctx.attr.rust_doc),
       rustc_lib = _get_files(ctx.attr.rustc_lib),
       rust_lib = _get_files(ctx.attr.rust_lib),
+      staticlib_ext = ctx.attr.staticlib_ext,
+      dylib_ext = ctx.attr.dylib_ext,
+      binary_ext = ctx.attr.binary_ext,
       crosstool_files = ctx.files._crosstool)
   return [toolchain]
 
@@ -151,6 +154,9 @@ rust_toolchain = rule(
         "rust_doc": attr.label(allow_files = True),
         "rustc_lib": attr.label_list(allow_files = True),
         "rust_lib": attr.label_list(allow_files = True),
+        "staticlib_ext": attr.string(mandatory = True),
+        "dylib_ext": attr.string(mandatory = True),
+        "binary_ext": attr.string(default = ""),
         "_crosstool": attr.label(
             default = Label("//tools/defaults:crosstool"),
         ),

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -143,7 +143,6 @@ def _rust_toolchain_impl(ctx):
       rust_lib = _get_files(ctx.attr.rust_lib),
       staticlib_ext = ctx.attr.staticlib_ext,
       dylib_ext = ctx.attr.dylib_ext,
-      binary_ext = ctx.attr.binary_ext,
       crosstool_files = ctx.files._crosstool)
   return [toolchain]
 
@@ -156,7 +155,6 @@ rust_toolchain = rule(
         "rust_lib": attr.label_list(allow_files = True),
         "staticlib_ext": attr.string(mandatory = True),
         "dylib_ext": attr.string(mandatory = True),
-        "binary_ext": attr.string(default = ""),
         "_crosstool": attr.label(
             default = Label("//tools/defaults:crosstool"),
         ),


### PR DESCRIPTION
Removes the hard coded rust_lib output, and declares the output file within the rust_library_impl. This lets us vary the file extension based on the toolchain -- OSX produces `.dylib` where linux would produce `.so`, for example.

Original description follows:
---
Tentatively addresses #36.

WIP: Need tests and understand platform implications

@davidzchen: Do we need the additional complexity of a hidden build rule? This change seems to work on my platform to produce dylibs that can be loaded correctly.

I've no idea how to handle different platforms. I added it as an additional attr, but I think a `config_setting` probably makes more sense.