### PR TITLE
Add version_file common attr

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -28,7 +28,7 @@
 
 <pre>
 rust_benchmark(<a href="#rust_benchmark-name">name</a>, <a href="#rust_benchmark-aliases">aliases</a>, <a href="#rust_benchmark-compile_data">compile_data</a>, <a href="#rust_benchmark-crate_features">crate_features</a>, <a href="#rust_benchmark-crate_root">crate_root</a>, <a href="#rust_benchmark-data">data</a>, <a href="#rust_benchmark-deps">deps</a>, <a href="#rust_benchmark-edition">edition</a>,
-               <a href="#rust_benchmark-out_dir_tar">out_dir_tar</a>, <a href="#rust_benchmark-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_benchmark-rustc_env">rustc_env</a>, <a href="#rust_benchmark-rustc_flags">rustc_flags</a>, <a href="#rust_benchmark-srcs">srcs</a>, <a href="#rust_benchmark-version">version</a>)
+               <a href="#rust_benchmark-out_dir_tar">out_dir_tar</a>, <a href="#rust_benchmark-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_benchmark-rustc_env">rustc_env</a>, <a href="#rust_benchmark-rustc_flags">rustc_flags</a>, <a href="#rust_benchmark-srcs">srcs</a>, <a href="#rust_benchmark-version">version</a>, <a href="#rust_benchmark-version_file">version_file</a>)
 </pre>
 
 Builds a Rust benchmark test.
@@ -125,7 +125,8 @@ Run the benchmark test using: `bazel run //fibonacci:fibonacci_bench`.
 | <a id="rust_benchmark-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="rust_benchmark-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_benchmark-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="rust_benchmark-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+| <a id="rust_benchmark-version"></a>version |  A version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | String | optional | "" |
+| <a id="rust_benchmark-version_file"></a>version_file |  A file containing a version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#rust_binary"></a>
@@ -135,7 +136,7 @@ Run the benchmark test using: `bazel run //fibonacci:fibonacci_bench`.
 <pre>
 rust_binary(<a href="#rust_binary-name">name</a>, <a href="#rust_binary-aliases">aliases</a>, <a href="#rust_binary-compile_data">compile_data</a>, <a href="#rust_binary-crate_features">crate_features</a>, <a href="#rust_binary-crate_root">crate_root</a>, <a href="#rust_binary-crate_type">crate_type</a>, <a href="#rust_binary-data">data</a>, <a href="#rust_binary-deps">deps</a>,
             <a href="#rust_binary-edition">edition</a>, <a href="#rust_binary-linker_script">linker_script</a>, <a href="#rust_binary-out_binary">out_binary</a>, <a href="#rust_binary-out_dir_tar">out_dir_tar</a>, <a href="#rust_binary-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_binary-rustc_env">rustc_env</a>, <a href="#rust_binary-rustc_flags">rustc_flags</a>,
-            <a href="#rust_binary-srcs">srcs</a>, <a href="#rust_binary-version">version</a>)
+            <a href="#rust_binary-srcs">srcs</a>, <a href="#rust_binary-version">version</a>, <a href="#rust_binary-version_file">version_file</a>)
 </pre>
 
 Builds a Rust binary crate.
@@ -243,7 +244,8 @@ Hello world
 | <a id="rust_binary-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="rust_binary-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_binary-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="rust_binary-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+| <a id="rust_binary-version"></a>version |  A version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | String | optional | "" |
+| <a id="rust_binary-version_file"></a>version_file |  A file containing a version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#rust_bindgen"></a>
@@ -454,7 +456,8 @@ rust_binary(
 
 <pre>
 rust_library(<a href="#rust_library-name">name</a>, <a href="#rust_library-aliases">aliases</a>, <a href="#rust_library-compile_data">compile_data</a>, <a href="#rust_library-crate_features">crate_features</a>, <a href="#rust_library-crate_root">crate_root</a>, <a href="#rust_library-crate_type">crate_type</a>, <a href="#rust_library-data">data</a>, <a href="#rust_library-deps">deps</a>,
-             <a href="#rust_library-edition">edition</a>, <a href="#rust_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_library-rustc_env">rustc_env</a>, <a href="#rust_library-rustc_flags">rustc_flags</a>, <a href="#rust_library-srcs">srcs</a>, <a href="#rust_library-version">version</a>)
+             <a href="#rust_library-edition">edition</a>, <a href="#rust_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_library-rustc_env">rustc_env</a>, <a href="#rust_library-rustc_flags">rustc_flags</a>, <a href="#rust_library-srcs">srcs</a>, <a href="#rust_library-version">version</a>,
+             <a href="#rust_library-version_file">version_file</a>)
 </pre>
 
 Builds a Rust library crate.
