### PR TITLE
Preserve and tidy stdout on failure

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -35,7 +35,6 @@ def _cargo_build_script_run(ctx, script):
         "HOST": toolchain.exec_triple,
         "OPT_LEVEL": compilation_mode_opt_level,
         "RUSTC": toolchain.rustc.path,
-        "RUST_BACKTRACE": "full",
         "TARGET": toolchain.target_triple,
         # OUT_DIR is set by the runner itself, rather than on the action.
     }

--- a/cargo/cargo_build_script_runner/lib.rs
+++ b/cargo/cargo_build_script_runner/lib.rs
@@ -50,14 +50,15 @@ impl BuildScriptOutput {
     fn new(line: &str) -> Option<BuildScriptOutput> {
         let split = line.splitn(2, '=').collect::<Vec<_>>();
         if split.len() <= 1 {
+            // Not a cargo directive.
             print!("{}", line);
             return None;
         }
         let param = split[1].trim().to_owned();
         let key_split = split[0].splitn(2, ':').collect::<Vec<_>>();
         if key_split.len() <= 1 || key_split[0] != "cargo" {
-            print!("{}", line);
             // Not a cargo directive.
+            print!("{}", line);
             return None
         }
         match key_split[1] {


### PR DESCRIPTION
Rather than discarding lines which are not directives to cargo, print
them.

Also, print a friendly message, rather than a backtrace, if the build
script itself exits non-0.