### PR TITLE
Add Rust target_triple utilities, convert repositories.bzl to use, add platform(..)

### DIFF
--- a/rust/BUILD
+++ b/rust/BUILD
@@ -1,28 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load(":triple_mappings.bzl", "define_platforms", "SUPPORTED_TRIPLES")
-
 exports_files([
     "rust.bzl",
     "toolchain.bzl",
     "repositories.bzl",
 ])
-
-constraint_setting(name = "rust_abi")
-
-constraint_value(
-    name = "gnu",
-    constraint_setting = ":rust_abi",
-)
-
-constraint_value(
-    name = "msvc",
-    constraint_setting = ":rust_abi",
-)
-
-constraint_value(
-    name = "musl",
-    constraint_setting = ":rust_abi",
-)
-
-define_platforms(CONFIGURED_TRIPLES)

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -1,7 +1,28 @@
 package(default_visibility = ["//visibility:public"])
 
+load(":triple_mappings.bzl", "define_platforms", "SUPPORTED_TRIPLES")
+
 exports_files([
     "rust.bzl",
     "toolchain.bzl",
     "repositories.bzl",
 ])
+
+constraint_setting(name = "rust_abi")
+
+constraint_value(
+    name = "gnu",
+    constraint_setting = ":rust_abi",
+)
+
+constraint_value(
+    name = "msvc",
+    constraint_setting = ":rust_abi",
+)
+
+constraint_value(
+    name = "musl",
+    constraint_setting = ":rust_abi",
+)
+
+define_platforms(CONFIGURED_TRIPLES)

--- a/rust/platforms/BUILD
+++ b/rust/platforms/BUILD
@@ -1,0 +1,25 @@
+# See https://forge.rust-lang.org/platform-support.html
+# for the full set of triples
+#
+# The list of supported triples consists of triples that can be unambiguously identified using
+# built in --cpu and --platform flags.
+SUPPORTED_TRIPLES = [
+    "aarch64-unknown-linux-gnu",
+    "i686-apple-darwin",
+    "i686-pc-windows-msvc",
+    "i686-unknown-freebsd",
+    "i686-unknown-linux-gnu",
+    "powerpc-unknown-linux-gnu",
+    "s390x-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-linux-gnu",
+]
+
+load("@io_bazel_rules_rust//:triple_mappings.bzl", "triple_to_constraint_set")
+
+[native.platform(
+    name = target_triple,
+    constraint_values = triple_to_constraint_set(target_triple),
+) for target_triple in SUPPORTED_TRIPLES]

--- a/rust/platforms/BUILD
+++ b/rust/platforms/BUILD
@@ -17,7 +17,7 @@ SUPPORTED_TRIPLES = [
     "x86_64-unknown-linux-gnu",
 ]
 
