### PR TITLE
Addressed additional Buildifier defects

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,9 @@
 workspace(name = "io_bazel_rules_rust")
 
+load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
+
+rust_repositories()
+
 load("@io_bazel_rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 
 rust_proto_repositories()
@@ -53,9 +57,9 @@ load("@examples//:examples_deps.bzl", examples_deps = "deps")
 
 examples_deps()
 
-load("@examples//:examples_extra_deps.bzl", examples_extra_deps = "extra_deps")
+load("@examples//:examples_transitive_deps.bzl", examples_transitive_deps = "transitive_deps")
 
-examples_extra_deps()
+examples_transitive_deps()
 
 # Load all dependencies for docs
 
@@ -70,4 +74,8 @@ docs_repositories()
 
 load("@docs//:docs_deps.bzl", docs_deps = "deps")
 
-docs_deps(is_top_level = True)
+docs_deps()
+
+load("@docs//:docs_transitive_deps.bzl", docs_transitive_deps = "transitive_deps")
+
+docs_transitive_deps(is_top_level = True)

--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
 load("@io_bazel_rules_rust//rust:private/legacy_cc_starlark_api_shim.bzl", "get_libs_for_static_executable")
 load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain")
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
 
 def rust_bindgen_library(
         name,
@@ -141,8 +141,8 @@ def _rust_bindgen_impl(ctx):
         )
 
 rust_bindgen = rule(
-    _rust_bindgen_impl,
     doc = "Generates a rust source file from a cc_library and a header.",
+    implementation = _rust_bindgen_impl,
     attrs = {
         "header": attr.label(
             doc = "The .h file to generate bindings for.",

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -1,7 +1,7 @@
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@io_bazel_rules_rust//rust:private/rustc.bzl", "BuildInfo", "DepInfo", "get_cc_toolchain", "get_compilation_mode_opts", "get_linker_and_args")
 load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain")
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _cargo_build_script_run(ctx, script):
     toolchain = find_toolchain(ctx)

--- a/docs/WORKSPACE
+++ b/docs/WORKSPACE
@@ -7,3 +7,7 @@ repositories()
 load(":docs_deps.bzl", "deps")
 
 deps()
+
+load(":docs_transitive_deps.bzl", "transitive_deps")
+
+transitive_deps()

--- a/docs/docs_deps.bzl
+++ b/docs/docs_deps.bzl
@@ -1,34 +1,10 @@
 """Define dependencies for `rules_rust` docs"""
 
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
-load("@io_bazel_rules_rust//proto:repositories.bzl", "rust_proto_repositories")
-load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-def deps(is_top_level = False):
-    """Define dependencies for `rules_rust` docs
-
-    Args:
-        is_top_level (bool, optional): Indicates wheather or not this is being called
-            from the root WORKSPACE file of `rules_rust`. Defaults to False.
-    """
+def deps():
+    """Define dependencies for `rules_rust` docs"""
     rust_repositories()
-    rust_proto_repositories()
-    bazel_version(name = "bazel_version")
-    stardoc_repositories()
 
-    # Rules proto does not declare a bzl_library, we stub it there for now.
-    # TODO: Remove this hack if/when rules_proto adds a bzl_library.
-    if is_top_level:
-        maybe(
-            native.local_repository,
-            name = "rules_proto",
-            path = "docs/rules_proto_stub",
-        )
-    else:
-        maybe(
-            native.local_repository,
-            name = "rules_proto",
-            path = "rules_proto_stub",
-        )
+    stardoc_repositories()

--- a/docs/docs_repositories.bzl
+++ b/docs/docs_repositories.bzl
@@ -18,16 +18,6 @@ def repositories(is_top_level = False):
 
     maybe(
         http_archive,
-        name = "bazel_skylib",
-        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
-        urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        ],
-    )
-
-    maybe(
-        http_archive,
         name = "io_bazel_stardoc",
         urls = [
             "https://github.com/bazelbuild/stardoc/archive/1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.zip",

--- a/docs/docs_transitive_deps.bzl
+++ b/docs/docs_transitive_deps.bzl
@@ -1,0 +1,31 @@
+"""Define transitive dependencies for `rules_rust` docs"""
+
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@io_bazel_rules_rust//:workspace.bzl", "rust_workspace")
+load("@io_bazel_rules_rust//proto:repositories.bzl", "rust_proto_repositories")
+
+def transitive_deps(is_top_level = False):
+    """Define transitive dependencies for `rules_rust` docs
+
+    Args:
+        is_top_level (bool, optional): Indicates wheather or not this is being called
+            from the root WORKSPACE file of `rules_rust`. Defaults to False.
+    """
+    rust_proto_repositories()
+
+    rust_workspace()
+
+    # Rules proto does not declare a bzl_library, we stub it there for now.
+    # TODO: Remove this hack if/when rules_proto adds a bzl_library.
+    if is_top_level:
+        maybe(
+            native.local_repository,
+            name = "rules_proto",
+            path = "docs/rules_proto_stub",
+        )
+    else:
+        maybe(
+            native.local_repository,
+            name = "rules_proto",
+            path = "rules_proto_stub",
+        )

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -595,8 +595,7 @@ toolchain(
 )
 ```
 
-Then, either add the label of the toolchain rule to register_toolchains in the WORKSPACE, or pass
-it to the "--extra_toolchains" flag for Bazel, and it will be used.
+Then, either add the label of the toolchain rule to register_toolchains in the WORKSPACE, or pass it to the "--extra_toolchains" flag for Bazel, and it will be used.
 
 See @io_bazel_rules_rust//proto:BUILD for examples of defining the toolchain.
 

--- a/docs/rust_proto.md
+++ b/docs/rust_proto.md
@@ -133,8 +133,7 @@ toolchain(
 )
 ```
 
-Then, either add the label of the toolchain rule to register_toolchains in the WORKSPACE, or pass
-it to the "--extra_toolchains" flag for Bazel, and it will be used.
+Then, either add the label of the toolchain rule to register_toolchains in the WORKSPACE, or pass it to the "--extra_toolchains" flag for Bazel, and it will be used.
 
 See @io_bazel_rules_rust//proto:BUILD for examples of defining the toolchain.
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -8,6 +8,6 @@ load(":examples_deps.bzl", "deps")
 
 deps()
 
-load(":examples_extra_deps.bzl", "extra_deps")
+load(":examples_transitive_deps.bzl", "transitive_deps")
 
-extra_deps()
+transitive_deps()

--- a/examples/examples_deps.bzl
+++ b/examples/examples_deps.bzl
@@ -1,23 +1,26 @@
 """Define dependencies for `rules_rust` examples"""
 
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "npm_install")
 load("@examples//hello_sys/raze:crates.bzl", "rules_rust_examples_hello_sys_fetch_remote_crates")
-load("@io_bazel_rules_rust//:workspace.bzl", "rust_workspace")
 load("@io_bazel_rules_rust//bindgen:repositories.bzl", "rust_bindgen_repositories")
 load("@io_bazel_rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories", "rust_repository_set")
 load("@io_bazel_rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_repositories")
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
 def deps():
     """Define dependencies for `rules_rust` examples"""
-    bazel_skylib_workspace()
 
     rust_repositories()
 
+    rust_bindgen_repositories()
+
+    rust_wasm_bindgen_repositories()
+
+    rust_proto_repositories()
+
+    # Example of `rust_repository_set`
     rust_repository_set(
         name = "fake_toolchain_for_test_of_sha256",
         edition = "2018",
@@ -32,8 +35,6 @@ def deps():
         version = "1.46.0",
     )
 
-    rust_proto_repositories()
-
     node_repositories()
 
     # Dependencies for the @examples//hello_world_wasm example.
@@ -43,17 +44,7 @@ def deps():
         package_lock_json = "@examples//:package-lock.json",
     )
 
-    rust_bindgen_repositories()
-
-    rust_wasm_bindgen_repositories()
-
-    rust_workspace()
-
     rules_rust_examples_hello_sys_fetch_remote_crates()
-
-    rules_proto_dependencies()
-
-    rules_proto_toolchains()
 
     maybe(
         http_archive,

--- a/examples/examples_repositories.bzl
+++ b/examples/examples_repositories.bzl
@@ -13,16 +13,6 @@ def repositories():
 
     maybe(
         http_archive,
-        name = "bazel_skylib",
-        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
-        urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        ],
-    )
-
-    maybe(
-        http_archive,
         name = "build_bazel_rules_nodejs",
         sha256 = "e1a0d6eb40ec89f61a13a028e7113aa3630247253bcb1406281b627e44395145",
         urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.0.1/rules_nodejs-1.0.1.tar.gz"],

--- a/examples/examples_transitive_deps.bzl
+++ b/examples/examples_transitive_deps.bzl
@@ -1,4 +1,4 @@
-"""Define extra dependencies for `rules_rust` examples
+"""Define transitive dependencies for `rules_rust` examples
 
 There are some transitive dependencies of the dependencies of the examples' 
 dependencies. This file contains the required macros to pull these dependencies

--- a/examples/examples_transitive_deps.bzl
+++ b/examples/examples_transitive_deps.bzl
@@ -4,10 +4,18 @@ There are some transitive dependencies of the dependencies of the examples'
 dependencies. This file contains the required macros to pull these dependencies
 """
 
+load("@io_bazel_rules_rust//:workspace.bzl", "rust_workspace")
 load("@npm//:install_bazel_dependencies.bzl", "install_bazel_dependencies")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
-def extra_deps():
-    """Define extra dependencies for `rules_rust` examples"""
+def transitive_deps():
+    """Define transitive dependencies for `rules_rust` examples"""
+
+    rules_proto_dependencies()
+
+    rules_proto_toolchains()
+
+    rust_workspace()
 
     # Install all Bazel dependencies needed for npm packages that supply Bazel rules
     install_bazel_dependencies()

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_proto//proto:defs.bzl", "ProtoInfo")
-
 """Rust Protobuf Rules
 
 These build rules are used for building [protobufs][protobuf]/[gRPC][grpc] in [Rust][rust] with Bazel.
@@ -43,6 +41,7 @@ load(
 )
 load("@io_bazel_rules_rust//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
 load("@io_bazel_rules_rust//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 
 RustProtoInfo = provider(
     fields = {
@@ -158,6 +157,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, grpc,
         crate_name,
         output_hash,
     ))
+
     result = rustc_compile_action(
         ctx = ctx,
         toolchain = find_toolchain(ctx),

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//proto/raze:crates.bzl", _crate_deps = "raze_fetch_remote_crates")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//proto/raze:crates.bzl", _crate_deps = "raze_fetch_remote_crates")
 
 # buildifier: disable=unnamed-macro
 def rust_proto_repositories():
@@ -40,16 +40,6 @@ def rust_proto_repositories():
             "https://github.com/bazelbuild/rules_python/archive/0.0.1.zip",
         ],
         sha256 = "f73c0cf51c32c7aaeaf02669ed03b32d12f2d92e1b05699eb938a75f35a210f4",
-    )
-
-    maybe(
-        http_archive,
-        name = "bazel_skylib",
-        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
-        urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        ],
     )
 
     maybe(

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -108,17 +108,17 @@ def _rust_proto_toolchain_impl(ctx):
         edition = ctx.attr.edition,
     )
 
+# Default dependencies needed to compile protobuf stubs.
 PROTO_COMPILE_DEPS = [
     "@io_bazel_rules_rust//proto/raze:protobuf",
 ]
-"""Default dependencies needed to compile protobuf stubs."""
 
+# Default dependencies needed to compile gRPC stubs.
 GRPC_COMPILE_DEPS = PROTO_COMPILE_DEPS + [
     "@io_bazel_rules_rust//proto/raze:grpc",
     "@io_bazel_rules_rust//proto/raze:tls_api",
     "@io_bazel_rules_rust//proto/raze:tls_api_stub",
 ]
-"""Default dependencies needed to compile gRPC stubs."""
 
 # TODO(damienmg): Once bazelbuild/bazel#6889 is fixed, reintroduce
 # proto_compile_deps and grpc_compile_deps and remove them from the
@@ -186,7 +186,7 @@ toolchain(
 )
 ```
 
-Then, either add the label of the toolchain rule to register_toolchains in the WORKSPACE, or pass
+Then, either add the label of the toolchain rule to register_toolchains in the WORKSPACE, or pass \
 it to the "--extra_toolchains" flag for Bazel, and it will be used.
 
 See @io_bazel_rules_rust//proto:BUILD for examples of defining the toolchain.

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "get_lib_name", "relativize")
-load("@io_bazel_rules_rust//rust:private/legacy_cc_starlark_api_shim.bzl", "get_libs_for_static_executable")
-load(
-    "@bazel_tools//tools/build_defs/cc:action_names.bzl",
-    "CPP_LINK_EXECUTABLE_ACTION_NAME",
-)
-load(
-    "@bazel_tools//tools/cpp:toolchain_utils.bzl",
-    "find_cpp_toolchain",
-)
 load("@bazel_skylib//lib:versions.bzl", "versions")
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "CPP_LINK_EXECUTABLE_ACTION_NAME")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@bazel_version//:def.bzl", "BAZEL_VERSION")
+load("@io_bazel_rules_rust//rust:private/legacy_cc_starlark_api_shim.bzl", "get_libs_for_static_executable")
+load("@io_bazel_rules_rust//rust:private/utils.bzl", "get_lib_name", "relativize")
 
 CrateInfo = provider(
     fields = {
@@ -298,7 +292,7 @@ def construct_arguments(
         out_dir,
         build_env_file,
         build_flags_files,
-        maker_path):
+        maker_path = None):
     output_dir = getattr(crate_info.output, "dirname") if hasattr(crate_info.output, "dirname") else None
 
     linker_script = getattr(file, "linker_script") if hasattr(file, "linker_script") else None
@@ -468,7 +462,6 @@ def rustc_compile_action(
         out_dir,
         build_env_file,
         build_flags_files,
-        maker_path = None,
     )
 
     if hasattr(ctx.attr, "version") and ctx.attr.version != "0.0.0":

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -1,10 +1,19 @@
 load(":known_shas.bzl", "FILE_KEY_TO_SHA")
-load("//rust/platform:triple_mappings.bzl", "system_to_binary_ext", "system_to_dylib_ext", "system_to_staticlib_ext", "system_to_stdlib_linkflags", "triple_to_constraint_set", "triple_to_system")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load(
+    "//rust/platform:triple_mappings.bzl",
+    "system_to_binary_ext",
+    "system_to_dylib_ext",
+    "system_to_staticlib_ext",
+    "system_to_stdlib_linkflags",
+    "triple_to_constraint_set",
+    "triple_to_system",
+)
 
 DEFAULT_TOOLCHAIN_NAME_PREFIX = "toolchain_for"
 
+# buildifier: disable=unnamed-macro
 def rust_repositories(
         version = "1.44.0",
         iso_date = None,
@@ -663,11 +672,10 @@ def rust_repository_set(
         edition = None,
         dev_components = False,
         sha256s = None):
-    # buildifier: disable=function-docstring-header
-    """Assembles a remote repository for the given toolchain params, produces a proxy repository
+    """Assembles a remote repository for the given toolchain params, produces a proxy repository \
     to contain the toolchain declaration, and registers the toolchains.
 
-    N.B. A "proxy repository" is needed to allow for registering the toolchain (with constraints)
+    N.B. A "proxy repository" is needed to allow for registering the toolchain (with constraints) \
     without actually downloading the toolchain.
 
     Args:

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -35,28 +35,28 @@ load(
 )
 
 rust_library = _rust_library
-""" See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description. """
+# See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description.
 
 rust_binary = _rust_binary
-""" See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description. """
+# See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description.
 
 rust_test = _rust_test
-""" See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description. """
+# See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description.
 
 rust_test_binary = _rust_test_binary
-""" See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description. """
+# See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description.
 
 rust_benchmark = _rust_benchmark
-""" See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description. """
+# See @io_bazel_rules_rust//rust:private/rust.bzl for a complete description.
 
 rust_doc = _rust_doc
-""" See @io_bazel_rules_rust//rust:private/rustdoc.bzl for a complete description. """
+# See @io_bazel_rules_rust//rust:private/rustdoc.bzl for a complete description.
 
 rust_doc_test = _rust_doc_test
-""" See @io_bazel_rules_rust//rust:private/rustdoc_test.bzl for a complete description. """
+# See @io_bazel_rules_rust//rust:private/rustdoc_test.bzl for a complete description.
 
 rust_clippy_aspect = _rust_clippy_aspect
-""" See @io_bazel_rules_rust//rust:private/clippy.bzl for a complete description. """
+# See @io_bazel_rules_rust//rust:private/clippy.bzl for a complete description.
 
 rust_clippy = _rust_clippy
-""" See @io_bazel_rules_rust//rust:private/clippy.bzl for a complete description. """
+# See @io_bazel_rules_rust//rust:private/clippy.bzl for a complete description.

--- a/wasm_bindgen/wasm_bindgen.bzl
+++ b/wasm_bindgen/wasm_bindgen.bzl
@@ -69,7 +69,7 @@ def _rust_wasm_bindgen_impl(ctx):
     )
 
 rust_wasm_bindgen = rule(
-    _rust_wasm_bindgen_impl,
+    implementation = _rust_wasm_bindgen_impl,
     doc = "Generates javascript and typescript bindings for a webassembly module.",
     attrs = {
         "wasm_file": attr.label(
@@ -101,7 +101,7 @@ def _rust_wasm_bindgen_toolchain_impl(ctx):
     )
 
 rust_wasm_bindgen_toolchain = rule(
-    _rust_wasm_bindgen_toolchain_impl,
+    implementation = _rust_wasm_bindgen_toolchain_impl,
     doc = "The tools required for the `rust_wasm_bindgen` rule.",
     attrs = {
         "bindgen": attr.label(

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -1,6 +1,8 @@
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
+_MINIMUM_SUPPORTED_BAZEL_VERSION = "0.17.1"
+
 def _bazel_version_impl(repository_ctx):
     """The implementation for the `bazel_version` rule
 
@@ -10,10 +12,15 @@ def _bazel_version_impl(repository_ctx):
     bazel_version = versions.get()
     if len(bazel_version) == 0:
         # buildifier: disable=print
-        print("You're using development build of Bazel, make sure it's at least version 0.17.1")
-    elif versions.is_at_most("0.17.0", bazel_version):
-        fail("Bazel {} is too old to use with rules_rust, please use at least Bazel 0.17.1, preferably newer.".format(bazel_version))
-    repository_ctx.file("BUILD", "exports_files(['def.bzl'])")
+        print("You're using development build of Bazel, make sure it's at least version {}".format(
+            _MINIMUM_SUPPORTED_BAZEL_VERSION,
+        ))
+    elif versions.is_at_most(_MINIMUM_SUPPORTED_BAZEL_VERSION, bazel_version):
+        fail("Bazel {} is too old to use with rules_rust, please use at least Bazel {}, preferably newer.".format(
+            bazel_version,
+            _MINIMUM_SUPPORTED_BAZEL_VERSION,
+        ))
+    repository_ctx.file("BUILD.bazel", "exports_files(['def.bzl'])")
     repository_ctx.file("def.bzl", "BAZEL_VERSION='" + bazel_version + "'")
 
 bazel_version = repository_rule(


### PR DESCRIPTION
This change takes more out of #420 and addresses some buildifier defects and structural inconsistencies.

The way docs and examples had their `WORKSPACE` setup didn't fully rely on `io_bazel_rules_rust` to provide all it's dependencies. This has now been updated. The only thing required to use `rules_rust` is to call `rust_repositories` and `rust_workspace` in your WORKSPACE which is now demonstrated within the project.

I apologize for this PR being larger than I'd like. A lot of this was pulled out of #420. Going forward, it should be easier to make each commit represent a fixed buildifier defect. 