### PR TITLE
Pass -p to mkdir to make sure we do not fails if bazel already created the output directory

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -265,7 +265,7 @@ def _create_out_dir_action(ctx):
     out_dir = ctx.actions.declare_directory(ctx.label.name + ".out_dir")
     ctx.actions.run_shell(
         # TODO: Remove system tar usage
-        command = "mkdir -p {dir} && tar -xzf {tar} -C {dir}".format(tar = tar_file.path, dir = out_dir.path),
+        command = "rm -fr {dir} && mkdir {dir} && tar -xzf {tar} -C {dir}".format(tar = tar_file.path, dir = out_dir.path),
         inputs = [tar_file],
         outputs = [out_dir],
         use_default_shell_env = True,  # Sets PATH for tar and gzip (tar's dependency)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -265,7 +265,7 @@ def _create_out_dir_action(ctx):
     out_dir = ctx.actions.declare_directory(ctx.label.name + ".out_dir")
     ctx.actions.run_shell(
         # TODO: Remove system tar usage
-        command = "mkdir {dir} && tar -xzf {tar} -C {dir}".format(tar = tar_file.path, dir = out_dir.path),
+        command = "mkdir -p {dir} && tar -xzf {tar} -C {dir}".format(tar = tar_file.path, dir = out_dir.path),
         inputs = [tar_file],
         outputs = [out_dir],
         use_default_shell_env = True,  # Sets PATH for tar and gzip (tar's dependency)


### PR DESCRIPTION
Should fix bazelbuild/continuous-integration#379