### PR TITLE
 Link flags are passed to transitive rdeps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -99,3 +99,6 @@ rbe_autoconfig(
 
 load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
 bazel_version(name = "bazel_version")
+
+load("@examples//hello_sys:workspace.bzl", "remote_deps")
+remote_deps()

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -33,10 +33,10 @@ def _cargo_build_script_run(ctx, script):
         "CARGO_MANIFEST_DIR": manifest_dir,
         "HOST": toolchain.exec_triple,
         "OPT_LEVEL": compilation_mode_opt_level,
-        "OUT_DIR": out_dir.path,
         "RUSTC": toolchain.rustc.path,
         "RUST_BACKTRACE": "full",
         "TARGET": toolchain.target_triple,
+        # OUT_DIR is set by the runner itself, rather than on the action.
     }
 
     # Pull in env vars which may be required for the cc_toolchain to work (e.g. on OSX, the SDK version).
@@ -77,7 +77,7 @@ def _cargo_build_script_run(ctx, script):
 
     ctx.actions.run_shell(
         command = cmd,
-        arguments = [ctx.executable._cargo_build_script_runner.path, script.path, crate_name, env_out.path, flags_out.path, dep_env_out.path],
+        arguments = [ctx.executable._cargo_build_script_runner.path, script.path, crate_name, out_dir.path, env_out.path, flags_out.path, dep_env_out.path],
         outputs = [out_dir, env_out, flags_out, dep_env_out],
         tools = tools,
         inputs = dep_env_files,

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -9,6 +9,7 @@ def _cargo_build_script_run(ctx, script):
     env_out = ctx.actions.declare_file(ctx.label.name + ".env")
     dep_env_out = ctx.actions.declare_file(ctx.label.name + ".depenv")
     flags_out = ctx.actions.declare_file(ctx.label.name + ".flags")
+    link_flags = ctx.actions.declare_file(ctx.label.name + ".linkflags")
     manifest_dir = "%s.runfiles/%s" % (script.path, ctx.label.workspace_name or ctx.workspace_name)
     compilation_mode_opt_level = get_compilation_mode_opts(ctx, toolchain).opt_level
 
@@ -77,8 +78,8 @@ def _cargo_build_script_run(ctx, script):
 
     ctx.actions.run_shell(
         command = cmd,
-        arguments = [ctx.executable._cargo_build_script_runner.path, script.path, crate_name, out_dir.path, env_out.path, flags_out.path, dep_env_out.path],
-        outputs = [out_dir, env_out, flags_out, dep_env_out],
+        arguments = [ctx.executable._cargo_build_script_runner.path, script.path, crate_name, out_dir.path, env_out.path, flags_out.path, link_flags.path, dep_env_out.path],
+        outputs = [out_dir, env_out, flags_out, link_flags, dep_env_out],
         tools = tools,
         inputs = dep_env_files,
         mnemonic = "CargoBuildScriptRun",
@@ -91,6 +92,7 @@ def _cargo_build_script_run(ctx, script):
             rustc_env = env_out,
             dep_env = dep_env_out,
             flags = flags_out,
+            link_flags = link_flags,
         ),
     ]
 

--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -18,8 +18,7 @@ extern crate cargo_build_script_output_parser;
 
 use cargo_build_script_output_parser::BuildScriptOutput;
 use std::env;
-use std::fs::{File, create_dir_all};
-use std::io::Write;
+use std::fs::{create_dir_all, write};
 use std::path::Path;
 use std::process::{exit, Command};
 
@@ -66,18 +65,12 @@ fn main() {
             }
 
             let output = BuildScriptOutput::from_command(&mut command);
