### PR TITLE
rust/private/dummy_cc_toolchain: be explicit about the repository

### DIFF
--- a/rust/private/dummy_cc_toolchain/BUILD
+++ b/rust/private/dummy_cc_toolchain/BUILD
@@ -7,7 +7,7 @@ dummy_cc_toolchain(name = "dummy_cc_wasm32")
 # TODO(jedmonds@spotify.com): Need to support linking C code to rust code when compiling for wasm32.
 toolchain(
     name = "dummy_cc_wasm32_toolchain",
-    target_compatible_with = ["//rust/platform:wasm32"],
+    target_compatible_with = ["@io_bazel_rules_rust//rust/platform:wasm32"],
     toolchain = ":dummy_cc_wasm32",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )


### PR DESCRIPTION
The compatible_with statements in this repository are mostly explicit
about the repository the target refers to, even if it is the main
repository @io_bazel_rules_rust itself. So so in rust/private/dummy_cc_toolchain
as well.

Fixes #271