### PR TITLE
Support passing link_flags to rust_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ rust_library(name, srcs, crate_root, crate_type, deps, data, crate_features, rus
       </td>
     </tr>
     <tr>
+      <td><code>link_flags</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>
+          List of link flags passed to <code>rustc</code>, those link flags
+          propagate in downstream dependencies.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>version</code></td>
       <td>
         <code>String, optional</code>
@@ -367,6 +377,16 @@ rust_binary(name, srcs, deps, data, crate_features, rustc_flags, version, out_di
       <td>
         <code>List of strings, optional</code>
         <p>List of compiler flags passed to <code>rustc</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>link_flags</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>
+          List of link flags passed to <code>rustc</code>, those link flags
+          propagate in downstream dependencies.
+        </p>
       </td>
     </tr>
     <tr>
@@ -577,6 +597,16 @@ rust_test(name, srcs, deps, data, crate_features, rustc_flags, version, out_dir_
       <td>
         <code>List of strings, optional</code>
         <p>List of compiler flags passed to <code>rustc</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>link_flags</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>
+          List of link flags passed to <code>rustc</code>, those link flags
+          propagate in downstream dependencies.
+        </p>
       </td>
     </tr>
     <tr>
@@ -838,6 +868,16 @@ easy to use a custom Rust toolchain, such as a nightly release.
       <td>
         <code>List of strings, optional</code>
         <p>List of compiler flags passed to <code>rustc</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>link_flags</code></td>
+      <td>
+        <code>List of strings, optional</code>
+        <p>
+          List of link flags passed to <code>rustc</code>, those link flags
+          propagate in downstream dependencies.
+        </p>
       </td>
     </tr>
     <tr>

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -186,6 +186,7 @@ _rust_common_attrs = {
     "deps": attr.label_list(),
     "crate_features": attr.string_list(),
     "rustc_flags": attr.string_list(),
+    "link_flags": attr.string_list(),
     "version": attr.string(default = "0.0.0"),
     "out_dir_tar": attr.label(
         allow_files = [
@@ -245,6 +246,8 @@ Args:
     configuration option. The features listed here will be passed to `rustc`
     with `--cfg feature="${feature_name}"` flags.
   rustc_flags: List of compiler flags passed to `rustc`.
+  link_flags: List of link flags passed to `rustc`, this list is also applied
+  to downstream dependencies.
   version: a version to inject in the cargo environment variable.
   out_dir_tar: An optional tar or tar.gz file unpacked and passed as OUT_DIR.
 
@@ -357,6 +360,8 @@ Args:
     configuration option. The features listed here will be passed to `rustc`
     with `--cfg feature="${feature_name}"` flags.
   rustc_flags: List of compiler flags passed to `rustc`.
+  link_flags: List of link flags passed to `rustc`, this list is also applied
+  to downstream dependencies.
   version: a version to inject in the cargo environment variable.
   out_dir_tar: An optional tar or tar.gz file unpacked and passed as OUT_DIR.
 
@@ -490,6 +495,8 @@ Args:
     configuration option. The features listed here will be passed to `rustc`
     with `--cfg feature="${feature_name}"` flags.
   rustc_flags: List of compiler flags passed to `rustc`.
+  link_flags: List of link flags passed to `rustc`, this list is also applied
+  to downstream dependencies.
   out_dir_tar: An optional tar or tar.gz file unpacked and passed as OUT_DIR.
 
     Many library crates in the Rust ecosystem require sources to be provided
@@ -668,6 +675,8 @@ Args:
     configuration option. The features listed here will be passed to `rustc`
     with `--cfg feature="${feature_name}"` flags.
   rustc_flags: List of compiler flags passed to `rustc`.
+  link_flags: List of link flags passed to `rustc`, this list is also applied
+  to downstream dependencies.
 
 Example:
   Suppose you have the following directory structure for a Rust project with a


### PR DESCRIPTION
If one needs to add extra link dependency to a library, e.g. on macOS to
link against a framework, then it needs to be included in the
`--codegen link-args=` argument. The way rustc_flag behave (passed
before the link-args) prevent the flag to be consumed by rustc. For more
those flags needs to be passed to all link action that link the crate,
hence a flag that propage to downstream dependency.

This was tested with using an example of gRPC and TLS on macOS, which
needs to link against the CoreFramework. libcore-framework-sys should be
the one carring that flag but `cargo raze` does not handle those at the
moment.