### PR TITLE
Support hyphens in target names

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -67,7 +67,7 @@ def _determine_lib_name(name, crate_type, toolchain, lib_hash = ""):
               "please file an issue!").format(crate_type))
 
     return "lib{name}-{lib_hash}{extension}".format(
-        name = name,
+        name = name.replace("-", "_"),
         lib_hash = lib_hash,
         extension = extension,
     )
@@ -133,7 +133,7 @@ def _rust_binary_impl(ctx):
     if (toolchain.target_arch == "wasm32"):
         output = ctx.actions.declare_file(ctx.label.name + ".wasm")
     else:
-        output = ctx.actions.declare_file(ctx.label.name)
+        output = ctx.actions.declare_file(ctx.label.name.replace("-", "_"))
 
     return rustc_compile_action(
         ctx = ctx,

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -66,8 +66,9 @@ def _determine_lib_name(name, crate_type, toolchain, lib_hash = ""):
         fail(("Unknown crate_type: {}. If this is a cargo-supported crate type, " +
               "please file an issue!").format(crate_type))
 
+    crate_name = name.replace("-", "_")
     return "lib{name}-{lib_hash}{extension}".format(
-        name = name.replace("-", "_"),
+        name = crate_name,
         lib_hash = lib_hash,
         extension = extension,
     )
@@ -110,12 +111,13 @@ def _rust_library_impl(ctx):
         output_hash,
     )
     rust_lib = ctx.actions.declare_file(rust_lib_name)
+    crate_name = ctx.label.name.replace("-", "_")
 
     return rustc_compile_action(
         ctx = ctx,
         toolchain = toolchain,
         crate_info = CrateInfo(
-            name = ctx.label.name,
+            name = crate_name,
             type = ctx.attr.crate_type,
             root = lib_rs,
             srcs = ctx.files.srcs,
@@ -129,17 +131,18 @@ def _rust_library_impl(ctx):
 
 def _rust_binary_impl(ctx):
     toolchain = find_toolchain(ctx)
+    crate_name = ctx.label.name.replace("-", "_")
 
     if (toolchain.target_arch == "wasm32"):
-        output = ctx.actions.declare_file(ctx.label.name + ".wasm")
+        output = ctx.actions.declare_file(crate_name + ".wasm")
     else:
-        output = ctx.actions.declare_file(ctx.label.name.replace("-", "_"))
+        output = ctx.actions.declare_file(crate_name)
 
     return rustc_compile_action(
         ctx = ctx,
         toolchain = toolchain,
         crate_info = CrateInfo(
-            name = ctx.label.name,
+            name = crate_name,
             type = "bin",
             root = _crate_root_src(ctx, "main.rs"),
             srcs = ctx.files.srcs,

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -66,9 +66,8 @@ def _determine_lib_name(name, crate_type, toolchain, lib_hash = ""):
         fail(("Unknown crate_type: {}. If this is a cargo-supported crate type, " +
               "please file an issue!").format(crate_type))
 
-    crate_name = name.replace("-", "_")
     return "lib{name}-{lib_hash}{extension}".format(
-        name = crate_name,
+        name = name,
         lib_hash = lib_hash,
         extension = extension,
     )
@@ -104,14 +103,14 @@ def _rust_library_impl(ctx):
     # Determine unique hash for this rlib
     output_hash = _determine_output_hash(lib_rs)
 
+    crate_name = ctx.label.name.replace("-", "_")
     rust_lib_name = _determine_lib_name(
-        ctx.attr.name,
+        crate_name,
         ctx.attr.crate_type,
         toolchain,
         output_hash,
     )
     rust_lib = ctx.actions.declare_file(rust_lib_name)
-    crate_name = ctx.label.name.replace("-", "_")
 
     return rustc_compile_action(
         ctx = ctx,

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -244,7 +244,7 @@ def rustc_compile_action(
 
     args = ctx.actions.args()
     args.add(crate_info.root)
-    args.add("--crate-name=" + crate_info.name)
+    args.add("--crate-name=" + crate_info.name.replace("-", "_"))
     args.add("--crate-type=" + crate_info.type)
 
     # Mangle symbols to disambiguate crates with the same name
@@ -405,7 +405,7 @@ def add_crate_link_flags(args, dep_info):
     )
 
 def _crate_to_link_flag(crate_info):
-    return ["--extern", "{}={}".format(crate_info.name, crate_info.dep.output.path)]
+    return ["--extern", "{}={}".format(crate_info.name.replace("-", "_"), crate_info.dep.output.path)]
 
 def _get_crate_dirname(crate):
     return crate.output.dirname

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -244,7 +244,7 @@ def rustc_compile_action(
 
     args = ctx.actions.args()
     args.add(crate_info.root)
-    args.add("--crate-name=" + crate_info.name.replace("-", "_"))
+    args.add("--crate-name=" + crate_info.name)
     args.add("--crate-type=" + crate_info.type)
 
     # Mangle symbols to disambiguate crates with the same name
@@ -405,7 +405,7 @@ def add_crate_link_flags(args, dep_info):
     )
 
 def _crate_to_link_flag(crate_info):
-    return ["--extern", "{}={}".format(crate_info.name.replace("-", "_"), crate_info.dep.output.path)]
+    return ["--extern", "{}={}".format(crate_info.name, crate_info.dep.output.path)]
 
 def _get_crate_dirname(crate):
     return crate.output.dirname


### PR DESCRIPTION
This PR makes it possible to define and depend on Rust targets whose `name` contains hyphen instead of underscore, primarily intended for case-matching names of third party libraries.

Example:

```bazel
rust_library(
    name = "thiserror-impl",
    srcs = glob(["vendor/thiserror-impl-1.0.11/src/**/*.rs"]),
    crate_type = "proc-macro",
    deps = [
        "//third-party:proc-macro2",
        "//third-party:quote",
        "//third-party:syn",
    ],
)
```

Tested with https://github.com/dtolnay/cxx/pull/37.