### PR TITLE
Expose futures library from proto/raze

### DIFF
--- a/proto/raze/BUILD
+++ b/proto/raze/BUILD
@@ -27,6 +27,10 @@ alias(
     actual = "@raze__log__0_4_6//:log",
 )
 alias(
+    name = "futures",
+    actual = "@raze__futures__0_1_29//:futures",
+)
+alias(
     name = "protobuf",
     actual = "@raze__protobuf__2_8_2//:protobuf",
 )


### PR DESCRIPTION
Right now we expose `protobuf` and `grpc` from proto/raze, so that dependencies can import them via targets like `@io_bazel_rules_rust//proto/raze:grpc`. But to use the full grpc library, e.g. with streaming grpc, we also need to import traits from the `futures` library that `grpc` is built against. That's not possible though, since it's not exported here.

By making futures visible, it means that dependencies can just add `@io_bazel_rules_rust//proto/raze:futures` as a dependency to make this work.