### PR TITLE
Rename `bazel_version` repository to avoid conflict

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -7,7 +7,7 @@ bzl_library(
     name = "all_deps",
     srcs = [
         "@bazel_tools//tools:bzl_srcs",
-        "@bazel_version//:def.bzl",
+        "@io_bazel_rules_rust_bazel_version//:def.bzl",
     ],
     deps = [
         "@bazel_skylib//:workspace",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -20,7 +20,7 @@ load(
     "C_COMPILE_ACTION_NAME",
 )
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@bazel_version//:def.bzl", "BAZEL_VERSION")
+load("@io_bazel_rules_rust_bazel_version//:def.bzl", "BAZEL_VERSION")
 load("@io_bazel_rules_rust//rust:private/legacy_cc_starlark_api_shim.bzl", "get_libs_for_static_executable")
 load("@io_bazel_rules_rust//rust:private/utils.bzl", "get_lib_name", "relativize")
 

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -41,4 +41,4 @@ def rust_workspace():
 
     bazel_skylib_workspace()
 
-    bazel_version(name = "bazel_version")
+    bazel_version(name = "io_bazel_rules_rust_bazel_version")

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -41,4 +41,8 @@ def rust_workspace():
 
     bazel_skylib_workspace()
 
+    # Give this repository a scoped name to avoid conflicting with other
+    # projects' similar workarounds when used in the same workspace
+    # (issue #268#issuecomment-713920963). TODO(#462): Investigate
+    # whether this can be entirely replaced with `native.bazel_version`.
     bazel_version(name = "io_bazel_rules_rust_bazel_version")


### PR DESCRIPTION
We use a synthetic `bazel_version` repository to make the Bazel version
available in more contexts (see [bazelbuild/bazel#8305][i8305]). But
some other repositories do so, too, with the same repository name and a
different repository structure. In particular, it is not currently
possible to use `rules_rust` and certain versions of `upb` (downstream
of protobuf) in the same repository, due to their definition here:

https://github.com/protocolbuffers/upb/blob/c1357afb2e39df671d89eaec49033b5329f36a3e/bazel/repository_defs.bzl#L7-L10

An easy workaround is to disambiguate the name. It looks much easier to
change `rules_rust` than to change `upb` and update its long chain of
workspace dependencies, hence this patch. :-)

See my comment on #268 for more details and a full repro:
https://github.com/bazelbuild/rules_rust/issues/268#issuecomment-713920963

[i8305]: https://github.com/bazelbuild/bazel/issues/8305

Test Plan:
Tested by adding the README’s workspace stanza to TensorBoard (at
current master, 8d629954c251). It fails at `rules_rust = 5998baf9016e`,
but succeeds with a `local_repository` that has this patch. Also, in
this repo, `git grep @bazel_version` no longer has any matches.

wchargin-branch: disambiguate-bazel-version-repo
