### PR TITLE
pass compile environment into build script

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -1,5 +1,5 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@io_bazel_rules_rust//rust:private/rustc.bzl", "BuildInfo", "DepInfo", "get_cc_toolchain", "get_compilation_mode_opts", "get_linker_and_args")
+load("@io_bazel_rules_rust//rust:private/rustc.bzl", "BuildInfo", "DepInfo", "get_cc_compile_env", "get_cc_toolchain", "get_compilation_mode_opts", "get_linker_and_args")
 load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain")
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
 
@@ -63,6 +63,12 @@ def _build_script_impl(ctx):
     cc_toolchain, feature_configuration = get_cc_toolchain(ctx)
     _, _, linker_env = get_linker_and_args(ctx, cc_toolchain, feature_configuration, None)
     env.update(**linker_env)
+
+    # MSVC requires INCLUDE to be set
+    cc_env = get_cc_compile_env(cc_toolchain, feature_configuration)
+    include = cc_env.get("INCLUDE")
+    if include:
+        env["INCLUDE"] = include
 
     if cc_toolchain:
         toolchain_tools.append(cc_toolchain.all_files)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "CPP_LINK_EXECUTABLE_ACTION_NAME")
+load(
+    "@bazel_tools//tools/build_defs/cc:action_names.bzl",
+    "CPP_LINK_EXECUTABLE_ACTION_NAME",
+    "C_COMPILE_ACTION_NAME",
+)
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@bazel_version//:def.bzl", "BAZEL_VERSION")
 load("@io_bazel_rules_rust//rust:private/legacy_cc_starlark_api_shim.bzl", "get_libs_for_static_executable")
@@ -230,6 +234,17 @@ def get_cc_toolchain(ctx):
         **kwargs
     )
     return cc_toolchain, feature_configuration
+
+def get_cc_compile_env(cc_toolchain, feature_configuration):
+    compile_variables = cc_common.create_compile_variables(
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+    )
+    return cc_common.get_environment_variables(
+        feature_configuration = feature_configuration,
+        action_name = C_COMPILE_ACTION_NAME,
+        variables = compile_variables,
+    )
 
 def get_cc_user_link_flags(ctx):
     """Get the current target's linkopt flags


### PR DESCRIPTION
On Windows, MSVC requires INCLUDE to be set to the path of the standard
include files. Not sure if this is the best solution, but it solved issues with
missing includes mentioned in #423 for me.