### PR TITLE
rustc: add arbitrary environment variables

### DIFF
--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -171,6 +171,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, grpc,
             aliases = {},
             output = rust_lib,
             edition = proto_toolchain.edition,
+            rustc_env = {},
         ),
         output_hash = output_hash,
     )

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -288,6 +288,11 @@ _rust_common_attrs = {
             These are other `rust_library` targets and will be presented as the new name given.
         """),
     ),
+    "rustc_env": attr.string_dict(
+        doc = _tidy("""
+            Dictionary of additional `"key": "value"` environment variables to set for rustc.
+        """),
+    ),
     "crate_features": attr.string_list(
         doc = _tidy("""
             List of features to enable for this crate.

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -124,6 +124,7 @@ def _rust_library_impl(ctx):
             aliases = ctx.attr.aliases,
             output = rust_lib,
             edition = _get_edition(ctx, toolchain),
+            rustc_env = ctx.attr.rustc_env,
         ),
         output_hash = output_hash,
     )
@@ -149,6 +150,7 @@ def _rust_binary_impl(ctx):
             aliases = ctx.attr.aliases,
             output = output,
             edition = _get_edition(ctx, toolchain),
+            rustc_env = ctx.attr.rustc_env,
         ),
     )
 
@@ -175,6 +177,7 @@ def _rust_test_common(ctx, test_binary):
             aliases = ctx.attr.aliases,
             output = test_binary,
             edition = crate.edition,
+            rustc_env = ctx.attr.rustc_env,
         )
     elif len(ctx.attr.deps) == 1 and len(ctx.files.srcs) == 0:
         dep = ctx.attr.deps[0].label
@@ -194,6 +197,7 @@ def _rust_test_common(ctx, test_binary):
             aliases = ctx.attr.aliases,
             output = test_binary,
             edition = _get_edition(ctx, toolchain),
+            rustc_env = ctx.attr.rustc_env,
         )
 
     return rustc_compile_action(

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -330,6 +330,10 @@ def rustc_compile_action(
     else:
         formatted_version = ""
 
+    # Update environment with user provided variables.
+    if hasattr(ctx.attr, "rustc_env"):
+        env.update(ctx.attr.rustc_env)
+
     ctx.actions.run_shell(
         command = command,
         inputs = compile_inputs,

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -35,6 +35,7 @@ CrateInfo = provider(
         "aliases": "Dict[Label, String]: Renamed and aliased crates",
         "output": "File: The output File that will be produced, depends on crate type.",
         "edition": "str: The edition of this crate.",
+        "rustc_env": """Dict[String, String]: Additional `"key": "value"` environment variables to set for rustc.""",
     },
 )
 
@@ -331,8 +332,7 @@ def rustc_compile_action(
         formatted_version = ""
 
     # Update environment with user provided variables.
-    if hasattr(ctx.attr, "rustc_env"):
-        env.update(ctx.attr.rustc_env)
+    env.update(crate_info.rustc_env)
 
     ctx.actions.run_shell(
         command = command,

--- a/test/build_env/BUILD
+++ b/test/build_env/BUILD
@@ -10,3 +10,11 @@ rust_test(
     srcs = ["tests/manifest_dir.rs"],
     data = ["src/manifest_dir_file.txt"],
 )
+
+rust_test(
+    name = "arbitrary_env_test",
+    srcs = ["tests/arbitrary_env.rs"],
+    rustc_env = {
+        "USER_DEFINED_KEY": "USER_DEFINED_VALUE",
+    },
+)

--- a/test/build_env/tests/arbitrary_env.rs
+++ b/test/build_env/tests/arbitrary_env.rs
@@ -1,0 +1,6 @@
+#[test]
+pub fn test_arbitrary_env() {
+    let actual = env!("USER_DEFINED_KEY");
+    let expected = "USER_DEFINED_VALUE".to_owned();
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
Rules that call `rustc` setup environment variables in line with `cargo`'s behaviour (see the [documentation here](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates)). However they don't allow passing in additional environment variables that may be required at compile time, such as the [`PROTOC` variable in `prost-build`](https://github.com/danburkert/prost/blob/2de785aca480779ab0d4442d4bc91a696e3e6c89/prost-build/src/lib.rs#L689).

This PR adds the `rustc_env` attribute to the common attribute set, allowing it to be set in the following rules:
- `rust_benchmark`
- `rust_binary`
- `rust_library`
- `rust_test`

Variables are provided in a string dictionary, and will be merged into the generated environment overriding existing values.