### PR TITLE
Transitively link native libraries properly.

### DIFF
--- a/examples/ffi/rust_calling_c/BUILD
+++ b/examples/ffi/rust_calling_c/BUILD
@@ -1,0 +1,34 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@//rust:rust.bzl", "rust_binary", "rust_library")
+
+# C++ library we are making Rust bindings for.
+cc_library(
+    name = "greeter",
+    hdrs = ["greeter.h"],
+    srcs = ["greeter.cpp"],
+)
+
+# C API for the above library that we will invoke from Rust via FFI.
+cc_library(
+    name = "greeter_c_api",
+    srcs = ["greeter_c_api.cpp"],
+    deps = [":greeter"],
+)
+
+# Rust bindings
+rust_library(
+    name = "rusty_greeter",
+    srcs = ["lib.rs"],
+    deps = [
+      ":greeter_c_api",
+      "@examples//fibonacci:fibonacci",
+    ],
+)
+
+# Rust program that uses the Rust bindings.
+rust_binary(
+    name = "hello",
+    srcs = ["main.rs"],
+    deps = [":rusty_greeter"],
+)

--- a/examples/ffi/rust_calling_c/greeter.cpp
+++ b/examples/ffi/rust_calling_c/greeter.cpp
@@ -1,0 +1,11 @@
+#include "ffi/rust_calling_c/greeter.h"
+
+#include <iostream>
+
+namespace greeter {
+
+void greet() {
+  std::cout << "Hello from C++!\n";
+}
+
+} // namespace greeter

--- a/examples/ffi/rust_calling_c/greeter.h
+++ b/examples/ffi/rust_calling_c/greeter.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace greeter {
+
+void greet();
+
+} // namespace greeter

--- a/examples/ffi/rust_calling_c/greeter_c_api.cpp
+++ b/examples/ffi/rust_calling_c/greeter_c_api.cpp
@@ -1,0 +1,9 @@
+#include "ffi/rust_calling_c/greeter.h"
+
+extern "C" {
+
+void greeter_greet() {
+  greeter::greet();
+}
+
+} // extern "C"

--- a/examples/ffi/rust_calling_c/lib.rs
+++ b/examples/ffi/rust_calling_c/lib.rs
@@ -1,0 +1,10 @@
+extern crate fibonacci;
+
+pub fn rusty_greeting() {
+    println!("The 10th fibonacci number is {}.", fibonacci::fibonacci(10));
+    unsafe { greeter_greet(); }
+}
+
+extern "C" {
+    fn greeter_greet();
+}

--- a/examples/ffi/rust_calling_c/main.rs
+++ b/examples/ffi/rust_calling_c/main.rs
@@ -1,0 +1,5 @@
+extern crate rusty_greeter;
+
+fn main() {
+    rusty_greeter::rusty_greeting();
+}


### PR DESCRIPTION
Prior to this change, the Rust rules have a conceptual mismatch with how the C++ rules work. This makes writing Rust bindings to a native library impossible.

Bazel's model of C++ linking is to underlink all intermediate `cc_library` targets and do the final link at the `cc_binary` target. To bring the Rust rules in line with the C++ rules, this change removes any native library linking from `rust_library` targets, but provides the information transitively so that the `rust_binary` target can link all transitive native libraries during the final link.

One thing to note is that Rust libraries (.rlib) behave slightly differently. While they do not contain their rlib dependencies, they do reference their rlib dependencies, so the proper behavior with rlibs is to always link (`--extern`) the direct rlib deps, regardless of whether we are building a `rust_library` or `rust_binary`.

I added an example to the ffi examples of the following dep chain:
  `rust_binary` -> `rust_library` -> `cc_library` -> `cc_library`

This is the typical way of binding a C++ library, where the `cc_library` on the far right is the actual C++ library you are binding and the one upstream from it is a C API over the C++ library. The `rust_library` upstream of that is the Rust FFI declarations and finally the `rust_binary` calls into the bindings through the `rust_library`. For good measure, I added an additional `rust_library` dependency to the `rust_library` to make sure that we still do the right thing with respect to `rust_library` -> `rust_library` dependencies.

Fixes #78.