### PR TITLE
Fix warnings in examples.

### DIFF
--- a/examples/ffi/c_calling_rust/BUILD
+++ b/examples/ffi/c_calling_rust/BUILD
@@ -12,6 +12,8 @@ rust_library(
 cc_library(
     name = "wrapper",
     srcs = [":rusty"],
+    # We could link dynamically by setting crate_type to cdylib
+    linkstatic = True,
 )
 
 cc_test(

--- a/examples/ffi/rust_calling_c/c/matrix_test.c
+++ b/examples/ffi/rust_calling_c/c/matrix_test.c
@@ -24,7 +24,7 @@ void matrix_print(const Matrix* m) {
     for (size_t j = 0; j < m->cols; ++j) {
       uint64_t val = 0;
       matrix_at(m, i, j, &val);
-      printf("%llu ", val);
+      printf("%lu ", val);
     }
     printf("\n");
   }

--- a/examples/hello_runfiles/src/lib.rs
+++ b/examples/hello_runfiles/src/lib.rs
@@ -22,7 +22,6 @@ pub fn get_runfiles_dir() -> io::Result<PathBuf> {
 mod test {
     use super::*;
 
-    use std::io;
     use std::io::prelude::*;
     use std::fs::File;
 


### PR DESCRIPTION
Removes a little noise from `bazel test @examples//... ...`

(Cherrpicked out of #108)