### PR TITLE
Make it possible for unit tests to have dev deps

### DIFF
--- a/examples/ffi/rust_calling_c/BUILD
+++ b/examples/ffi/rust_calling_c/BUILD
@@ -16,7 +16,7 @@ rust_library(
 
 rust_test(
     name = "matrix_test",
-    deps = [":matrix"],
+    crate = ":matrix",
 )
 
 rust_doc(
@@ -41,7 +41,7 @@ rust_library(
 
 rust_test(
     name = "matrix_dylib_test",
-    deps = [":matrix_dynamically_linked"],
+    crate = ":matrix_dynamically_linked",
 )
 
 rust_doc(

--- a/examples/ffi/rust_calling_c/simple/BUILD
+++ b/examples/ffi/rust_calling_c/simple/BUILD
@@ -23,5 +23,5 @@ rust_binary(
 
 rust_test(
     name = "simple_test",
-    deps = [":simple_example"],
+    crate = ":simple_example",
 )

--- a/examples/fibonacci/BUILD
+++ b/examples/fibonacci/BUILD
@@ -14,7 +14,7 @@ rust_library(
 
 rust_test(
     name = "fibonacci_test",
-    deps = [":fibonacci"],
+    crate = ":fibonacci",
 )
 
 rust_benchmark(

--- a/examples/hello_lib/BUILD
+++ b/examples/hello_lib/BUILD
@@ -47,7 +47,7 @@ rust_library(
 
 rust_test(
     name = "hello_lib_test",
-    deps = [":hello_lib"],
+    crate = ":hello_lib",
 )
 
 rust_test(

--- a/examples/hello_out_dir/BUILD
+++ b/examples/hello_out_dir/BUILD
@@ -20,5 +20,5 @@ rust_binary(
 rust_test(
     name = "hello_out_dir_test",
     out_dir_tar = ":repacked_srcs.tar.gz",
-    deps = [":hello_out_dir"],
+    crate = ":hello_out_dir",
 )

--- a/examples/per_platform_printer/BUILD
+++ b/examples/per_platform_printer/BUILD
@@ -32,5 +32,5 @@ rust_library(
 
 rust_test(
     name = "printer_test",
-    deps = [":printer"],
+    crate = ":printer",
 )

--- a/test/chained_direct_deps/BUILD
+++ b/test/chained_direct_deps/BUILD
@@ -27,17 +27,17 @@ rust_library(
 
 rust_test(
     name = "mod1_test",
-    deps = [":mod1"],
+    crate = ":mod1",
 )
 
 rust_test(
     name = "mod2_test",
-    deps = [":mod2"],
+    crate = ":mod2",
 )
 
 rust_test(
     name = "mod3_test",
-    deps = [":mod3"],
+    crate = ":mod3",
 )
 
 rust_doc_test(

--- a/test/conflicting_deps/BUILD
+++ b/test/conflicting_deps/BUILD
@@ -16,7 +16,5 @@ rust_library(
 
 rust_test(
     name = "conflicting_deps_test",
-    deps = [
-        ":conflicting_deps",
-    ],
+    crate = ":conflicting_deps",
 )

--- a/test/inline_test_with_deps/dep/BUILD
+++ b/test/inline_test_with_deps/dep/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "//rust:rust.bzl",
+    "rust_library",
+)
+
+rust_library(
+    name = "dep",
+    srcs = ["src/lib.rs"],
+)

--- a/test/inline_test_with_deps/dep/src/lib.rs
+++ b/test/inline_test_with_deps/dep/src/lib.rs
@@ -1,0 +1,4 @@
+/// This exists purely to give us a dep to compile against
+pub fn example_test_dep_fn() -> u32 {
+    1
+}

--- a/test/inline_test_with_deps/test/BUILD
+++ b/test/inline_test_with_deps/test/BUILD
@@ -1,0 +1,19 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "//rust:rust.bzl",
+    "rust_library",
+    "rust_test",
+)
+
+rust_library(
+    name = "inline",
+    edition = "2018",
+    srcs = ["src/lib.rs"],
+)
+
+rust_test(
+    name = "inline_test",
+    crate = ":inline",
+    deps = ["//test/inline_test_with_deps/dep"],
+)

--- a/test/inline_test_with_deps/test/src/lib.rs
+++ b/test/inline_test_with_deps/test/src/lib.rs
@@ -1,0 +1,15 @@
+#[allow(dead_code)]
+fn multiply(val: u32) -> u32 {
+    val * 100
+}
+
+#[cfg(test)]
+mod tests {
+    use super::multiply;
+    use dep::example_test_dep_fn;
+
+    #[test]
+    fn test() {
+        assert_eq!(100, multiply(example_test_dep_fn()));
+    }
+}

--- a/test/inline_test_with_deps/test_with_srcs/BUILD
+++ b/test/inline_test_with_deps/test_with_srcs/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "//rust:rust.bzl",
+    "rust_library",
+    "rust_test",
+)
+
+rust_library(
+    name = "inline",
+    edition = "2018",
+    srcs = ["src/lib.rs"],
+)
+
+rust_test(
+    name = "inline_test",
+    crate = ":inline",
+    srcs = ["src/extra.rs"],
+    deps = ["//test/inline_test_with_deps/dep"],
+)

--- a/test/inline_test_with_deps/test_with_srcs/src/extra.rs
+++ b/test/inline_test_with_deps/test_with_srcs/src/extra.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+pub(crate) fn extra_test_fn() -> u32 {
+    100
+}

--- a/test/inline_test_with_deps/test_with_srcs/src/lib.rs
+++ b/test/inline_test_with_deps/test_with_srcs/src/lib.rs
@@ -1,0 +1,18 @@
+#[allow(dead_code)]
+fn multiply(val: u32) -> u32 {
+    val * 100
+}
+
+#[cfg(test)]
+mod extra;
+
+#[cfg(test)]
+mod tests {
+    use super::{multiply, extra};
+    use dep::example_test_dep_fn;
+
+    #[test]
+    fn test() {
+        assert_eq!(extra::extra_test_fn(), multiply(example_test_dep_fn()));
+    }
+}

--- a/tools/runfiles/BUILD
+++ b/tools/runfiles/BUILD
@@ -14,7 +14,7 @@ rust_library(
 rust_test(
     name = "runfiles_test",
     data = ["data/sample.txt"],
-    deps = [":runfiles"],
+    crate = ":runfiles",
 )
 
 rust_doc_test(


### PR DESCRIPTION
Due to the way unit tests are handled with the rules, it is tricky for a
unit test to have additional deps.

Consider some source code like such

```rust
fn some_fn() -> u32 {
    2
}

mod tests {
    use super::some_fn();

    // This following line is not going to work
    use pretty_assertions::assert_eq;

    #[test]
    fn test_is_2() {
        assert_eq!(1, some_fn());
    }
}
```

With a build function like so

```python
rust_library(
    name = "example",
    srcs = ["lib.rs"]
)

rust_test(
    name = "example_test",
    deps = [
        ":example",
        "//third_party/rust:pretty_assertion",
    ],
)
```

Presently, due to the handling of ‟unit tests” the extra deps will
conflict with rust_rules ideas about how to identify the test, and give
an error along the lines of

```
attribute srcs: No lib.rs or example_test.rs source file found.
```

With this change we make it possible for tests to express ‟dev
dependencies”. This lets us avoid adding deps that are strictly for
testing.

This is somewhat distinct from `testonly` attributes as it does not
always hold that a dependency is always and only ever `testonly` in all
library circumstances, consider for example the usage of
https://github.com/pingcap/fail-rs. There are instances where this needs
to be used both in source code *and* test code, and is not easily
seperated from a cargo-raze perspective.

Closes #202