### PR TITLE
Make badge use master status (part II)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://badge.buildkite.com/76523cc666caab9ca91c2a08d9ac8f84af28cb25a92f387293.svg)](https://buildkite.com/bazel/rustlang-rules-rust-postsubmit?branch=master)
+[![Build status](https://badge.buildkite.com/76523cc666caab9ca91c2a08d9ac8f84af28cb25a92f387293.svg?branch=master)](https://buildkite.com/bazel/rustlang-rules-rust-postsubmit?branch=master)
 
 # Rust Rules
 


### PR DESCRIPTION
The last iteration of this fix only fixed the path to the status page -- we also need to fix the SVG url.

cc: @buchgr 