### PR TITLE
Skip linking for clippy aspect for faster builds

### DIFF
--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -93,6 +93,7 @@ def _clippy_aspect_impl(target, ctx):
         build_flags_files = build_flags_files,
         maker_path = clippy_marker.path,
         aspect = True,
+        emit = ["dep-info", "metadata"],
     )
 
     # Deny the default-on clippy warning levels.


### PR DESCRIPTION
Skipping linking for clippy can dramatically accelerate results. Local testing in my repo shows a speedup anywhere from 30-70% with real time going from ~12-15s -> 4-8s for leaf targets. Larger targets will generally reap greater results from skipping linking.