### PR TITLE
Fix rust_doc rule with transitive native dependencies.

### DIFF
--- a/examples/ffi/rust_calling_c/BUILD
+++ b/examples/ffi/rust_calling_c/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//ffi/rust_calling_c:__subpackages__"])
 
-load("@//rust:rust.bzl", "rust_library", "rust_test", "rust_binary")
+load("@//rust:rust.bzl", "rust_library", "rust_test", "rust_binary", "rust_doc")
 
 rust_library(
     name = "matrix",
@@ -18,6 +18,11 @@ rust_library(
 rust_test(
     name = "matrix_test",
     deps = [":matrix"],
+)
+
+rust_doc(
+    name = "matrix_doc",
+    dep = ":matrix",
 )
 
 ## Do the same as above, but with a dynamic c library.
@@ -38,4 +43,9 @@ rust_library(
 rust_test(
     name = "matrix_dylib_test",
     deps = [":matrix_dynamically_linked"],
+)
+
+rust_doc(
+    name = "matrix_dylib_doc",
+    dep = ":matrix_dynamically_linked",
 )

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -523,7 +523,7 @@ def _rust_doc_impl(ctx):
         target.name,
         output_dir,
         toolchain,
-        allow_cc_deps = False,
+        allow_cc_deps = True,
     )
 
     # Rustdoc flags.

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -125,7 +125,7 @@ def build_rustdoc_command(ctx, toolchain, rust_doc_zip, depinfo, lib_rs, target,
         ] + doc_flags +
         depinfo.search_flags +
         # rustdoc can't do anything with native link flags, and blows up on them
-        [f for f in depinfo.link_flags if f.startswith("--extern") +
+        [f for f in depinfo.link_flags if f.startswith("--extern")]+
         [
             "&&",
             "(cd %s" % docs_dir,

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -124,7 +124,9 @@ def build_rustdoc_command(ctx, toolchain, rust_doc_zip, depinfo, lib_rs, target,
             "-o %s" % docs_dir,
         ] + doc_flags +
         depinfo.search_flags +
-        depinfo.link_flags + [
+        # rustdoc can't do anything with native link flags, and blows up on them
+        [f for f in depinfo.link_flags if f.startswith("--extern") +
+        [
             "&&",
             "(cd %s" % docs_dir,
             "&&",


### PR DESCRIPTION
Not the cleanest way to do it, but I wanted to avoid a larger refactor.