### PR TITLE
Make rule tests compatible with the new string representations in Skylark

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -15,7 +15,7 @@ rule_test(
     name ="hello_lib_rule_test",
     generates = ["libhello_lib.rlib"],
     provides = {
-        "rust_lib": "/libhello_lib.rlib$",
+        "rust_lib": "/libhello_lib.rlib>\\?$",
         "transitive_libs": "^\\[\\]$"
     },
     rule = "@examples//hello_lib:hello_lib",


### PR DESCRIPTION
In the future string representations of file object will be different and it will look like `<generated file path/to/file.txt>`, therefore the test has been changed to check for this optional additional angular bracket.