### PR TITLE
Support CARGO_BIN_EXE env vars

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -144,9 +144,9 @@ def _rust_binary_impl(ctx):
     crate_name = ctx.label.name.replace("-", "_")
 
     if (toolchain.target_arch == "wasm32"):
-        output = ctx.actions.declare_file(crate_name + ".wasm")
+        output = ctx.actions.declare_file(ctx.label.name + ".wasm")
     else:
-        output = ctx.actions.declare_file(crate_name)
+        output = ctx.actions.declare_file(ctx.label.name)
 
     return rustc_compile_action(
         ctx = ctx,

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -348,6 +348,13 @@ def rustc_compile_action(
     else:
         formatted_version = ""
 
+    # Make bin crate data deps available to tests.
+    for data in getattr(ctx.attr, "data", []):
+        if CrateInfo in data:
+            dep_crate_info = data[CrateInfo]
+            if dep_crate_info.type == "bin":
+                env["CARGO_BIN_EXE_" + dep_crate_info.output.basename] = dep_crate_info.output.short_path
+
     # Update environment with user provided variables.
     env.update(crate_info.rustc_env)
 

--- a/test/test_env/BUILD
+++ b/test/test_env/BUILD
@@ -1,0 +1,18 @@
+load(
+    "//rust:rust.bzl",
+    "rust_binary",
+    "rust_test",
+)
+
+rust_binary(
+    name = "hello-world",
+    srcs = ["src/main.rs"],
+    edition = "2018",
+)
+
+rust_test(
+    name = "test",
+    srcs = ["tests/run.rs"],
+    data = [":hello-world"],
+    edition = "2018",
+)

--- a/test/test_env/src/main.rs
+++ b/test/test_env/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello world");
+}

--- a/test/test_env/tests/run.rs
+++ b/test/test_env/tests/run.rs
@@ -1,0 +1,6 @@
+#[test]
+fn run() {
+    let path = env!("CARGO_BIN_EXE_hello-world");
+    let output = std::process::Command::new(path).output().expect("Failed to run process");
+    assert_eq!(&b"Hello world\n"[..], output.stdout.as_slice());
+}


### PR DESCRIPTION
Since 1.43 cargo will set `CARGO_BIN_EXE`-prefixed env vars for each binary your crate depends on, so you can access them in integration tests.

Also, output binary names with the same name as the target, rather than replacing `-`s with `_`s, to better emulate how Cargo works.