### PR TITLE
Define the toolchain_type used by rust rules.

### DIFF
--- a/rust/BUILD
+++ b/rust/BUILD
@@ -7,3 +7,7 @@ exports_files([
     "toolchain.bzl",
     "triple_mappings.bzl",
 ])
+
+toolchain_type(
+    name = "toolchain",
+)


### PR DESCRIPTION
Fixes #128.