### PR TITLE
Fixed build errors by regenerating cargo raze

### DIFF
--- a/bindgen/raze/remote/ansi_term-0.11.0.BUILD
+++ b/bindgen/raze/remote/ansi_term-0.11.0.BUILD
@@ -38,8 +38,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(target_os = "windows")
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/bindgen/raze/remote/atty-0.2.14.BUILD
+++ b/bindgen/raze/remote/atty-0.2.14.BUILD
@@ -61,8 +61,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/bindgen/raze/remote/libloading-0.5.0.BUILD
+++ b/bindgen/raze/remote/libloading-0.5.0.BUILD
@@ -41,8 +41,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/bindgen/raze/remote/termcolor-1.1.0.BUILD
+++ b/bindgen/raze/remote/termcolor-1.1.0.BUILD
@@ -38,8 +38,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_bindgen__winapi_util__0_1_5//:winapi_util",
         ],

--- a/bindgen/raze/remote/winapi-0.3.9.BUILD
+++ b/bindgen/raze/remote/winapi-0.3.9.BUILD
@@ -36,23 +36,7 @@ rust_library(
     name = "winapi",
     crate_type = "lib",
     deps = [
-    ] + selects.with_or({
-        # i686-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-        ): [
-            "@rules_rust_bindgen__winapi_i686_pc_windows_gnu__0_4_0//:winapi_i686_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # x86_64-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
-        ): [
-            "@rules_rust_bindgen__winapi_x86_64_pc_windows_gnu__0_4_0//:winapi_x86_64_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",
@@ -78,6 +62,4 @@ rust_library(
         "winerror",
         "winnt",
     ],
-    aliases = {
-    },
 )

--- a/bindgen/raze/remote/winapi-util-0.1.5.BUILD
+++ b/bindgen/raze/remote/winapi-util-0.1.5.BUILD
@@ -38,8 +38,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/proto/raze/remote/mio-0.6.21.BUILD
+++ b/proto/raze/remote/mio-0.6.21.BUILD
@@ -66,8 +66,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_proto__kernel32_sys__0_2_2//:kernel32_sys",
             "@rules_rust_proto__miow__0_2_1//:miow",

--- a/proto/raze/remote/net2-0.2.33.BUILD
+++ b/proto/raze/remote/net2-0.2.33.BUILD
@@ -62,8 +62,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_proto__winapi__0_3_8//:winapi",
         ],

--- a/proto/raze/remote/parking_lot_core-0.6.2.BUILD
+++ b/proto/raze/remote/parking_lot_core-0.6.2.BUILD
@@ -63,8 +63,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_proto__winapi__0_3_8//:winapi",
         ],

--- a/proto/raze/remote/tokio-tls-api-0.1.22.BUILD
+++ b/proto/raze/remote/tokio-tls-api-0.1.22.BUILD
@@ -71,8 +71,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
         ],
         "//conditions:default": [],

--- a/proto/raze/remote/winapi-0.3.8.BUILD
+++ b/proto/raze/remote/winapi-0.3.8.BUILD
@@ -36,23 +36,7 @@ rust_library(
     name = "winapi",
     crate_type = "lib",
     deps = [
-    ] + selects.with_or({
-        # i686-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-        ): [
-            "@rules_rust_proto__winapi_i686_pc_windows_gnu__0_4_0//:winapi_i686_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # x86_64-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
-        ): [
-            "@rules_rust_proto__winapi_x86_64_pc_windows_gnu__0_4_0//:winapi_x86_64_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",
@@ -77,6 +61,4 @@ rust_library(
         "ws2ipdef",
         "ws2tcpip",
     ],
-    aliases = {
-    },
 )

--- a/wasm_bindgen/raze/remote/atty-0.2.14.BUILD
+++ b/wasm_bindgen/raze/remote/atty-0.2.14.BUILD
@@ -61,8 +61,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/backtrace-0.3.53.BUILD
+++ b/wasm_bindgen/raze/remote/backtrace-0.3.53.BUILD
@@ -46,8 +46,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
         ],
         "//conditions:default": [],

--- a/wasm_bindgen/raze/remote/buf_redux-0.8.4.BUILD
+++ b/wasm_bindgen/raze/remote/buf_redux-0.8.4.BUILD
@@ -46,7 +46,7 @@ rust_library(
             "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
             "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
             "@io_bazel_rules_rust//rust/platform:i686-linux-android",
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
             "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
             "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
             "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
@@ -54,7 +54,7 @@ rust_library(
             "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
             "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
             "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
             "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [

--- a/wasm_bindgen/raze/remote/chrono-0.4.19.BUILD
+++ b/wasm_bindgen/raze/remote/chrono-0.4.19.BUILD
@@ -50,8 +50,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/curl-0.4.34.BUILD
+++ b/wasm_bindgen/raze/remote/curl-0.4.34.BUILD
@@ -61,6 +61,16 @@ rust_library(
             "@rules_rust_wasm_bindgen__openssl_sys__0_9_58//:openssl_sys",
         ],
         "//conditions:default": [],
+    }) + selects.with_or({
+        # cfg(target_env = "msvc")
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@rules_rust_wasm_bindgen__schannel__0_1_19//:schannel",
+            "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
+        ],
+        "//conditions:default": [],
     }),
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",

