### PR TITLE
Do not add CcInfo from dependencies that don't have them

### DIFF
--- a/examples/hello_lib/BUILD
+++ b/examples/hello_lib/BUILD
@@ -45,6 +45,26 @@ rust_library(
     crate_type = "staticlib",
 )
 
+# Regression test for #368: static lib with dependencies fail.
+rust_library(
+    name = "hello_test_staticlib",
+    srcs = [
+        "tests/greeting.rs",
+    ],
+    deps = [":hello_lib"],
+    crate_type = "staticlib",
+)
+
+# Regression test for #368: cdylib lib with dependencies fail.
+rust_library(
+    name = "hello_test_cdylib",
+    srcs = [
+        "tests/greeting.rs",
+    ],
+    deps = [":hello_lib"],
+    crate_type = "cdylib",
+)
+
 rust_test(
     name = "hello_lib_test",
     crate = ":hello_lib",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -548,7 +548,7 @@ def establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configur
         linker_inputs = depset([link_input]),
     )
 
-    cc_infos = [dep[CcInfo] for dep in ctx.attr.deps]
+    cc_infos = [dep[CcInfo] for dep in ctx.attr.deps if CcInfo in dep]
     cc_infos.append(CcInfo(linking_context = linking_context))
 
     return [cc_common.merge_cc_infos(cc_infos = cc_infos)]


### PR DESCRIPTION
The current code is failing for any cdylib or staticlib with
a rust dependency (without CcInfo provider).

Fixes #368.