### PR TITLE
Add --extern proc_macro for 2018 crates

### DIFF
--- a/examples/hello_macro/BUILD
+++ b/examples/hello_macro/BUILD
@@ -16,6 +16,15 @@ rust_library(
     crate_type = "proc-macro",
 )
 
+rust_library(
+    name = "hello_macro_2018",
+    srcs = [
+        "src/lib_2018.rs",
+    ],
+    crate_type = "proc-macro",
+    edition = "2018",
+)
+
 rust_test(
     name = "hello_macro_test",
     crate = ":hello_macro",

--- a/examples/hello_macro/src/lib_2018.rs
+++ b/examples/hello_macro/src/lib_2018.rs
@@ -1,0 +1,25 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This differs from the edition 2015 version because it does not have an `extern proc_macro`
+// statement, which became optional in edition 2018.
+
+use proc_macro::TokenStream;
+
+/// This macro is a no-op; it is exceedingly simple as a result
+/// of avoiding dependencies on both the syn and quote crates.
+#[proc_macro_derive(HelloWorld)]
+pub fn hello_world(_input: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -518,6 +518,10 @@ def construct_arguments(
     add_native_link_flags(args, dep_info)
     add_crate_link_flags(args, dep_info)
 
+    if crate_info.type == "proc-macro" and crate_info.edition != "2015":
+        args.add("--extern")
+        args.add("proc_macro")
+
     # Make bin crate data deps available to tests.
     for data in getattr(ctx.attr, "data", []):
         if CrateInfo in data:


### PR DESCRIPTION
This is done implicitly by cargo.