### PR TITLE
Extract cargo from rust toolchain tar

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -417,7 +417,7 @@ def _load_rust_compiler(ctx):
         iso_date = ctx.attr.iso_date,
         target_triple = target_triple,
         tool_name = "rust",
-        tool_subdirectories = ["rustc", "clippy-preview"],
+        tool_subdirectories = ["rustc", "clippy-preview", "cargo"],
         version = ctx.attr.version,
     )
 


### PR DESCRIPTION
This allows for `cargo` to be used from scripts which may want to invoke
`cargo`, while coupling the version used with the rest of the toolchain
used for the build.