### PR TITLE
Add proc macro example, propagate crate-type through rustdoc

### DIFF
--- a/examples/hello_macro/BUILD
+++ b/examples/hello_macro/BUILD
@@ -1,0 +1,38 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_doc",
+    "rust_doc_test",
+    "rust_library",
+    "rust_test",
+)
+
+rust_library(
+    name = "hello_macro",
+    srcs = [
+        "src/lib.rs",
+    ],
+    crate_type = "proc-macro",
+)
+
+rust_test(
+    name = "hello_macro_test",
+    crate = ":hello_macro",
+)
+
+rust_test(
+    name = "greeting_test",
+    srcs = ["tests/greeting.rs"],
+    deps = [":hello_macro"],
+)
+
+rust_doc(
+    name = "hello_macro_doc",
+    dep = ":hello_macro",
+)
+
+rust_doc_test(
+    name = "hello_macro_doc_test",
+    dep = ":hello_macro",
+)

--- a/examples/hello_macro/src/lib.rs
+++ b/examples/hello_macro/src/lib.rs
@@ -1,0 +1,24 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+/// This macro is a no-op; it is exceedingly simple as a result
+/// of avoiding dependencies on both the syn and quote crates.
+#[proc_macro_derive(HelloWorld)]
+pub fn hello_world(_input: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/examples/hello_macro/tests/greeting.rs
+++ b/examples/hello_macro/tests/greeting.rs
@@ -1,0 +1,26 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate hello_macro;
+
+use hello_macro::HelloWorld;
+
+#[derive(HelloWorld)]
+struct TestStruct {
+}
+
+#[test]
+fn test_hello_world_macro() {
+    let _ = TestStruct {};
+}

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -38,6 +38,7 @@ def _rust_doc_impl(ctx):
     args = ctx.actions.args()
     args.add(crate.root.path)
     args.add("--crate-name", crate.name)
+    args.add("--crate-type", crate.type)
     args.add("--output", output_dir.path)
     add_edition_flags(args, crate)
 


### PR DESCRIPTION
- Added a no-op proc macro to "examples".
- While adding this macro, the following error message came from
"rust_doc":

    warning: Trying to document proc macro crate without passing
    '--crate-type proc-macro to rustdoc

  To resolve this issue, the rust_doc rule was modified to propagate
  the underlying crate type.