### PR TITLE
Don't test on Ubuntu 14.04

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -7,9 +7,6 @@ default_targets: &default_targets
 # Bindgen currently only has a working toolchain for 18.04
 - "-@examples//ffi/rust_calling_c/simple/..."
 tasks:
-  ubuntu1404:
-    build_targets: *default_targets
-    test_targets: *default_targets
   ubuntu1604:
     build_targets: *default_targets
     test_targets: *default_targets


### PR DESCRIPTION
Ubuntu 14.04 is about to be end-of-life and Bazel CI will stop supporting it shortly afterwards.

Context: https://groups.google.com/d/msg/bazel-dev/_D6XzfNkQQE/8TNKiNmsCAAJ