### PR TITLE
Explicitly provide rustc the paths to the standard library.

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -245,6 +245,12 @@ def rustc_compile_action(
         args.add_all(getattr(ctx.attr, "crate_features"), before_each = "--cfg", format_each = 'feature="%s"')
     if hasattr(ctx.attr, "linker_script") and linker_script != None:
         args.add(linker_script.path, format = "--codegen=link-arg=-T%s")
+
+    # Gets the paths to the folders containing the standard library (or libcore)
+    rust_lib_paths = depset([file.dirname for file in toolchain.rust_lib.files.to_list()]).to_list()
+    # Tell Rustc where to find the standard library
+    args.add_all(rust_lib_paths, before_each = "-L", format_each="%s")
+
     args.add_all(rust_flags)
     args.add_all(getattr(ctx.attr, "rustc_flags", []))
     add_edition_flags(args, crate_info)


### PR DESCRIPTION
This provides the directories containing the rust standard library (or libcore) as linker arguments to rustc, so the compiler can also find them if they are not in the standard location. This is especially useful when you want to download the different toolchain and target parts in your workspace and construct a custom toolchain from that.
Passing these arguments should be harmless when the standard libraries are in their regular paths.

Adding tests with a custom toolchain would be a bit of a hassle, but I'm willing to write those if you think it would be worth it.

I believe this also fixes #213.