### PR TITLE
Allow usage of $(location ...) in rustc_env as well, to include_str!() generated files.

### DIFF
--- a/examples/env_locations/BUILD
+++ b/examples/env_locations/BUILD
@@ -42,7 +42,8 @@ rust_test(
     edition = "2018",
     rustc_env = {
         "SOURCE_FILE": "$(rootpath source.file)",
-        "GENERATED_DATA": "$(rootpath generated.data)",
+        "GENERATED_DATA_ROOT": "$(rootpath generated.data)",
+        "GENERATED_DATA_ABS": "$(execpath generated.data)",
         "SOME_TOOL": "$(rootpath @com_google_protobuf//:protoc)",
     },
     deps = [

--- a/examples/env_locations/main.rs
+++ b/examples/env_locations/main.rs
@@ -3,9 +3,10 @@ fn test() {
     // our source file should be readable
     let source_file = std::fs::read_to_string(env!("SOURCE_FILE")).unwrap();
     assert_eq!(source_file, "source\n");
-    // our generated data file should be readable
+    // our generated data file should be readable at run time and build time
     let generated_data = std::fs::read_to_string(env!("GENERATED_DATA")).unwrap();
-    assert_eq!(generated_data, "hello\n");
+    let generated_data2 = include_str!(env!("GENERATED_DATA"));
+    assert_eq!(generated_data, generated_data2);
     // and we should be able to read (and thus execute) our tool
     assert_eq!(std::fs::read(env!("SOME_TOOL")).unwrap().is_empty(), false);
 }

--- a/examples/env_locations/main.rs
+++ b/examples/env_locations/main.rs
@@ -4,8 +4,8 @@ fn test() {
     let source_file = std::fs::read_to_string(env!("SOURCE_FILE")).unwrap();
     assert_eq!(source_file, "source\n");
     // our generated data file should be readable at run time and build time
-    let generated_data = std::fs::read_to_string(env!("GENERATED_DATA")).unwrap();
-    let generated_data2 = include_str!(env!("GENERATED_DATA"));
+    let generated_data = std::fs::read_to_string(env!("GENERATED_DATA_ROOT")).unwrap();
+    let generated_data2 = include_str!(env!("GENERATED_DATA_ABS"));
     assert_eq!(generated_data, generated_data2);
     // and we should be able to read (and thus execute) our tool
     assert_eq!(std::fs::read(env!("SOME_TOOL")).unwrap().is_empty(), false);

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -20,6 +20,7 @@ load(
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
     "@io_bazel_rules_rust//rust:private/utils.bzl",
+    "expand_locations",
     "get_lib_name",
     "get_libs_for_static_executable",
     "relativize",
@@ -293,24 +294,6 @@ def get_linker_and_args(ctx, cc_toolchain, feature_configuration, rpaths):
 
     return ld, link_args, link_env
 
-def _expand_locations(ctx, env, data):
-    """Performs location-macro expansion on string values.
-
-    Note: Only `$(rootpath ...)` is recommended  as `$(execpath ...)` will fail
-    in the case of generated sources.
-
-    Args:
-        ctx (ctx): The rule's context object
-        env (str): The value possibly containing location macros to expand.
-        data (sequence of Targets): The targets which may be referenced by
-            location macros. This is expected to be the `data` attribute of
-            the target, though may have other targets or attributes mixed in.
-
-    Returns:
-        dict: A dict of environment variables with expanded location macros
-    """
-    return dict([(k, ctx.expand_location(v, data)) for (k, v) in env.items()])
-
 def _process_build_scripts(
         ctx,
         file,
@@ -545,7 +528,7 @@ def construct_arguments(
                 env["CARGO_BIN_EXE_" + dep_crate_info.output.basename] = dep_crate_info.output.short_path
 
     # Update environment with user provided variables.
-    env.update(_expand_locations(
+    env.update(expand_locations(
         ctx,
         crate_info.rustc_env,
         getattr(rule_attrs(ctx, aspect), "data", []),


### PR DESCRIPTION
The ${pwd} resolution in build_script_env is necessary during the compilation stage as well, as otherwise we can't use things like include_str!() on generated files. Starting with a test that demonstrates the issue; will follow up with a fix.