-            let mut f =
-                File::create(&envfile).expect(&format!("Unable to create file {}", envfile));
-            f.write_all(BuildScriptOutput::to_env(&output).as_bytes())
-                .expect(&format!("Unable to write file {}", envfile));
-            let mut f =
-                File::create(&depenvfile).expect(&format!("Unable to create file {}", depenvfile));
-            f.write_all(BuildScriptOutput::to_dep_env(&output, &crate_name).as_bytes())
-                .expect(&format!("Unable to write file {}", depenvfile));
-            let mut f =
-                File::create(&flagfile).expect(&format!("Unable to create file {}", flagfile));
-            f.write_all(BuildScriptOutput::to_flags(&output).as_bytes())
-                .expect(&format!("Unable to write file {}", flagfile));
+            write(&envfile, BuildScriptOutput::to_env(&output).as_bytes())
+                .expect(&format!("Unable to write file {:?}", envfile));
+            write(&depenvfile, BuildScriptOutput::to_dep_env(&output, &crate_name).as_bytes())
+                .expect(&format!("Unable to write file {:?}", depenvfile));
+            write(&flagfile, BuildScriptOutput::to_flags(&output).as_bytes())
+                .expect(&format!("Unable to write file {:?}", flagfile));
         }
         _ => {
             eprintln!("Usage: $0 progname crate_name envfile flagfile depenvfile [arg1...argn]");

--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -69,7 +69,7 @@ fn main() {
             write(&depenvfile, BuildScriptOutput::to_dep_env(&output, &crate_name).as_bytes())
                 .expect(&format!("Unable to write file {:?}", depenvfile));
 
-            let CompileAndLinkFlags { compile_flags, link_flags } = BuildScriptOutput::to_flags(&output);
+            let CompileAndLinkFlags { compile_flags, link_flags } = BuildScriptOutput::to_flags(&output, &exec_root.to_string_lossy());
 
             write(&flagfile, compile_flags.as_bytes())
                 .expect(&format!("Unable to write file {:?}", flagfile));

--- a/cargo/cargo_build_script_runner/lib.rs
+++ b/cargo/cargo_build_script_runner/lib.rs
@@ -17,6 +17,12 @@
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Command, Stdio};
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct CompileAndLinkFlags {
+    pub compile_flags: String,
+    pub link_flags: String,
+}
+
 /// Enum containing all the considered return value from the script
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BuildScriptOutput {
@@ -141,17 +147,23 @@ impl BuildScriptOutput {
     }
 
     /// Convert a vector of [BuildScriptOutput] into a flagfile.
-    pub fn to_flags(v: &Vec<BuildScriptOutput>) -> String {
-        v.iter()
-            .filter_map(|x| match x {
-                BuildScriptOutput::Cfg(e) => Some(format!("--cfg={}", e)),
-                BuildScriptOutput::Flags(e) => Some(e.to_owned()),
-                BuildScriptOutput::LinkLib(e) => Some(format!("-l{}", e)),
-                BuildScriptOutput::LinkSearch(e) => Some(format!("-L{}", e)),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join(" ")
+    pub fn to_flags(v: &Vec<BuildScriptOutput>) -> CompileAndLinkFlags {
+        let mut compile_flags = Vec::new();
+        let mut link_flags = Vec::new();
+
+        for flag in v {
+            match flag {
+                BuildScriptOutput::Cfg(e) => compile_flags.push(format!("--cfg={}", e)),
+                BuildScriptOutput::Flags(e) => compile_flags.push(e.to_owned()),
+                BuildScriptOutput::LinkLib(e) => link_flags.push(format!("-l{}", e)),
+                BuildScriptOutput::LinkSearch(e) => link_flags.push(format!("-L{}", e)),
+                _ => { },
+            }
+        }
+        CompileAndLinkFlags {
+            compile_flags: compile_flags.join(" "),
+            link_flags: link_flags.join(" "),
+        }
     }
 }
 
@@ -200,7 +212,12 @@ cargo:version_number=1010107f
         );
         assert_eq!(
             BuildScriptOutput::to_flags(&result),
-            "-lsdfsdf -Lbleh -Lblah --cfg=feature=awesome".to_owned()
+            CompileAndLinkFlags {
+                // -Lblah was output as a rustc-flags, so even though it probably _should_ be a link
+                // flag, we don't treat it like one.
+                compile_flags: "-Lblah --cfg=feature=awesome".to_owned(),
+                link_flags: "-lsdfsdf -Lbleh".to_owned(),
+            }
         );
     }
 

--- a/cargo/cargo_build_script_runner/lib.rs
+++ b/cargo/cargo_build_script_runner/lib.rs
@@ -162,7 +162,7 @@ impl BuildScriptOutput {
         }
         CompileAndLinkFlags {
             compile_flags: compile_flags.join(" "),
-            link_flags: link_flags.join(" ").replace(exec_root, "$EXEC_ROOT"),
+            link_flags: link_flags.join(" ").replace(exec_root, "${EXEC_ROOT}"),
         }
     }
 }
@@ -216,7 +216,7 @@ cargo:version_number=1010107f
                 // -Lblah was output as a rustc-flags, so even though it probably _should_ be a link
                 // flag, we don't treat it like one.
                 compile_flags: "-Lblah --cfg=feature=awesome".to_owned(),
