### PR TITLE
Fix rustc_lib srcs glob and allow it to be empty.

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -89,8 +89,8 @@ filegroup(
     name = "rustc_lib",
     srcs = glob(
         [
-        "lib/*{dylib_ext}",
-        "lib/rustlib/{target_triple}/codegen-backends/*{dylib_ext}",
+            "lib/*{dylib_ext}",
+            "lib/rustlib/{target_triple}/codegen-backends/*{dylib_ext}",
         ],
         allow_empty = True,
     ),

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -87,10 +87,13 @@ filegroup(
 
 filegroup(
     name = "rustc_lib",
-    srcs = glob([
+    srcs = glob(
+        [
         "lib/*{dylib_ext}",
         "lib/rustlib/{target_triple}/codegen-backends/*{dylib_ext}",
-    ]),
+        ],
+        allow_empty = True,
+    ),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
My team uses the `build --incompatible_disallow_empty_glob` flag in our .bazelrc. When using `rust_repositories(version = "nightly", iso_date = "2020-05-15")` in our BUILD file, the build fails with the error:  
 ```
glob pattern 'lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/*.so' didn't match anything, but allow_empty is set to False.
```
This glob is part of the rustc_lib filegroup. This PR adds allow_empty to that glob, similar to the change made in #245.