### PR TITLE
Fix helloworld_test to work on hosts without IPv6

### DIFF
--- a/examples/proto/helloworld/greeter_client/greeter_client.rs
+++ b/examples/proto/helloworld/greeter_client/greeter_client.rs
@@ -35,7 +35,7 @@ fn parse_args() -> (String, u16) {
 
 fn main() {
     let (name, port) = parse_args();
-    let client = GreeterClient::new_plain("::1", port, Default::default()).unwrap();
+    let client = GreeterClient::new_plain("localhost", port, Default::default()).unwrap();
     let mut req = HelloRequest::new();
     req.set_name(name);
     let resp = client.say_hello(grpc::RequestOptions::new(), req);


### PR DESCRIPTION
Saw this in the logs after we migrated to run all CI jobs in Docker containers:

```
Started server on port 34711
thread 'test_client_server' panicked at ''message: "Hello world"' not found in 'Err(Http(ClientDied(Some(IoError(Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" })))))
'', external/examples/proto/helloworld/helloworld_test.rs:112:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```
(from https://storage.googleapis.com/bazel-untrusted-buildkite-artifacts/9488b198-a478-4957-b975-e73ac35e3108/xamples/proto/helloworld/helloworld_test/attempt_1.log)