### PR TITLE
Rename wasm_transition to relate to what it actually does

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -14,7 +14,7 @@
 
 load("@io_bazel_rules_rust//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
 load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain")
-load("@io_bazel_rules_rust//rust:private/transitions.bzl", "wasm_transition")
+load("@io_bazel_rules_rust//rust:private/transitions.bzl", "proc_macro_host_transition")
 
 _OLD_INLINE_TEST_CRATE_MSG = """
 --------------------------------------------------------------------------------
@@ -343,7 +343,7 @@ rust_library = rule(
                  _rust_library_attrs.items()),
     fragments = ["cpp"],
     host_fragments = ["cpp"],
-    cfg = wasm_transition,
+    cfg = proc_macro_host_transition,
     toolchains = [
         "@io_bazel_rules_rust//rust:toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",

--- a/rust/private/transitions.bzl
+++ b/rust/private/transitions.bzl
@@ -1,4 +1,4 @@
-def _wasm_transition(settings, attr):
+def _proc_macro_host_transition(settings, attr):
     if attr.crate_type == "proc-macro":
         return {"//command_line_option:platforms": "@local_config_platform//:host"}
     else:
@@ -7,8 +7,8 @@ def _wasm_transition(settings, attr):
 def _wasm_bindgen_transition(settings, attr):
     return {"//command_line_option:platforms": "@io_bazel_rules_rust//rust/platform:wasm"}
 
-wasm_transition = transition(
-    implementation = _wasm_transition,
+proc_macro_host_transition = transition(
+    implementation = _proc_macro_host_transition,
     inputs = ["//command_line_option:platforms"],
     outputs = ["//command_line_option:platforms"],
 )


### PR DESCRIPTION
I didn't actually notice that #240 closed #205, so I figure since the transition literally only deals with transitioning on `proc-macro` it should probably be called that.

@acmcarther if the reason for it has nothing to do with #205 please ignore this PR.