-load("@io_bazel_rules_rust//:triple_mappings.bzl", "triple_to_constraint_set")
+load("@io_bazel_rules_rust//rust:triple_mappings.bzl", "triple_to_constraint_set")
 
 [native.platform(
     name = target_triple,

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -45,8 +45,8 @@ def _BUILD_for_toolchain(name, target_triple):
     constraint_set = triple_to_constraint_set(target_triple)
 
     constraint_set_strs = []
-    for constraint in constraint_set_strs:
-        constraint_set_strs.append("\"{}\"", constraint)
+    for constraint in constraint_set:
+        constraint_set_strs.append("\"{}\"".format(constraint))
 
     constraint_sets_serialized = "[{}]".format(", ".join(constraint_set_strs))
 

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -1,193 +1,99 @@
 load(":known_shas.bzl", "FILE_KEY_TO_SHA")
+load(":triple_mappings.bzl", "triple_to_system", "triple_to_constraint_set", "system_to_binary_ext", "system_to_dylib_ext", "system_to_staticlib_ext")
 
-RUST_DARWIN_BUILD_FILE = """
-filegroup(
+def _generic_build_file(target_triple):
+    system = triple_to_system(target_triple)
+    return """filegroup(
     name = "rustc",
-    srcs = ["rustc/bin/rustc"],
+    srcs = ["rustc/bin/rustc{binary_ext}"],
     visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "rustc_lib",
-    srcs = glob(["rustc/lib/*.dylib"]),
+    srcs = glob(["rustc/lib/*.{dylib_ext}"]),
     visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "rustdoc",
-    srcs = ["rustc/bin/rustdoc"],
+    srcs = ["rustc/bin/rustdoc{binary_ext}"],
     visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "rust_lib",
     srcs = glob([
-        "rust-std-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/*.rlib",
-        "rust-std-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/*.dylib",
-        "rust-std-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/*.a",
-        "rustc/lib/rustlib/x86_64-apple-darwin/lib/*.rlib",
-        "rustc/lib/rustlib/x86_64-apple-darwin/lib/*.dylib",
-        "rustc/lib/rustlib/x86_64-apple-darwin/lib/*.a",
+        "rust-std-{target_triple}/lib/rustlib/{target_triple}/lib/*.rlib",
+        "rust-std-{target_triple}/lib/rustlib/{target_triple}/lib/*.{dylib_ext}",
+        "rust-std-{target_triple}/lib/rustlib/{target_triple}/lib/*.{staticlib_ext}",
+        "rustc/lib/rustlib/{target_triple}/lib/*.rlib",
+        "rustc/lib/rustlib/{target_triple}/lib/*.{dylib_ext}",
+        "rustc/lib/rustlib/{target_triple}/lib/*.{staticlib_ext}",
     ]),
     visibility = ["//visibility:public"],
 )
-"""
+""".format(
+        binary_ext = system_to_binary_ext(system),
+        staticlib_ext = system_to_staticlib_ext(system),
+        dylib_ext = system_to_dylib_ext(system),
+        target_triple = target_triple,
+    )
 
-RUST_LINUX_BUILD_FILE = """
-filegroup(
-    name = "rustc",
-    srcs = ["rustc/bin/rustc"],
-    visibility = ["//visibility:public"],
+def _BUILD_for_toolchain(name, target_triple):
+    system = triple_to_system(target_triple)
+    constraint_set = triple_to_constraint_set(target_triple)
+
+    constraint_set_strs = []
+    for constraint in constraint_set_strs:
+        constraint_set_strs.append("\"{}\"", constraint)
+
+    constraint_sets_serialized = "[{}]".format(", ".join(constraint_set_strs))
+
+    return """toolchain(
+    name = "{toolchain_name}",
+    exec_compatible_with = {constraint_sets_serialized},
+    target_compatible_with = {constraint_sets_serialized},
+    toolchain = ":{toolchain_name}_impl",
+    toolchain_type = "@io_bazel_rules_rust//rust:toolchain",
 )
 
-filegroup(
-    name = "rustc_lib",
-    srcs = glob(["rustc/lib/*.so"]),
+rust_toolchain(
+    name = "{toolchain_name}_impl",
+    rust_doc = "@{toolchain_workspace_name}//:rustdoc",
+    rust_lib = ["@{toolchain_workspace_name}//:rust_lib"],
+    rustc = "@{toolchain_workspace_name}//:rustc",
+    rustc_lib = ["@{toolchain_workspace_name}//:rustc_lib"],
+    staticlib_ext = "{staticlib_ext}",
+    dylib_ext = "{dylib_ext}",
+    os = "{system}",
     visibility = ["//visibility:public"],
 )
+""".format(
+        toolchain_name = name,
+        toolchain_workspace_name = name.replace("-", "_"),
+        staticlib_ext = system_to_staticlib_ext(system),
+        dylib_ext = system_to_dylib_ext(system),
+        system = system,
+        constraint_sets_serialized = constraint_sets_serialized,
+    )
 
-filegroup(
-    name = "rustdoc",
-    srcs = ["rustc/bin/rustdoc"],
-    visibility = ["//visibility:public"],
-)
+def _default_toolchains():
+    all_toolchains = [
+        ("rust-linux-x86_64", "x86_64-unknown-linux-gnu"),
+        ("rust-darwin-x86_64", "x86_64-apple-darwin"),
+        ("rust-freebsd-x86_64", "x86_64-unknown-freebsd"),
+    ]
 
-filegroup(
-    name = "rust_lib",
-    srcs = glob([
-        "rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.rlib",
-        "rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so",
-        "rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.a",
-        "rustc/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.rlib",
-        "rustc/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.so",
-        "rustc/lib/rustlib/x86_64-unknown-linux-gnu/lib/*.a",
-        "rustc/lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/*.rlib",
-        "rustc/lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/*.so",
-        "rustc/lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/*.a",
-    ]),
-    visibility = ["//visibility:public"],
-)
-"""
+    all_toolchain_BUILDs = []
+    for toolchain in all_toolchains:
+        all_toolchain_BUILDs.append(_BUILD_for_toolchain(toolchain[0], toolchain[1]))
 
-RUST_FREEBSD_BUILD_FILE = """
-filegroup(
-    name = "rustc",
-    srcs = ["rustc/bin/rustc"],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "rustc_lib",
-    srcs = glob(["rustc/lib/*.so"]),
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "rustdoc",
-    srcs = ["rustc/bin/rustdoc"],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "rust_lib",
-    srcs = glob([
-        "rust-std-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/*.rlib",
-        "rust-std-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/*.so",
-        "rust-std-x86_64-unknown-freebsd/lib/rustlib/x86_64-unknown-freebsd/lib/*.a",
-        "rustc/lib/rustlib/x86_64-unknown-freebsd/lib/*.rlib",
-        "rustc/lib/rustlib/x86_64-unknown-freebsd/lib/*.so",
-        "rustc/lib/rustlib/x86_64-unknown-freebsd/lib/*.a",
-        "rustc/lib/rustlib/x86_64-unknown-freebsd/codegen-backends/*.rlib",
-        "rustc/lib/rustlib/x86_64-unknown-freebsd/codegen-backends/*.so",
-        "rustc/lib/rustlib/x86_64-unknown-freebsd/codegen-backends/*.a",
-    ]),
-    visibility = ["//visibility:public"],
-)
-"""
-
-# This defines the default toolchain separately from the actual repositories, so that the remote
-# repositories will only be downloaded if they are actually used.
-DEFAULT_TOOLCHAINS = """
+    return """
 load("@io_bazel_rules_rust//rust:toolchain.bzl", "rust_toolchain")
 
-toolchain(
-    name = "rust-linux-x86_64",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
-    ],
-    target_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
-    ],
-    toolchain = ":rust-linux-x86_64_impl",
-    toolchain_type = "@io_bazel_rules_rust//rust:toolchain",
-)
-
-rust_toolchain(
-    name = "rust-linux-x86_64_impl",
-    rust_doc = "@rust_linux_x86_64//:rustdoc",
-    rust_lib = ["@rust_linux_x86_64//:rust_lib"],
-    rustc = "@rust_linux_x86_64//:rustc",
-    rustc_lib = ["@rust_linux_x86_64//:rustc_lib"],
-    staticlib_ext = ".a",
-    dylib_ext = ".so",
-    os = "linux",
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "rust-darwin-x86_64",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
-    ],
-    target_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
-    ],
-    toolchain = ":rust-darwin-x86_64_impl",
-    toolchain_type = "@io_bazel_rules_rust//rust:toolchain",
-)
-
-rust_toolchain(
-    name = "rust-darwin-x86_64_impl",
-    rust_doc = "@rust_darwin_x86_64//:rustdoc",
-    rust_lib = ["@rust_darwin_x86_64//:rust_lib"],
-    rustc = "@rust_darwin_x86_64//:rustc",
-    rustc_lib = ["@rust_darwin_x86_64//:rustc_lib"],
-    staticlib_ext = ".a",
-    dylib_ext = ".dylib",
-    os = "mac os x",
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "rust-freebsd-x86_64",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:freebsd",
-        "@bazel_tools//platforms:x86_64",
-    ],
-    target_compatible_with = [
-        "@bazel_tools//platforms:freebsd",
-        "@bazel_tools//platforms:x86_64",
-    ],
-    toolchain = ":rust-freebsd-x86_64_impl",
-    toolchain_type = "@io_bazel_rules_rust//rust:toolchain",
-)
-
-rust_toolchain(
-    name = "rust-freebsd-x86_64_impl",
-    rust_doc = "@rust_freebsd_x86_64//:rustdoc",
-    rust_lib = ["@rust_freebsd_x86_64//:rust_lib"],
-    rustc = "@rust_freebsd_x86_64//:rustc",
-    rustc_lib = ["@rust_freebsd_x86_64//:rustc_lib"],
-    staticlib_ext = ".a",
-    dylib_ext = ".so",
-    os = "freebsd",
-    visibility = ["//visibility:public"],
-)
-"""
+{all_toolchain_BUILDs}
+""".format(all_toolchain_BUILDs = "\n".join(all_toolchain_BUILDs))
 
 # Eventually with better toolchain hosting options we could load only one of these, not both.
 def rust_repositories():
