### PR TITLE
Update compiler toolchain to 1.20.0.

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -120,17 +120,17 @@ rust_toolchain(
 def rust_repositories():
   native.new_http_archive(
       name = "rust_linux_x86_64",
-      url = "http://bazel-mirror.storage.googleapis.com/static.rust-lang.org/dist/rust-1.15.1-x86_64-unknown-linux-gnu.tar.gz",
-      strip_prefix = "rust-1.15.1-x86_64-unknown-linux-gnu",
-      sha256 = "b1e7c818a3cc8b010932f0efc1cf0ede7471958310f808d543b6e32d2ec748e7",
+      url = "https://static.rust-lang.org/dist/rust-1.20.0-x86_64-unknown-linux-gnu.tar.gz",
+      strip_prefix = "rust-1.20.0-x86_64-unknown-linux-gnu",
+      sha256 = "ca1cf3aed73ff03d065a7d3e57ecca92228d35dc36d9274a6597441319f18eb8",
       build_file_content = RUST_LINUX_BUILD_FILE,
   )
 
   native.new_http_archive(
       name = "rust_darwin_x86_64",
-      url = "http://bazel-mirror.storage.googleapis.com/static.rust-lang.org/dist/rust-1.15.1-x86_64-apple-darwin.tar.gz",
-      strip_prefix = "rust-1.15.1-x86_64-apple-darwin",
-      sha256 = "38606e464b31a778ffa7d25d490a9ac53b472102bad8445b52e125f63726ac64",
+      url = "https://static.rust-lang.org/dist/rust-1.20.0-x86_64-apple-darwin.tar.gz",
+      strip_prefix = "rust-1.20.0-x86_64-apple-darwin",
+      sha256 = "fa1fb8896d5e327cbe6deeb50e6e9a3346de629f2e6bcbd8c10f19f3e2ed67d5",
       build_file_content = RUST_DARWIN_BUILD_FILE,
   )
 


### PR DESCRIPTION
The `1.15.1` compiler used in the Rust rules is quite outdated at this point. This updates the compiler version to the most recent release, `1.20.0`.

The URLs point directly at the rust-lang.org site instead of the Bazel mirror site. If you upload the newer compiler to that site I can update the URLs as necessary.