### PR TITLE
Fix RBE by including codegen-backends from rustc/

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,3 +24,9 @@ platforms:
     - "-@examples//ffi/rust_calling_c:matrix_dynamically_linked"
     build_targets: *targets
     test_targets: *targets
+  rbe_ubuntu1604:
+    test_targets:
+    - "--"
+    - "//test/..."
+    - "@examples//..."
+    - "-//test/conflicting_deps:conflicting_deps_test"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -30,3 +30,6 @@ platforms:
     - "//test/..."
     - "@examples//..."
     - "-//test/conflicting_deps:conflicting_deps_test"
+    # Runfiles currently not working properly with remote execution
+    # https://github.com/bazelbuild/rules_rust/issues/112
+    - "-@examples//hello_runfiles:hello_runfiles_test"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,6 +5,7 @@ load(
     "git_repository",
     "new_git_repository",
 )
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
     name = "examples",
@@ -48,3 +49,13 @@ git_repository(
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
 
 skydoc_repositories()
+
+http_archive(
+    name = "bazel_toolchains",
+    sha256 = "c3b08805602cd1d2b67ebe96407c1e8c6ed3d4ce55236ae2efe2f1948f38168d",
+    strip_prefix = "bazel-toolchains-5124557861ebf4c0b67f98180bff1f8551e0b421",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/5124557861ebf4c0b67f98180bff1f8551e0b421.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/5124557861ebf4c0b67f98180bff1f8551e0b421.tar.gz",
+    ],
+)

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -38,8 +38,8 @@ filegroup(
 filegroup(
     name = "rustc_lib",
     srcs = glob([
-      "lib/*{dylib_ext}",
-      "lib/rustlib/{target_triple}/codegen-backends/*{dylib_ext}",
+        "lib/*{dylib_ext}",
+        "lib/rustlib/{target_triple}/codegen-backends/*{dylib_ext}",
     ]),
     visibility = ["//visibility:public"],
 )

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -37,7 +37,10 @@ filegroup(
 
 filegroup(
     name = "rustc_lib",
-    srcs = glob(["lib/*{dylib_ext}"]),
+    srcs = glob([
+      "lib/*{dylib_ext}",
+      "lib/rustlib/{target_triple}/codegen-backends/*{dylib_ext}",
+    ]),
     visibility = ["//visibility:public"],
 )
 
@@ -50,6 +53,7 @@ filegroup(
         binary_ext = system_to_binary_ext(system),
         staticlib_ext = system_to_staticlib_ext(system),
         dylib_ext = system_to_dylib_ext(system),
+        target_triple = target_triple,
     )
 
 def BUILD_for_stdlib(target_triple):


### PR DESCRIPTION
Partially fixes some tests disabled in https://github.com/bazelbuild/rules_rust/pull/111

Resolves (partially) https://github.com/bazelbuild/rules_rust/issues/112 EXCEPT for runfiles.

@xingao267, @mfarrugi 

EDIT:
I have to say, this build caching is totally amazing:

See [build results latest commit](https://buildkite.com/bazel/rules-rust-rustlang/builds/152#902b1e98-4f07-4ecf-ad8e-d02741d92378). It didn't have to run any of the tests since the tests from the last commit were still valid as you would expect under local execution.