### PR TITLE
Migrate rules_rust for https://github.com/bazelbuild/bazel/issues/7153 and https://github.com/bazelbuild/bazel/issues/7152

### DIFF
--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -15,9 +15,12 @@
 """Toolchain for compiling rust stubs from protobug and gRPC."""
 
 def generated_file_stem(f):
-    basename = f.rsplit("/", 2)[-1]
+    basename = f.short_path.rsplit("/", 2)[-1]
     basename = basename.replace("-", "_")
     return basename.rsplit(".", 2)[0]
+
+def _to_basename(a):
+  return a.basename
 
 def rust_generate_proto(
         ctx,
@@ -83,7 +86,7 @@ def rust_generate_proto(
         format_joined = "--descriptor_set_in=%s",
     )
 
-    args.add_all(protos)
+    args.add_all(imports, map_each = _to_basename)
     ctx.actions.run(
         inputs = depset(
             transitive = [

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -3,14 +3,14 @@ load("@io_bazel_rules_rust//proto:proto.bzl", "rust_proto_library")
 proto_library(
     name = "a_proto",
     srcs = ["a.proto"],
-    proto_source_root = "test/proto",
+    strip_import_prefix = "/test/proto",
 )
 
 proto_library(
     name = "b_proto",
     srcs = ["b.proto"],
     deps = [":a_proto"],
-    proto_source_root = "test/proto",
+    strip_import_prefix = "/test/proto",
 )
 
 rust_proto_library(


### PR DESCRIPTION
This PR migrates rules_rust for following Bazel incompatible changes:

* https://github.com/bazelbuild/bazel/issues/7152 (removal of legacy `dep.proto` provider)
* https://github.com/bazelbuild/bazel/issues/7153 (removal of `proto_source_root`)

7152 is trivial, just not compatible with Bazel <= 0.21 which at this point is fine I guess?

7153 part is very controversial. I think we're missing Bazel APIs in ProtoInfo to implement fully correct code. The PR passes the test suite, but that says nothing about the actual quality of my code :) It introduces many bugs:

* I created https://github.com/bazelbuild/rules_rust/pull/234 to demonstrate edge cases that are missed before this PR, and well, they are still missed after this PR.
* I honestly didn't understand the current implementation, especially why was `_compute_proto_source_path` introduced (I know very little about protos), it may be that this PR broke smth I don't understand yet.

So pls bear with me and be careful with your review :)

Thanks!