@@ -540,7 +543,8 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="rust_library-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+| <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | String | optional | "" |
+| <a id="rust_library-version_file"></a>version_file |  A file containing a version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#rust_proto_library"></a>
@@ -647,7 +651,7 @@ See @io_bazel_rules_rust//proto:BUILD for examples of defining the toolchain.
 
 <pre>
 rust_test(<a href="#rust_test-name">name</a>, <a href="#rust_test-aliases">aliases</a>, <a href="#rust_test-compile_data">compile_data</a>, <a href="#rust_test-crate">crate</a>, <a href="#rust_test-crate_features">crate_features</a>, <a href="#rust_test-crate_root">crate_root</a>, <a href="#rust_test-data">data</a>, <a href="#rust_test-deps">deps</a>, <a href="#rust_test-edition">edition</a>,
-          <a href="#rust_test-out_dir_tar">out_dir_tar</a>, <a href="#rust_test-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_test-rustc_env">rustc_env</a>, <a href="#rust_test-rustc_flags">rustc_flags</a>, <a href="#rust_test-srcs">srcs</a>, <a href="#rust_test-version">version</a>)
+          <a href="#rust_test-out_dir_tar">out_dir_tar</a>, <a href="#rust_test-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_test-rustc_env">rustc_env</a>, <a href="#rust_test-rustc_flags">rustc_flags</a>, <a href="#rust_test-srcs">srcs</a>, <a href="#rust_test-version">version</a>, <a href="#rust_test-version_file">version_file</a>)
 </pre>
 
 Builds a Rust test crate.
@@ -798,7 +802,8 @@ Run the test with `bazel build //hello_lib:hello_lib_test`.
 | <a id="rust_test-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="rust_test-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_test-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="rust_test-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+| <a id="rust_test-version"></a>version |  A version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | String | optional | "" |
+| <a id="rust_test-version_file"></a>version_file |  A file containing a version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#rust_toolchain"></a>

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -10,7 +10,7 @@
 
 <pre>
 rust_benchmark(<a href="#rust_benchmark-name">name</a>, <a href="#rust_benchmark-aliases">aliases</a>, <a href="#rust_benchmark-compile_data">compile_data</a>, <a href="#rust_benchmark-crate_features">crate_features</a>, <a href="#rust_benchmark-crate_root">crate_root</a>, <a href="#rust_benchmark-data">data</a>, <a href="#rust_benchmark-deps">deps</a>, <a href="#rust_benchmark-edition">edition</a>,
-               <a href="#rust_benchmark-out_dir_tar">out_dir_tar</a>, <a href="#rust_benchmark-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_benchmark-rustc_env">rustc_env</a>, <a href="#rust_benchmark-rustc_flags">rustc_flags</a>, <a href="#rust_benchmark-srcs">srcs</a>, <a href="#rust_benchmark-version">version</a>)
+               <a href="#rust_benchmark-out_dir_tar">out_dir_tar</a>, <a href="#rust_benchmark-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_benchmark-rustc_env">rustc_env</a>, <a href="#rust_benchmark-rustc_flags">rustc_flags</a>, <a href="#rust_benchmark-srcs">srcs</a>, <a href="#rust_benchmark-version">version</a>, <a href="#rust_benchmark-version_file">version_file</a>)
 </pre>
 
 Builds a Rust benchmark test.
@@ -107,7 +107,8 @@ Run the benchmark test using: `bazel run //fibonacci:fibonacci_bench`.
 | <a id="rust_benchmark-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="rust_benchmark-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_benchmark-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="rust_benchmark-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+| <a id="rust_benchmark-version"></a>version |  A version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | String | optional | "" |
+| <a id="rust_benchmark-version_file"></a>version_file |  A file containing a version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#rust_binary"></a>
@@ -117,7 +118,7 @@ Run the benchmark test using: `bazel run //fibonacci:fibonacci_bench`.
 <pre>
 rust_binary(<a href="#rust_binary-name">name</a>, <a href="#rust_binary-aliases">aliases</a>, <a href="#rust_binary-compile_data">compile_data</a>, <a href="#rust_binary-crate_features">crate_features</a>, <a href="#rust_binary-crate_root">crate_root</a>, <a href="#rust_binary-crate_type">crate_type</a>, <a href="#rust_binary-data">data</a>, <a href="#rust_binary-deps">deps</a>,
             <a href="#rust_binary-edition">edition</a>, <a href="#rust_binary-linker_script">linker_script</a>, <a href="#rust_binary-out_binary">out_binary</a>, <a href="#rust_binary-out_dir_tar">out_dir_tar</a>, <a href="#rust_binary-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_binary-rustc_env">rustc_env</a>, <a href="#rust_binary-rustc_flags">rustc_flags</a>,
-            <a href="#rust_binary-srcs">srcs</a>, <a href="#rust_binary-version">version</a>)
+            <a href="#rust_binary-srcs">srcs</a>, <a href="#rust_binary-version">version</a>, <a href="#rust_binary-version_file">version_file</a>)
 </pre>
 
 Builds a Rust binary crate.
