### PR TITLE
support --action_env vars in build scripts

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -40,7 +40,11 @@ def _build_script_impl(ctx):
 
     cc_toolchain = find_cpp_toolchain(ctx)
 
-    env = {
+    # Start with the default shell env, which contains any --action_env
+    # settings passed in on the command line.
+    env = dict(ctx.configuration.default_shell_env)
+
+    env.update({
         "CARGO_MANIFEST_DIR": manifest_dir,
         "CARGO_PKG_NAME": crate_name,
         "HOST": toolchain.exec_triple,
@@ -48,7 +52,7 @@ def _build_script_impl(ctx):
         "RUSTC": toolchain.rustc.path,
         "TARGET": toolchain.target_triple,
         # OUT_DIR is set by the runner itself, rather than on the action.
-    }
+    })
 
     if ctx.attr.version:
         version = ctx.attr.version.split("+")[0].split(".")


### PR DESCRIPTION
The existing rustc_env attribute is useful when the provided env var
will not differ between machines, but is not practical when each
user of the build script may require a different value, such as passing
in a custom path to a tool on their machine.

Fixes the issue mentioned in
https://github.com/bazelbuild/rules_rust/pull/314#issuecomment-624524139
by starting from the default environment. I did not make a change in rustc.bzl,
so this only applies to build scripts at the moment.