### PR TITLE
Fix setup snippet in the README (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
+    strip_prefix = "bazel-skylib-0.6.0",
+    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz",
+)
+
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 rust_repositories()
 


### PR DESCRIPTION
Quick fix to make the README correct.

Right thing to do is to make the `rust_repositories` function setup skylib and bazel_version.. but I vaguely recall having some problems doing that.