### PR TITLE
Cleanups for compatibility with future Bazel releases

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,23 +30,29 @@ new_git_repository(
 )
 
 load("//proto:repositories.bzl", "rust_proto_repositories")
+
 rust_proto_repositories()
 
 # Used for documenting Rust rules.
-git_repository(
+http_archive(
     name = "io_bazel_rules_sass",
-    remote = "https://github.com/bazelbuild/rules_sass.git",
-    tag = "0.0.3",
+    sha256 = "76ae498b9a96fa029f026f8358ed44b93c934dde4691a798cb3a4137c307b7dc",
+    strip_prefix = "rules_sass-1.15.1",
+    url = "https://github.com/bazelbuild/rules_sass/archive/1.15.1.zip",
 )
 
-load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")
+load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
+
+rules_sass_dependencies()
+
+load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 
 sass_repositories()
 
 git_repository(
     name = "io_bazel_skydoc",
+    commit = "9bbdf62c03b5c3fed231604f78d3976f47753d79",  # 2018-11-20
     remote = "https://github.com/bazelbuild/skydoc.git",
-    tag = "0.1.4",
 )
 
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
@@ -65,10 +71,11 @@ http_archive(
 
 http_archive(
     name = "bazel_skylib",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.tar.gz",
     sha256 = "b5f6abe419da897b7901f90cbab08af958b97a8f3575b0d3dd062ac7ce78541f",
-    strip_prefix = "bazel-skylib-0.5.0"
+    strip_prefix = "bazel-skylib-0.5.0",
+    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.tar.gz",
 )
 
 load(":workspace.bzl", "bazel_version")
+
 bazel_version(name = "bazel_version")

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -34,13 +34,12 @@ rust_proto_repositories()
 
 load(
     "//proto:toolchain.bzl",
-    "rust_proto_toolchain",
-    "PROTO_COMPILE_DEPS",
     "GRPC_COMPILE_DEPS",
-    _generate_proto = "rust_generate_proto",
+    "PROTO_COMPILE_DEPS",
     _file_stem = "file_stem",
+    _generate_proto = "rust_generate_proto",
 )
-load("//rust:private/rustc.bzl", "CrateInfo", "DepInfo", "rustc_compile_action")
+load("//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
 load("//rust:private/utils.bzl", "find_toolchain")
 
 def _gen_lib(ctx, grpc, deps, srcs, lib):
@@ -67,7 +66,7 @@ def _rust_proto_compile(inputs, descriptor_sets, imports, crate_name, ctx, grpc,
     # Create all the source in a specific folder
     toolchain = ctx.toolchains["@io_bazel_rules_rust//proto:toolchain"]
     output_dir = "%s.%s.rust" % (crate_name, "grpc" if grpc else "proto")
-    
+
     # Generate the proto stubs
     srcs = _generate_proto(
         ctx,
@@ -87,7 +86,10 @@ def _rust_proto_compile(inputs, descriptor_sets, imports, crate_name, ctx, grpc,
     # And simulate rust_library behavior
     output_hash = repr(hash(lib_rs.path))
     rust_lib = ctx.actions.declare_file("%s/lib%s-%s.rlib" % (
-        output_dir, crate_name, output_hash))
+        output_dir,
+        crate_name,
+        output_hash,
+    ))
     result = rustc_compile_action(
         ctx = ctx,
         toolchain = find_toolchain(ctx),

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -12,22 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//proto/raze:crates.bzl", _crate_deps="raze_fetch_remote_crates")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//proto/raze:crates.bzl", _crate_deps = "raze_fetch_remote_crates")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def rust_proto_repositories():
-  """Declare dependencies needed for proto compilation."""
-  if not native.existing_rule("com_google_protobuf"):
-    http_archive(
-      name="com_google_protobuf",
-      urls=["https://github.com/google/protobuf/archive/v3.5.1.zip"],
-      strip_prefix="protobuf-3.5.1",
-      sha256="1f8b9b202e9a4e467ff0b0f25facb1642727cdf5e69092038f15b37c75b99e45",
-    )
+    """Declare dependencies needed for proto compilation."""
+    if not native.existing_rule("com_google_protobuf"):
+        git_repository(
+            name = "com_google_protobuf",
+            remote = "https://github.com/protocolbuffers/protobuf.git",
+            commit = "7b28271a61a3da0a37f6fda399b0c4c86464e5b3",  # 2018-11-16
+        )
 
-  _crate_deps()
-  
-  # Register toolchains
-  native.register_toolchains(
-      "@io_bazel_rules_rust//proto:default-proto-toolchain",
-  )
+    _crate_deps()
+
+    # Register toolchains
+    native.register_toolchains(
+        "@io_bazel_rules_rust//proto:default-proto-toolchain",
+    )

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -59,6 +59,7 @@ def rust_generate_proto(
         # Add grpc stubs to the list of outputs
         grpc_files = [ctx.actions.declare_file(path + "_grpc.rs") for path in paths]
         outs.extend(grpc_files)
+
         # gRPC stubs is generated only if a service is defined in the proto,
         # so we create an empty grpc module in the other case.
         tools.append(proto_toolchain.grpc_plugin)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain", "relative_path")
+load("@io_bazel_rules_rust//rust:private/utils.bzl", "relative_path")
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
@@ -115,7 +115,7 @@ def collect_deps(deps, toolchain):
 
     crate_list = transitive_crates.to_list()
     transitive_libs = depset([c.output for c in crate_list]) + transitive_staticlibs + transitive_dylibs
-    indirect_crates = depset([crate for crate in crate_list if crate not in direct_crates])
+    indirect_crates = depset([crate for crate in crate_list if crate not in direct_crates.to_list()])
 
     return DepInfo(
         direct_crates = direct_crates,
@@ -123,7 +123,7 @@ def collect_deps(deps, toolchain):
         transitive_crates = transitive_crates,
         transitive_dylibs = transitive_dylibs,
         transitive_staticlibs = transitive_staticlibs,
-        transitive_libs = list(transitive_libs),
+        transitive_libs = transitive_libs.to_list(),
     )
 
 def _get_linker_and_args(ctx, rpaths):
@@ -304,7 +304,8 @@ def add_crate_link_flags(args, dep_info):
         dep_info.transitive_crates,
         map_each = _get_crate_dirname,
         uniquify = True,
-        format_each = "-Ldependency=%s")
+        format_each = "-Ldependency=%s",
+    )
 
 def _crate_to_link_flag(crate_info):
     return ["--extern", "{}={}".format(crate_info.name, crate_info.output.path)]

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -92,6 +92,8 @@ def collect_deps(deps, toolchain):
     Returns:
       Returns a DepInfo provider.
     """
+
+    # TODO: Fix depset union (https://docs.bazel.build/versions/master/skylark/depsets.html)
     direct_crates = depset()
     transitive_crates = depset()
     transitive_dylibs = depset(order = "topological")  # dylib link flag ordering matters.
@@ -115,6 +117,8 @@ def collect_deps(deps, toolchain):
 
     crate_list = transitive_crates.to_list()
     transitive_libs = depset([c.output for c in crate_list]) + transitive_staticlibs + transitive_dylibs
+
+    # TODO: Avoid depset flattening.
     indirect_crates = depset([crate for crate in crate_list if crate not in direct_crates.to_list()])
 
     return DepInfo(

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -79,9 +79,9 @@ rust_doc = rule(
     attrs = {
         "dep": attr.label(mandatory = True),
         "markdown_css": attr.label_list(allow_files = [".css"]),
-        "html_in_header": attr.label(allow_files = [".html", ".md"], single_file = True),
-        "html_before_content": attr.label(allow_files = [".html", ".md"], single_file = True),
-        "html_after_content": attr.label(allow_files = [".html", ".md"], single_file = True),
+        "html_in_header": attr.label(allow_single_file = [".html", ".md"]),
+        "html_before_content": attr.label(allow_single_file = [".html", ".md"]),
+        "html_after_content": attr.label(allow_single_file = [".html", ".md"]),
         "_zipper": attr.label(default = Label("@bazel_tools//tools/zip:zipper"), cfg = "host", executable = True),
     },
     outputs = {

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_rust//rust:private/rustc.bzl", "CrateInfo", "DepInfo", "collect_deps", "get_lib_name")
+load("@io_bazel_rules_rust//rust:private/rustc.bzl", "CrateInfo", "DepInfo", "get_lib_name")
 load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain")
 
 def _rust_doc_test_impl(ctx):
@@ -28,10 +28,10 @@ def _rust_doc_test_impl(ctx):
 
     # Construct rustdoc test command, which will be written to a shell script
     # to be executed to run the test.
-    ctx.file_action(
+    ctx.actions.write(
         output = rust_doc_test,
         content = _build_rustdoc_test_script(toolchain, dep_info, crate),
-        executable = True,
+        is_executable = True,
     )
 
     # The test script compiles the crate and runs it, so it needs both compile and runtime inputs.
@@ -91,7 +91,7 @@ set -e;
 rust_doc_test = rule(
     _rust_doc_test_impl,
     attrs = {
-        "dep": attr.label(mandatory = True, providers=[CrateInfo]),
+        "dep": attr.label(mandatory = True, providers = [CrateInfo]),
     },
     executable = True,
     test = True,


### PR DESCRIPTION
Many of the changes were made using Buildifier (which is why the files
are reformatted).

Also, update some of the dependencies

Progress towards #161