### PR TITLE
Use Bazel's COMPILATION_MODE var to determine opt-level and debuginfo…

### DIFF
--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -52,6 +52,10 @@ def build_rustc_command(ctx, toolchain, crate_name, crate_type, src, output_dir,
   extra_filename = ""
   if output_hash:
     extra_filename = "-%s" % output_hash
+    
+  # TODO consider handling 'fastbuild'
+  # opt_level and debug_info combination roughly matches Cargo's "dev" and "release" profiles
+  (opt_level, debug_info) = (0, 2) if ctx.var["COMPILATION_MODE"] == "dbg" else (3, 0)
 
   return " ".join(
       ["set -e;"] +
@@ -68,7 +72,8 @@ def build_rustc_command(ctx, toolchain, crate_name, crate_type, src, output_dir,
           src.path,
           "--crate-name %s" % crate_name,
           "--crate-type %s" % crate_type,
-          "--codegen opt-level=3",  # @TODO Might not want to do -o3 on tests
+          "--codegen opt-level=%s" % opt_level,  # @TODO Might not want to do -o3 on tests
+          "--codegen debuginfo=%s" % debug_info,
           # Disambiguate this crate from similarly named ones
           "--codegen metadata=%s" % extra_filename,
           "--codegen extra-filename='%s'" % extra_filename,

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -25,26 +25,12 @@ def _get_rustc_env(ctx):
     "CARGO_PKG_HOMEPAGE=",
   ]
 
-def _get_comp_mode_codegen_opts(ctx):
+def _get_comp_mode_codegen_opts(ctx, toolchain):
   comp_mode = ctx.var["COMPILATION_MODE"]
-  opt_level = None
-  debug_info = None
-  if comp_mode == "dbg":
-    opt_level = 0
-    debug_info = 2
-  elif comp_mode == "opt":
-    opt_level = 3
-    debug_info = 0
-  elif comp_mode == "fastbuild":
-    opt_level = 0
-    debug_info = 0
-  else:
-    fail("Unrecognized COMPILATION_MODE: %s" % comp_mode)
-
-  return struct(
-    opt_level = opt_level,
-    debug_info = debug_info
-  )
+  if not comp_mode in toolchain.compilation_mode_opts:
+    fail("Unrecognized compilation mode %s for toolchain." % comp_mode)
+  
+  return toolchain.compilation_mode_opts[comp_mode]
 
 # Utility methods that use the toolchain provider.
 def build_rustc_command(ctx, toolchain, crate_name, crate_type, src, output_dir,
@@ -74,7 +60,7 @@ def build_rustc_command(ctx, toolchain, crate_name, crate_type, src, output_dir,
   if output_hash:
     extra_filename = "-%s" % output_hash
     
-  codegen_opts = _get_comp_mode_codegen_opts(ctx)
+  codegen_opts = _get_comp_mode_codegen_opts(ctx, toolchain)
 
   return " ".join(
       ["set -e;"] +
@@ -91,7 +77,7 @@ def build_rustc_command(ctx, toolchain, crate_name, crate_type, src, output_dir,
           src.path,
           "--crate-name %s" % crate_name,
           "--crate-type %s" % crate_type,
-          "--codegen opt-level=%s" % codegen_opts.opt_level,  # @TODO Might not want to do -o3 on tests
+          "--codegen opt-level=%s" % codegen_opts.opt_level,
           "--codegen debuginfo=%s" % codegen_opts.debug_info,
           # Disambiguate this crate from similarly named ones
           "--codegen metadata=%s" % extra_filename,
@@ -221,6 +207,15 @@ def _out_dir_setup_cmd(out_dir_tar):
 # The rust_toolchain rule definition and implementation.
 
 def _rust_toolchain_impl(ctx):
+  compilation_mode_opts = {}
+  for k, v in ctx.attr.opt_level.items():
+     if not k in ctx.attr.debug_info:
+       fail("Compilation mode %s is not defined in debug_info but is defined opt_level" % k)
+     compilation_mode_opts[k] = struct(opt_level = v, debug_info = ctx.attr.debug_info[k])
+  for k, v in ctx.attr.debug_info.items():
+     if not k in ctx.attr.opt_level:
+       fail("Compilation mode %s is not defined in opt_level but is defined debug_info" % k)
+  
   toolchain = platform_common.ToolchainInfo(
       rustc = _get_first_file(ctx.attr.rustc),
       rust_doc = _get_first_file(ctx.attr.rust_doc),
@@ -229,6 +224,7 @@ def _rust_toolchain_impl(ctx):
       staticlib_ext = ctx.attr.staticlib_ext,
       dylib_ext = ctx.attr.dylib_ext,
       os = ctx.attr.os,
+      compilation_mode_opts = compilation_mode_opts,
       crosstool_files = ctx.files._crosstool)
   return [toolchain]
 
@@ -245,6 +241,8 @@ rust_toolchain = rule(
         "_crosstool": attr.label(
             default = Label("//tools/defaults:crosstool"),
         ),
+        "opt_level": attr.string_dict(default = {"opt": "3", "dbg": "0", "fastbuild": "0"}),
+        "debug_info": attr.string_dict(default = {"opt": "0", "dbg": "2", "fastbuild": "0"}),
     },
 )
 


### PR DESCRIPTION
… codegen options

This change looks at Bazel's `COMPILATION_MODE` var, surfaced on the CLI as `-c [dbg|fastbuild|opt]`, and adjusts the `opt-level` and `debuginfo` codegen options passed to `rustc`.  I tried to mirror what `cargo` does in its `dev` and `release` build profiles.

If there's a better way (I'm fairly new to `bazel` and `bazel rust`), I'm all ears.