### PR TITLE
Fix `CcDep` info related to `rust_test`

### DIFF
--- a/examples/ffi/c_calling_rust/BUILD
+++ b/examples/ffi/c_calling_rust/BUILD
@@ -1,10 +1,15 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library", "rust_test")
 
 rust_library(
     name = "rusty",
     srcs = ["lib.rs"],
     crate_type = "staticlib",
+)
+
+rust_test(
+    name = "rusty_test",
+    crate = ":rusty",
 )
 
 cc_test(

--- a/examples/ffi/c_calling_rust/lib.rs
+++ b/examples/ffi/c_calling_rust/lib.rs
@@ -2,3 +2,13 @@
 pub extern fn my_favorite_number() -> i32 {
     4
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_my_favorite_number() {
+        assert_eq!(4, my_favorite_number());
+    }
+}

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -172,6 +172,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, grpc,
             output = rust_lib,
             edition = proto_toolchain.edition,
             rustc_env = {},
+            is_test = False,
         ),
         output_hash = output_hash,
     )

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -126,6 +126,7 @@ def _rust_library_impl(ctx):
             output = rust_lib,
             edition = get_edition(ctx.attr, toolchain),
             rustc_env = ctx.attr.rustc_env,
+            is_test = False,
         ),
         output_hash = output_hash,
     )
@@ -152,6 +153,7 @@ def _rust_binary_impl(ctx):
             output = output,
             edition = get_edition(ctx.attr, toolchain),
             rustc_env = ctx.attr.rustc_env,
+            is_test = False,
         ),
     )
 
@@ -182,6 +184,7 @@ def _rust_test_common(ctx, toolchain, output):
             output = output,
             edition = crate.edition,
             rustc_env = ctx.attr.rustc_env,
+            is_test = True,
         )
     else:
         # Target is a standalone crate. Build the test binary as its own crate.
@@ -196,6 +199,7 @@ def _rust_test_common(ctx, toolchain, output):
             output = output,
             edition = get_edition(ctx.attr, toolchain),
             rustc_env = ctx.attr.rustc_env,
+            is_test = True,
         )
 
     return rustc_compile_action(

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -37,6 +37,7 @@ CrateInfo = provider(
         "output": "File: The output File that will be produced, depends on crate type.",
         "edition": "str: The edition of this crate.",
         "rustc_env": """Dict[String, String]: Additional `"key": "value"` environment variables to set for rustc.""",
+        "is_test": "bool: If the crate is being compiled in a test context",
     },
 )
 
@@ -512,14 +513,14 @@ def rustc_compile_action(
             # nb. This field is required for cc_library to depend on our output.
             files = depset([crate_info.output]),
             runfiles = runfiles,
-            executable = crate_info.output if crate_info.type == "bin" or "--test" in rust_flags or out_binary else None,
+            executable = crate_info.output if crate_info.type == "bin" or crate_info.is_test or out_binary else None,
         ),
     ]
 
 def establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configuration):
     """ If the produced crate is suitable yield a CcInfo to allow for interop with cc rules """
 
-    if crate_info.type not in ("staticlib", "cdylib"):
+    if crate_info.is_test or crate_info.type not in ("staticlib", "cdylib"):
         return []
 
     if crate_info.type == "staticlib":


### PR DESCRIPTION
This is a small fix I discovered where a `staticlib` or `cdylib` claims to export `CcInfo` for test crates.

Instead of mapping this all the way through (I am not sure what depending on a `rust_test` would mean) we just ignore / disallow `CcInfo` for test contexts.