### PR TITLE
Fix 'data' field not being made available to rust_test rule.

### DIFF
--- a/examples/hello_runfiles/BUILD
+++ b/examples/hello_runfiles/BUILD
@@ -1,0 +1,26 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+rust_library(
+    name = "runfiles",
+    srcs = ["src/lib.rs"],
+)
+
+rust_binary(
+    name = "hello_runfiles",
+    srcs = ["src/main.rs"],
+    data = ["data/sample.txt"],
+    deps = [":runfiles"],
+)
+
+rust_test(
+    name = "hello_runfiles_test",
+    data = ["data/sample.txt"],
+    deps = [":runfiles"],
+)

--- a/examples/hello_runfiles/data/sample.txt
+++ b/examples/hello_runfiles/data/sample.txt
@@ -1,0 +1,1 @@
+Example Text!

--- a/examples/hello_runfiles/src/lib.rs
+++ b/examples/hello_runfiles/src/lib.rs
@@ -1,0 +1,37 @@
+use std::io;
+use std::path::PathBuf;
+
+/// Returns the .runfiles directory for the currently executing binary.
+pub fn get_runfiles_dir() -> io::Result<PathBuf> {
+    let mut path = std::env::current_exe()?;
+
+    let mut name = path.file_name().unwrap().to_owned();
+    name.push(".runfiles");
+
+    path.pop();
+    path.push(name);
+
+    Ok(path)
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::io;
+    use std::io::prelude::*;
+    use std::fs::File;
+
+    #[test]
+    fn test_can_read_data_from_runfiles() {
+        let runfiles = get_runfiles_dir().unwrap();
+
+        let mut f = File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap();
+        let mut buffer = String::new();
+
+        f.read_to_string(&mut buffer).unwrap();
+
+        assert_eq!("Example Text!", buffer);
+    }
+}

--- a/examples/hello_runfiles/src/main.rs
+++ b/examples/hello_runfiles/src/main.rs
@@ -1,0 +1,16 @@
+extern crate runfiles;
+
+use std::io::prelude::*;
+use std::fs::File;
+
+
+fn main() {
+    let runfiles = runfiles::get_runfiles_dir().unwrap();
+
+    let mut f = File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap();
+    let mut buffer = String::new();
+
+    f.read_to_string(&mut buffer).unwrap();
+
+    println!("{}", buffer);
+}

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -373,6 +373,7 @@ def _rust_test_common(ctx, test_binary):
                              rust_flags = ["--test"])
 
   compile_inputs = (target.srcs +
+		    ctx.files.data +
                     depinfo.libs +
                     depinfo.transitive_libs +
                     [toolchain.rustc] +
@@ -394,6 +395,9 @@ def _rust_test_impl(ctx):
   Implementation for rust_test Skylark rule.
   """
   _rust_test_common(ctx, ctx.outputs.executable)
+
+  runfiles = ctx.runfiles(files = ctx.files.data, collect_data = True)
+  return struct(runfiles = runfiles)
 
 def _rust_bench_test_impl(ctx):
   """Implementation for the rust_bench_test Skylark rule."""

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -325,9 +325,12 @@ def _rust_binary_impl(ctx):
       progress_message = ("Compiling Rust binary %s (%d files)"
                           % (ctx.label.name, len(ctx.files.srcs))))
 
+  runfiles = ctx.runfiles(files = ctx.files.data, collect_data = True)
+
   return struct(rust_srcs = ctx.files.srcs,
                 crate_root = main_rs,
-                rust_deps = ctx.attr.deps)
+                rust_deps = ctx.attr.deps,
+                runfiles = runfiles)
 
 def _rust_test_common(ctx, test_binary):
   """Builds a Rust test binary.
@@ -373,7 +376,7 @@ def _rust_test_common(ctx, test_binary):
                              rust_flags = ["--test"])
 
   compile_inputs = (target.srcs +
-		    ctx.files.data +
+                    ctx.files.data +
                     depinfo.libs +
                     depinfo.transitive_libs +
                     [toolchain.rustc] +


### PR DESCRIPTION
Setting data wasn't actually being made available to tests, this fixes that.