### PR TITLE
Fix the label for Clang's BUILD file

### DIFF
--- a/bindgen/repositories.bzl
+++ b/bindgen/repositories.bzl
@@ -54,7 +54,7 @@ def _linux_rust_bindgen_repositories():
         urls = ["http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz"],
         strip_prefix = "clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04",
         sha256 = "e74ce06d99ed9ce42898e22d2a966f71ae785bdf4edbded93e628d696858921a",
-        build_file = "@//bindgen:clang.BUILD",
+        build_file = Label("//bindgen:clang.BUILD"),
     )
 
 LIBSTDCPP_LINUX = """


### PR DESCRIPTION
...otherwise it fails when imported from a repository