### PR TITLE
Updated minimum supported version from 3.0.0 to 3.4.0

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -20,7 +20,7 @@ tasks:
       - "//test/versioned_dylib:versioned_dylib_test"
   ubuntu2004:
     name: "Minimum Supported Version"
-    bazel: "3.0.0"
+    bazel: "3.4.0"
     build_targets: *default_linux_targets
     test_targets: *default_linux_targets
   macos:


### PR DESCRIPTION
This unblocks https://github.com/bazelbuild/rules_rust/pull/519 since it introduces the use of `incompatible_use_toolchain_transition` which was only added in `3.4.0` (https://github.com/bazelbuild/bazel/commit/099cf2f9c57936617e912cff73399bbf65f14e64)

Also, version bumps should be their own commits so they're more discoverable IMO.