### PR TITLE
Added 'wasm32-unknown-unknown' platform triple

### DIFF
--- a/rust/platform/platform.bzl
+++ b/rust/platform/platform.bzl
@@ -34,6 +34,7 @@ _SUPPORTED_T2_PLATFORM_TRIPLES = [
     "x86_64-apple-ios",
     "x86_64-linux-android",
     "x86_64-unknown-freebsd",
+    "wasm32-unknown-unknown",
 ]
 
 _SUPPORTED_CPU_ARCH = [


### PR DESCRIPTION
Just as the title says, this adds the `@io_bazel_rules_rust//rust/platform:wasm32-unknown-unknown` target. I feel this makes the interactions with wasm more consistent with other platforms.