### PR TITLE
Add the ability to pass environment variables to rustc

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -313,6 +313,14 @@ _rust_common_attrs = {
     "rustc_flags": attr.string_list(
         doc = "List of compiler flags passed to `rustc`.",
     ),
+    "rustc_env": attr.string_list(
+        doc = _tidy("""
+            List of environment variables passed to `rustc`.
+
+            This should have a similar effect to the `cargo:rustc-env=VAR=VALUE`
+            declaration which can be emitted from build scripts.
+        """),
+    ),
     "version": attr.string(
         doc = "A version to inject in the cargo environment variable.",
         default = "0.0.0",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -62,7 +62,8 @@ def _get_rustc_env(ctx, toolchain):
         patch, pre = patch.split("-", 1)
     else:
         pre = ""
-    return {
+
+    env = {
         "CARGO_PKG_VERSION": version,
         "CARGO_PKG_VERSION_MAJOR": major,
         "CARGO_PKG_VERSION_MINOR": minor,
@@ -75,6 +76,14 @@ def _get_rustc_env(ctx, toolchain):
         "CARGO_CFG_TARGET_OS": toolchain.os,
         "CARGO_CFG_TARGET_ARCH": toolchain.target_arch,
     }
+
+    # Add any additional explicitly passed environment variables.
+    extra_envs = []
+    for kv in getattr(ctx.attr, "rustc_env", []):
+      k, v = kv.split("=")
+      extra_envs.append([k, v])
+    env.update(extra_envs)
+    return env
 
 def _get_compilation_mode_opts(ctx, toolchain):
     comp_mode = ctx.var["COMPILATION_MODE"]

--- a/test/build_env/BUILD
+++ b/test/build_env/BUILD
@@ -6,7 +6,12 @@ load(
 )
 
 rust_test(
-    name = "conflicting_deps_test",
+    name = "environment_variable_test",
     srcs = ["tests/manifest_dir.rs"],
     data = ["src/manifest_dir_file.txt"],
+
+    rustc_env = [
+        "ARBITRARY_ENV1=Value1",
+        "ARBITRARY_ENV2=Value2",
+    ],
 )

--- a/test/build_env/tests/manifest_dir.rs
+++ b/test/build_env/tests/manifest_dir.rs
@@ -4,3 +4,9 @@ pub fn test_manifest_dir() {
     let expected = "This file tests that CARGO_MANIFEST_DIR is set for the build environment\n";
     assert_eq!(actual, expected);
 }
+
+#[test]
+pub fn test_arbitrary_env() {
+    assert_eq!(env!("ARBITRARY_ENV1"), "Value1");
+    assert_eq!(env!("ARBITRARY_ENV2"), "Value2");
+}


### PR DESCRIPTION
This patch enables callers to supply an additional
parameter to rust targets (such as "rust_library", "rust_binary",
etc):

  rustc_env = [
    "KEY=VALUE",
  ]

This parameter parses the key/value pairs, and appends them
to the list of environment variables supplied to rustc.

This parameter emulated the impact of "cargo:rustc-env=VAR=VALUE"
lines, which are common in build scripts.