### PR TITLE
add flag to allow putting out binary whenever

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -137,12 +137,14 @@ def _rust_binary_impl(ctx):
     else:
         output = ctx.actions.declare_file(crate_name)
 
+    bin_crate_type = getattr(ctx.attr, "bin_crate_type")
+
     return rustc_compile_action(
         ctx = ctx,
         toolchain = toolchain,
         crate_info = CrateInfo(
             name = crate_name,
-            type = "bin",
+            type = bin_crate_type,
             root = _crate_root_src(ctx, "main.rs"),
             srcs = ctx.files.srcs,
             deps = ctx.attr.deps,
@@ -435,6 +437,10 @@ _rust_binary_attrs = {
         cfg = "host",
         allow_single_file = True,
     ),
+    "bin_crate_type": attr.string(
+        default = "bin",
+    ),
+    "always_out_binary": attr.bool(),
 }
 
 rust_binary = rule(

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -137,14 +137,14 @@ def _rust_binary_impl(ctx):
     else:
         output = ctx.actions.declare_file(crate_name)
 
-    bin_crate_type = getattr(ctx.attr, "bin_crate_type")
+    crate_type = getattr(ctx.attr, "crate_type")
 
     return rustc_compile_action(
         ctx = ctx,
         toolchain = toolchain,
         crate_info = CrateInfo(
             name = crate_name,
-            type = bin_crate_type,
+            type = crate_type,
             root = _crate_root_src(ctx, "main.rs"),
             srcs = ctx.files.srcs,
             deps = ctx.attr.deps,
@@ -437,10 +437,10 @@ _rust_binary_attrs = {
         cfg = "host",
         allow_single_file = True,
     ),
-    "bin_crate_type": attr.string(
+    "crate_type": attr.string(
         default = "bin",
     ),
-    "always_out_binary": attr.bool(),
+    "out_binary": attr.bool(),
 }
 
 rust_binary = rule(

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -345,8 +345,10 @@ def rustc_compile_action(
         files = dep_info.transitive_dylibs.to_list() + getattr(ctx.files, "data", []),
         collect_data = True,
     )
-
-    always_out_binary = getattr(ctx.attr, "always_out_binary")
+    
+    out_binary = False
+    if hasattr(ctx.attr, "out_binary"):
+        out_binary = getattr(ctx.attr, "out_binary")
 
     return [
         crate_info,
@@ -355,7 +357,7 @@ def rustc_compile_action(
             # nb. This field is required for cc_library to depend on our output.
             files = depset([crate_info.output]),
             runfiles = runfiles,
-            executable = crate_info.output if crate_info.type == "bin" or always_out_binary else None,
+            executable = crate_info.output if crate_info.type == "bin" or out_binary else None,
         ),
     ]
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -346,6 +346,8 @@ def rustc_compile_action(
         collect_data = True,
     )
 
+    always_out_binary = getattr(ctx.attr, "always_out_binary")
+
     return [
         crate_info,
         dep_info,
@@ -353,7 +355,7 @@ def rustc_compile_action(
             # nb. This field is required for cc_library to depend on our output.
             files = depset([crate_info.output]),
             runfiles = runfiles,
-            executable = crate_info.output if crate_info.type == "bin" else None,
+            executable = crate_info.output if crate_info.type == "bin" or always_out_binary else None,
         ),
     ]
 


### PR DESCRIPTION
We had an opportunity to put out binary without specifying `crate_type` as `bin`. 
In this case, we should add configurable crate_type and a flag to put out binary whenever.
With this patch, we can tackle this situation.