### PR TITLE
Update documentation with the right load() for rust_repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ http_archive(
         "https://github.com/bazelbuild/rules_rust/archive/0.0.5.tar.gz",
     ],
 )
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_repositories")
+load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories()
 ```

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -33,7 +33,7 @@ http_archive(
         "https://github.com/bazelbuild/rules_rust/archive/0.0.5.tar.gz",
     ],
 )
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_repositories")
+load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories()
 ```


### PR DESCRIPTION
Fixes links in the documentation for the correct location of the rust_repositories macro.

See https://github.com/bazelbuild/rules_rust/pull/45#issuecomment-296577998