### PR TITLE
Fix root detection in clippy for bin crates

### DIFF
--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -51,10 +51,7 @@ def _clippy_aspect_impl(target, ctx):
 
     toolchain = find_toolchain(ctx)
     crate_info = target[CrateInfo]
-    if crate_info.type == 'bin':
-        root = crate_root_src(ctx.rule.attr, srcs = rust_srcs, file_name = "main.rs")
-    else:
-        root = crate_root_src(ctx.rule.attr, srcs = rust_srcs)
+    root = crate_root_src(ctx.rule.attr, rust_srcs, crate_info.type)
 
     dep_info, build_info = collect_deps(
         ctx.label,

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -50,8 +50,11 @@ def _clippy_aspect_impl(target, ctx):
         return []
 
     toolchain = find_toolchain(ctx)
-    root = crate_root_src(ctx.rule.attr, srcs = rust_srcs)
     crate_info = target[CrateInfo]
+    if crate_info.type == 'bin':
+        root = crate_root_src(ctx.rule.attr, srcs = rust_srcs, file_name = "main.rs")
+    else:
+        root = crate_root_src(ctx.rule.attr, srcs = rust_srcs)
 
     dep_info, build_info = collect_deps(
         ctx.label,


### PR DESCRIPTION
Prior to this PR, bin crates with more than one file in srcs would fail with this error:
```
$ bazel build --aspects=@io_bazel_rules_rust//rust:rust.bzl%rust_clippy_aspect --output_groups=clippy_checks //...
INFO: Invocation ID: c3647be4-e5fe-4f90-a1a4-c9a84c17c45c
ERROR: /home/user/repo/BUILD:5:12: in @io_bazel_rules_rust//rust:private/clippy.bzl%rust_clippy_aspect aspect on rust_binary rule //foo:bar:
Traceback (most recent call last):
        File ".../io_bazel_rules_rust/rust/private/clippy.bzl", line 53, column 26, in _clippy_aspect_impl
                root = crate_root_src(ctx.rule.attr, srcs = rust_srcs)
        File ".../io_bazel_rules_rust/rust/private/rust.bzl", line 115, column 13, in crate_root_src
                fail("No {} source file found.".format(" or ".join(file_names)), "srcs")
Error in fail: attribute srcs: No lib.rs or bar.rs source file found.
ERROR: Analysis of aspect '@io_bazel_rules_rust//rust:rust.bzl%rust_clippy_aspect of //foo:bar' failed; build aborted: Analysis of target '//foo:bar' failed
```