@@ -225,7 +226,8 @@ Hello world
 | <a id="rust_binary-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="rust_binary-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_binary-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="rust_binary-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+| <a id="rust_binary-version"></a>version |  A version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | String | optional | "" |
+| <a id="rust_binary-version_file"></a>version_file |  A file containing a version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#rust_library"></a>
@@ -234,7 +236,8 @@ Hello world
 
 <pre>
 rust_library(<a href="#rust_library-name">name</a>, <a href="#rust_library-aliases">aliases</a>, <a href="#rust_library-compile_data">compile_data</a>, <a href="#rust_library-crate_features">crate_features</a>, <a href="#rust_library-crate_root">crate_root</a>, <a href="#rust_library-crate_type">crate_type</a>, <a href="#rust_library-data">data</a>, <a href="#rust_library-deps">deps</a>,
-             <a href="#rust_library-edition">edition</a>, <a href="#rust_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_library-rustc_env">rustc_env</a>, <a href="#rust_library-rustc_flags">rustc_flags</a>, <a href="#rust_library-srcs">srcs</a>, <a href="#rust_library-version">version</a>)
+             <a href="#rust_library-edition">edition</a>, <a href="#rust_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_library-rustc_env">rustc_env</a>, <a href="#rust_library-rustc_flags">rustc_flags</a>, <a href="#rust_library-srcs">srcs</a>, <a href="#rust_library-version">version</a>,
+             <a href="#rust_library-version_file">version_file</a>)
 </pre>
 
 Builds a Rust library crate.
@@ -320,7 +323,8 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="rust_library-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+| <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | String | optional | "" |
+| <a id="rust_library-version_file"></a>version_file |  A file containing a version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#rust_test"></a>
@@ -329,7 +333,7 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 
 <pre>
 rust_test(<a href="#rust_test-name">name</a>, <a href="#rust_test-aliases">aliases</a>, <a href="#rust_test-compile_data">compile_data</a>, <a href="#rust_test-crate">crate</a>, <a href="#rust_test-crate_features">crate_features</a>, <a href="#rust_test-crate_root">crate_root</a>, <a href="#rust_test-data">data</a>, <a href="#rust_test-deps">deps</a>, <a href="#rust_test-edition">edition</a>,
-          <a href="#rust_test-out_dir_tar">out_dir_tar</a>, <a href="#rust_test-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_test-rustc_env">rustc_env</a>, <a href="#rust_test-rustc_flags">rustc_flags</a>, <a href="#rust_test-srcs">srcs</a>, <a href="#rust_test-version">version</a>)
+          <a href="#rust_test-out_dir_tar">out_dir_tar</a>, <a href="#rust_test-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_test-rustc_env">rustc_env</a>, <a href="#rust_test-rustc_flags">rustc_flags</a>, <a href="#rust_test-srcs">srcs</a>, <a href="#rust_test-version">version</a>, <a href="#rust_test-version_file">version_file</a>)
 </pre>
 
 Builds a Rust test crate.
@@ -480,6 +484,7 @@ Run the test with `bazel build //hello_lib:hello_lib_test`.
 | <a id="rust_test-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="rust_test-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_test-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="rust_test-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+| <a id="rust_test-version"></a>version |  A version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | String | optional | "" |
+| <a id="rust_test-version_file"></a>version_file |  A file containing a version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/examples/hello_version/BUILD
+++ b/examples/hello_version/BUILD
@@ -1,0 +1,38 @@
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "hello_version",
+    srcs = ["src/main.rs"],
+    version = "0.1.2-alpha0",
+)
+
+rust_binary(
+    name = "hello_version_generated",
+    srcs = ["src/main.rs"],
+    version_file = ":generated-version",
+)
+
+genrule(
+    name = "generated-version",
+    outs = ["generated.version"],
+    cmd = "echo 0.1.2-alpha0 > $@",
+)
+
+sh_test(
+    name = "test",
+    srcs = ["test.sh"],
+    args = ["$(location :hello_version)"],
+    data = [":hello_version"],
+)
+
+sh_test(
+    name = "test-generated",
+    srcs = ["test.sh"],
+    args = ["$(location :hello_version_generated)"],
+    data = [":hello_version_generated"],
+)

--- a/examples/hello_version/src/main.rs
+++ b/examples/hello_version/src/main.rs
@@ -1,0 +1,7 @@
+fn main() {
+    println!("Version: {}", env!("CARGO_PKG_VERSION"));
+    println!("Major: {}", env!("CARGO_PKG_VERSION_MAJOR"));
+    println!("Minor: {}", env!("CARGO_PKG_VERSION_MINOR"));
+    println!("Patch: {}", env!("CARGO_PKG_VERSION_PATCH"));
+    println!("Pre: {}", env!("CARGO_PKG_VERSION_PRE"));
+}

