### PR TITLE
Add edition to rust_repositories, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ The rules are under active development, as such the lastest commit on the master
 To build with a particular version of the Rust compiler, pass that version to `rust_repositories`:
 
 ```python
-rust_repositories(version = "1.42.0")
+rust_repositories(version = "1.42.0", edition="2018")
 ```
 
 As well as an exact version, `version` can be set to `"nightly"` or `"beta"`. If set to these values, `iso_date` must also be set:
 
 ```python
-rust_repositories(version = "nightly", iso_date = "2020-04-19")
+rust_repositories(version = "nightly", iso_date = "2020-04-19", edition="2018")
 ```
 
 Similarly, `rustfmt_version` may also be configured:
@@ -95,11 +95,10 @@ Similarly, `rustfmt_version` may also be configured:
 rust_repositories(rustfmt_version = "1.4.8")
 ```
 
-
 ### External Dependencies
 
-Currently the most common approach to managing external dependencies is using 
-[cargo-raze](https://github.com/google/cargo-raze) to generate `BUILD` files for Cargo crates.  
+Currently the most common approach to managing external dependencies is using
+[cargo-raze](https://github.com/google/cargo-raze) to generate `BUILD` files for Cargo crates.
 
 <a name="roadmap"></a>
 ## Roadmap

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 DEFAULT_TOOLCHAIN_NAME_PREFIX = "toolchain_for"
 
-def rust_repositories(version = "1.39.0", iso_date = None, rustfmt_version = "1.4.8"):
+def rust_repositories(version = "1.39.0", iso_date = None, rustfmt_version = "1.4.8", edition = None):
     """Emits a default set of toolchains for Linux, OSX, and Freebsd
 
     Skip this macro and call the `rust_repository_set` macros directly if you need a compiler for
@@ -15,6 +15,7 @@ def rust_repositories(version = "1.39.0", iso_date = None, rustfmt_version = "1.
       version: The version of Rust. Either "nightly", "beta", or an exact version.
       rustfmt_version: The version of rustfmt. Either "nightly", "beta", or an exact version.
       iso_date: The date of the nightly or beta release (or None, if the version is a specific version).
+      edition: The rust edition to be used by default (2015 (default) or 2018)
     """
 
     maybe(
@@ -33,6 +34,7 @@ def rust_repositories(version = "1.39.0", iso_date = None, rustfmt_version = "1.
         version = version,
         iso_date = iso_date,
         rustfmt_version = rustfmt_version,
+        edition = edition,
     )
 
     rust_repository_set(
@@ -42,6 +44,7 @@ def rust_repositories(version = "1.39.0", iso_date = None, rustfmt_version = "1.
         version = version,
         iso_date = iso_date,
         rustfmt_version = rustfmt_version,
+        edition = edition,
     )
 
     rust_repository_set(
@@ -51,6 +54,7 @@ def rust_repositories(version = "1.39.0", iso_date = None, rustfmt_version = "1.
         version = version,
         iso_date = iso_date,
         rustfmt_version = rustfmt_version,
+        edition = edition,
     )
 
 def _check_version_valid(version, iso_date, param_prefix = ""):


### PR DESCRIPTION
Hopefully this will make it clear that the 2018 edition needs to be
explicitly specified.  This caught me by surprise initially, and seems
to have popped up in a few other areas.

See google/cargo-raze#165