### PR TITLE
Propagate linkopts from native deps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,10 +19,14 @@ local_repository(
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
-    strip_prefix = "bazel-skylib-0.6.0",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+    ],
+    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
 )
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
 
 # TODO: Move this to examples/WORKSPACE when recursive repositories are enabled.
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")

--- a/test/analysis/BUILD
+++ b/test/analysis/BUILD
@@ -1,0 +1,3 @@
+load(":native_deps_test.bzl", "native_deps_test_suite")
+
+native_deps_test_suite(name = "native_deps_test_suite")

--- a/test/analysis/native_deps_test.bzl
+++ b/test/analysis/native_deps_test.bzl
@@ -1,0 +1,42 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//rust:rust.bzl", "rust_binary")
+
+def _linkopts_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    subject = analysistest.target_under_test(env)
+    actions = analysistest.target_actions(env)
+
+    asserts.true(env, "-lsystem_lib" in actions[0].argv)
+
+    return analysistest.end(env)
+
+linkopts_test = analysistest.make(_linkopts_test_impl)
+
+def _linkopts_test():
+    cc_library(
+        name = "native",
+        linkopts = ["-lsystem_lib"],
+        tags = ["manual"],
+    )
+    rust_binary(
+        name = "main",
+        deps = [":native"],
+        srcs = ["main.rs"],
+        tags = ["manual"],
+    )
+    linkopts_test(
+        name = "linkopts_test",
+        target_under_test = ":main",
+    )
+
+def native_deps_test_suite(name):
+    _linkopts_test()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":linkopts_test",
+        ],
+    )


### PR DESCRIPTION
This PR ensures that `linkopts` attributes from dependencies such as `cc_library` make it to the `rust_binary` linker invocation.

Not-so-great but still motivating example is that with this PR we can make openssl-sys crate work with system installed openssl just by pushing additional_deps `cc_libraries`:

```
cc_library(
  name = "crypto",
  linkopts = ["-lcrypto"],
)

cc_library(
  name = "ssl",
  linkopts = ["-lssl"],
  deps = [":crypt"],
)
```


I updated skylib and made use of its unittest.bzl framework for adding the unittest.

And since I was there, I added one TODO regarding libraries to link ordering.