### PR TITLE
Add cfg = proc_macro_host_transition to all rules

### DIFF
--- a/examples/proto/BUILD
+++ b/examples/proto/BUILD
@@ -1,8 +1,31 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_rust//proto:proto.bzl", "rust_proto_library")
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
 
 package(default_visibility = ["//proto:__subpackages__"])
 
 proto_library(
     name = "common",
     srcs = ["common.proto"],
+)
+
+rust_proto_library(
+    name = "common_proto_rust",
+    deps = [":common"],
+)
+
+rust_library(
+    name = "common_lib",
+    srcs = ["lib.rs"],
+    deps = [":common_proto_rust"],
+)
+
+rust_binary(
+    name = "common_bin",
+    srcs = ["main.rs"],
+    deps = [
+        ":common_lib",
+        ":common_proto_rust",
+    ],
 )

--- a/examples/proto/lib.rs
+++ b/examples/proto/lib.rs
@@ -1,0 +1,5 @@
+extern crate common_proto_rust;
+
+pub fn do_something(x: &common_proto_rust::Config) -> bool {
+    true
+}

--- a/examples/proto/main.rs
+++ b/examples/proto/main.rs
@@ -1,0 +1,6 @@
+extern crate common_lib;
+extern crate common_proto_rust;
+
+pub fn main() {
+    common_lib::do_something(&common_proto_rust::Config::new());
+}

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -321,6 +321,9 @@ _rust_common_attrs = {
         ],
     ),
     "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
+    "_whitelist_function_transition": attr.label(
+        default = "//tools/whitelists/function_transition_whitelist",
+    ),
 }
 
 _rust_library_attrs = {
@@ -332,9 +335,6 @@ _rust_library_attrs = {
             The exact output file will depend on the toolchain used.
         """),
         default = "rlib",
-    ),
-    "_whitelist_function_transition": attr.label(
-        default = "//tools/whitelists/function_transition_whitelist",
     ),
 }
 
@@ -443,6 +443,7 @@ rust_binary = rule(
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],
+    cfg = proc_macro_host_transition,
     toolchains = [
         "@io_bazel_rules_rust//rust:toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
@@ -540,6 +541,7 @@ rust_test = rule(
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],
+    cfg = proc_macro_host_transition,
     test = True,
     toolchains = [
         "@io_bazel_rules_rust//rust:toolchain",
@@ -688,6 +690,7 @@ rust_benchmark = rule(
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],
+    cfg = proc_macro_host_transition,
     toolchains = [
         "@io_bazel_rules_rust//rust:toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",

--- a/rust/private/transitions.bzl
+++ b/rust/private/transitions.bzl
@@ -1,5 +1,5 @@
 def _proc_macro_host_transition(settings, attr):
-    if attr.crate_type == "proc-macro":
+    if hasattr(attr, "crate_type") and attr.crate_type == "proc-macro":
         return {"//command_line_option:platforms": "@local_config_platform//:host"}
     else:
         return settings


### PR DESCRIPTION
The rust_library rule specifies a cfg option.  This performs transitions
in order to support WASM.  Other rules, such as rust_binary, do not have
this configuration, which causes Bazel to build and link some libraries
into the final binary twice, resulting in compilation errors.  This is
detailed in pull request #294 and issue #300.  The issue was introduced
in commit 7cde1e46.

This adds the example from @colin353 in PR #294 as an example that would
otherwise fail.

Fixes #300