### PR TITLE
run build scripts in the crate folder instead of the workspace

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -20,7 +20,7 @@ def _build_script_impl(ctx):
     dep_env_out = ctx.actions.declare_file(ctx.label.name + ".depenv")
     flags_out = ctx.actions.declare_file(ctx.label.name + ".flags")
     link_flags = ctx.actions.declare_file(ctx.label.name + ".linkflags")
-    manifest_dir = "%s.runfiles/%s" % (script.path, ctx.label.workspace_name or ctx.workspace_name)
+    manifest_dir = "%s.runfiles/%s/%s" % (script.path, ctx.label.workspace_name or ctx.workspace_name, ctx.label.package)
     compilation_mode_opt_level = get_compilation_mode_opts(ctx, toolchain).opt_level
 
     crate_name = ctx.attr.crate_name

--- a/examples/cargo/build_script.rs
+++ b/examples/cargo/build_script.rs
@@ -19,7 +19,7 @@ fn main() {
     let bleh = env::var("CARGO_FEATURE_BLEH").unwrap();
     let some_env = env::var("SOME_ENV").unwrap();
     let out_dir = env::var("OUT_DIR").unwrap();
-    let data = std::fs::read("cargo/test.txt").unwrap();
+    let data = std::fs::read("test.txt").unwrap();
     assert!(!bleh.is_empty());
     assert_eq!(some_env, "42");
     println!(r#"cargo:rustc-env=FOO=BAR


### PR DESCRIPTION
Various crates expect to be able to access files relative to the
crate root, and we were giving them the parent directory (eg __main__)
instead. An example crate that fails to compile without this change
is blake3.