### PR TITLE
Switching "host" configurations to "exec"

### DIFF
--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -197,27 +197,27 @@ rust_bindgen_toolchain = rule(
         "bindgen": attr.label(
             doc = "The label of a `bindgen` executable.",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "rustfmt": attr.label(
             doc = "The label of a `rustfmt` executable. If this is provided, generated sources will be formatted.",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             mandatory = False,
         ),
         "clang": attr.label(
             doc = "The label of a `clang` executable.",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "libclang": attr.label(
             doc = "A cc_library that provides bindgen's runtime dependency on libclang.",
-            cfg = "host",
+            cfg = "exec",
             providers = [CcInfo],
         ),
         "libstdcxx": attr.label(
             doc = "A cc_library that satisfies libclang's libstdc++ dependency.",
-            cfg = "host",
+            cfg = "exec",
             providers = [CcInfo],
         ),
     },

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -147,7 +147,7 @@ _build_script_run = rule(
             executable = True,
             allow_files = True,
             mandatory = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "crate_name": attr.string(
             doc = "Name of the crate associated with this build script target",
@@ -171,7 +171,7 @@ _build_script_run = rule(
             executable = True,
             allow_files = True,
             default = Label("//cargo/cargo_build_script_runner:cargo_build_script_runner"),
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     fragments = ["cpp"],

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -293,7 +293,7 @@ rust_proto_library = rule(
         ),
         "_optional_output_wrapper": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label(
                 "@io_bazel_rules_rust//proto:optional_output_wrapper",
             ),
@@ -372,7 +372,7 @@ rust_grpc_library = rule(
         ),
         "_optional_output_wrapper": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label(
                 "@io_bazel_rules_rust//proto:optional_output_wrapper",
             ),

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -130,13 +130,13 @@ rust_proto_toolchain = rule(
         "protoc": attr.label(
             doc = "The location of the `protoc` binary. It should be an executable target.",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@com_google_protobuf//:protoc"),
         ),
         "proto_plugin": attr.label(
             doc = "The location of the Rust protobuf compiler plugin used to generate rust sources.",
             allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label(
                 "@io_bazel_rules_rust//proto:protoc_gen_rust",
             ),
@@ -144,7 +144,7 @@ rust_proto_toolchain = rule(
         "grpc_plugin": attr.label(
             doc = "The location of the Rust protobuf compiler plugin to generate rust gRPC stubs.",
             allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label(
                 "@io_bazel_rules_rust//proto:protoc_gen_rust_grpc",
             ),

--- a/wasm_bindgen/wasm_bindgen.bzl
+++ b/wasm_bindgen/wasm_bindgen.bzl
@@ -109,7 +109,7 @@ rust_wasm_bindgen_toolchain = rule(
         "bindgen": attr.label(
             doc = "The label of a `bindgen` executable.",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
 )


### PR DESCRIPTION
https://docs.bazel.build/versions/master/skylark/rules.html#configurations

> Note: Historically, Bazel didn’t have the concept of execution platforms, and instead all build actions were considered to run on the host machine. Because of this, there is a single “host” configuration, and a “host” transition that can be used to build a dependency in the host configuration. Many rules still use the “host” transition for their tools, but this is currently deprecated and being migrated to use “exec” transitions where possible.
> 
> There are numerous differences between the “host” and “exec” configurations:
> 
> - “host” is terminal, “exec” isn’t: Once a dependency is in the “host” configuration, no more transitions are allowed. You can keep making further configuration transitions once you’re in an “exec” configuration.
> - “host” is monolithic, “exec” isn’t: There is only one “host” configuration, but there can be a different “exec” configuration for each execution platform.
> - “host” assumes you run tools on the same machine as Bazel, or on a significantly similar machine. This is no longer true: you can run build actions on your local machine, or on a remote executor, and there’s no guarantee that the remote executor is the same CPU and OS as your local machine.