### PR TITLE
Allow `rust_binary` to depend on `cc_library`

### DIFF
--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -323,7 +323,7 @@ def _rust_binary_impl(ctx):
   depinfo = _setup_deps(ctx.attr.deps,
                         ctx.label.name,
                         output_dir,
-                        allow_cc_deps=False)
+                        allow_cc_deps=True)
 
   # Build rustc command.
   toolchain = _find_toolchain(ctx)


### PR DESCRIPTION
Both the documentation and the error message say that it is possible for `rust_binary` targets to depend on `cc_library` targets. Currently, trying to do so results in an error.

I believe this one small change is all that is necessary. I have tested this with my own project and it appears to work but I am unfamiliar enough with Bazel and Skylark that I am not 100% certain that it is correct. 