### PR TITLE
Add --color=always to rust output

### DIFF
--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -77,6 +77,7 @@ def build_rustc_command(ctx, toolchain, crate_name, crate_type, src, output_dir,
           "--codegen link-args='%s'" % ' '.join(cpp_fragment.link_options),
           "--out-dir %s" % output_dir,
           "--emit=dep-info,link",
+          "--color always",
       ] +
       ["--codegen link-arg='-Wl,-rpath={}'".format(rpath) for rpath in rpaths] +
       features_flags +


### PR DESCRIPTION
So that colors are transmitted to Bazel output and the end-users get them
too.