### PR TITLE
fix deadlock while waiting for build script output

### DIFF
--- a/cargo/cargo_build_script_runner/lib.rs
+++ b/cargo/cargo_build_script_runner/lib.rs
@@ -114,9 +114,9 @@ impl BuildScriptOutput {
             .stdout(Stdio::piped())
             .spawn()
             .expect("Unable to start binary");
-        let ecode = child.wait().expect("failed to wait on child");
         let reader = BufReader::new(child.stdout.as_mut().expect("Failed to open stdout"));
         let output = Self::from_reader(reader);
+        let ecode = child.wait().expect("failed to wait on child");
         if ecode.success() {
             Ok(output)
         } else {


### PR DESCRIPTION
If the build script outputs enough, it fills up the stdout pipe,
blocks, and wait() never returns. Windows has a smaller pipe buffer,
so when compiling the blake3 crate for example, the compile gets stuck
after a few files have been compiled with the cc crate.