### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,6 @@ bazel_version(name = "bazel_version")
 ```
 The rules are under active development, as such the lastest commit on the master branch should be used. `master` currently requires Bazel >= 0.26.0.
 
-## Example
-
-Here's an example to build a Hello World:
-
-```python
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
-
-rust_binary(
-    name = "rs",
-    srcs = ["hello.rs"],
-)
-```
-
 ### External Dependencies
 
 Currently the most common approach to managing external dependencies is using 

--- a/README.md
+++ b/README.md
@@ -38,21 +38,23 @@ with an overview [here](proto/README.md).
 To use the Rust rules, add the following to your `WORKSPACE` file to add the external repositories for the Rust toolchain:
 
 ```python
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_rust",
-    sha256 = "c82118824b2448b77146f1dae97b6eaa717babedad0822aca4879f3cbbf2b7b5",
-    strip_prefix = "rules_rust-3228ccd3814c2ad0d7307d2f87fb8ff9616149d7",
+    sha256 = "b6da34e057a31b8a85e343c732de4af92a762f804fc36b0baa6c001423a70ebc",
+    strip_prefix = "rules_rust-55f77017a7f5b08e525ebeab6e11d8896a4499d2",
     urls = [
-        # Master branch as of 2018-12-11
-        "https://github.com/bazelbuild/rules_rust/archive/3228ccd3814c2ad0d7307d2f87fb8ff9616149d7.tar.gz",
+        # Master branch as of 2019-10-07
+        "https://github.com/bazelbuild/rules_rust/archive/55f77017a7f5b08e525ebeab6e11d8896a4499d2.tar.gz",
     ],
 )
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
-    strip_prefix = "bazel-skylib-0.6.0",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz",
+    sha256 = "9a737999532daca978a158f94e77e9af6a6a169709c0cee274f0a4c3359519bd",
+    strip_prefix = "bazel-skylib-1.0.0",
+    url = "https://github.com/bazelbuild/bazel-skylib/archive/1.0.0.tar.gz",
 )
 
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
@@ -61,7 +63,20 @@ rust_repositories()
 load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
 bazel_version(name = "bazel_version")
 ```
-The rules are under active development, as such the lastest commit on the master branch should be used. `master` currently requires Bazel >= 0.17.0.
+The rules are under active development, as such the lastest commit on the master branch should be used. `master` currently requires Bazel >= 0.26.0.
+
+## Example
+
+Here's an example to build a Hello World:
+
+```python
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
+
+rust_binary(
+    name = "rs",
+    srcs = ["hello.rs"],
+)
+```
 
 ### External Dependencies
 


### PR DESCRIPTION
- The commit hash was not compatible with recent versions of Bazel
- Update the dependency on skylib
- Add the load statement for `http_archive`, for easier copy-pasting
- Add an example of use (users shouldn't have to guess the load label)
- Update the version requirement (0.25.0 can't build the code)