### PR TITLE
Make rust_proto_library work with proto_library rules using import_prefix / strip_import_prefix .

### DIFF
--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -52,6 +52,10 @@ RustProtoProvider = provider(
 def _compute_proto_source_path(file, source_root_attr):
     """Take the short path of file and make it suitable for protoc."""
 
+    virtual_imports = "/_virtual_imports/"
+    if virtual_imports in file.path:
+        return file.path.split(virtual_imports)[1].split("/", 1)[1]
+
     # For proto, they need to be requested with their absolute name to be
     # compatible with the descriptor_set passed by proto_library.
     # I.e. if you compile a protobuf at @repo1//package:file.proto, the proto
@@ -260,7 +264,7 @@ rust_grpc_library = rule(
         ),
         "rust_deps": attr.label_list(
             doc = "The crates the generated library depends on.",
-            default = GRPC_COMPILE_DEPS
+            default = GRPC_COMPILE_DEPS,
         ),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
         "_optional_output_wrapper": attr.label(

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -52,6 +52,9 @@ RustProtoProvider = provider(
 def _compute_proto_source_path(file, source_root_attr):
     """Take the short path of file and make it suitable for protoc."""
 
+    # Bazel creates symlinks to the .proto files under a directory called
+    # "_virtual_imports/<rule name>" if we do any sort of munging of import
+    # paths (e.g. using strip_import_prefix / import_prefix attributes)
     virtual_imports = "/_virtual_imports/"
     if virtual_imports in file.path:
         return file.path.split(virtual_imports)[1].split("/", 1)[1]

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -106,7 +106,7 @@ def _rust_proto_toolchain_impl(ctx):
         proto_plugin = ctx.file.proto_plugin,
         grpc_plugin = ctx.file.grpc_plugin,
         edition = ctx.attr.edition,
-   )
+    )
 
 PROTO_COMPILE_DEPS = [
     "@io_bazel_rules_rust//proto/raze:protobuf",


### PR DESCRIPTION
In addition, this makes it possible to fix http://github.com/bazelbuild/bazel/issues/7157 (patch upcoming)