### PR TITLE
Add cc toolchain files to rustc dependencies (for linker)

### DIFF
--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -216,6 +216,7 @@ rust_proto_library = rule(
     toolchains = [
         "@io_bazel_rules_rust//proto:toolchain",
         "@io_bazel_rules_rust//rust:toolchain",
+        "@bazel_tools//tools/cpp:toolchain_type",
     ],
     doc = """
 Builds a Rust library crate from a set of `proto_library`s.
@@ -275,6 +276,7 @@ rust_grpc_library = rule(
     toolchains = [
         "@io_bazel_rules_rust//proto:toolchain",
         "@io_bazel_rules_rust//rust:toolchain",
+        "@bazel_tools//tools/cpp:toolchain_type",
     ],
     doc = """
 Builds a Rust library crate from a set of `proto_library`s suitable for gRPC.

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -334,7 +334,10 @@ rust_library = rule(
                  _rust_library_attrs.items()),
     fragments = ["cpp"],
     host_fragments = ["cpp"],
-    toolchains = ["@io_bazel_rules_rust//rust:toolchain"],
+    toolchains = [
+        "@io_bazel_rules_rust//rust:toolchain",
+        "@bazel_tools//tools/cpp:toolchain_type"
+    ],
     doc = """
 Builds a Rust library crate.
 
@@ -417,7 +420,10 @@ rust_binary = rule(
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],
-    toolchains = ["@io_bazel_rules_rust//rust:toolchain"],
+    toolchains = [
+        "@io_bazel_rules_rust//rust:toolchain",
+        "@bazel_tools//tools/cpp:toolchain_type"
+    ],
     doc = """
 Builds a Rust binary crate.
 
@@ -512,7 +518,10 @@ rust_test = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     test = True,
-    toolchains = ["@io_bazel_rules_rust//rust:toolchain"],
+    toolchains = [
+        "@io_bazel_rules_rust//rust:toolchain",
+        "@bazel_tools//tools/cpp:toolchain_type"
+    ],
     doc = """
 Builds a Rust test crate.
 
@@ -656,7 +665,10 @@ rust_benchmark = rule(
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],
-    toolchains = ["@io_bazel_rules_rust//rust:toolchain"],
+    toolchains = [
+        "@io_bazel_rules_rust//rust:toolchain",
+        "@bazel_tools//tools/cpp:toolchain_type"
+    ],
     doc = """
 Builds a Rust benchmark test.
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -194,6 +194,7 @@ def rustc_compile_action(
         dep_info.transitive_libs +
         [toolchain.rustc] +
         toolchain.crosstool_files +
+        ctx.files._cc_toolchain +
         ([] if linker_script == None else [linker_script]),
         transitive = [
             toolchain.rustc_lib.files,

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -194,12 +194,12 @@ def rustc_compile_action(
         dep_info.transitive_libs +
         [toolchain.rustc] +
         toolchain.crosstool_files +
-        ctx.files._cc_toolchain +
         ([] if linker_script == None else [linker_script]),
         transitive = [
             toolchain.rustc_lib.files,
             toolchain.rust_lib.files,
-        ],
+            # TODO wait for CcToolchainInfo.all_files to be available
+        ] + ctx.files._cc_toolchain,
     )
 
     args = ctx.actions.args()

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -188,8 +188,13 @@ def rustc_compile_action(
 
     linker_script = getattr(ctx.file, "linker_script") if hasattr(ctx.file, "linker_script") else None
 
-    # TODO wait for CcToolchainInfo.all_files to be available
-    toolchain_depset = depset(ctx.files._cc_toolchain)
+    cc_toolchain = find_cpp_toolchain(ctx)
+
+    if (len(BAZEL_VERSION) == 0 or
+         versions.is_at_least("0.25.0", BAZEL_VERSION)):
+        linker_depset = find_cpp_toolchain(ctx).all_files
+    else:
+        linker_depset = depset(ctx.files._cc_toolchain)
 
     compile_inputs = depset(
         crate_info.srcs +
@@ -201,7 +206,7 @@ def rustc_compile_action(
         transitive = [
             toolchain.rustc_lib.files,
             toolchain.rust_lib.files,
-            toolchain_depset
+            linker_depset,
         ],
     )
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -188,6 +188,9 @@ def rustc_compile_action(
 
     linker_script = getattr(ctx.file, "linker_script") if hasattr(ctx.file, "linker_script") else None
 
+    # TODO wait for CcToolchainInfo.all_files to be available
+    toolchain_depset = depset(ctx.files._cc_toolchain)
+
     compile_inputs = depset(
         crate_info.srcs +
         getattr(ctx.files, "data", []) +
@@ -198,8 +201,8 @@ def rustc_compile_action(
         transitive = [
             toolchain.rustc_lib.files,
             toolchain.rust_lib.files,
-            # TODO wait for CcToolchainInfo.all_files to be available
-        ] + ctx.files._cc_toolchain,
+            toolchain_depset
+        ],
     )
 
     args = ctx.actions.args()


### PR DESCRIPTION
Currently if you're using an artifacted compiler the Rust rules will complain that they can't find the linker script. This is because it is not a dependency.

I'm pretty sure there's a correct way to do this with the new toolchain system but I was looking around and saw that people mostly stuck with this with some TODOs to find a better way.

I tried to get it using `ctx.toolchains` but that doesn't actually have files, it seems.