### PR TITLE
Set the target triplet when invoking rustc

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -229,6 +229,7 @@ def rustc_compile_action(
             output_dir,
             "--emit=dep-info,link",
             "--color always",
+            "--target=" + toolchain.target_triplet,
         ] +
         ["--codegen link-arg='-Wl,-rpath={}'".format(rpath) for rpath in rpaths] +
         features_flags +


### PR DESCRIPTION
The target triplet is coming from the toolchain and should be passed
along to rustc.