### PR TITLE
Make rust_proto_library not require the proto_library.proto_source_ro…

### DIFF
--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -83,7 +83,12 @@ def _compute_proto_source_path(file, source_root_attr):
 def _rust_proto_aspect_impl(target, ctx):
     if ProtoInfo not in target:
         return None
-    source_root = ctx.rule.attr.proto_source_root
+
+    if hasattr(ctx.rule.attr, "proto_source_root"):
+        source_root = ctx.rule.attr.proto_source_root
+    else:
+        source_root = ""
+
     if source_root and source_root[-1] != "/":
         source_root += "/"
 


### PR DESCRIPTION
…ot attribute.

It's going away in Bazel 1.0.

Unfortunately, I can't just remove the code to support it so that
rules_rust supports Bazel versions that still have it.