### PR TITLE
Add linker_script option to rust_binary

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -354,9 +354,18 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 """,
 )
 
+_rust_binary_attrs = {
+    "linker_script": attr.label(
+        doc = _tidy("""
+            Link script to forward into linker via rustc options.
+        """),
+        allow_single_file = True,
+    ),
+}
+
 rust_binary = rule(
     _rust_binary_impl,
-    attrs = _rust_common_attrs,
+    attrs = dict(_rust_common_attrs.items() + _rust_binary_attrs.items()),
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -359,6 +359,7 @@ _rust_binary_attrs = {
         doc = _tidy("""
             Link script to forward into linker via rustc options.
         """),
+        cfg = "host",
         allow_single_file = True,
     ),
 }


### PR DESCRIPTION
This explicitly adds a `linker_script` option to `rust_binary` as suggested in the bottom of #204.

It's fundamentally identical to adding the ldscript to data and then adding `--codegen=link-args=-T$(location //:ldscript)` to `rustc_flags`, but now without the hassle of figuring that out yourself.