@@ -196,7 +102,7 @@ def rust_repositories():
         url = "https://static.rust-lang.org/dist/rust-1.26.1-x86_64-unknown-linux-gnu.tar.gz",
         strip_prefix = "rust-1.26.1-x86_64-unknown-linux-gnu",
         sha256 = FILE_KEY_TO_SHA.get("rust-1.26.1-x86_64-unknown-linux-gnu") or "",
-        build_file_content = RUST_LINUX_BUILD_FILE,
+        build_file_content = _generic_build_file("x86_64-unknown-linux-gnu"),
     )
 
     native.new_http_archive(
@@ -204,7 +110,7 @@ def rust_repositories():
         url = "https://static.rust-lang.org/dist/rust-1.26.1-x86_64-apple-darwin.tar.gz",
         strip_prefix = "rust-1.26.1-x86_64-apple-darwin",
         sha256 = FILE_KEY_TO_SHA.get("rust-1.26.1-x86_64-apple-darwin") or "",
-        build_file_content = RUST_DARWIN_BUILD_FILE,
+        build_file_content = _generic_build_file("x86_64-apple-darwin"),
     )
 
     native.new_http_archive(
@@ -212,13 +118,13 @@ def rust_repositories():
         url = "https://static.rust-lang.org/dist/rust-1.26.1-x86_64-unknown-freebsd.tar.gz",
         strip_prefix = "rust-1.26.1-x86_64-unknown-freebsd",
         sha256 = FILE_KEY_TO_SHA.get("rust-1.26.1-x86_64-unknown-freebsd") or "",
-        build_file_content = RUST_FREEBSD_BUILD_FILE,
+        build_file_content = _generic_build_file("x86_64-unknown-freebsd"),
     )
 
     native.new_local_repository(
         name = "rust_default_toolchains",
         path = ".",
-        build_file_content = DEFAULT_TOOLCHAINS,
+        build_file_content = _default_toolchains(),
     )
 
     # Register toolchains

