### PR TITLE
Fix rust_doc_test with transitive dependencies and add tests for it

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -31,6 +31,7 @@ platforms:
     - "@examples//..."
     - "-//test/conflicting_deps:conflicting_deps_test"
     # rust_doc_test is likely not fully sandboxed
+    - "-//test/chained_direct_deps:mod3_doc_test"
     - "-@examples//fibonacci:fibonacci_doc_test"
     - "-@examples//hello_lib:hello_lib_doc_test"
     - "-//tools/runfiles:runfiles_doc_test"

--- a/test/chained_direct_deps/BUILD
+++ b/test/chained_direct_deps/BUILD
@@ -2,6 +2,7 @@ load(
     "//rust:rust.bzl",
     "rust_library",
     "rust_test",
+    "rust_doc_test",
 )
 
 rust_library(
@@ -37,4 +38,9 @@ rust_test(
 rust_test(
     name = "mod3_test",
     deps = [":mod3"],
+)
+
+rust_doc_test(
+    name = "mod3_doc_test",
+    dep = ":mod3",
 )

--- a/test/chained_direct_deps/mod3.rs
+++ b/test/chained_direct_deps/mod3.rs
@@ -18,11 +18,11 @@ pub fn greet_default() {
 ///
 /// ```rust
 /// # assert!(
-///   am_i_the_world("world") == true
-/// #)
+///   mod3::am_i_the_world("world") == true
+/// #);
 /// # assert!(
-///   am_i_the_world("myself") == false
-/// #)
+///   mod3::am_i_the_world("myself") == false
+/// #);
 /// ```
 pub fn am_i_the_world(me: &str) -> bool {
     return me == mod1::world();

--- a/test/chained_direct_deps/mod3.rs
+++ b/test/chained_direct_deps/mod3.rs
@@ -12,6 +12,18 @@ pub fn greet_default() {
     println!("{}", mod2::default_greeter())
 }
 
+/// This is a documentation.
+///
+/// # Examples
+///
+/// ```rust
+/// # assert!(
+///   am_i_the_world("world") == true
+/// #)
+/// # assert!(
+///   am_i_the_world("myself") == false
+/// #)
+/// ```
 pub fn am_i_the_world(me: &str) -> bool {
     return me == mod1::world();
 }


### PR DESCRIPTION
Add tests that fails with:
error[E0463]: can't find crate for
 --> test/chained_direct_deps/mod3.rs:4:1
  |
4 | extern crate mod1;
  | ^^^^^^^^^^^^^^^^^^ can't find crate

And fix it.