### PR TITLE
Fix failure to build without iterable depset pt. 2

### DIFF
--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -108,7 +108,7 @@ def _rust_bindgen_impl(ctx):
             "CLANG_PATH": clang_bin.path,
             # Bindgen loads libclang at runtime, which also needs libstdc++, so we setup LD_LIBRARY_PATH
             "LIBCLANG_PATH": libclang_dir,
-            "LD_LIBRARY_PATH": ":".join([f.dirname for f in get_libs_for_static_executable(libstdcxx)]),
+            "LD_LIBRARY_PATH": ":".join([f.dirname for f in get_libs_for_static_executable(libstdcxx).to_list()]),
         },
         arguments = [args],
         tools = [clang_bin],


### PR DESCRIPTION
Fixes #218's newly reported problem.

I don't think there's a way to actually test this without having more comprehensive unit tests, which I don't have time to work on right now.