### PR TITLE
Test rustc flag and feature flags

### DIFF
--- a/examples/hello_lib/BUILD
+++ b/examples/hello_lib/BUILD
@@ -14,7 +14,7 @@ rust_library(
         "src/greeter.rs",
         "src/lib.rs",
     ],
-    rustc_flags = ["--cap-lints allow"],
+    rustc_flags = ["--cap-lints=allow"],
     crate_features = ["default"],
 )
 

--- a/examples/hello_lib/BUILD
+++ b/examples/hello_lib/BUILD
@@ -14,6 +14,8 @@ rust_library(
         "src/greeter.rs",
         "src/lib.rs",
     ],
+    rustc_flags = ["--cap-lints allow"],
+    crate_features = ["default"],
 )
 
 rust_library(

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -208,7 +208,7 @@ def rustc_compile_action(
     args.add("--emit=dep-info,link")
     args.add("--color", "always")
     args.add("--target", toolchain.target_triple)
-    args.add_all(ctx.attr.crate_features, before_each = "--cfg", format_each = "feature=%s")
+    args.add_all(ctx.attr.crate_features, before_each = "--cfg", format_each = "feature=\"%s\"")
     args.add_all(rust_flags)
     args.add_all(ctx.attr.rustc_flags)
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -208,7 +208,7 @@ def rustc_compile_action(
     args.add("--emit=dep-info,link")
     args.add("--color", "always")
     args.add("--target", toolchain.target_triple)
-    args.add_all(ctx.attr.crate_features, before_each = "--cfg", format_each = "feature=\"%s\"")
+    args.add_all(ctx.attr.crate_features, before_each = "--cfg", format_each = 'feature="%s"')
     args.add_all(rust_flags)
     args.add_all(ctx.attr.rustc_flags)
 


### PR DESCRIPTION
PR #151 broke some usage of those flags that make `cargo raze` build file not work any more.

This PR adds those 2 flag to a library so we notice those breakage. It allow the change for "rustc_flags" and fix the "features" argument.

As a consequence passing `["--arg value"]` to rustc_flags no longer works but that's fine (it's a reasonable breaking change). One should either do `["--arg", "value"]` or `["--arg=value"]`.