### PR TITLE
add cfg_flags for boolean feature flags

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -307,6 +307,9 @@ _rust_common_attrs = {
             Dictionary of additional `"key": "value"` environment variables to set for rustc.
         """),
     ),
+    "cfg_flags": attr.string_list(
+        doc = "List of source configuration flags passed to `rustc`. Use cfg_opts to pass var=val pairs.",
+    ),
     "crate_features": attr.string_list(
         doc = _tidy("""
             List of features to enable for this crate.

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -308,7 +308,10 @@ _rust_common_attrs = {
         """),
     ),
     "cfg_flags": attr.string_list(
-        doc = "List of source configuration flags passed to `rustc`. Use cfg_opts to pass var=val pairs.",
+        doc = _tidy("""
+           List of boolean configuration flags passed to `rustc` as `--cfg foo`.
+           Use crate_features to pass '--cfg feature=val',
+    """)
     ),
     "crate_features": attr.string_list(
         doc = _tidy("""

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -274,6 +274,7 @@ def rustc_compile_action(
 
     args.add_all(rust_flags)
     args.add_all(getattr(ctx.attr, "rustc_flags", []))
+    args.add_all(getattr(ctx.attr, "cfg_flags", []), before_each = "--cfg")
     add_edition_flags(args, crate_info)
 
     # Link!


### PR DESCRIPTION
Add support for boolean config flags.  --cfg 'feature="foo"' does not work; --cfg foo does.  This change supports the latter.

Signed-off-by: Gregg Reynolds <601396+mobileink@users.noreply.github.com>