### PR TITLE
Add "build_script_output" parsing to common attributes.

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -330,6 +330,20 @@ _rust_common_attrs = {
             ".tar.gz",
         ],
     ),
+    "build_script_output": attr.label(
+        doc = _tidy("""
+            An optional file containing the stdout results of the a build script.
+
+            These typically take the form of multiple lines formatted with
+            the syntax "cargo:COMMAND=VALUE"
+
+            See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script for additional contet.
+
+            WARNING: Currently only "cargo:rustc-env" and "cargo:rustc-cfg" are
+                     supported.
+        """),
+        allow_single_file = True,
+    ),
     "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
 }
 

--- a/test/build_script/BUILD
+++ b/test/build_script/BUILD
@@ -1,0 +1,26 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+rust_library(
+    name = "test_build_script",
+    srcs = ["src/lib.rs"],
+    build_script_output = ":buildrs_output.txt",
+)
+
+rust_binary(
+    name = "test_build_script_bin",
+    srcs = ["src/main.rs"],
+    build_script_output = ":buildrs_output.txt",
+)
+
+rust_test(
+    name = "test_build_script_test",
+    crate = ":test_build_script",
+    build_script_output = ":buildrs_output.txt",
+)

--- a/test/build_script/buildrs_output.txt
+++ b/test/build_script/buildrs_output.txt
@@ -1,0 +1,4 @@
+cargo:rustc-env=SECRET1=VALUE1
+cargo:rustc-env=SECRET2=VALUE2
+cargo:rustc-cfg=foo
+cargo:rustc-cfg=bar

--- a/test/build_script/src/lib.rs
+++ b/test/build_script/src/lib.rs
@@ -1,0 +1,27 @@
+#[allow(dead_code)]
+struct Demo {
+    secret: String,
+}
+
+impl Demo {
+    #[allow(dead_code)]
+    pub fn new() -> Demo {
+        Demo {
+            secret: env!("SECRET1").to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_env_contents() {
+        assert_eq!(env!("SECRET1"), "VALUE1");
+        assert_eq!(env!("SECRET2"), "VALUE2");
+    }
+    #[test]
+    fn test_cfg_contents() {
+        assert!(cfg!(foo));
+        assert!(cfg!(bar));
+    }
+}

--- a/test/build_script/src/main.rs
+++ b/test/build_script/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("The secret was {}", env!("SECRET1"));
+}


### PR DESCRIPTION
Support parsing the stdout of build scripts, and add
a test which validates this behavior.

Currently only the following build script invocations
are processed:
  cargo:rustc-env=...
  cargo:rustc-cfg=...