### PR TITLE
skip link step when running clippy

### DIFF
--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -93,6 +93,7 @@ def _clippy_aspect_impl(target, ctx):
         build_flags_files = build_flags_files,
         maker_path = clippy_marker.path,
         aspect = True,
+        emit = "dep-info,metadata",
     )
 
     # Deny the default-on clippy warning levels.

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -412,7 +412,8 @@ def construct_arguments(
         build_env_file,
         build_flags_files,
         maker_path = None,
-        aspect = False):
+        aspect = False,
+        emit = "dep-info,link"):
     """Builds an Args object containing common rustc flags
 
     Args:
@@ -431,6 +432,7 @@ def construct_arguments(
         build_flags_files (list): The output files of a `cargo_build_script` actions containing rustc build flags
         maker_path (File): An optional clippy marker file
         aspect (bool): True if called in an aspect context.
+        emit (str): a string to pass to --emit
 
     Returns:
         tuple: A tuple of the following items
@@ -512,7 +514,7 @@ def construct_arguments(
     args.add("--codegen=opt-level=" + compilation_mode.opt_level)
     args.add("--codegen=debuginfo=" + compilation_mode.debug_info)
 
-    args.add("--emit=dep-info,link")
+    args.add("--emit=" + emit)
     args.add("--color=always")
     args.add("--target=" + toolchain.target_triple)
     if hasattr(ctx.attr, "crate_features"):


### PR DESCRIPTION
I have a crate that uses pyo3 to create a Python extension module.
On macOS, special link flags are required:

    rustc_flags = selects.with_or({
        (
            "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
        ): [
            "-Clink-arg=-undefined",
            "-Clink-arg=dynamic_lookup",
        ],
        "//conditions:default": [],
    }),

Without them, the linker on macOS fails, as the Python API is not
available until runtime.

rules_rust's clippy implementation was passing --emit=dep-info,link
to the clippy invocation, causing a clippy run to fail with linking
errors. This patch changes the invocation to use
--emit=dep-info,metadata instead, which is what cargo uses. It also
shaves a bit of time off the check, as linking no longer needs to happen.

Tangentially related to #428 and #421 - currently the clippy aspect
seems to be falling back on a non-worker compile, so it's still
noticeably slower than running cargo clippy directly when minor
changes have been made.