### PR TITLE
STATIC_RUST_URL sets the static.rust-lang.org URL

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -206,7 +206,8 @@ def load_arbitrary_tool(ctx, tool_name, param_prefix, tool_subdirectory, version
     # N.B. See https://static.rust-lang.org/dist/index.html to find the tool_suburl for a given
     # tool.
     tool_suburl = produce_tool_suburl(tool_name, target_triple, version, iso_date)
-    url = "https://static.rust-lang.org/dist/{}.tar.gz".format(tool_suburl)
+    static_rust = ctx.os.environ["STATIC_RUST_URL"] if "STATIC_RUST_URL" in ctx.os.environ else "https://static.rust-lang.org/"
+    url = "{}/dist/{}.tar.gz".format(static_rust, tool_suburl)
 
     tool_path = produce_tool_path(tool_name, target_triple, version)
     ctx.download_and_extract(


### PR DESCRIPTION
This change add the STATIC_RUST_URL environment variable to overwrite
the URL to https://static.rust-lang.org when downloading the rust
toolchain. This let the user specify using --action_env a mirror of
static.rust-lang.org instead.

This is particularly useful in China where https://static.rust-lang.org
is really slow. For chinese user, the best way to proceed after this
change is to add the following line in your ~/.bazelrc:

```
build --action_env STATIC_RUST_URL=http://mirrors.ustc.edu.cn/rust-static
```

Note that we do not make the rule recompile on the change of the environment variable since it should not matter which way we fetch the binary, as long as we get it and the checksum match in the end.