### PR TITLE
Add allow_empty to glob, as the patterns don't necessarily match something

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,11 +64,11 @@ sass_repositories()
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "5962fe677a43226c409316fcb321d668fc4b7fa97cb1f9ef45e7dc2676097b26",
-    strip_prefix = "bazel-toolchains-be10bee3010494721f08a0fccd7f57411a1e773e",
+    sha256 = "d8c2f20deb2f6143bac792d210db1a4872102d81529fe0ea3476c1696addd7ff",
+    strip_prefix = "bazel-toolchains-0.28.3",
     urls = [
-      "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz",
-      "https://github.com/bazelbuild/bazel-toolchains/archive/be10bee3010494721f08a0fccd7f57411a1e773e.tar.gz",
+      "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.28.3.tar.gz",
+      "https://github.com/bazelbuild/bazel-toolchains/archive/0.28.3.tar.gz",
     ],
 )
 

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -99,6 +99,7 @@ filegroup(
             "lib/rustlib/{target_triple}/lib/*{dylib_ext}",
             "lib/rustlib/{target_triple}/lib/*{staticlib_ext}",
         ],
+        # Some patterns (e.g. `lib/*.a`) don't match anything, see https://github.com/bazelbuild/rules_rust/pull/245
         allow_empty = True,
     ),
     visibility = ["//visibility:public"],

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -93,11 +93,14 @@ def BUILD_for_stdlib(target_triple):
     return """
 filegroup(
     name = "rust_lib-{target_triple}",
-    srcs = glob([
-        "lib/rustlib/{target_triple}/lib/*.rlib",
-        "lib/rustlib/{target_triple}/lib/*{dylib_ext}",
-        "lib/rustlib/{target_triple}/lib/*{staticlib_ext}",
-    ]),
+    srcs = glob(
+        [
+            "lib/rustlib/{target_triple}/lib/*.rlib",
+            "lib/rustlib/{target_triple}/lib/*{dylib_ext}",
+            "lib/rustlib/{target_triple}/lib/*{staticlib_ext}",
+        ],
+        allow_empty = True,
+    ),
     visibility = ["//visibility:public"],
 )
 """.format(


### PR DESCRIPTION
This is needed for the change in Bazel --incompatible_disallow_empty_glob