### PR TITLE
support iOS cross compile

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -43,6 +43,7 @@ _SYSTEM_TO_BINARY_EXT = {
     "linux": "",
     "windows": ".exe",
     "darwin": "",
+    "ios": "",
     "emscripten": ".js",
     # This is currently a hack allowing us to have the proper
     # generated extension for the wasm target, similarly to the
@@ -54,6 +55,7 @@ _SYSTEM_TO_STATICLIB_EXT = {
     "freebsd": ".a",
     "linux": ".a",
     "darwin": ".a",
+    "ios": ".a",
     "windows": ".lib",
     "emscripten": ".js",
     "unknown": "",
@@ -63,6 +65,7 @@ _SYSTEM_TO_DYLIB_EXT = {
     "freebsd": ".so",
     "linux": ".so",
     "darwin": ".dylib",
+    "ios": ".dylib",
     "windows": ".dll",
     "emscripten": ".js",
     "unknown": ".wasm",


### PR DESCRIPTION
Fixes:
ERROR: An error occurred during the fetch of repository 'rust_darwin_x86_64':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_dae/5bd71d68278317a4c19e40755fc15392/external/io_bazel_rules_rust/rust/repositories.bzl", line 549, column 50, in _rust_toolchain_repository_impl
		build_components.append(_load_rust_stdlib(ctx, target_triple))
	File "/private/var/tmp/_bazel_dae/5bd71d68278317a4c19e40755fc15392/external/io_bazel_rules_rust/rust/repositories.bzl", line 477, column 41, in _load_rust_stdlib
		stdlib_build_file = BUILD_for_stdlib(target_triple)
	File "/private/var/tmp/_bazel_dae/5bd71d68278317a4c19e40755fc15392/external/io_bazel_rules_rust/rust/repositories.bzl", line 253, column 42, in BUILD_for_stdlib
		binary_ext = system_to_binary_ext(system),
	File "/private/var/tmp/_bazel_dae/5bd71d68278317a4c19e40755fc15392/external/io_bazel_rules_rust/rust/platform/triple_mappings.bzl", line 153, column 33, in system_to_binary_ext
		return _SYSTEM_TO_BINARY_EXT[system]
Error: key "ios" not found in dictionary