### PR TITLE
Set the target triplet when invoking rustc

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -229,6 +229,7 @@ def rustc_compile_action(
             output_dir,
             "--emit=dep-info,link",
             "--color always",
+            "--target=" + toolchain.target_triple,
         ] +
         ["--codegen link-arg='-Wl,-rpath={}'".format(rpath) for rpath in rpaths] +
         features_flags +

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -22,6 +22,8 @@ def _rust_toolchain_impl(ctx):
         rust_lib = _get_files(ctx.attr.rust_lib),
         staticlib_ext = ctx.attr.staticlib_ext,
         dylib_ext = ctx.attr.dylib_ext,
+        target_triple = ctx.attr.target_triple,
+        exec_triple = ctx.attr.exec_triple,
         os = ctx.attr.os,
         compilation_mode_opts = compilation_mode_opts,
         crosstool_files = ctx.files._crosstool,


### PR DESCRIPTION
The target triplet is coming from the toolchain and should be passed
along to rustc.