### PR TITLE
rust_repositories() was not honoring edition default on Windows

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -101,6 +101,7 @@ def rust_repositories(
         iso_date = iso_date,
         rustfmt_version = rustfmt_version,
         sha256s = sha256s,
+        edition = edition,
     )
 
 def _check_version_valid(version, iso_date, param_prefix = ""):


### PR DESCRIPTION
The Windows toolchain was ignoring the default provided to rust_repositories(), always using edition 2015, which caused errors about crates being unavailable if extern crate references were not in the code.