### PR TITLE
When inferring crate root, take the match with shortest filepath

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -97,8 +97,12 @@ def _shortest_src_with_basename(srcs, basename):
     """
     Finds the shortest among the paths in srcs that match the desired basename.
     """
-    files = sorted([f for f in srcs if f.basename == basename], lambda f: len(f.dirname)])
-    return files[0] if len(files) else None
+    shortest = None
+    for f in srcs:
+        if f.basename == basename:
+            if not shortest or len(f.dirname) < len(shortest.dirname):
+                shortest = f
+    return shortest
 
 def _rust_library_impl(ctx):
     # Find lib.rs

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -97,12 +97,8 @@ def _shortest_src_with_basename(srcs, basename):
     """
     Finds the shortest among the paths in srcs that match the desired basename.
     """
-    shortest = None
-    for f in srcs:
-        if f.basename == basename:
-            if not shortest or len(f.dirname) < len(shortest.dirname):
-                shortest = f
-    return shortest
+    files = sorted([f for f in srcs if f.basename == basename], lambda f: len(f.dirname)])
+    return files[0] if len(files) else None
 
 def _rust_library_impl(ctx):
     # Find lib.rs


### PR DESCRIPTION
I had a situation where a rust_library target contained both `src/cratename.rs` (the intended crate root) and `src/some/coincidental/inner/cratename.rs`. It seems fine to prefer the shortest one in this case, rather than a random one.