### PR TITLE
use target platform for CARGO_CFG_TARGET_*

### DIFF
--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -154,6 +154,10 @@ fn get_target_env_vars<P: AsRef<Path>>(rustc: &P) -> Result<BTreeMap<String, Str
     // As done by Cargo when constructing a cargo::core::compiler::build_context::target_info::TargetInfo.
     let output = Command::new(rustc.as_ref())
         .arg("--print=cfg")
+        .arg(format!(
+            "--target={}",
+            env::var("TARGET").expect("missing TARGET")
+        ))
         .output()
         .map_err(|err| format!("Error running rustc to get target information: {}", err))?;
     if !output.status.success() {


### PR DESCRIPTION
build_script_runner was gathering details based on the host platform
instead of the target platform. This was causing a cross-compile of the
ring crate to fail to link, as it was making build-time decisions based
on the host OS instead of the target one.