--- a/rust/triple_mappings.bzl
+++ b/rust/triple_mappings.bzl
@@ -1,0 +1,129 @@
+# CPUs that map to a "@bazel_tools//platforms entry
+_CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX = {
+    "x86_64": "x86_64",
+    "powerpc": "ppc",
+    "aarch64": "aarch64",
+    "arm": "arm",
+    "i686": "x86_32",
+    "s390x": "s390x",
+    "asmjs": None,
+    "i386": None,
+    "i586": None,
+    "powerpc64": None,
+    "powerpc64le": None,
+    "armv7": None,
+    "armv7s": None,
+    "s390": None,
+    "le32": None,
+    "mips": None,
+    "mipsel": None,
+}
+
+# Systems that map to a "@bazel_tools//platforms entry
+_SYSTEM_TO_BUILTIN_SYS_SUFFIX = {
+    "freebsd": "freebsd",
+    "linux": "linux",
+    "darwin": "osx",
+    "windows": "windows",
+    "ios": "ios",
+    "android": "android",
+    "emscripten": None,
+    "nacl": None,
+    "bitrig": None,
+    "dragonfly": None,
+    "netbsd": None,
+    "openbsd": None,
+    "solaris": None,
+}
+
+_SYSTEM_TO_BINARY_EXT = {
+    "freebsd": "",
+    "linux": "",
+    # TODO(acmcarther): To be verified
+    "darwin": "",
+    "windows": ".exe",
+    "emscripten": ".js",
+}
+
+_SYSTEM_TO_STATICLIB_EXT = {
+    "freebsd": ".a",
+    "linux": ".a",
+    "darwin": ".a",
+    # TODO(acmcarther): To be verified
+    "windows": ".lib",
+    "emscripten": ".js",
+}
+
+_SYSTEM_TO_DYLIB_EXT = {
+    "freebsd": ".so",
+    "linux": ".so",
+    "darwin": ".dylib",
+    # TODO(acmcarther): To be verified
+    "windows": ".dll",
+    "emscripten": ".js",
+}
+
+def _cpu_arch_to_constraints(cpu_arch):
+    plat_suffix = _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX[cpu_arch]
+
+    if not plat_suffix:
+        fail("CPU architecture \"{}\" is not supported by rules_rust".format(cpu_arch))
+
+    return ["@bazel_tools//platforms:{}".format(plat_suffix)]
+
+def _vendor_to_constraints(vendor):
+    # TODO(acmcarther): Review:
+    #
+    # My current understanding is that vendors can't have a material impact on
+    # constraint sets.
+    return []
+
+def _system_to_constraints(system):
+    sys_suffix = _SYSTEM_TO_BUILTIN_SYS_SUFFIX[system]
+
+    if not sys_suffix:
+        fail("System \"{}\" is not supported by rules_rust".format(sys_suffix))
+
+    return ["@bazel_tools//platforms:{}".format(sys_suffix)]
+
+def _abi_to_constraints(abi):
+    # TODO(acmcarther): Implement when C++ toolchain is more mature and we
+    # figure out how they're doing this
+    return []
+
+def triple_to_system(triple):
+    component_parts = triple.split("-")
+    if len(component_parts) < 3:
+        fail("Expected target triple to contain at least three sections separated by '-'")
+
+    return component_parts[2]
+
+def system_to_dylib_ext(system):
+    return _SYSTEM_TO_DYLIB_EXT[system]
+
+def system_to_staticlib_ext(system):
+    return _SYSTEM_TO_STATICLIB_EXT[system]
+
+def system_to_binary_ext(system):
+    return _SYSTEM_TO_BINARY_EXT[system]
+
+def triple_to_constraint_set(triple):
+    component_parts = triple.split("-")
+    if len(component_parts) < 3:
+        fail("Expected target triple to contain at least three sections separated by '-'")
+
+    cpu_arch = component_parts[0]
+    vendor = component_parts[1]
+    system = component_parts[2]
+    abi = None
+
+    if len(component_parts) == 4:
+        abi = component_parts[3]
+
+    constraint_set = []
+    constraint_set += _cpu_arch_to_constraints(cpu_arch)
+    constraint_set += _vendor_to_constraints(vendor)
+    constraint_set += _system_to_constraints(system)
+    constraint_set += _abi_to_constraints(abi)
+
+    return constraint_set


### PR DESCRIPTION
This PR adds some target triple manipulating utilities that will be needed for cross compilation support per https://github.com/bazelbuild/rules_rust/issues/101. In order to avoid this new code being dead code, I converted the existing repositories.bzl to use these utilities internally.

I also added platforms derived from the target triples accessible via @io_bazel_rules_rust//platforms (e.g. @io_bazel_rules_rust//platforms:x86_64-unknown-linux-gnu) which can be specified as a constraint on the command line using something like
```
bazel build @examples//hello_world:hello_world --platforms="@io_bazel_rules_rust//rust/platforms:s390x-unknown-linux-gnu"
```
... but since none of the current toolchains are cross compilation compatible, this is pointless as exec_triple will always equal target_triple...

```
INFO: Build options have changed, discarding analysis cache.
ERROR: While resolving toolchains for target @examples//hello_world:hello_world: no matching toolchains found for types @io_bazel_rules_rust//rust:toolchain
ERROR: Analysis of target '@examples//hello_world:hello_world' failed; build aborted: no matching toolchains found for types @io_bazel_rules_rust//rust:toolchain
INFO: Elapsed time: 0.271s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
```

No rush on review
R: @mfarrugi @damienmg 