### PR TITLE
Fix runfiles test: Macos runfiles are quite different

### DIFF
--- a/examples/hello_runfiles/src/lib.rs
+++ b/examples/hello_runfiles/src/lib.rs
@@ -5,11 +5,15 @@ use std::path::PathBuf;
 pub fn get_runfiles_dir() -> io::Result<PathBuf> {
     let mut path = std::env::current_exe()?;
 
-    let mut name = path.file_name().unwrap().to_owned();
-    name.push(".runfiles");
-
-    path.pop();
-    path.push(name);
+    if cfg!(target_os = "macos") {
+      path.pop();
+      path.push("data");
+    } else {
+      let mut name = path.file_name().unwrap().to_owned();
+      name.push(".runfiles");
+      path.pop();
+      path.push(name);
+    }
 
     Ok(path)
 }
@@ -27,7 +31,11 @@ mod test {
     fn test_can_read_data_from_runfiles() {
         let runfiles = get_runfiles_dir().unwrap();
 
-        let mut f = File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap();
+        let mut f = if cfg!(target_os = "macos") {
+          File::open(runfiles.join("sample.txt")).unwrap()
+        } else {
+          File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap()
+        };
         let mut buffer = String::new();
 
         f.read_to_string(&mut buffer).unwrap();

--- a/examples/hello_runfiles/src/lib.rs
+++ b/examples/hello_runfiles/src/lib.rs
@@ -7,7 +7,6 @@ pub fn get_runfiles_dir() -> io::Result<PathBuf> {
 
     if cfg!(target_os = "macos") {
       path.pop();
-      path.push("data");
     } else {
       let mut name = path.file_name().unwrap().to_owned();
       name.push(".runfiles");
@@ -32,7 +31,7 @@ mod test {
         let runfiles = get_runfiles_dir().unwrap();
 
         let mut f = if cfg!(target_os = "macos") {
-          File::open(runfiles.join("sample.txt")).unwrap()
+          File::open(runfiles.join("data/sample.txt")).unwrap()
         } else {
           File::open(runfiles.join("examples/hello_runfiles/data/sample.txt")).unwrap()
         };


### PR DESCRIPTION
Apparently runfiles under macos have an important difference from Unix (and I presume, windows): I believe they live directly in the working directory, not "$target_name.runfiles"

This is a sloppy fix that changes the mechanics of the test according to the target os.

Notice: @mfarrugi

EDIT: Fix silly mistake regarding runfiles explanation: "data" is the data file itself.