### PR TITLE
Fix rustdoc path in rustdoc_test with --nolegacy_external_runfiles option

### DIFF
--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -89,7 +89,7 @@ set -e;
     --crate-name={crate_name} \\
     {flags}
 """.format(
-        rust_doc = toolchain.rust_doc.path,
+        rust_doc = toolchain.rust_doc.short_path,
         crate_root = crate.root.path,
         crate_name = crate.name,
         # TODO: Should be possible to do this with ctx.actions.Args, but can't seem to get them as a str and into the template.


### PR DESCRIPTION
Using File.path breaks builds with --nolegacy_external_runfiles option
as the gnerated script has use `external/rust/bin/rustdoc` that
referrers to legacy runfiles and File.short_path uses `../rust/bin/rustdoc`