### PR TITLE
fail build on any warnings when running clippy

### DIFF
--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -46,6 +46,7 @@ def rust_bindgen_library(
     rust_library(
         name = name,
         srcs = [name + "__bindgen.rs"],
+        tags = ["__bindgen"],
         deps = [cc_lib],
         **kwargs
     )

--- a/examples/hello_lib/tests/greeting.rs
+++ b/examples/hello_lib/tests/greeting.rs
@@ -14,6 +14,10 @@
 
 extern crate hello_lib;
 
+// test gate is not usually required in an integration test, but the BUILD
+// script is using this file to test cdylib compilation as well, and when
+// compiled in that mode, greeter is an unused import.
+#[cfg(test)]
 use hello_lib::greeter;
 
 #[test]

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -96,15 +96,22 @@ def _clippy_aspect_impl(target, ctx):
         emit = ["dep-info", "metadata"],
     )
 
-    # Deny the default-on clippy warning levels.
-    #
-    # If these are left as warnings, then Bazel will consider the execution
-    # result of the aspect to be "success", and Clippy won't be re-triggered
-    # unless the source file is modified.
-    args.add("-Dclippy::style")
-    args.add("-Dclippy::correctness")
-    args.add("-Dclippy::complexity")
-    args.add("-Dclippy::perf")
+    # Turn any warnings from clippy or rustc into an error, as otherwise
+    # Bazel will consider the execution result of the aspect to be "success",
+    # and Clippy won't be re-triggered unless the source file is modified.
+    if "__bindgen" in ctx.rule.attr.tags:
+        # bindgen-generated content is likely to trigger warnings, so
+        # only fail on clippy warnings
+        args.add("-Dclippy::style")
+        args.add("-Dclippy::correctness")
+        args.add("-Dclippy::complexity")
+        args.add("-Dclippy::perf")
+    else:
+        # fail on any warning
+        args.add("-Dwarnings")
+
+    if crate_info.is_test:
+        args.add("--test")
 
     ctx.actions.run(
         executable = ctx.executable._process_wrapper,


### PR DESCRIPTION
This is exactly https://github.com/bazelbuild/rules_rust/pull/456, but up-to-date with the base branch