### PR TITLE
add buildscript link flags only to parent crate

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -724,15 +724,10 @@ def _create_extra_input_args(ctx, file, build_info, dep_info):
     if build_info:
         out_dir = build_info.out_dir.path
         build_env_file = build_info.rustc_env.path
-
-        # out_dir will be added as input by the transitive_build_infos loop below.
         build_flags_files.append(build_info.flags.path)
-
-    # This should probably only actually be exposed to actions which link.
-    for dep_build_info in dep_info.transitive_build_infos.to_list():
-        input_files.append(dep_build_info.out_dir)
-        build_flags_files.append(dep_build_info.link_flags.path)
-        input_files.append(dep_build_info.link_flags)
+        build_flags_files.append(build_info.link_flags.path)
+        input_files.append(build_info.out_dir)
+        input_files.append(build_info.link_flags)
 
     return input_files, out_dir, build_env_file, build_flags_files
 

--- a/test/transitive_lib/BUILD
+++ b/test/transitive_lib/BUILD
@@ -1,0 +1,34 @@
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary", "rust_library")
+
+# sets link alias
+cargo_build_script(
+    name = "buildscript",
+    srcs = ["build.rs"],
+    crate_root = "build.rs",
+    edition = "2018",
+)
+
+# links to a symbol in shell32
+rust_library(
+    name = "dll_user",
+    srcs = ["dll_user.rs"],
+    crate_type = "lib",
+    edition = "2018",
+    deps = [
+        ":buildscript",
+    ],
+)
+
+# does not link to any symbol in shell32
+rust_binary(
+    name = "dll_user_user",
+    srcs = ["dll_user_user.rs"],
+    edition = "2018",
+    deps = [
+        ":dll_user",
+    ],
+)

--- a/test/transitive_lib/build.rs
+++ b/test/transitive_lib/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+   println!("cargo:rustc-link-lib=alias:shell32");
+}

--- a/test/transitive_lib/dll_user.rs
+++ b/test/transitive_lib/dll_user.rs
@@ -1,0 +1,5 @@
+#[link(name = "alias")]
+extern "C" {
+    // random symbol from shell32
+    pub fn LocalFree(ptr: *mut std::os::raw::c_void);
+}

--- a/test/transitive_lib/dll_user_user.rs
+++ b/test/transitive_lib/dll_user_user.rs
@@ -1,0 +1,5 @@
+fn main() {
+    // this file does not link to any shell32 symbols directly, and
+    // will thus cause a compile error if -lalias:shell32
+    // is present in the link flags
+}


### PR DESCRIPTION
@illicitonion Would you mind looking over this and seeing if it's sane? It's modifying code that was added in a previous pull request of yours: https://github.com/bazelbuild/rules_rust/pull/346

I use a crate for creating Python extension modules called pyo3. It has code in it like this:

```
#[cfg_attr(windows, link(name = "pythonXY"))]
extern "C" {
    pub fn PyNode_Compile(arg1: *mut _node, arg2: *const c_char) -> *mut PyCodeObject;
```

Its build.rs script locates the relevant library name, and spits out a link flag that maps it to the alias:

```
-lpythonXY:python38
```

The pyo3 crate compiles successfully, but when I attempt to compile a crate that depends on pyo3 on Windows, the build fails, complaining that the above alias has been provided but there are no mentions of pythonXY in my crate - because the aliases are only in the pyo3 crate.

When I compile my crate using cargo instead of bazel, I can see that pyo3's build script link flags are not being passed in when compiling my crate - so the current behaviour of rules_rust does not seem to match what cargo is doing.

The change in this PR fixes the issue for me, and hasn't caused any problems here. But your PR specifically mentions transitive deps, so I wonder if I am missing something. Does this change cause a regression in the problem you were originally trying to fix?