### PR TITLE
Change dash to underscore in generated filenames

### DIFF
--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -36,8 +36,8 @@ load(
     "//proto:toolchain.bzl",
     "GRPC_COMPILE_DEPS",
     "PROTO_COMPILE_DEPS",
-    _file_stem = "file_stem",
     _generate_proto = "rust_generate_proto",
+    _generated_file_stem = "generated_file_stem",
 )
 load("//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
 load("//rust:private/utils.bzl", "find_toolchain")
@@ -106,11 +106,11 @@ def _gen_lib(ctx, grpc, srcs, lib):
         content.append("extern crate grpc;")
         content.append("extern crate tls_api;")
     for f in srcs.to_list():
-        content.append("pub mod %s;" % _file_stem(f))
-        content.append("pub use %s::*;" % _file_stem(f))
+        content.append("pub mod %s;" % _generated_file_stem(f))
+        content.append("pub use %s::*;" % _generated_file_stem(f))
         if grpc:
-            content.append("pub mod %s_grpc;" % _file_stem(f))
-            content.append("pub use %s_grpc::*;" % _file_stem(f))
+            content.append("pub mod %s_grpc;" % _generated_file_stem(f))
+            content.append("pub use %s_grpc::*;" % _generated_file_stem(f))
     ctx.actions.write(lib, "\n".join(content))
 
 def _expand_provider(lst, provider):

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -14,8 +14,9 @@
 
 """Toolchain for compiling rust stubs from protobug and gRPC."""
 
-def file_stem(f):
+def generated_file_stem(f):
     basename = f.rsplit("/", 2)[-1]
+    basename = basename.replace("-", "_")
     return basename.rsplit(".", 2)[0]
 
 def rust_generate_proto(
@@ -49,7 +50,7 @@ def rust_generate_proto(
 
     if not protos:
         fail("Protobuf compilation requested without inputs!")
-    paths = ["%s/%s" % (output_dir, file_stem(i)) for i in protos.to_list()]
+    paths = ["%s/%s" % (output_dir, generated_file_stem(i)) for i in protos.to_list()]
     outs = [ctx.actions.declare_file(path + ".rs") for path in paths]
     output_directory = outs[0].dirname
 


### PR DESCRIPTION
The generated rust file for `my-file.proto` is `my_file.rs`.
Declared outputs for *_proto and *_grpc rules should reflect this.