--- a/examples/hello_version/test.sh
+++ b/examples/hello_version/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+if [[ $# -ne 1 ]]; then
+  echo >&2 "Usage: $0 binary-to-run"
+  exit 1
+fi
+
+want="Version: 0.1.2-alpha0
+Major: 0
+Minor: 1
+Patch: 2
+Pre: alpha0"
+
+got="$($1)"
+if [[ "${got}" != "${want}" ]]; then
+  echo >&2 "Wanted:
+${want}
+
+Got:
+${got}"
+  exit 1
+fi

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -66,7 +66,7 @@ def _clippy_aspect_impl(target, ctx):
         toolchain,
     )
 
-    compile_inputs, out_dir, build_env_file, build_flags_files = collect_inputs(
+    compile_inputs, out_dir, build_env_file, build_flags_files, version_file = collect_inputs(
         ctx,
         ctx.rule.file,
         ctx.rule.files,
@@ -87,6 +87,7 @@ def _clippy_aspect_impl(target, ctx):
         ctx.file,
         toolchain,
         toolchain.clippy_driver.path,
+        version_file.path,
         cc_toolchain,
         feature_configuration,
         crate_info,

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -453,8 +453,11 @@ _rust_common_attrs = {
         doc = "List of compiler flags passed to `rustc`.",
     ),
     "version": attr.string(
-        doc = "A version to inject in the cargo environment variable.",
-        default = "0.0.0",
+        doc = "A version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.",
+    ),
+    "version_file": attr.label(
+        doc = "A file containing a version to inject in the cargo environment variable. At most one of version and version_file may be set. If neither are set, defaults to 0.0.0.",
+        allow_single_file = True,
     ),
     "out_dir_tar": attr.label(
         doc = "__Deprecated__, do not use, see [#cargo_build_script] instead.",

--- a/util/process_wrapper/utils.cc
+++ b/util/process_wrapper/utils.cc
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <iostream>
 #include <streambuf>
+#include <sstream>
 
 #if defined(PW_WIN_UNICODE)
 #include <codecvt>
@@ -99,5 +100,43 @@ bool ReadFileToArray(const System::StrType& file_path,
   }
   return true;
 } 
+
+std::vector<System::StrType> SplitN(const System::StrType input, const System::StrType::value_type delimiter, const size_t n) {
+  size_t start = 0;
+  std::vector<System::StrType> parts;
+  if (n == 0) {
+    return parts;
+  }
+
+  size_t remaining = n;
+  while (--remaining >= 1) {
+    size_t end = input.find(delimiter, start);
+    if (end == std::string::npos) {
+      break;
+    } else {
+      parts.push_back(input.substr(start, end - start));
+      start = end + 1;
+      if (end == input.length()) {
+         break;
+      }
+    }
+  }
+  if (start <= input.length()) {
+    parts.push_back(input.substr(start, input.length() - start));
+  }
+  return parts;
+}
+
+System::StrType MakeEnv(const System::StrType name, const System::StrType value) {
+#if defined(PW_WIN_UNICODE)
+  std::wstringstream env;
+#else
+  std::stringstream env;
+#endif
+  env << name;
+  env << PW_SYS_STR('=');
+  env << value;
+  return env.str();
+}
 
 }  // namespace process_wrapper

--- a/util/process_wrapper/utils.h
+++ b/util/process_wrapper/utils.h
@@ -32,6 +32,13 @@ void ReplaceToken(System::StrType& str, const System::StrType& token,
 // Reads a file in text mode and feeds each line to item in the vec output
 bool ReadFileToArray(const System::StrType& file_path, System::StrVecType& vec);
 
+// Splits input into at most n substrings. If delimiter appears more than n-1 times, the remaining characters will be in the last element of the vector.
+// If n == 0, an empty vector will be returned.
+std::vector<System::StrType> SplitN(const System::StrType input, const System::StrType::value_type delimiter, const size_t n);
+
+// Makes a value suitable for adding to an environment variables vector.
+System::StrType MakeEnv(const System::StrType name, const System::StrType value);
+
 }  // namespace process_wrapper
 
 #endif  // LIB_PROCESS_WRAPPER_UTILS_H_


### PR DESCRIPTION
This allows folks to generate version files, e.g. using
volatile-status.txt, rather than requiring them to be hard-coded in
BUILD files.

Both ways are still supported, but only one can be used for any
particular target.

I don't love that this moves the version logic into process-wrapper, but the alternatives:
* Need the user to know the 5 different env vars to set in their version_file file
* Write a standalone tool to convert a version_file into a file with the 5 env vars
both seemed worse.