### PR TITLE
Fix failure to build without iterable depset

### DIFF
--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -45,7 +45,8 @@ def _rust_bindgen_impl(ctx):
     # nb. We can't grab the cc_library`s direct headers, so a header must be provided.
     cc_lib = ctx.attr.cc_lib
     header = ctx.file.header
-    if header not in cc_lib[CcInfo].compilation_context.headers:
+    cc_header_list = ctx.attr.cc_lib[CcInfo].compilation_context.headers.to_list()
+    if header not in cc_header_list:
         fail("Header {} is not in {}'s transitive headers.".format(ctx.attr.header, cc_lib), "header")
 
     toolchain = ctx.toolchains["@io_bazel_rules_rust//bindgen:bindgen_toolchain"]


### PR DESCRIPTION
This fixes the issue raised in https://github.com/bazelbuild/rules_rust/issues/218.

Depsets are not backed by hash sets do not have a trivial check for existence. Thus we need to explicitly flatten the depset into a list of headers before we see if the header is in the set.

I'm not clear enough on how bindgen works to propose a more elegant fix. Doing this check at all requires flattening to a list, and I don't know how/if we could avoid doing this check.