### PR TITLE
Export `CcInfo` for `staticlib` & `cdylib` allowing rust outputs to be used in c++ rules

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_rust//rust:private/rustc.bzl", "BuildInfo", "DepInfo", "get_compilation_mode_opts", "get_linker_and_args")
+load("@io_bazel_rules_rust//rust:private/rustc.bzl", "BuildInfo", "DepInfo", "get_compilation_mode_opts", "get_cc_toolchain", "get_linker_and_args")
 load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain")
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
@@ -41,7 +41,8 @@ def _cargo_build_script_run(ctx, script):
 
     # Pull in env vars which may be required for the cc_toolchain to work (e.g. on OSX, the SDK version).
     # We hope that the linker env is sufficient for the whole cc_toolchain.
-    _, _, linker_env = get_linker_and_args(ctx, None)
+    cc_toolchain, feature_configuration = get_cc_toolchain(ctx)
+    _, _, linker_env = get_linker_and_args(ctx, cc_toolchain, feature_configuration, None)
     env.update(**linker_env)
 
     if cc_toolchain:

--- a/examples/ffi/c_calling_rust/BUILD
+++ b/examples/ffi/c_calling_rust/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
 
 rust_library(
@@ -7,16 +7,8 @@ rust_library(
     crate_type = "staticlib",
 )
 
-# cc_* rules expect cc_* deps, so we need to wrap our rust staticlib.
-cc_library(
-    name = "wrapper",
-    srcs = [":rusty"],
-    # We could link dynamically by setting crate_type to cdylib
-    linkstatic = True,
-)
-
 cc_test(
     name = "main",
     srcs = ["main.c"],
-    deps = [":wrapper"],
+    deps = [":rusty"],
 )

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -18,6 +18,7 @@ load(
     "collect_deps",
     "collect_inputs",
     "construct_arguments",
+    "get_cc_toolchain",
 )
 load(
     "@io_bazel_rules_rust//rust:private/rust.bzl",
@@ -73,11 +74,15 @@ def _clippy_aspect_impl(target, ctx):
     # This file is necessary because "ctx.actions.run" mandates an output.
     clippy_marker = ctx.actions.declare_file(ctx.label.name + "_clippy.ok")
 
+    cc_toolchain, feature_configuration = get_cc_toolchain(ctx)
+
     args, env = construct_arguments(
         ctx,
         ctx.file,
         toolchain,
         toolchain.clippy_driver.path,
+        cc_toolchain,
+        feature_configuration,
         crate_info,
         dep_info,
         output_hash = repr(hash(root.path)),

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -22,6 +22,7 @@ def _rust_toolchain_impl(ctx):
         binary_ext = ctx.attr.binary_ext,
         staticlib_ext = ctx.attr.staticlib_ext,
         dylib_ext = ctx.attr.dylib_ext,
+        stdlib_linkflags = ctx.attr.stdlib_linkflags,
         target_triple = ctx.attr.target_triple,
         exec_triple = ctx.attr.exec_triple,
         os = ctx.attr.os,
@@ -60,6 +61,10 @@ rust_toolchain = rule(
         "binary_ext": attr.string(mandatory = True),
         "staticlib_ext": attr.string(mandatory = True),
         "dylib_ext": attr.string(mandatory = True),
+        "stdlib_linkflags": attr.string_list(
+            doc = """Additional linker libs used when std lib is linked,
+                see https://github.com/rust-lang/rust/blob/master/src/libstd/build.rs""",
+            mandatory = True),
         "os": attr.string(mandatory = True),
         "default_edition": attr.string(
             doc = "The edition to use for rust_* rules that don't specify an edition.",
@@ -103,6 +108,7 @@ rust_toolchain(
   binary_ext = "",
   staticlib_ext = ".a",
   dylib_ext = ".so",
+  stdlib_linkflags = ["-lpthread", "-ldl"],
   os = "linux",
 )
 


### PR DESCRIPTION
Its minor but since `CcInfo` now exists we can state `staticlib` to be a statlclib and `cdylib` to be the relevant `.so`