### PR TITLE
Update rules_sass to the latest version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,7 +25,7 @@ new_git_repository(
 git_repository(
     name = "io_bazel_rules_sass",
     remote = "https://github.com/bazelbuild/rules_sass.git",
-    tag = "0.0.2",
+    tag = "0.0.3",
 )
 
 load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")


### PR DESCRIPTION
For compatibility with the future versions of Bazel (namely: it won't be allowed to have the deprecated `set` function even in the parts of the code that are not executed).