### PR TITLE
Remove incorrect paren in bingen repositories

### DIFF
--- a/bindgen/repositories.bzl
+++ b/bindgen/repositories.bzl
@@ -38,7 +38,7 @@ workspace(name = "{}")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive()
+http_archive(
     name = "rules_cc",
     url = "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.zip",
     sha256 = "8c7e8bf24a2bf515713445199a677ee2336e1c487fa1da41037c6026de04bbc3",


### PR DESCRIPTION
I was trying to setup some testing on various versions of bazel when I
kept running into this issue that causes bazel query to error out.
However, the error handling is specifc to earlier 3.X series versions of
bazel.  Prior to this patch, this causes and error:
```
bazel-3.4.0 query -- //... - @examples//...
```
however, this does not error out:
```
bazel-3.5.0 query -- //... - @examples//...
```
which is why rules_rust tests are probably still passing.

This removes the unintentional paren, which removes the issue in all 3.X
cases that I tested.