### PR TITLE
Allow sha256 values to be specified in rust_toolchain_repository

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -8,9 +8,27 @@ local_repository(
     path = "..",
 )
 
-load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
+load(
+    "@io_bazel_rules_rust//rust:repositories.bzl",
+    "rust_repositories",
+    "rust_repository_set",
+)
 
 rust_repositories()
+
+rust_repository_set(
+    name = "fake_toolchain_for_test_of_sha256",
+    edition = "2018",
+    exec_triple = "x86_64-unknown-linux-gnu",
+    extra_target_triples = [],
+    rustfmt_version = "1.4.12",
+    sha256s = {
+        "rust-1.46.0-x86_64-unknown-linux-gnu": "e3b98bc3440fe92817881933f9564389eccb396f5f431f33d48b979fa2fbdcf5",
+        "rustfmt-1.4.12-x86_64-unknown-linux-gnu": "1894e76913303d66bf40885a601462844eec15fca9e76a6d13c390d7000d64b0",
+        "rust-std-1.46.0-x86_64-unknown-linux-gnu": "ac04aef80423f612c0079829b504902de27a6997214eb58ab0765d02f7ec1dbc",
+    },
+    version = "1.46.0",
+)
 
 http_archive(
     name = "libc",
@@ -37,7 +55,6 @@ http_archive(
     ],
 )
 
-
 http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "e1a0d6eb40ec89f61a13a028e7113aa3630247253bcb1406281b627e44395145",
@@ -45,6 +62,7 @@ http_archive(
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "npm_install")
+
 node_repositories()
 
 # Dependencies for the @examples//hello_world_wasm example.
@@ -56,6 +74,7 @@ npm_install(
 
 # Install all Bazel dependencies needed for npm packages that supply Bazel rules
 load("@npm//:install_bazel_dependencies.bzl", "install_bazel_dependencies")
+
 install_bazel_dependencies()
 
 load("@io_bazel_rules_rust//bindgen:repositories.bzl", "rust_bindgen_repositories")


### PR DESCRIPTION
Previously this was pulling from a list of known shas, but this list is
non-exhaustive, and needs to be updated every rust release.  This allows
the shas to be specified in rust_toolchain_repository,
rust_repository_set, rust_repositories.