-                link_flags: "-lsdfsdf -L$EXEC_ROOT/bleh".to_owned(),
+                link_flags: "-lsdfsdf -L${EXEC_ROOT}/bleh".to_owned(),
             }
         );
     }

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -69,3 +69,7 @@ rust_wasm_bindgen_repositories()
 load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
 
 bazel_version(name = "bazel_version")
+
+load("@examples//hello_sys:workspace.bzl", "remote_deps")
+
+remote_deps()

--- a/examples/hello_sys/BUILD
+++ b/examples/hello_sys/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+)
+
+rust_binary(
+    name = "hello_sys",
+    srcs = ["src/main.rs"],
+    edition = "2018",
+    deps = ["@bzip2"],
+)
+
+sh_test(
+    name = "test",
+    srcs = ["test.sh"],
+    args = ["$(location :hello_sys)"],
+    data = [":hello_sys"],
+)

--- a/examples/hello_sys/bzip2-0.3.3.BUILD
+++ b/examples/hello_sys/bzip2-0.3.3.BUILD
@@ -1,0 +1,21 @@
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+)
+
+rust_library(
+    name = "bzip2",
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.3.3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bzip2_sys",
+        "@libc",
+    ],
+)

--- a/examples/hello_sys/bzip2-sys-0.1.9+1.0.8.BUILD
+++ b/examples/hello_sys/bzip2-sys-0.1.9+1.0.8.BUILD
@@ -1,0 +1,41 @@
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+)
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "bzip2_sys_build_script",
+    srcs = glob(["**/*.rs"]),
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.1.9+1.0.8",
+    deps = [
+        "@cc",
+        "@pkg_config",
+    ],
+)
+
+rust_library(
+    name = "bzip2_sys",
+    srcs = glob(["**/*.rs"]),
+    crate_root = "lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.1.9+1.0.8",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":bzip2_sys_build_script",
+        "@libc",
+    ],
+)

--- a/examples/hello_sys/cc-1.0.54.BUILD
+++ b/examples/hello_sys/cc-1.0.54.BUILD
@@ -1,0 +1,17 @@
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+)
+
+rust_library(
+    name = "cc",
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.0.54",
+    visibility = ["//visibility:public"],
+)

--- a/examples/hello_sys/pkg-config-0.3.17.BUILD
+++ b/examples/hello_sys/pkg-config-0.3.17.BUILD
@@ -1,0 +1,17 @@
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+)
+
+rust_library(
+    name = "pkg_config",
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.3.17",
+    visibility = ["//visibility:public"],
+)

--- a/examples/hello_sys/src/main.rs
+++ b/examples/hello_sys/src/main.rs
@@ -1,0 +1,42 @@
+use bzip2::read::BzEncoder;
+use bzip2::Compression;
+use std::io::Read;
+
+fn main() {
+    let stdin = std::io::stdin();
+    let stdin = stdin.lock();
+    let mut raw_counter = CountingStream::new(stdin);
+
+    let compressed_count = {
+        let compressor = BzEncoder::new(&mut raw_counter, Compression::Best);
+        let mut compressed_counter = CountingStream::new(compressor);
+        std::io::copy(&mut compressed_counter, &mut std::io::sink()).unwrap();
+        compressed_counter.count
+    };
+
+    println!(
+        "Compressed {} to {} bytes",
+        raw_counter.count, compressed_count
+    );
+}
+
+struct CountingStream<R: Read> {
+    stream: R,
+    count: usize,
+}
+
+impl<R: Read> CountingStream<R> {
+    fn new(stream: R) -> Self {
+        CountingStream { stream, count: 0 }
+    }
+}
+
+impl<R: Read> Read for CountingStream<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let result = self.stream.read(buf);
+        if let Ok(read_bytes) = result {
+            self.count += read_bytes;
+        }
+        result
+    }
+}

--- a/examples/hello_sys/test.sh
+++ b/examples/hello_sys/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eu
+
+out="$(echo -n "Hello world" | "$1")"
+
+[[ "${out}" == "Compressed 11 to 50 bytes" ]] || (echo "Got ${out}" && exit 1)

