### PR TITLE
Include wasm-lld in toolchain

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -39,8 +39,6 @@ tasks:
     - "-@examples//ffi/rust_calling_c/simple/..."
     # See https://github.com/bazelbuild/bazel/issues/9987
     - "-@examples//ffi/rust_calling_c:matrix_dylib_test"
-    # rust-lld isn't available on RBE
-    - "-@examples//hello_world_wasm:hello_world_wasm_test"
   windows:
     build_flags:
     - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -161,6 +161,8 @@ filegroup(
             "bin/*{dylib_ext}",
             "lib/*{dylib_ext}",
             "lib/rustlib/{target_triple}/codegen-backends/*{dylib_ext}",
+            "lib/rustlib/{target_triple}/bin/rust-lld{binary_ext}",
+            "lib/rustlib/{target_triple}/lib/*{dylib_ext}",
         ],
         allow_empty = True,
     ),


### PR DESCRIPTION
Before this change, `rust-lld` is not found in RBE environment because they are not part of toolchain definition. This PR adds `rust-lld` and its runtime dependencies into toolchain definition, so they can work in RBE / docker-sandbox.