### PR TITLE
Add --remap-path-prefix=$PWD to make dbg builds more reproducible.

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -225,6 +225,7 @@ def rustc_compile_action(
             "--codegen ar=%s" % ar,
             "--codegen linker=%s" % cc,
             "--codegen link-args='%s'" % " ".join(cpp_fragment.link_options),
+            "--remap-path-prefix {}={}".format("$(pwd)", "__bazel_redacted_pwd"),
             "--out-dir",
             output_dir,
             "--emit=dep-info,link",


### PR DESCRIPTION
This should make debug binaries come out (closer to) identical when built by different users or machines.

See also https://github.com/rust-lang/cargo/issues/5505

PWD was usually something like `/home/marco/.cache/bazel/_bazel_marco/5e2375638c8763207dcac6c950a3684d/sandbox/linux-sandbox/14/execroot/`, which is a transient path. This should already be cause debugging problems, if there are any.

Edit:
This is visible w/ `strings`, eg:
```
>> bazel run -s -c dbg //tools/runfiles:runfiles_test && strings bazel-bin/tools/runfiles/runfiles_test | grep -e $USER -e bazel
/checkout/src/liballoc/raw_vec.rsio_bazel_rules_rust/tools/runfiles/data/sample.txtExample Text!assertion failed: `(left == right)`
/home/marco/.cache/bazel/_bazel_marco/4e38d4394f29c071904de81d6fb3e103/sandbox/linux-sandbox/1/execroot/io_bazel_rules_rust

```

---

Tangentially related, we could also remap "external/" to "" to make paths in stacktraces attempt to correspond to the source root, rather than the execroot... but I am not convinced this is a good idea.

eg. 
```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `427`,
 right: `428`', external/examples/hello_runfiles/hello_runfiles.rs:16:5
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::print
             at libstd/sys_common/backtrace.rs:71
             at libstd/sys_common/backtrace.rs:59
   2: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:207
   3: std::panicking::default_hook
             at libstd/panicking.rs:223
   4: std::panicking::rust_panic_with_hook
             at libstd/panicking.rs:402
   5: std::panicking::begin_panic_fmt
             at libstd/panicking.rs:349
   6: hello_runfiles::main
             at external/examples/hello_runfiles/hello_runfiles.rs:16
   7: std::rt::lang_start::{{closure}}
             at /checkout/src/libstd/rt.rs:74
   8: std::panicking::try::do_call
             at libstd/rt.rs:59
             at libstd/panicking.rs:306
   9: __rust_maybe_catch_panic
             at libpanic_unwind/lib.rs:102
  10: std::rt::lang_start_internal
             at libstd/panicking.rs:285
             at libstd/panic.rs:361
             at libstd/rt.rs:58
  11: std::rt::lang_start
             at /checkout/src/libstd/rt.rs:74
  12: main
  13: __libc_start_main
  14: _start
```

to

```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `427`,
 right: `428`', examples/hello_runfiles/hello_runfiles.rs:16:5
...
   6: hello_runfiles::main
             at examples/hello_runfiles/hello_runfiles.rs:16
...
```