--- a/wasm_bindgen/raze/remote/curl-sys-0.4.38+curl-7.73.0.BUILD
+++ b/wasm_bindgen/raze/remote/curl-sys-0.4.38+curl-7.73.0.BUILD
@@ -59,10 +59,18 @@ rust_library(
         ],
         "//conditions:default": [],
     }) + selects.with_or({
+        # cfg(target_env = "msvc")
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/dirs-1.0.5.BUILD
+++ b/wasm_bindgen/raze/remote/dirs-1.0.5.BUILD
@@ -60,8 +60,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/filetime-0.2.12.BUILD
+++ b/wasm_bindgen/raze/remote/filetime-0.2.12.BUILD
@@ -61,8 +61,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/libz-sys-1.1.2.BUILD
+++ b/wasm_bindgen/raze/remote/libz-sys-1.1.2.BUILD
@@ -37,7 +37,15 @@ rust_library(
     crate_type = "lib",
     deps = [
         "@rules_rust_wasm_bindgen__libc__0_2_79//:libc",
-    ],
+    ] + selects.with_or({
+        # cfg(target_env = "msvc")
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",
@@ -52,4 +60,6 @@ rust_library(
     crate_features = [
         "libc",
     ],
+    aliases = {
+    },
 )

--- a/wasm_bindgen/raze/remote/openssl-sys-0.9.58.BUILD
+++ b/wasm_bindgen/raze/remote/openssl-sys-0.9.58.BUILD
@@ -37,7 +37,15 @@ rust_library(
     crate_type = "lib",
     deps = [
         "@rules_rust_wasm_bindgen__libc__0_2_79//:libc",
-    ],
+    ] + selects.with_or({
+        # cfg(target_env = "msvc")
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",
@@ -64,4 +72,6 @@ rust_library(
     ],
     crate_features = [
     ],
+    aliases = {
+    },
 )

--- a/wasm_bindgen/raze/remote/rand-0.4.6.BUILD
+++ b/wasm_bindgen/raze/remote/rand-0.4.6.BUILD
@@ -63,8 +63,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/rand-0.5.6.BUILD
+++ b/wasm_bindgen/raze/remote/rand-0.5.6.BUILD
@@ -67,8 +67,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/rand-0.6.5.BUILD
+++ b/wasm_bindgen/raze/remote/rand-0.6.5.BUILD
@@ -74,8 +74,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/rand_jitter-0.1.4.BUILD
+++ b/wasm_bindgen/raze/remote/rand_jitter-0.1.4.BUILD
@@ -52,8 +52,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(target_os = "windows")
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/rand_os-0.1.3.BUILD
+++ b/wasm_bindgen/raze/remote/rand_os-0.1.3.BUILD
@@ -62,8 +62,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/remove_dir_all-0.5.3.BUILD
+++ b/wasm_bindgen/raze/remote/remove_dir_all-0.5.3.BUILD
@@ -38,8 +38,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/socket2-0.3.15.BUILD
+++ b/wasm_bindgen/raze/remote/socket2-0.3.15.BUILD
@@ -61,8 +61,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/tempfile-3.1.0.BUILD
+++ b/wasm_bindgen/raze/remote/tempfile-3.1.0.BUILD
@@ -66,8 +66,8 @@ rust_library(
     }) + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/term-0.5.2.BUILD
+++ b/wasm_bindgen/raze/remote/term-0.5.2.BUILD
@@ -40,8 +40,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/termcolor-1.1.0.BUILD
+++ b/wasm_bindgen/raze/remote/termcolor-1.1.0.BUILD
@@ -38,8 +38,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi_util__0_1_5//:winapi_util",
         ],

--- a/wasm_bindgen/raze/remote/time-0.1.44.BUILD
+++ b/wasm_bindgen/raze/remote/time-0.1.44.BUILD
@@ -39,8 +39,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],

--- a/wasm_bindgen/raze/remote/winapi-0.3.9.BUILD
+++ b/wasm_bindgen/raze/remote/winapi-0.3.9.BUILD
@@ -36,23 +36,7 @@ rust_library(
     name = "winapi",
     crate_type = "lib",
     deps = [
-    ] + selects.with_or({
-        # i686-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-        ): [
-            "@rules_rust_wasm_bindgen__winapi_i686_pc_windows_gnu__0_4_0//:winapi_i686_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # x86_64-pc-windows-gnu
-        (
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
-        ): [
-            "@rules_rust_wasm_bindgen__winapi_x86_64_pc_windows_gnu__0_4_0//:winapi_x86_64_pc_windows_gnu",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2015",
@@ -97,6 +81,4 @@ rust_library(
         "ws2ipdef",
         "ws2tcpip",
     ],
-    aliases = {
-    },
 )

--- a/wasm_bindgen/raze/remote/winapi-util-0.1.5.BUILD
+++ b/wasm_bindgen/raze/remote/winapi-util-0.1.5.BUILD
@@ -38,8 +38,8 @@ rust_library(
     ] + selects.with_or({
         # cfg(windows)
         (
-            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-gnu",
-            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-gnu",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
             "@rules_rust_wasm_bindgen__winapi__0_3_9//:winapi",
         ],


### PR DESCRIPTION
`cargo-raze` now needs https://github.com/google/cargo-raze/pull/245