### PR TITLE
fix: add all_files to the dummy cc_toolchain

### DIFF
--- a/rust/private/dummy_cc_toolchain/dummy_cc_toolchain.bzl
+++ b/rust/private/dummy_cc_toolchain/dummy_cc_toolchain.bzl
@@ -1,5 +1,6 @@
 def _dummy_cc_toolchain_impl(ctx):
-    return [platform_common.ToolchainInfo()]
+    # The `all_files` attribute is referenced by rustc_compile_action().
+    return [platform_common.ToolchainInfo(all_files = depset([]))]
 
 dummy_cc_toolchain = rule(
     implementation = _dummy_cc_toolchain_impl,


### PR DESCRIPTION
This avoids a problem where rustc_compile_action() tries to use the
`all_files` property of the cc_toolchain.

This problem only occurs after turning on the following Bazel flag:
    --incompatible_enable_cc_toolchain_resolution

The dummy cc toolchain is only used for building for wasm32.