--- a/examples/hello_sys/workspace.bzl
+++ b/examples/hello_sys/workspace.bzl
@@ -1,0 +1,38 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def remote_deps():
+    http_archive(
+        name = "bzip2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/bzip2/bzip2-0.3.3.crate",
+        sha256 = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b",
+        type = "tar.gz",
+        strip_prefix = "bzip2-0.3.3",
+        build_file = "@examples//hello_sys:bzip2-0.3.3.BUILD",
+    )
+
+    http_archive(
+        name = "bzip2_sys",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/bzip2-sys/bzip2-sys-0.1.9+1.0.8.crate",
+        sha256 = "ad3b39a260062fca31f7b0b12f207e8f2590a67d32ec7d59c20484b07ea7285e",
+        type = "tar.gz",
+        strip_prefix = "bzip2-sys-0.1.9+1.0.8",
+        build_file = "@examples//hello_sys:bzip2-sys-0.1.9+1.0.8.BUILD",
+    )
+
+    http_archive(
+        name = "cc",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cc/cc-1.0.54.crate",
+        sha256 = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311",
+        type = "tar.gz",
+        strip_prefix = "cc-1.0.54",
+        build_file = "@examples//hello_sys:cc-1.0.54.BUILD",
+    )
+
+    http_archive(
+        name = "pkg_config",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/pkg-config/pkg-config-0.3.17.crate",
+        sha256 = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677",
+        type = "tar.gz",
+        strip_prefix = "pkg-config-0.3.17",
+        build_file = "@examples//hello_sys:pkg-config-0.3.17.BUILD",
+    )

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -70,12 +70,13 @@ def _clippy_aspect_impl(target, ctx):
         build_info
     )
 
-    args, env = construct_arguments(
+    args, env, dynamic_env = construct_arguments(
         ctx,
         ctx.rule.file,
         toolchain,
         crate_info,
         dep_info,
+        out_dir,
         output_hash = repr(hash(root.path)),
         rust_flags = [])
 
@@ -89,7 +90,7 @@ def _clippy_aspect_impl(target, ctx):
         toolchain,
         crate_info,
         build_info,
-        out_dir,
+        dynamic_env,
     ) + (" && touch %s" % clippy_marker.path)
 
     # Deny the default-on clippy warning levels.

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -60,7 +60,7 @@ def _clippy_aspect_impl(target, ctx):
         toolchain,
     )
 
-    compile_inputs, out_dir = collect_inputs(
+    compile_inputs, prep_commands, dynamic_env = collect_inputs(
         ctx,
         ctx.rule.file,
         ctx.rule.files,
@@ -76,9 +76,9 @@ def _clippy_aspect_impl(target, ctx):
         toolchain,
         crate_info,
         dep_info,
-        out_dir,
         output_hash = repr(hash(root.path)),
-        rust_flags = [])
+        rust_flags = [],
+        dynamic_env = dynamic_env)
 
     # A marker file indicating clippy has executed successfully.
     # This file is necessary because "ctx.actions.run" mandates an output.
@@ -90,6 +90,7 @@ def _clippy_aspect_impl(target, ctx):
         toolchain,
         crate_info,
         build_info,
+        prep_commands,
         dynamic_env,
     ) + (" && touch %s" % clippy_marker.path)
 

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -60,7 +60,7 @@ def _clippy_aspect_impl(target, ctx):
         toolchain,
     )
 
-    compile_inputs, prep_commands, dynamic_env = collect_inputs(
+    compile_inputs, prep_commands, dynamic_env, dynamic_build_flags = collect_inputs(
         ctx,
         ctx.rule.file,
         ctx.rule.files,
@@ -90,8 +90,10 @@ def _clippy_aspect_impl(target, ctx):
         toolchain,
         crate_info,
         build_info,
+        dep_info,
         prep_commands,
         dynamic_env,
+        dynamic_build_flags,
     ) + (" && touch %s" % clippy_marker.path)
 
     # Deny the default-on clippy warning levels.

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -46,6 +46,7 @@ BuildInfo = provider(
         "out_dir": """File: directory containing the result of a build script""",
         "rustc_env": """File: file containing additional environment variables to set for rustc.""",
         "dep_env": """File: extra build script environment varibles to be set to direct dependencies.""",
+        "link_flags": """File: file containing flags to pass to the linker""",
     },
 )
 


### PR DESCRIPTION
And absolute paths are redacted into $EXEC_ROOT-relative paths

This mirrors Cargo's behaviour of accumulating link flags and passing
them to the linker - otherwise there's not much point in sys libraries
outputting them.

This currently over-adds out_dirs and link flags to all actions, rather
than just those that will invoke the linker - we can reduce that if we
have a clear indication of what targets will invoke a linker, but I
wanted to go with a safe-but-over-invalidating solution rather than
picking a bad heuristic.

Commits are separately useful to review.

Depends on https://github.com/bazelbuild/rules_rust/pull/343 (the first commit of this PR).

I have a WIP PR which removes both the new usage of system `tar` and the existing usages in the PR by building small implementations of `tar` and `untar` in Rust - will publish it shortly, but it's non-trivial enough to prefer doing as a follow-up :)