### PR TITLE
fix: Add rustc dylib directory to compile action search paths

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,7 +26,7 @@ http_archive(
 
 # TODO: Move this to examples/WORKSPACE when recursive repositories are enabled.
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
-rust_repositories()
+rust_repositories(version = "nightly", iso_date = "2020-06-23", dev_components = True)
 
 new_git_repository(
     name = "libc",

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -10,7 +10,7 @@ local_repository(
 
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 
-rust_repositories()
+rust_repositories(version = "nightly", iso_date = "2020-06-23", dev_components = True)
 
 http_archive(
     name = "libc",

--- a/examples/hello_rustc_private/BUILD
+++ b/examples/hello_rustc_private/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
+
+rust_binary(
+  name = "hello_rustc_private",
+  srcs = ["main.rs"],
+  edition = "2018",
+)

--- a/examples/hello_rustc_private/main.rs
+++ b/examples/hello_rustc_private/main.rs
@@ -1,0 +1,7 @@
+#![feature(rustc_private)]
+
+extern crate rustc_driver;
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -327,8 +327,10 @@ def construct_arguments(
 
     # Gets the paths to the folders containing the standard library (or libcore)
     rust_lib_paths = depset([file.dirname for file in toolchain.rust_lib.files.to_list()]).to_list()
+    # Gets the paths to the folders containing the rustc dynamic libraries
+    rustc_lib_paths = depset([file.dirname for file in toolchain.rustc_lib.files.to_list()]).to_list()
     # Tell Rustc where to find the standard library
-    args.add_all(rust_lib_paths, before_each = "-L", format_each = "%s")
+    args.add_all(rust_lib_paths+rustc_lib_paths, before_each = "-L", format_each = "%s")
 
     args.add_all(rust_flags)
     args.add_all(getattr(ctx.attr, "rustc_flags", []))


### PR DESCRIPTION
Currently, the library paths for rustc are not included as search paths during compile time. These paths include libLLVM, which are necessary when building crates that use the rustc_private crates