### PR TITLE
More bazel --incompatible fixes (#161)

### DIFF
--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -51,6 +51,7 @@ RustProtoProvider = provider(
 
 def _compute_proto_source_path(file, source_root_attr):
     """Take the short path of file and make it suitable for protoc."""
+
     # For proto, they need to be requested with their absolute name to be
     # compatible with the descriptor_set passed by proto_library.
     # I.e. if you compile a protobuf at @repo1//package:file.proto, the proto
@@ -104,7 +105,7 @@ def _gen_lib(ctx, grpc, srcs, lib):
     if grpc:
         content.append("extern crate grpc;")
         content.append("extern crate tls_api;")
-    for f in srcs:
+    for f in srcs.to_list():
         content.append("pub mod %s;" % _file_stem(f))
         content.append("pub use %s::*;" % _file_stem(f))
         if grpc:

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -49,7 +49,7 @@ def rust_generate_proto(
 
     if not protos:
         fail("Protobuf compilation requested without inputs!")
-    paths = ["%s/%s" % (output_dir, file_stem(i)) for i in protos]
+    paths = ["%s/%s" % (output_dir, file_stem(i)) for i in protos.to_list()]
     outs = [ctx.actions.declare_file(path + ".rs") for path in paths]
     output_directory = outs[0].dirname
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -108,8 +108,8 @@ def collect_deps(deps, toolchain):
             transitive_staticlibs = depset(transitive = [transitive_staticlibs, dep[DepInfo].transitive_staticlibs])
         elif hasattr(dep, "cc"):
             # This dependency is a cc_library
-            dylibs = [l for l in dep.cc.libs if l.basename.endswith(toolchain.dylib_ext)]
-            staticlibs = [l for l in dep.cc.libs if l.basename.endswith(toolchain.staticlib_ext)]
+            dylibs = [l for l in dep.cc.libs.to_list() if l.basename.endswith(toolchain.dylib_ext)]
+            staticlibs = [l for l in dep.cc.libs.to_list() if l.basename.endswith(toolchain.staticlib_ext)]
             transitive_dylibs = depset(transitive = [transitive_dylibs, depset(dylibs)])
             transitive_staticlibs = depset(transitive = [transitive_staticlibs, depset(staticlibs)])
         else:
@@ -294,7 +294,7 @@ def _compute_rpaths(toolchain, output_dir, dep_info):
     # Multiple dylibs can be present in the same directory, so deduplicate them.
     return depset([
         relative_path(output_dir, lib_dir)
-        for lib_dir in _get_dir_names(dep_info.transitive_dylibs)
+        for lib_dir in _get_dir_names(dep_info.transitive_dylibs.to_list())
     ])
 
 def _get_dir_names(files):

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -102,16 +102,16 @@ def collect_deps(deps, toolchain):
         if CrateInfo in dep:
             # This dependency is a rust_library
             direct_crates += [dep[CrateInfo]]
-            transitive_crates += [dep[CrateInfo]]
-            transitive_crates += dep[DepInfo].transitive_crates
-            transitive_dylibs += dep[DepInfo].transitive_dylibs
-            transitive_staticlibs += dep[DepInfo].transitive_staticlibs
+            transitive_crates = depset([dep[CrateInfo]], transitive = [transitive_crates])
+            transitive_crates = depset(transitive = [transitive_crates, dep[DepInfo].transitive_crates])
+            transitive_dylibs = depset(transitive = [transitive_dylibs, dep[DepInfo].transitive_dylibs])
+            transitive_staticlibs = depset(transitive = [transitive_staticlibs, dep[DepInfo].transitive_staticlibs])
         elif hasattr(dep, "cc"):
             # This dependency is a cc_library
             dylibs = [l for l in dep.cc.libs if l.basename.endswith(toolchain.dylib_ext)]
             staticlibs = [l for l in dep.cc.libs if l.basename.endswith(toolchain.staticlib_ext)]
-            transitive_dylibs += dylibs
-            transitive_staticlibs += staticlibs
+            transitive_dylibs = depset(transitive = [transitive_dylibs, depset(dylibs)])
+            transitive_staticlibs = depset(transitive = [transitive_staticlibs, depset(staticlibs)])
         else:
             fail("rust targets can only depend on rust_library, rust_*_library or cc_library targets." + str(dep), "deps")
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -38,7 +38,6 @@ CrateInfo = provider(
 DepInfo = provider(
     fields = {
         "direct_crates": "depset[CrateInfo]",
-        "indirect_crates": "depset[CrateInfo]",
         "transitive_crates": "depset[CrateInfo]",
         "transitive_dylibs": "depset[File]",
         "transitive_staticlibs": "depset[File]",
@@ -115,17 +114,13 @@ def collect_deps(deps, toolchain):
         else:
             fail("rust targets can only depend on rust_library, rust_*_library or cc_library targets." + str(dep), "deps")
 
-    crate_list = transitive_crates.to_list()
     transitive_libs = depset(
-        [c.output for c in crate_list],
+        [c.output for c in transitive_crates.to_list()],
         transitive = [transitive_staticlibs, transitive_dylibs],
     )
 
-    indirect_crates = depset([crate for crate in crate_list if crate not in direct_crates])
-
     return DepInfo(
         direct_crates = depset(direct_crates),
-        indirect_crates = indirect_crates,
         transitive_crates = transitive_crates,
         transitive_dylibs = transitive_dylibs,
         transitive_staticlibs = transitive_staticlibs,

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -186,14 +186,16 @@ def rustc_compile_action(
         toolchain,
     )
 
-    compile_inputs = (
+    compile_inputs = depset(
         crate_info.srcs +
         getattr(ctx.files, "data", []) +
         dep_info.transitive_libs +
         [toolchain.rustc] +
-        toolchain.rustc_lib +
-        toolchain.rust_lib +
-        toolchain.crosstool_files
+        toolchain.crosstool_files,
+        transitive = [
+            toolchain.rustc_lib.files,
+            toolchain.rust_lib.files,
+        ],
     )
 
     args = ctx.actions.args()
@@ -232,7 +234,7 @@ def rustc_compile_action(
     # We awkwardly construct this command because we cannot reference $PWD from ctx.actions.run(executable=toolchain.rustc)
     out_dir = _create_out_dir_action(ctx)
     if out_dir:
-        compile_inputs.append(out_dir)
+        compile_inputs = depset([out_dir], transitive = [compile_inputs])
         out_dir_env = "OUT_DIR=$(pwd)/{} ".format(out_dir.path)
     else:
         out_dir_env = ""

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -26,7 +26,7 @@ def _rust_doc_impl(ctx):
 
     rustdoc_inputs = (
         crate.srcs +
-        [c.output for c in dep_info.transitive_crates] +
+        [c.output for c in dep_info.transitive_crates.to_list()] +
         [toolchain.rust_doc] +
         toolchain.rustc_lib +
         toolchain.rust_lib

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -24,12 +24,14 @@ def _rust_doc_impl(ctx):
 
     toolchain = find_toolchain(ctx)
 
-    rustdoc_inputs = (
+    rustdoc_inputs = depset(
         crate.srcs +
         [c.output for c in dep_info.transitive_crates.to_list()] +
-        [toolchain.rust_doc] +
-        toolchain.rustc_lib +
-        toolchain.rust_lib
+        [toolchain.rust_doc],
+        transitive = [
+            toolchain.rustc_lib.files,
+            toolchain.rust_lib.files,
+        ],
     )
 
     output_dir = ctx.actions.declare_directory(ctx.label.name)

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -36,7 +36,7 @@ def _rust_doc_impl(ctx):
     args = ctx.actions.args()
     args.add(crate.root.path)
     args.add("--crate-name", crate.name)
-    args.add("--output", output_dir)
+    args.add("--output", output_dir.path)
 
     # nb. rustdoc can't do anything with native link flags; we must omit them.
     add_crate_link_flags(args, dep_info)

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -64,14 +64,15 @@ def _build_rustdoc_test_script(toolchain, dep_info, crate):
     link_flags = []
     link_search_flags = []
 
+    # TODO: This should be able to use ctx.actions.Args()
     link_flags += ["--extern " + crate.name + "=" + crate.output.short_path]
-    link_flags += ["--extern " + c.name + "=" + c.output.short_path for c in d.direct_crates]
-    link_search_flags += ["-Ldependency={}".format(dirname(c.output.short_path)) for c in d.transitive_crates]
+    link_flags += ["--extern " + c.name + "=" + c.output.short_path for c in d.direct_crates.to_list()]
+    link_search_flags += ["-Ldependency={}".format(dirname(c.output.short_path)) for c in d.transitive_crates.to_list()]
 
     link_flags += ["-ldylib=" + get_lib_name(lib) for lib in d.transitive_dylibs.to_list()]
-    link_search_flags += ["-Lnative={}".format(dirname(lib.short_path)) for lib in d.transitive_dylibs]
+    link_search_flags += ["-Lnative={}".format(dirname(lib.short_path)) for lib in d.transitive_dylibs.to_list()]
     link_flags += ["-lstatic=" + get_lib_name(lib) for lib in d.transitive_staticlibs.to_list()]
-    link_search_flags += ["-Lnative={}".format(dirname(lib.short_path)) for lib in d.transitive_staticlibs]
+    link_search_flags += ["-Lnative={}".format(dirname(lib.short_path)) for lib in d.transitive_staticlibs.to_list()]
 
     return """\
 #!/usr/bin/env bash

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -35,19 +35,21 @@ def _rust_doc_test_impl(ctx):
     )
 
     # The test script compiles the crate and runs it, so it needs both compile and runtime inputs.
-    compile_inputs = (
+    compile_inputs = depset(
         crate.srcs +
         [crate.output] +
         dep_info.transitive_libs +
         [toolchain.rust_doc] +
         [toolchain.rustc] +
-        toolchain.rustc_lib +
-        toolchain.rust_lib +
-        toolchain.crosstool_files
+        toolchain.crosstool_files,
+        transitive = [
+            toolchain.rustc_lib.files,
+            toolchain.rust_lib.files,
+        ],
     )
 
     runfiles = ctx.runfiles(
-        files = compile_inputs,
+        files = compile_inputs.to_list(),
         collect_data = True,
     )
     return struct(runfiles = runfiles)

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -121,9 +121,9 @@ def BUILD_for_rust_toolchain(workspace_name, name, exec_triple, target_triple):
 rust_toolchain(
     name = "{toolchain_name}_impl",
     rust_doc = "@{workspace_name}//:rustdoc",
-    rust_lib = ["@{workspace_name}//:rust_lib-{target_triple}"],
+    rust_lib = "@{workspace_name}//:rust_lib-{target_triple}",
     rustc = "@{workspace_name}//:rustc",
-    rustc_lib = ["@{workspace_name}//:rustc_lib"],
+    rustc_lib = "@{workspace_name}//:rustc_lib",
     staticlib_ext = "{staticlib_ext}",
     dylib_ext = "{dylib_ext}",
     os = "{system}",

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -2,9 +2,6 @@
 The rust_toolchain rule definition and implementation.
 """
 
-def _get_files(labels):
-    return [f for l in labels for f in getattr(l, "files", [])]
-
 def _rust_toolchain_impl(ctx):
     compilation_mode_opts = {}
     for k, v in ctx.attr.opt_level.items():
@@ -18,8 +15,8 @@ def _rust_toolchain_impl(ctx):
     toolchain = platform_common.ToolchainInfo(
         rustc = ctx.file.rustc,
         rust_doc = ctx.file.rust_doc,
-        rustc_lib = ctx.attr.rustc_lib.files.to_list(),
-        rust_lib = ctx.attr.rust_lib.files.to_list(),
+        rustc_lib = ctx.attr.rustc_lib,
+        rust_lib = ctx.attr.rust_lib,
         staticlib_ext = ctx.attr.staticlib_ext,
         dylib_ext = ctx.attr.dylib_ext,
         target_triple = ctx.attr.target_triple,
@@ -33,10 +30,20 @@ def _rust_toolchain_impl(ctx):
 rust_toolchain = rule(
     _rust_toolchain_impl,
     attrs = {
-        "rustc": attr.label(allow_single_file = True),
-        "rust_doc": attr.label(allow_single_file = True),
-        "rustc_lib": attr.label(),
-        "rust_lib": attr.label(),
+        "rustc": attr.label(
+            doc = "The rustc executable.",
+            allow_single_file = True,
+        ),
+        "rust_doc": attr.label(
+            doc = "The rustdoc executable.",
+            allow_single_file = True,
+        ),
+        "rustc_lib": attr.label(
+            doc = "Libraries used by rustc at runtime.",
+        ),
+        "rust_lib": attr.label(
+            doc = "The rust standard library.",
+        ),
         "staticlib_ext": attr.string(mandatory = True),
         "dylib_ext": attr.string(mandatory = True),
         "os": attr.string(mandatory = True),

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -18,6 +18,7 @@ def _rust_toolchain_impl(ctx):
     toolchain = platform_common.ToolchainInfo(
         rustc = ctx.file.rustc,
         rust_doc = ctx.file.rust_doc,
+        # TODO: Why are these attrs a list?
         rustc_lib = _get_files(ctx.attr.rustc_lib),
         rust_lib = _get_files(ctx.attr.rust_lib),
         staticlib_ext = ctx.attr.staticlib_ext,

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -18,9 +18,8 @@ def _rust_toolchain_impl(ctx):
     toolchain = platform_common.ToolchainInfo(
         rustc = ctx.file.rustc,
         rust_doc = ctx.file.rust_doc,
-        # TODO: Why are these attrs a list?
-        rustc_lib = _get_files(ctx.attr.rustc_lib),
-        rust_lib = _get_files(ctx.attr.rust_lib),
+        rustc_lib = ctx.attr.rustc_lib.files.to_list(),
+        rust_lib = ctx.attr.rust_lib.files.to_list(),
         staticlib_ext = ctx.attr.staticlib_ext,
         dylib_ext = ctx.attr.dylib_ext,
         target_triple = ctx.attr.target_triple,
@@ -36,8 +35,8 @@ rust_toolchain = rule(
     attrs = {
         "rustc": attr.label(allow_single_file = True),
         "rust_doc": attr.label(allow_single_file = True),
-        "rustc_lib": attr.label_list(allow_files = True),
-        "rust_lib": attr.label_list(allow_files = True),
+        "rustc_lib": attr.label(),
+        "rust_lib": attr.label(),
         "staticlib_ext": attr.string(mandatory = True),
         "dylib_ext": attr.string(mandatory = True),
         "os": attr.string(mandatory = True),
@@ -92,8 +91,8 @@ Example:
   rust_toolchain(
     name = "rust_cpuX_impl",
     rustc = "@rust_cpuX//:rustc",
-    rustc_lib = ["@rust_cpuX//:rustc_lib"],
-    rust_lib = ["@rust_cpuX//:rust_lib"],
+    rustc_lib = "@rust_cpuX//:rustc_lib",
+    rust_lib = "@rust_cpuX//:rust_lib",
     rust_doc = "@rust_cpuX//:rustdoc",
     staticlib_ext = ".a",
     dylib_ext = ".so",


### PR DESCRIPTION
This gets us from
```
bazel-20 test //... --all_incompatible_changes --incompatible_disable_deprecated_attr_params=false --incompatible_depset_is_not_iterable=false --incompatible_depset_union=false --incompatible_new_actions_api=false
```
to 
```
bazel-20 test  --all_incompatible_changes //... @examples//... --incompatible_disable_deprecated_attr_params=false --incompatible_new_actions_api=false
```

Remaining issues:
```
>> bazel-20 test  --all_incompatible_changes //... @examples//... --keep_going

INFO: Invocation ID: deecf474-694f-4adc-9995-b09b2a5fc850
DEBUG: /home/marco/.cache/bazel/_bazel_marco/4e38d4394f29c071904de81d6fb3e103/external/bazel_skylib/skylark_library.bzl:23:1: WARNING: skylark_library.bzl is deprecated and will go away in the future, please use bzl_library.bzl instead.                  
ERROR: /home/marco/.cache/bazel/_bazel_marco/4e38d4394f29c071904de81d6fb3e103/external/bazel_tools/tools/build_rules/test_rules.bzl:308:17: Traceback (most recent call last):                                                                                
        File "/home/marco/.cache/bazel/_bazel_marco/4e38d4394f29c071904de81d6fb3e103/external/bazel_tools/tools/build_rules/test_rules.bzl", line 306                                                                                                         
                rule(attrs = {"file": attr.label(mand...))}, <3 more arguments>)
        File "/home/marco/.cache/bazel/_bazel_marco/4e38d4394f29c071904de81d6fb3e103/external/bazel_tools/tools/build_rules/test_rules.bzl", line 308, in rule                                                                                                
                attr.label(mandatory = True, allow_files = Tr..., ...)
'single_file' is no longer supported. use allow_single_file instead. You can use --incompatible_disable_deprecated_attr_params to temporarily disable this check.                                                                                             
ERROR: error loading package 'test': Extension file 'tools/build_rules/test_rules.bzl' has errors
```

Does it make sense that there are errors in `@bazel_tools`?