### PR TITLE
Use C++ environment variables when constructing link command line

### DIFF
--- a/rust/private/legacy_cc_starlark_api_shim.bzl
+++ b/rust/private/legacy_cc_starlark_api_shim.bzl
@@ -13,13 +13,7 @@ def get_libs_for_static_executable(dep):
       A depset[File]
     """
     libraries_to_link = dep[CcInfo].linking_context.libraries_to_link
-
-    # Remove `if` line once Bazel 0.27 is used
-    # (https://github.com/bazelbuild/bazel/issues/8118)
-    if type(libraries_to_link) == type(depset()):
-        libraries_to_link = libraries_to_link.to_list()
-
-    return depset([_get_preferred_artifact(lib) for lib in libraries_to_link])
+    return depset([_get_preferred_artifact(lib) for lib in libraries_to_link.to_list()])
 
 def _get_preferred_artifact(library_to_link):
     return (


### PR DESCRIPTION
This PR makes sure that rustc action also takes declared environment
variables from the C++ toolchain when constructing the action. This way
the C++ toolchain can start using more environment variables without
breaking rust.