### PR TITLE
Perform - to _ replacement in test output names

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -1,6 +1,7 @@
 # buildifier: disable=module-docstring
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@io_bazel_rules_rust//rust:private/rust.bzl", "name_to_crate_name")
 load("@io_bazel_rules_rust//rust:private/rustc.bzl", "BuildInfo", "DepInfo", "get_cc_toolchain", "get_compilation_mode_opts", "get_linker_and_args")
 load("@io_bazel_rules_rust//rust:private/utils.bzl", "expand_locations", "find_toolchain")
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
@@ -107,7 +108,7 @@ def _build_script_impl(ctx):
             env["AR"] = ar_executable
 
     for f in ctx.attr.crate_features:
-        env["CARGO_FEATURE_" + f.upper().replace("-", "_")] = "1"
+        env["CARGO_FEATURE_" + name_to_crate_name(f).upper()] = "1"
 
     env.update(expand_locations(
         ctx,

--- a/examples/hello_lib/BUILD
+++ b/examples/hello_lib/BUILD
@@ -66,7 +66,7 @@ rust_library(
 )
 
 rust_test(
-    name = "hello_lib_test",
+    name = "hello-lib-test",
     crate = ":hello_lib",
 )
 

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -14,9 +14,11 @@
 
 """Toolchain for compiling rust stubs from protobuf and gRPC."""
 
+load("@io_bazel_rules_rust//rust:private/rust.bzl", "name_to_crate_name")
+
 def generated_file_stem(f):
     basename = f.rsplit("/", 2)[-1]
-    basename = basename.replace("-", "_")
+    basename = name_to_crate_name(basename)
     return basename.rsplit(".", 2)[0]
 
 def rust_generate_proto(


### PR DESCRIPTION
Right now if you have a rust_test/benchmark which has -s in the name,
you get an error that the output file wasn't created by the action.

This renames a `rust_test` in examples to hit the bug, and then fixes it.