### PR TITLE
use -msvc variant on Windows

### DIFF
--- a/rust/platform/platform.bzl
+++ b/rust/platform/platform.bzl
@@ -11,16 +11,16 @@ load(
 # All T1 Platforms should be supported, but aren't, see inline notes.
 _SUPPORTED_T1_PLATFORM_TRIPLES = [
     "i686-apple-darwin",
-    "i686-pc-windows-gnu",
+    "i686-pc-windows-msvc",
     "i686-unknown-linux-gnu",
     "x86_64-apple-darwin",
-    "x86_64-pc-windows-gnu",
+    "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",
     # N.B. These "alternative" envs are not supported, as bazel cannot distinguish between them
     # and others using existing @platforms// config_values
     #
-    #"i686-pc-windows-msvc",
-    #"x86_64-pc-windows-msvc",
+    #"i686-pc-windows-gnu",
+    #"x86_64-pc-windows-gnu",
 ]
 
 # Some T2 Platforms are supported, provided we have mappings to @platforms// entries.


### PR DESCRIPTION
use -msvc variant on Windows

Both the standard Rust installer, and rust_repositories() in this repo
default to the -msvc platform. Since it is the default on Windows,
this change comments out the -gnu variant instead.

This change (along with some fixes in cargo raze) allows crates with
msvc-specific build deps to compile. I do not know enough about Bazel
to say if it will have any unintended side effects, but it seems to
work for me, and allows a moderate sized project with about 250
crate dependencies to compile using the default toolchain.