### PR TITLE
Update shebang to use env

### DIFF
--- a/examples/hello_runfiles/src/lib.rs
+++ b/examples/hello_runfiles/src/lib.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 /// Returns the .runfiles directory for the currently executing binary.
 pub fn get_runfiles_dir() -> io::Result<PathBuf> {
     let mut path = std::env::current_exe()?;
+    println!("current_exe: {:?}", path);
 
     let mut name = path.file_name().unwrap().to_owned();
     name.push(".runfiles");
@@ -26,6 +27,11 @@ mod test {
     #[test]
     fn test_can_read_data_from_runfiles() {
         let runfiles = get_runfiles_dir().unwrap();
+        println!("supposed runfiles dir: {:?}", runfiles);
+
+        for entry in std::fs::read_dir(&runfiles) {
+          println!("entry in 'runfiles' {:?}", entry);
+        }
 
         let mut f = File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap();
         let mut buffer = String::new();

--- a/examples/hello_runfiles/src/lib.rs
+++ b/examples/hello_runfiles/src/lib.rs
@@ -4,22 +4,14 @@ use std::path::PathBuf;
 /// Returns the .runfiles directory for the currently executing binary.
 pub fn get_runfiles_dir() -> io::Result<PathBuf> {
     let mut path = std::env::current_exe()?;
-    println!("--current_exe: {:?}", path);
 
-    let mut parent_path = path.clone();
-    for idx in 0..2 {
-      parent_path.pop();
-      for entry in std::fs::read_dir(&parent_path).unwrap() {
-        println!("--entry in exe parent {} {:?}", idx, entry);
-      }
-    }
-
-    path.pop();
     if cfg!(target_os = "macos") {
+      path.pop();
       path.push("data");
     } else {
       let mut name = path.file_name().unwrap().to_owned();
       name.push(".runfiles");
+      path.pop();
       path.push(name);
     }
 
@@ -38,13 +30,12 @@ mod test {
     #[test]
     fn test_can_read_data_from_runfiles() {
         let runfiles = get_runfiles_dir().unwrap();
-        println!("--supposed runfiles dir: {:?}", runfiles);
 
-        for entry in std::fs::read_dir(&runfiles).unwrap() {
-          println!("--entry in 'runfiles' {:?}", entry);
-        }
-
-        let mut f = File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap();
+        let mut f = if cfg!(target_os = "macos") {
+          File::open(runfiles.join("sample.txt")).unwrap()
+        } else {
+          File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap()
+        };
         let mut buffer = String::new();
 
         f.read_to_string(&mut buffer).unwrap();

--- a/examples/hello_runfiles/src/lib.rs
+++ b/examples/hello_runfiles/src/lib.rs
@@ -6,16 +6,17 @@ pub fn get_runfiles_dir() -> io::Result<PathBuf> {
     let mut path = std::env::current_exe()?;
 
     if cfg!(target_os = "macos") {
-        path.pop();
+      path.pop();
     } else {
-        let mut name = path.file_name().unwrap().to_owned();
-        name.push(".runfiles");
-        path.pop();
-        path.push(name);
+      let mut name = path.file_name().unwrap().to_owned();
+      name.push(".runfiles");
+      path.pop();
+      path.push(name);
     }
 
     Ok(path)
 }
+
 
 #[cfg(test)]
 mod test {
@@ -30,9 +31,9 @@ mod test {
         let runfiles = get_runfiles_dir().unwrap();
 
         let mut f = if cfg!(target_os = "macos") {
-            File::open(runfiles.join("data/sample.txt")).unwrap()
+          File::open(runfiles.join("data/sample.txt")).unwrap()
         } else {
-            File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap()
+          File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap()
         };
         let mut buffer = String::new();
 

--- a/examples/hello_runfiles/src/lib.rs
+++ b/examples/hello_runfiles/src/lib.rs
@@ -6,7 +6,6 @@ pub fn get_runfiles_dir() -> io::Result<PathBuf> {
     let mut path = std::env::current_exe()?;
     println!("--current_exe: {:?}", path);
 
-    let mut name = path.file_name().unwrap().to_owned();
     let mut parent_path = path.clone();
     for idx in 0..2 {
       parent_path.pop();
@@ -15,10 +14,14 @@ pub fn get_runfiles_dir() -> io::Result<PathBuf> {
       }
     }
 
-    name.push(".runfiles");
-
     path.pop();
-    path.push(name);
+    if cfg!(target_os = "macos") {
+      path.push("data");
+    } else {
+      let mut name = path.file_name().unwrap().to_owned();
+      name.push(".runfiles");
+      path.push(name);
+    }
 
     Ok(path)
 }

--- a/examples/hello_runfiles/src/lib.rs
+++ b/examples/hello_runfiles/src/lib.rs
@@ -4,9 +4,17 @@ use std::path::PathBuf;
 /// Returns the .runfiles directory for the currently executing binary.
 pub fn get_runfiles_dir() -> io::Result<PathBuf> {
     let mut path = std::env::current_exe()?;
-    println!("current_exe: {:?}", path);
+    println!("--current_exe: {:?}", path);
 
     let mut name = path.file_name().unwrap().to_owned();
+    let mut parent_path = path.clone();
+    for idx in 0..2 {
+      parent_path.pop();
+      for entry in std::fs::read_dir(&parent_path).unwrap() {
+        println!("--entry in exe parent {} {:?}", idx, entry);
+      }
+    }
+
     name.push(".runfiles");
 
     path.pop();
@@ -27,10 +35,10 @@ mod test {
     #[test]
     fn test_can_read_data_from_runfiles() {
         let runfiles = get_runfiles_dir().unwrap();
-        println!("supposed runfiles dir: {:?}", runfiles);
+        println!("--supposed runfiles dir: {:?}", runfiles);
 
-        for entry in std::fs::read_dir(&runfiles) {
-          println!("entry in 'runfiles' {:?}", entry);
+        for entry in std::fs::read_dir(&runfiles).unwrap() {
+          println!("--entry in 'runfiles' {:?}", entry);
         }
 
         let mut f = File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap();

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -412,7 +412,7 @@ def _rust_bench_test_impl(ctx):
   ctx.file_action(
       output = rust_bench_test,
       content = " ".join([
-          "#!/bin/bash\n",
+          "#!/usr/bin/env bash\n",
           "set -e\n",
           "%s --bench\n" % test_binary.short_path]),
       executable = True)

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -88,7 +88,7 @@ def build_rustdoc_test_command(ctx, toolchain, depinfo, lib_rs):
   Constructs the rustdocc command used to test the current target.
   """
   return " ".join(
-      ["#!/bin/bash\n"] +
+      ["#!/usr/bin/env bash\n"] +
       ["set -e\n"] +
       depinfo.setup_cmd +
       [


### PR DESCRIPTION
This PR replaces "/bin/bash" with the more general "/usr/bin/env bash". This is necessary on platforms that don't have `bash` in `/bin`, namely BSD and esoteric linux distributions such as Guix and NixOS.

FWIW: This is a pervasive problem is Bazel. My own build rules for Bazel apply a [multi thousand line patch](https://github.com/acmcarther/essentials/blob/master/nix/packages/bazel/fix_shebangs.patch) just to let Bazel build on NixOS. I'm OK with this PR being closed if you feel this is too much of a niche problem.