### PR TITLE
Establish `CARGO_MANIFEST_DIR`

### DIFF
--- a/test/build_env/BUILD
+++ b/test/build_env/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "//rust:rust.bzl",
+    "rust_test",
+)
+
+rust_test(
+    name = "conflicting_deps_test",
+    srcs = ["tests/manifest_dir.rs"],
+    data = ["src/manifest_dir_file.txt"],
+)

--- a/test/build_env/src/manifest_dir_file.txt
+++ b/test/build_env/src/manifest_dir_file.txt
@@ -1,0 +1,1 @@
+This file tests that CARGO_MANIFEST_DIR is set for the build environment

--- a/test/build_env/tests/manifest_dir.rs
+++ b/test/build_env/tests/manifest_dir.rs
@@ -1,0 +1,6 @@
+#[test]
+pub fn test_manifest_dir() {
+    let actual = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/manifest_dir_file.txt"));
+    let expected = "This file tests that CARGO_MANIFEST_DIR is set for the build environment\n";
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
Several popular crates, as well as some source code has a habit of using `env!("CARGO_MANIFEST_DIR")` to find files in a crate. This causes things like google/cargo-raze#71.

Following @acmcarther suggestions this is an attempt at solution 3, which appears to handle (ab)uses of `CARGO_MANIFEST_DIR` I have tested (tera, askuma).