### PR TITLE
Removed unused file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
This is a followup to the conversation in #407 

`renovate.json` is unused and should therefore be removed.