### PR TITLE
Fix rust_benchmark rule

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -68,6 +68,7 @@ tasks:
       - "-@examples//ffi/rust_calling_c/simple/..."
       - "-@examples//hello_sys/..."
       - "-@examples//complex_sys/..."
+      - "-@examples//criterion_bench/..."
       - "-@examples//proto/..."
       - "-@examples//wasm/..."
     build_targets: *windows_targets

--- a/examples/criterion_bench/BUILD
+++ b/examples/criterion_bench/BUILD
@@ -1,0 +1,26 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_benchmark")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_benchmark(
+    name = "criterion_bench",
+    srcs = ["benches/fibonacci.rs"],
+    edition = "2018",
+    deps = [
+        "//criterion_bench/raze:criterion",
+    ],
+)

--- a/examples/criterion_bench/Cargo.toml
+++ b/examples/criterion_bench/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rules_rust_examples_criterion_bench"
+version = "0.0.1"
+edition = "2018"
+
+[dev-dependencies]
+criterion = "=0.3.3"
+
+[lib]
+name = "dummy"
+path = "dummy.rs"
+
+[package.metadata.raze]
+workspace_path = "//criterion_bench/raze"
+genmode = "Remote"
+gen_workspace_prefix = "rules_rust_examples_criterion_bench"
+default_gen_buildrs = true
+
+[package.metadata.raze.crates.bstr.'*']
+data_attr = "glob([\"src/**\"])"
+
+[package.metadata.raze.crates.criterion.'*']
+data_attr = "glob([\"src/**\"])"

--- a/examples/criterion_bench/benches/fibonacci.rs
+++ b/examples/criterion_bench/benches/fibonacci.rs
@@ -1,0 +1,19 @@
+// extern crate criterion;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn fibonacci(n: u64) -> u64 {
+    match n {
+        0 => 1,
+        1 => 1,
+        n => fibonacci(n-1) + fibonacci(n-2),
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("fib 20", |b| b.iter(|| fibonacci(black_box(20))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);
+

--- a/examples/criterion_bench/raze/BUILD.bazel
+++ b/examples/criterion_bench/raze/BUILD.bazel
@@ -1,0 +1,22 @@
+"""
+@generated
+cargo-raze generated Bazel file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+licenses([
+    "notice",  # See individual crates for specific licenses
+])
+
+# Aliased targets
+alias(
+    name = "criterion",
+    actual = "@rules_rust_examples_criterion_bench__criterion__0_3_3//:criterion",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)

--- a/examples/criterion_bench/raze/crates.bzl
+++ b/examples/criterion_bench/raze/crates.bzl
@@ -1,0 +1,682 @@
+"""
+@generated
+cargo-raze generated Bazel file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")  # buildifier: disable=load
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")  # buildifier: disable=load
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")  # buildifier: disable=load
+
+def rules_rust_examples_criterion_bench_fetch_remote_crates():
+    """This function defines a collection of repos and should be called in a WORKSPACE file"""
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__atty__0_2_14",
+        url = "https://crates.io/api/v1/crates/atty/0.2.14/download",
+        type = "tar.gz",
+        sha256 = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
+        strip_prefix = "atty-0.2.14",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.atty-0.2.14.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__autocfg__1_0_1",
+        url = "https://crates.io/api/v1/crates/autocfg/1.0.1/download",
+        type = "tar.gz",
+        sha256 = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a",
+        strip_prefix = "autocfg-1.0.1",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.autocfg-1.0.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__bitflags__1_2_1",
+        url = "https://crates.io/api/v1/crates/bitflags/1.2.1/download",
+        type = "tar.gz",
+        sha256 = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693",
+        strip_prefix = "bitflags-1.2.1",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.bitflags-1.2.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__bstr__0_2_14",
+        url = "https://crates.io/api/v1/crates/bstr/0.2.14/download",
+        type = "tar.gz",
+        sha256 = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf",
+        strip_prefix = "bstr-0.2.14",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.bstr-0.2.14.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__bumpalo__3_4_0",
+        url = "https://crates.io/api/v1/crates/bumpalo/3.4.0/download",
+        type = "tar.gz",
+        sha256 = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820",
+        strip_prefix = "bumpalo-3.4.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.bumpalo-3.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__byteorder__1_3_4",
+        url = "https://crates.io/api/v1/crates/byteorder/1.3.4/download",
+        type = "tar.gz",
+        sha256 = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de",
+        strip_prefix = "byteorder-1.3.4",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.byteorder-1.3.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__cast__0_2_3",
+        url = "https://crates.io/api/v1/crates/cast/0.2.3/download",
+        type = "tar.gz",
+        sha256 = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0",
+        strip_prefix = "cast-0.2.3",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.cast-0.2.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__cfg_if__0_1_10",
+        url = "https://crates.io/api/v1/crates/cfg-if/0.1.10/download",
+        type = "tar.gz",
+        sha256 = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
+        strip_prefix = "cfg-if-0.1.10",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.cfg-if-0.1.10.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__cfg_if__1_0_0",
+        url = "https://crates.io/api/v1/crates/cfg-if/1.0.0/download",
+        type = "tar.gz",
+        sha256 = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+        strip_prefix = "cfg-if-1.0.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.cfg-if-1.0.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__clap__2_33_3",
+        url = "https://crates.io/api/v1/crates/clap/2.33.3/download",
+        type = "tar.gz",
+        sha256 = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002",
+        strip_prefix = "clap-2.33.3",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.clap-2.33.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__const_fn__0_4_4",
+        url = "https://crates.io/api/v1/crates/const_fn/0.4.4/download",
+        type = "tar.gz",
+        sha256 = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826",
+        strip_prefix = "const_fn-0.4.4",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.const_fn-0.4.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__criterion__0_3_3",
+        url = "https://crates.io/api/v1/crates/criterion/0.3.3/download",
+        type = "tar.gz",
+        sha256 = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8",
+        strip_prefix = "criterion-0.3.3",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.criterion-0.3.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__criterion_plot__0_4_3",
+        url = "https://crates.io/api/v1/crates/criterion-plot/0.4.3/download",
+        type = "tar.gz",
+        sha256 = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d",
+        strip_prefix = "criterion-plot-0.4.3",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.criterion-plot-0.4.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__crossbeam_channel__0_5_0",
+        url = "https://crates.io/api/v1/crates/crossbeam-channel/0.5.0/download",
+        type = "tar.gz",
+        sha256 = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775",
+        strip_prefix = "crossbeam-channel-0.5.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.crossbeam-channel-0.5.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__crossbeam_deque__0_8_0",
+        url = "https://crates.io/api/v1/crates/crossbeam-deque/0.8.0/download",
+        type = "tar.gz",
+        sha256 = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9",
+        strip_prefix = "crossbeam-deque-0.8.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.crossbeam-deque-0.8.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__crossbeam_epoch__0_9_1",
+        url = "https://crates.io/api/v1/crates/crossbeam-epoch/0.9.1/download",
+        type = "tar.gz",
+        sha256 = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d",
+        strip_prefix = "crossbeam-epoch-0.9.1",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.crossbeam-epoch-0.9.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__crossbeam_utils__0_8_1",
+        url = "https://crates.io/api/v1/crates/crossbeam-utils/0.8.1/download",
+        type = "tar.gz",
+        sha256 = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d",
+        strip_prefix = "crossbeam-utils-0.8.1",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.crossbeam-utils-0.8.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__csv__1_1_5",
+        url = "https://crates.io/api/v1/crates/csv/1.1.5/download",
+        type = "tar.gz",
+        sha256 = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97",
+        strip_prefix = "csv-1.1.5",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.csv-1.1.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__csv_core__0_1_10",
+        url = "https://crates.io/api/v1/crates/csv-core/0.1.10/download",
+        type = "tar.gz",
+        sha256 = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90",
+        strip_prefix = "csv-core-0.1.10",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.csv-core-0.1.10.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__either__1_6_1",
+        url = "https://crates.io/api/v1/crates/either/1.6.1/download",
+        type = "tar.gz",
+        sha256 = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457",
+        strip_prefix = "either-1.6.1",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.either-1.6.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__half__1_6_0",
+        url = "https://crates.io/api/v1/crates/half/1.6.0/download",
+        type = "tar.gz",
+        sha256 = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177",
+        strip_prefix = "half-1.6.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.half-1.6.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__hermit_abi__0_1_17",
+        url = "https://crates.io/api/v1/crates/hermit-abi/0.1.17/download",
+        type = "tar.gz",
+        sha256 = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8",
+        strip_prefix = "hermit-abi-0.1.17",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.hermit-abi-0.1.17.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__itertools__0_9_0",
+        url = "https://crates.io/api/v1/crates/itertools/0.9.0/download",
+        type = "tar.gz",
+        sha256 = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b",
+        strip_prefix = "itertools-0.9.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.itertools-0.9.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__itoa__0_4_6",
+        url = "https://crates.io/api/v1/crates/itoa/0.4.6/download",
+        type = "tar.gz",
+        sha256 = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6",
+        strip_prefix = "itoa-0.4.6",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.itoa-0.4.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__js_sys__0_3_46",
+        url = "https://crates.io/api/v1/crates/js-sys/0.3.46/download",
+        type = "tar.gz",
+        sha256 = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175",
+        strip_prefix = "js-sys-0.3.46",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.js-sys-0.3.46.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__lazy_static__1_4_0",
+        url = "https://crates.io/api/v1/crates/lazy_static/1.4.0/download",
+        type = "tar.gz",
+        sha256 = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+        strip_prefix = "lazy_static-1.4.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.lazy_static-1.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__libc__0_2_81",
+        url = "https://crates.io/api/v1/crates/libc/0.2.81/download",
+        type = "tar.gz",
+        sha256 = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb",
+        strip_prefix = "libc-0.2.81",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.libc-0.2.81.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__log__0_4_11",
+        url = "https://crates.io/api/v1/crates/log/0.4.11/download",
+        type = "tar.gz",
+        sha256 = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b",
+        strip_prefix = "log-0.4.11",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.log-0.4.11.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__memchr__2_3_4",
+        url = "https://crates.io/api/v1/crates/memchr/2.3.4/download",
+        type = "tar.gz",
+        sha256 = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525",
+        strip_prefix = "memchr-2.3.4",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.memchr-2.3.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__memoffset__0_6_1",
+        url = "https://crates.io/api/v1/crates/memoffset/0.6.1/download",
+        type = "tar.gz",
+        sha256 = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87",
+        strip_prefix = "memoffset-0.6.1",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.memoffset-0.6.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__num_traits__0_2_14",
+        url = "https://crates.io/api/v1/crates/num-traits/0.2.14/download",
+        type = "tar.gz",
+        sha256 = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290",
+        strip_prefix = "num-traits-0.2.14",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.num-traits-0.2.14.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__num_cpus__1_13_0",
+        url = "https://crates.io/api/v1/crates/num_cpus/1.13.0/download",
+        type = "tar.gz",
+        sha256 = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3",
+        strip_prefix = "num_cpus-1.13.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.num_cpus-1.13.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__oorandom__11_1_3",
+        url = "https://crates.io/api/v1/crates/oorandom/11.1.3/download",
+        type = "tar.gz",
+        sha256 = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575",
+        strip_prefix = "oorandom-11.1.3",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.oorandom-11.1.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__plotters__0_2_15",
+        url = "https://crates.io/api/v1/crates/plotters/0.2.15/download",
+        type = "tar.gz",
+        sha256 = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb",
+        strip_prefix = "plotters-0.2.15",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.plotters-0.2.15.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__proc_macro2__1_0_24",
+        url = "https://crates.io/api/v1/crates/proc-macro2/1.0.24/download",
+        type = "tar.gz",
+        sha256 = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71",
+        strip_prefix = "proc-macro2-1.0.24",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.proc-macro2-1.0.24.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__quote__1_0_7",
+        url = "https://crates.io/api/v1/crates/quote/1.0.7/download",
+        type = "tar.gz",
+        sha256 = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37",
+        strip_prefix = "quote-1.0.7",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.quote-1.0.7.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__rayon__1_5_0",
+        url = "https://crates.io/api/v1/crates/rayon/1.5.0/download",
+        type = "tar.gz",
+        sha256 = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674",
+        strip_prefix = "rayon-1.5.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.rayon-1.5.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__rayon_core__1_9_0",
+        url = "https://crates.io/api/v1/crates/rayon-core/1.9.0/download",
+        type = "tar.gz",
+        sha256 = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a",
+        strip_prefix = "rayon-core-1.9.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.rayon-core-1.9.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__regex__1_4_2",
+        url = "https://crates.io/api/v1/crates/regex/1.4.2/download",
+        type = "tar.gz",
+        sha256 = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c",
+        strip_prefix = "regex-1.4.2",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.regex-1.4.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__regex_automata__0_1_9",
+        url = "https://crates.io/api/v1/crates/regex-automata/0.1.9/download",
+        type = "tar.gz",
+        sha256 = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4",
+        strip_prefix = "regex-automata-0.1.9",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.regex-automata-0.1.9.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__regex_syntax__0_6_21",
+        url = "https://crates.io/api/v1/crates/regex-syntax/0.6.21/download",
+        type = "tar.gz",
+        sha256 = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189",
+        strip_prefix = "regex-syntax-0.6.21",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.regex-syntax-0.6.21.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__rustc_version__0_2_3",
+        url = "https://crates.io/api/v1/crates/rustc_version/0.2.3/download",
+        type = "tar.gz",
+        sha256 = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a",
+        strip_prefix = "rustc_version-0.2.3",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.rustc_version-0.2.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__ryu__1_0_5",
+        url = "https://crates.io/api/v1/crates/ryu/1.0.5/download",
+        type = "tar.gz",
+        sha256 = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e",
+        strip_prefix = "ryu-1.0.5",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.ryu-1.0.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__same_file__1_0_6",
+        url = "https://crates.io/api/v1/crates/same-file/1.0.6/download",
+        type = "tar.gz",
+        sha256 = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+        strip_prefix = "same-file-1.0.6",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.same-file-1.0.6.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__scopeguard__1_1_0",
+        url = "https://crates.io/api/v1/crates/scopeguard/1.1.0/download",
+        type = "tar.gz",
+        sha256 = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+        strip_prefix = "scopeguard-1.1.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.scopeguard-1.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__semver__0_9_0",
+        url = "https://crates.io/api/v1/crates/semver/0.9.0/download",
+        type = "tar.gz",
+        sha256 = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403",
+        strip_prefix = "semver-0.9.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.semver-0.9.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__semver_parser__0_7_0",
+        url = "https://crates.io/api/v1/crates/semver-parser/0.7.0/download",
+        type = "tar.gz",
+        sha256 = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3",
+        strip_prefix = "semver-parser-0.7.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.semver-parser-0.7.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__serde__1_0_118",
+        url = "https://crates.io/api/v1/crates/serde/1.0.118/download",
+        type = "tar.gz",
+        sha256 = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800",
+        strip_prefix = "serde-1.0.118",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.serde-1.0.118.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__serde_cbor__0_11_1",
+        url = "https://crates.io/api/v1/crates/serde_cbor/0.11.1/download",
+        type = "tar.gz",
+        sha256 = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622",
+        strip_prefix = "serde_cbor-0.11.1",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.serde_cbor-0.11.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__serde_derive__1_0_118",
+        url = "https://crates.io/api/v1/crates/serde_derive/1.0.118/download",
+        type = "tar.gz",
+        sha256 = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df",
+        strip_prefix = "serde_derive-1.0.118",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.serde_derive-1.0.118.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__serde_json__1_0_60",
+        url = "https://crates.io/api/v1/crates/serde_json/1.0.60/download",
+        type = "tar.gz",
+        sha256 = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779",
+        strip_prefix = "serde_json-1.0.60",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.serde_json-1.0.60.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__syn__1_0_54",
+        url = "https://crates.io/api/v1/crates/syn/1.0.54/download",
+        type = "tar.gz",
+        sha256 = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44",
+        strip_prefix = "syn-1.0.54",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.syn-1.0.54.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__textwrap__0_11_0",
+        url = "https://crates.io/api/v1/crates/textwrap/0.11.0/download",
+        type = "tar.gz",
+        sha256 = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060",
+        strip_prefix = "textwrap-0.11.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.textwrap-0.11.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__tinytemplate__1_1_0",
+        url = "https://crates.io/api/v1/crates/tinytemplate/1.1.0/download",
+        type = "tar.gz",
+        sha256 = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f",
+        strip_prefix = "tinytemplate-1.1.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.tinytemplate-1.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__unicode_width__0_1_8",
+        url = "https://crates.io/api/v1/crates/unicode-width/0.1.8/download",
+        type = "tar.gz",
+        sha256 = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3",
+        strip_prefix = "unicode-width-0.1.8",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.unicode-width-0.1.8.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__unicode_xid__0_2_1",
+        url = "https://crates.io/api/v1/crates/unicode-xid/0.2.1/download",
+        type = "tar.gz",
+        sha256 = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564",
+        strip_prefix = "unicode-xid-0.2.1",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.unicode-xid-0.2.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__walkdir__2_3_1",
+        url = "https://crates.io/api/v1/crates/walkdir/2.3.1/download",
+        type = "tar.gz",
+        sha256 = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d",
+        strip_prefix = "walkdir-2.3.1",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.walkdir-2.3.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__wasm_bindgen__0_2_69",
+        url = "https://crates.io/api/v1/crates/wasm-bindgen/0.2.69/download",
+        type = "tar.gz",
+        sha256 = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e",
+        strip_prefix = "wasm-bindgen-0.2.69",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.wasm-bindgen-0.2.69.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__wasm_bindgen_backend__0_2_69",
+        url = "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.69/download",
+        type = "tar.gz",
+        sha256 = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62",
+        strip_prefix = "wasm-bindgen-backend-0.2.69",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.wasm-bindgen-backend-0.2.69.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__wasm_bindgen_macro__0_2_69",
+        url = "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.69/download",
+        type = "tar.gz",
+        sha256 = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084",
+        strip_prefix = "wasm-bindgen-macro-0.2.69",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.wasm-bindgen-macro-0.2.69.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__wasm_bindgen_macro_support__0_2_69",
+        url = "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.69/download",
+        type = "tar.gz",
+        sha256 = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549",
+        strip_prefix = "wasm-bindgen-macro-support-0.2.69",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.wasm-bindgen-macro-support-0.2.69.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__wasm_bindgen_shared__0_2_69",
+        url = "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.69/download",
+        type = "tar.gz",
+        sha256 = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158",
+        strip_prefix = "wasm-bindgen-shared-0.2.69",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.wasm-bindgen-shared-0.2.69.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__web_sys__0_3_46",
+        url = "https://crates.io/api/v1/crates/web-sys/0.3.46/download",
+        type = "tar.gz",
+        sha256 = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3",
+        strip_prefix = "web-sys-0.3.46",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.web-sys-0.3.46.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__winapi__0_3_9",
+        url = "https://crates.io/api/v1/crates/winapi/0.3.9/download",
+        type = "tar.gz",
+        sha256 = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+        strip_prefix = "winapi-0.3.9",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.winapi-0.3.9.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__winapi_i686_pc_windows_gnu__0_4_0",
+        url = "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download",
+        type = "tar.gz",
+        sha256 = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        strip_prefix = "winapi-i686-pc-windows-gnu-0.4.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__winapi_util__0_1_5",
+        url = "https://crates.io/api/v1/crates/winapi-util/0.1.5/download",
+        type = "tar.gz",
+        sha256 = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+        strip_prefix = "winapi-util-0.1.5",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.winapi-util-0.1.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_examples_criterion_bench__winapi_x86_64_pc_windows_gnu__0_4_0",
+        url = "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download",
+        type = "tar.gz",
+        sha256 = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",
+        build_file = Label("//criterion_bench/raze/remote:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"),
+    )

--- a/examples/criterion_bench/raze/remote/BUILD.atty-0.2.14.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.atty-0.2.14.bazel
@@ -1,0 +1,87 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "atty" with type "example" omitted
+
+rust_library(
+    name = "atty",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.14",
+    # buildifier: leave-alone
+    deps = [
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@io_bazel_rules_rust//rust/platform:aarch64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:aarch64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:aarch64-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
+            "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:i686-linux-android",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:s390x-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@rules_rust_examples_criterion_bench__libc__0_2_81//:libc",
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@rules_rust_examples_criterion_bench__winapi__0_3_9//:winapi",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/examples/criterion_bench/raze/remote/BUILD.autocfg-1.0.1.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.autocfg-1.0.1.bazel
@@ -1,0 +1,62 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "integers" with type "example" omitted
+
+# Unsupported target "paths" with type "example" omitted
+
+# Unsupported target "traits" with type "example" omitted
+
+# Unsupported target "versions" with type "example" omitted
+
+rust_library(
+    name = "autocfg",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "rustflags" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.bitflags-1.2.1.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.bitflags-1.2.1.bazel
@@ -1,0 +1,82 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "bitflags_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.2.1",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "bitflags",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.2.1",
+    # buildifier: leave-alone
+    deps = [
+        ":bitflags_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.bstr-0.2.14.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.bstr-0.2.14.bazel
@@ -1,0 +1,81 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "graphemes" with type "example" omitted
+
+# Unsupported target "graphemes-std" with type "example" omitted
+
+# Unsupported target "lines" with type "example" omitted
+
+# Unsupported target "lines-std" with type "example" omitted
+
+# Unsupported target "uppercase" with type "example" omitted
+
+# Unsupported target "uppercase-std" with type "example" omitted
+
+# Unsupported target "words" with type "example" omitted
+
+# Unsupported target "words-std" with type "example" omitted
+
+rust_library(
+    name = "bstr",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "lazy_static",
+        "regex-automata",
+        "serde",
+        "serde1",
+        "serde1-nostd",
+        "std",
+        "unicode",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = glob(["src/**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.14",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__lazy_static__1_4_0//:lazy_static",
+        "@rules_rust_examples_criterion_bench__memchr__2_3_4//:memchr",
+        "@rules_rust_examples_criterion_bench__regex_automata__0_1_9//:regex_automata",
+        "@rules_rust_examples_criterion_bench__serde__1_0_118//:serde",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.bumpalo-3.4.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.bumpalo-3.4.0.bazel
@@ -1,0 +1,71 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "benches" with type "bench" omitted
+
+rust_library(
+    name = "bumpalo",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "3.4.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "alloc_fill" with type "test" omitted
+
+# Unsupported target "alloc_with" with type "test" omitted
+
+# Unsupported target "quickchecks" with type "test" omitted
+
+# Unsupported target "readme_up_to_date" with type "test" omitted
+
+# Unsupported target "string" with type "test" omitted
+
+# Unsupported target "tests" with type "test" omitted
+
+# Unsupported target "try_alloc" with type "test" omitted
+
+# Unsupported target "vec" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.byteorder-1.3.4.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.byteorder-1.3.4.bazel
@@ -1,0 +1,82 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "byteorder_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.3.4",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "byteorder",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.3.4",
+    # buildifier: leave-alone
+    deps = [
+        ":byteorder_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.cast-0.2.3.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.cast-0.2.3.bazel
@@ -1,0 +1,85 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "cast_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.3",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@rules_rust_examples_criterion_bench__rustc_version__0_2_3//:rustc_version",
+    ],
+)
+
+rust_library(
+    name = "cast",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.3",
+    # buildifier: leave-alone
+    deps = [
+        ":cast_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.cfg-if-0.1.10.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "cfg_if",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.10",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "xcrate" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.cfg-if-1.0.0.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "cfg_if",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "xcrate" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.clap-2.33.3.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.clap-2.33.3.bazel
@@ -1,0 +1,80 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "clap",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "2.33.3",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__bitflags__1_2_1//:bitflags",
+        "@rules_rust_examples_criterion_bench__textwrap__0_11_0//:textwrap",
+        "@rules_rust_examples_criterion_bench__unicode_width__0_1_8//:unicode_width",
+    ] + selects.with_or({
+        # cfg(not(windows))
+        (
+            "@io_bazel_rules_rust//rust/platform:aarch64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:aarch64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:aarch64-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
+            "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:i686-linux-android",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:s390x-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:wasm32-unknown-unknown",
+            "@io_bazel_rules_rust//rust/platform:wasm32-wasi",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/examples/criterion_bench/raze/remote/BUILD.const_fn-0.4.4.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.const_fn-0.4.4.bazel
@@ -1,0 +1,80 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "const_fn_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.4",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "const_fn",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "proc-macro",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.4",
+    # buildifier: leave-alone
+    deps = [
+        ":const_fn_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.criterion-0.3.3.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.criterion-0.3.3.bazel
@@ -1,0 +1,78 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "bench_main" with type "bench" omitted
+
+rust_library(
+    name = "criterion",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    data = glob(["src/**"]),
+    edition = "2018",
+    proc_macro_deps = [
+        "@rules_rust_examples_criterion_bench__serde_derive__1_0_118//:serde_derive",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.3",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__atty__0_2_14//:atty",
+        "@rules_rust_examples_criterion_bench__cast__0_2_3//:cast",
+        "@rules_rust_examples_criterion_bench__clap__2_33_3//:clap",
+        "@rules_rust_examples_criterion_bench__criterion_plot__0_4_3//:criterion_plot",
+        "@rules_rust_examples_criterion_bench__csv__1_1_5//:csv",
+        "@rules_rust_examples_criterion_bench__itertools__0_9_0//:itertools",
+        "@rules_rust_examples_criterion_bench__lazy_static__1_4_0//:lazy_static",
+        "@rules_rust_examples_criterion_bench__num_traits__0_2_14//:num_traits",
+        "@rules_rust_examples_criterion_bench__oorandom__11_1_3//:oorandom",
+        "@rules_rust_examples_criterion_bench__plotters__0_2_15//:plotters",
+        "@rules_rust_examples_criterion_bench__rayon__1_5_0//:rayon",
+        "@rules_rust_examples_criterion_bench__regex__1_4_2//:regex",
+        "@rules_rust_examples_criterion_bench__serde__1_0_118//:serde",
+        "@rules_rust_examples_criterion_bench__serde_cbor__0_11_1//:serde_cbor",
+        "@rules_rust_examples_criterion_bench__serde_json__1_0_60//:serde_json",
+        "@rules_rust_examples_criterion_bench__tinytemplate__1_1_0//:tinytemplate",
+        "@rules_rust_examples_criterion_bench__walkdir__2_3_1//:walkdir",
+    ],
+)
+
+# Unsupported target "criterion_tests" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.criterion-plot-0.4.3.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.criterion-plot-0.4.3.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "criterion_plot",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.3",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__cast__0_2_3//:cast",
+        "@rules_rust_examples_criterion_bench__itertools__0_9_0//:itertools",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.crossbeam-channel-0.5.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.crossbeam-channel-0.5.0.bazel
@@ -1,0 +1,93 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "crossbeam" with type "bench" omitted
+
+# Unsupported target "fibonacci" with type "example" omitted
+
+# Unsupported target "matching" with type "example" omitted
+
+# Unsupported target "stopwatch" with type "example" omitted
+
+rust_library(
+    name = "crossbeam_channel",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "crossbeam-utils",
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.5.0",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__cfg_if__1_0_0//:cfg_if",
+        "@rules_rust_examples_criterion_bench__crossbeam_utils__0_8_1//:crossbeam_utils",
+    ],
+)
+
+# Unsupported target "after" with type "test" omitted
+
+# Unsupported target "array" with type "test" omitted
+
+# Unsupported target "golang" with type "test" omitted
+
+# Unsupported target "iter" with type "test" omitted
+
+# Unsupported target "list" with type "test" omitted
+
+# Unsupported target "mpsc" with type "test" omitted
+
+# Unsupported target "never" with type "test" omitted
+
+# Unsupported target "ready" with type "test" omitted
+
+# Unsupported target "same_channel" with type "test" omitted
+
+# Unsupported target "select" with type "test" omitted
+
+# Unsupported target "select_macro" with type "test" omitted
+
+# Unsupported target "thread_locals" with type "test" omitted
+
+# Unsupported target "tick" with type "test" omitted
+
+# Unsupported target "zero" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.crossbeam-deque-0.8.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.crossbeam-deque-0.8.0.bazel
@@ -1,0 +1,67 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "crossbeam_deque",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "crossbeam-epoch",
+        "crossbeam-utils",
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.8.0",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__cfg_if__1_0_0//:cfg_if",
+        "@rules_rust_examples_criterion_bench__crossbeam_epoch__0_9_1//:crossbeam_epoch",
+        "@rules_rust_examples_criterion_bench__crossbeam_utils__0_8_1//:crossbeam_utils",
+    ],
+)
+
+# Unsupported target "fifo" with type "test" omitted
+
+# Unsupported target "injector" with type "test" omitted
+
+# Unsupported target "lifo" with type "test" omitted
+
+# Unsupported target "steal" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.crossbeam-epoch-0.9.1.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.crossbeam-epoch-0.9.1.bazel
@@ -1,0 +1,73 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "defer" with type "bench" omitted
+
+# Unsupported target "flush" with type "bench" omitted
+
+# Unsupported target "pin" with type "bench" omitted
+
+# Unsupported target "sanitize" with type "example" omitted
+
+# Unsupported target "treiber_stack" with type "example" omitted
+
+rust_library(
+    name = "crossbeam_epoch",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "alloc",
+        "lazy_static",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    proc_macro_deps = [
+        "@rules_rust_examples_criterion_bench__const_fn__0_4_4//:const_fn",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.1",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__cfg_if__1_0_0//:cfg_if",
+        "@rules_rust_examples_criterion_bench__crossbeam_utils__0_8_1//:crossbeam_utils",
+        "@rules_rust_examples_criterion_bench__lazy_static__1_4_0//:lazy_static",
+        "@rules_rust_examples_criterion_bench__memoffset__0_6_1//:memoffset",
+        "@rules_rust_examples_criterion_bench__scopeguard__1_1_0//:scopeguard",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.crossbeam-utils-0.8.1.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.crossbeam-utils-0.8.1.bazel
@@ -1,0 +1,103 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "crossbeam_utils_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "lazy_static",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.8.1",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@rules_rust_examples_criterion_bench__autocfg__1_0_1//:autocfg",
+    ],
+)
+
+# Unsupported target "atomic_cell" with type "bench" omitted
+
+rust_library(
+    name = "crossbeam_utils",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "lazy_static",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.8.1",
+    # buildifier: leave-alone
+    deps = [
+        ":crossbeam_utils_build_script",
+        "@rules_rust_examples_criterion_bench__cfg_if__1_0_0//:cfg_if",
+        "@rules_rust_examples_criterion_bench__lazy_static__1_4_0//:lazy_static",
+    ],
+)
+
+# Unsupported target "atomic_cell" with type "test" omitted
+
+# Unsupported target "cache_padded" with type "test" omitted
+
+# Unsupported target "parker" with type "test" omitted
+
+# Unsupported target "sharded_lock" with type "test" omitted
+
+# Unsupported target "thread" with type "test" omitted
+
+# Unsupported target "wait_group" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.csv-1.1.5.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.csv-1.1.5.bazel
@@ -1,0 +1,133 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+# Unsupported target "cookbook-read-basic" with type "example" omitted
+
+# Unsupported target "cookbook-read-colon" with type "example" omitted
+
+# Unsupported target "cookbook-read-no-headers" with type "example" omitted
+
+# Unsupported target "cookbook-read-serde" with type "example" omitted
+
+# Unsupported target "cookbook-write-basic" with type "example" omitted
+
+# Unsupported target "cookbook-write-serde" with type "example" omitted
+
+# Unsupported target "tutorial-error-01" with type "example" omitted
+
+# Unsupported target "tutorial-error-02" with type "example" omitted
+
+# Unsupported target "tutorial-error-03" with type "example" omitted
+
+# Unsupported target "tutorial-error-04" with type "example" omitted
+
+# Unsupported target "tutorial-perf-alloc-01" with type "example" omitted
+
+# Unsupported target "tutorial-perf-alloc-02" with type "example" omitted
+
+# Unsupported target "tutorial-perf-alloc-03" with type "example" omitted
+
+# Unsupported target "tutorial-perf-core-01" with type "example" omitted
+
+# Unsupported target "tutorial-perf-serde-01" with type "example" omitted
+
+# Unsupported target "tutorial-perf-serde-02" with type "example" omitted
+
+# Unsupported target "tutorial-perf-serde-03" with type "example" omitted
+
+# Unsupported target "tutorial-pipeline-pop-01" with type "example" omitted
+
+# Unsupported target "tutorial-pipeline-search-01" with type "example" omitted
+
+# Unsupported target "tutorial-pipeline-search-02" with type "example" omitted
+
+# Unsupported target "tutorial-read-01" with type "example" omitted
+
+# Unsupported target "tutorial-read-delimiter-01" with type "example" omitted
+
+# Unsupported target "tutorial-read-headers-01" with type "example" omitted
+
+# Unsupported target "tutorial-read-headers-02" with type "example" omitted
+
+# Unsupported target "tutorial-read-serde-01" with type "example" omitted
+
+# Unsupported target "tutorial-read-serde-02" with type "example" omitted
+
+# Unsupported target "tutorial-read-serde-03" with type "example" omitted
+
+# Unsupported target "tutorial-read-serde-04" with type "example" omitted
+
+# Unsupported target "tutorial-read-serde-invalid-01" with type "example" omitted
+
+# Unsupported target "tutorial-read-serde-invalid-02" with type "example" omitted
+
+# Unsupported target "tutorial-setup-01" with type "example" omitted
+
+# Unsupported target "tutorial-write-01" with type "example" omitted
+
+# Unsupported target "tutorial-write-02" with type "example" omitted
+
+# Unsupported target "tutorial-write-delimiter-01" with type "example" omitted
+
+# Unsupported target "tutorial-write-serde-01" with type "example" omitted
+
+# Unsupported target "tutorial-write-serde-02" with type "example" omitted
+
+rust_library(
+    name = "csv",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.1.5",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__bstr__0_2_14//:bstr",
+        "@rules_rust_examples_criterion_bench__csv_core__0_1_10//:csv_core",
+        "@rules_rust_examples_criterion_bench__itoa__0_4_6//:itoa",
+        "@rules_rust_examples_criterion_bench__ryu__1_0_5//:ryu",
+        "@rules_rust_examples_criterion_bench__serde__1_0_118//:serde",
+    ],
+)
+
+# Unsupported target "tests" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.csv-core-0.1.10.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.csv-core-0.1.10.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "csv_core",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.10",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__memchr__2_3_4//:memchr",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.either-1.6.1.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.either-1.6.1.bazel
@@ -1,0 +1,52 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "either",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.6.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.half-1.6.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.half-1.6.0.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "convert" with type "bench" omitted
+
+rust_library(
+    name = "half",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.6.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "version-numbers" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.hermit-abi-0.1.17.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.hermit-abi-0.1.17.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "hermit_abi",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.17",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__libc__0_2_81//:libc",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.itertools-0.9.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.itertools-0.9.0.bazel
@@ -1,0 +1,89 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench1" with type "bench" omitted
+
+# Unsupported target "combinations_with_replacement" with type "bench" omitted
+
+# Unsupported target "fold_specialization" with type "bench" omitted
+
+# Unsupported target "tree_fold1" with type "bench" omitted
+
+# Unsupported target "tuple_combinations" with type "bench" omitted
+
+# Unsupported target "tuples" with type "bench" omitted
+
+# Unsupported target "iris" with type "example" omitted
+
+rust_library(
+    name = "itertools",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "use_std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.0",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__either__1_6_1//:either",
+    ],
+)
+
+# Unsupported target "adaptors_no_collect" with type "test" omitted
+
+# Unsupported target "fold_specialization" with type "test" omitted
+
+# Unsupported target "merge_join" with type "test" omitted
+
+# Unsupported target "peeking_take_while" with type "test" omitted
+
+# Unsupported target "quick" with type "test" omitted
+
+# Unsupported target "specializations" with type "test" omitted
+
+# Unsupported target "test_core" with type "test" omitted
+
+# Unsupported target "test_std" with type "test" omitted
+
+# Unsupported target "tuples" with type "test" omitted
+
+# Unsupported target "zip" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.itoa-0.4.6.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.itoa-0.4.6.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "itoa",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.6",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.js-sys-0.3.46.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.js-sys-0.3.46.bazel
@@ -1,0 +1,67 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "js_sys",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.46",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__wasm_bindgen__0_2_69//:wasm_bindgen",
+    ] + selects.with_or({
+        # cfg(target_arch = "wasm32")
+        (
+            "@io_bazel_rules_rust//rust/platform:wasm32-unknown-unknown",
+            "@io_bazel_rules_rust//rust/platform:wasm32-wasi",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "headless" with type "test" omitted
+
+# Unsupported target "wasm" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.lazy_static-1.4.0.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "lazy_static",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.4.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "no_std" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.libc-0.2.81.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.libc-0.2.81.bazel
@@ -1,0 +1,86 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "libc_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.81",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "libc",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.81",
+    # buildifier: leave-alone
+    deps = [
+        ":libc_build_script",
+    ],
+)
+
+# Unsupported target "const_fn" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.log-0.4.11.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.log-0.4.11.bazel
@@ -1,0 +1,85 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "log_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.11",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "log",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.11",
+    # buildifier: leave-alone
+    deps = [
+        ":log_build_script",
+        "@rules_rust_examples_criterion_bench__cfg_if__0_1_10//:cfg_if",
+    ],
+)
+
+# Unsupported target "filters" with type "test" omitted
+
+# Unsupported target "macros" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.memchr-2.3.4.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.memchr-2.3.4.bazel
@@ -1,0 +1,84 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "memchr_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "std",
+        "use_std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "2.3.4",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "memchr",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "std",
+        "use_std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "2.3.4",
+    # buildifier: leave-alone
+    deps = [
+        ":memchr_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.memoffset-0.6.1.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.memoffset-0.6.1.bazel
@@ -1,0 +1,83 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "memoffset_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.6.1",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@rules_rust_examples_criterion_bench__autocfg__1_0_1//:autocfg",
+    ],
+)
+
+rust_library(
+    name = "memoffset",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.6.1",
+    # buildifier: leave-alone
+    deps = [
+        ":memoffset_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.num-traits-0.2.14.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.num-traits-0.2.14.bazel
@@ -1,0 +1,87 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "num_traits_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.14",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@rules_rust_examples_criterion_bench__autocfg__1_0_1//:autocfg",
+    ],
+)
+
+rust_library(
+    name = "num_traits",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.14",
+    # buildifier: leave-alone
+    deps = [
+        ":num_traits_build_script",
+    ],
+)
+
+# Unsupported target "cast" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.num_cpus-1.13.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.num_cpus-1.13.0.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "values" with type "example" omitted
+
+rust_library(
+    name = "num_cpus",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.13.0",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__libc__0_2_81//:libc",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.oorandom-11.1.3.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.oorandom-11.1.3.bazel
@@ -1,0 +1,52 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "oorandom",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "11.1.3",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.plotters-0.2.15.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.plotters-0.2.15.bazel
@@ -1,0 +1,130 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "benchmark" with type "bench" omitted
+
+# Unsupported target "animation" with type "example" omitted
+
+# Unsupported target "area-chart" with type "example" omitted
+
+# Unsupported target "blit-bitmap" with type "example" omitted
+
+# Unsupported target "boxplot" with type "example" omitted
+
+# Unsupported target "chart" with type "example" omitted
+
+# Unsupported target "console" with type "example" omitted
+
+# Unsupported target "errorbar" with type "example" omitted
+
+# Unsupported target "histogram" with type "example" omitted
+
+# Unsupported target "mandelbrot" with type "example" omitted
+
+# Unsupported target "matshow" with type "example" omitted
+
+# Unsupported target "normal-dist" with type "example" omitted
+
+# Unsupported target "normal-dist2" with type "example" omitted
+
+# Unsupported target "relative_size" with type "example" omitted
+
+# Unsupported target "sierpinski" with type "example" omitted
+
+# Unsupported target "slc-temp" with type "example" omitted
+
+# Unsupported target "snowflake" with type "example" omitted
+
+# Unsupported target "stock" with type "example" omitted
+
+# Unsupported target "two-scales" with type "example" omitted
+
+rust_library(
+    name = "plotters",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "area_series",
+        "line_series",
+        "svg",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.15",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__num_traits__0_2_14//:num_traits",
+    ] + selects.with_or({
+        # cfg(not(target_arch = "wasm32"))
+        (
+            "@io_bazel_rules_rust//rust/platform:aarch64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:aarch64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:aarch64-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
+            "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:i686-linux-android",
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:s390x-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # cfg(target_arch = "wasm32")
+        (
+            "@io_bazel_rules_rust//rust/platform:wasm32-unknown-unknown",
+            "@io_bazel_rules_rust//rust/platform:wasm32-wasi",
+        ): [
+            "@rules_rust_examples_criterion_bench__js_sys__0_3_46//:js_sys",
+            "@rules_rust_examples_criterion_bench__wasm_bindgen__0_2_69//:wasm_bindgen",
+            "@rules_rust_examples_criterion_bench__web_sys__0_3_46//:web_sys",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/examples/criterion_bench/raze/remote/BUILD.proc-macro2-1.0.24.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.proc-macro2-1.0.24.bazel
@@ -1,0 +1,95 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "proc_macro2_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.24",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "proc_macro2",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.24",
+    # buildifier: leave-alone
+    deps = [
+        ":proc_macro2_build_script",
+        "@rules_rust_examples_criterion_bench__unicode_xid__0_2_1//:unicode_xid",
+    ],
+)
+
+# Unsupported target "comments" with type "test" omitted
+
+# Unsupported target "features" with type "test" omitted
+
+# Unsupported target "marker" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted
+
+# Unsupported target "test_fmt" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.quote-1.0.7.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.quote-1.0.7.bazel
@@ -1,0 +1,59 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "quote",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "proc-macro",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.7",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__proc_macro2__1_0_24//:proc_macro2",
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted
+
+# Unsupported target "test" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.rayon-1.5.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.rayon-1.5.0.bazel
@@ -1,0 +1,114 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "rayon_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.5.0",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@rules_rust_examples_criterion_bench__autocfg__1_0_1//:autocfg",
+    ],
+)
+
+# Unsupported target "cpu_monitor" with type "example" omitted
+
+rust_library(
+    name = "rayon",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.5.0",
+    # buildifier: leave-alone
+    deps = [
+        ":rayon_build_script",
+        "@rules_rust_examples_criterion_bench__crossbeam_deque__0_8_0//:crossbeam_deque",
+        "@rules_rust_examples_criterion_bench__either__1_6_1//:either",
+        "@rules_rust_examples_criterion_bench__rayon_core__1_9_0//:rayon_core",
+    ],
+)
+
+# Unsupported target "chars" with type "test" omitted
+
+# Unsupported target "clones" with type "test" omitted
+
+# Unsupported target "collect" with type "test" omitted
+
+# Unsupported target "cross-pool" with type "test" omitted
+
+# Unsupported target "debug" with type "test" omitted
+
+# Unsupported target "intersperse" with type "test" omitted
+
+# Unsupported target "issue671" with type "test" omitted
+
+# Unsupported target "issue671-unzip" with type "test" omitted
+
+# Unsupported target "iter_panic" with type "test" omitted
+
+# Unsupported target "named-threads" with type "test" omitted
+
+# Unsupported target "octillion" with type "test" omitted
+
+# Unsupported target "producer_split_at" with type "test" omitted
+
+# Unsupported target "sort-panic-safe" with type "test" omitted
+
+# Unsupported target "str" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.rayon-core-1.9.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.rayon-core-1.9.0.bazel
@@ -1,0 +1,141 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "rayon_core_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.9.0",
+    visibility = ["//visibility:private"],
+    deps = [
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@io_bazel_rules_rust//rust/platform:aarch64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:aarch64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:aarch64-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
+            "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:i686-linux-android",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:s390x-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+rust_library(
+    name = "rayon_core",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.9.0",
+    # buildifier: leave-alone
+    deps = [
+        ":rayon_core_build_script",
+        "@rules_rust_examples_criterion_bench__crossbeam_channel__0_5_0//:crossbeam_channel",
+        "@rules_rust_examples_criterion_bench__crossbeam_deque__0_8_0//:crossbeam_deque",
+        "@rules_rust_examples_criterion_bench__crossbeam_utils__0_8_1//:crossbeam_utils",
+        "@rules_rust_examples_criterion_bench__lazy_static__1_4_0//:lazy_static",
+        "@rules_rust_examples_criterion_bench__num_cpus__1_13_0//:num_cpus",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@io_bazel_rules_rust//rust/platform:aarch64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:aarch64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:aarch64-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:arm-unknown-linux-gnueabi",
+            "@io_bazel_rules_rust//rust/platform:i686-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:i686-linux-android",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:i686-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:powerpc-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:s390x-unknown-linux-gnu",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-darwin",
+            "@io_bazel_rules_rust//rust/platform:x86_64-apple-ios",
+            "@io_bazel_rules_rust//rust/platform:x86_64-linux-android",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-freebsd",
+            "@io_bazel_rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "double_init_fail" with type "test" omitted
+
+# Unsupported target "init_zero_threads" with type "test" omitted
+
+# Unsupported target "scope_join" with type "test" omitted
+
+# Unsupported target "scoped_threadpool" with type "test" omitted
+
+# Unsupported target "simple_panic" with type "test" omitted
+
+# Unsupported target "stack_overflow_crash" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.regex-1.4.2.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.regex-1.4.2.bazel
@@ -1,0 +1,84 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "shootout-regex-dna" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-bytes" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-cheat" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-replace" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-single" with type "example" omitted
+
+# Unsupported target "shootout-regex-dna-single-cheat" with type "example" omitted
+
+rust_library(
+    name = "regex",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.4.2",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__regex_syntax__0_6_21//:regex_syntax",
+    ],
+)
+
+# Unsupported target "backtrack" with type "test" omitted
+
+# Unsupported target "backtrack-bytes" with type "test" omitted
+
+# Unsupported target "backtrack-utf8bytes" with type "test" omitted
+
+# Unsupported target "crates-regex" with type "test" omitted
+
+# Unsupported target "default" with type "test" omitted
+
+# Unsupported target "default-bytes" with type "test" omitted
+
+# Unsupported target "nfa" with type "test" omitted
+
+# Unsupported target "nfa-bytes" with type "test" omitted
+
+# Unsupported target "nfa-utf8bytes" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.regex-automata-0.1.9.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.regex-automata-0.1.9.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "regex_automata",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.9",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__byteorder__1_3_4//:byteorder",
+    ],
+)
+
+# Unsupported target "default" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.regex-syntax-0.6.21.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.regex-syntax-0.6.21.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "regex_syntax",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.6.21",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.rustc_version-0.2.3.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.rustc_version-0.2.3.bazel
@@ -1,0 +1,53 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "rustc_version",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.3",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__semver__0_9_0//:semver",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.ryu-1.0.5.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.ryu-1.0.5.bazel
@@ -1,0 +1,98 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR BSL-1.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "ryu_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.5",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+# Unsupported target "bench" with type "bench" omitted
+
+# Unsupported target "upstream_benchmark" with type "example" omitted
+
+rust_library(
+    name = "ryu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.5",
+    # buildifier: leave-alone
+    deps = [
+        ":ryu_build_script",
+    ],
+)
+
+# Unsupported target "common_test" with type "test" omitted
+
+# Unsupported target "d2s_table_test" with type "test" omitted
+
+# Unsupported target "d2s_test" with type "test" omitted
+
+# Unsupported target "exhaustive" with type "test" omitted
+
+# Unsupported target "f2s_test" with type "test" omitted
+
+# Unsupported target "s2d_test" with type "test" omitted
+
+# Unsupported target "s2f_test" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.same-file-1.0.6.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.same-file-1.0.6.bazel
@@ -1,0 +1,67 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "is_same_file" with type "example" omitted
+
+# Unsupported target "is_stderr" with type "example" omitted
+
+rust_library(
+    name = "same_file",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.6",
+    # buildifier: leave-alone
+    deps = [
+    ] + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@rules_rust_examples_criterion_bench__winapi_util__0_1_5//:winapi_util",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/examples/criterion_bench/raze/remote/BUILD.scopeguard-1.1.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.scopeguard-1.1.0.bazel
@@ -1,0 +1,54 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "readme" with type "example" omitted
+
+rust_library(
+    name = "scopeguard",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.1.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.semver-0.9.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.semver-0.9.0.bazel
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "semver",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.9.0",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__semver_parser__0_7_0//:semver_parser",
+    ],
+)
+
+# Unsupported target "deprecation" with type "test" omitted
+
+# Unsupported target "regression" with type "test" omitted
+
+# Unsupported target "serde" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.semver-parser-0.7.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.semver-parser-0.7.0.bazel
@@ -1,0 +1,52 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "semver_parser",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.7.0",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.serde-1.0.118.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.serde-1.0.118.bazel
@@ -1,0 +1,84 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "serde_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.118",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "serde",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.118",
+    # buildifier: leave-alone
+    deps = [
+        ":serde_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.serde_cbor-0.11.1.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.serde_cbor-0.11.1.bazel
@@ -1,0 +1,76 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "readme" with type "example" omitted
+
+# Unsupported target "tags" with type "example" omitted
+
+rust_library(
+    name = "serde_cbor",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.11.1",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__half__1_6_0//:half",
+        "@rules_rust_examples_criterion_bench__serde__1_0_118//:serde",
+    ],
+)
+
+# Unsupported target "bennofs" with type "test" omitted
+
+# Unsupported target "canonical" with type "test" omitted
+
+# Unsupported target "de" with type "test" omitted
+
+# Unsupported target "enum" with type "test" omitted
+
+# Unsupported target "ser" with type "test" omitted
+
+# Unsupported target "std_types" with type "test" omitted
+
+# Unsupported target "tags" with type "test" omitted
+
+# Unsupported target "value" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.serde_derive-1.0.118.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.serde_derive-1.0.118.bazel
@@ -1,0 +1,85 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "serde_derive_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.118",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "serde_derive",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "proc-macro",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.118",
+    # buildifier: leave-alone
+    deps = [
+        ":serde_derive_build_script",
+        "@rules_rust_examples_criterion_bench__proc_macro2__1_0_24//:proc_macro2",
+        "@rules_rust_examples_criterion_bench__quote__1_0_7//:quote",
+        "@rules_rust_examples_criterion_bench__syn__1_0_54//:syn",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.serde_json-1.0.60.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.serde_json-1.0.60.bazel
@@ -1,0 +1,87 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "serde_json_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.60",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "serde_json",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.60",
+    # buildifier: leave-alone
+    deps = [
+        ":serde_json_build_script",
+        "@rules_rust_examples_criterion_bench__itoa__0_4_6//:itoa",
+        "@rules_rust_examples_criterion_bench__ryu__1_0_5//:ryu",
+        "@rules_rust_examples_criterion_bench__serde__1_0_118//:serde",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.syn-1.0.54.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.syn-1.0.54.bazel
@@ -1,0 +1,157 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "syn_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "clone-impls",
+        "default",
+        "derive",
+        "full",
+        "parsing",
+        "printing",
+        "proc-macro",
+        "quote",
+        "visit",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.54",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+# Unsupported target "file" with type "bench" omitted
+
+# Unsupported target "rust" with type "bench" omitted
+
+rust_library(
+    name = "syn",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "clone-impls",
+        "default",
+        "derive",
+        "full",
+        "parsing",
+        "printing",
+        "proc-macro",
+        "quote",
+        "visit",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.0.54",
+    # buildifier: leave-alone
+    deps = [
+        ":syn_build_script",
+        "@rules_rust_examples_criterion_bench__proc_macro2__1_0_24//:proc_macro2",
+        "@rules_rust_examples_criterion_bench__quote__1_0_7//:quote",
+        "@rules_rust_examples_criterion_bench__unicode_xid__0_2_1//:unicode_xid",
+    ],
+)
+
+# Unsupported target "test_asyncness" with type "test" omitted
+
+# Unsupported target "test_attribute" with type "test" omitted
+
+# Unsupported target "test_derive_input" with type "test" omitted
+
+# Unsupported target "test_expr" with type "test" omitted
+
+# Unsupported target "test_generics" with type "test" omitted
+
+# Unsupported target "test_grouping" with type "test" omitted
+
+# Unsupported target "test_ident" with type "test" omitted
+
+# Unsupported target "test_item" with type "test" omitted
+
+# Unsupported target "test_iterators" with type "test" omitted
+
+# Unsupported target "test_lit" with type "test" omitted
+
+# Unsupported target "test_meta" with type "test" omitted
+
+# Unsupported target "test_parse_buffer" with type "test" omitted
+
+# Unsupported target "test_parse_stream" with type "test" omitted
+
+# Unsupported target "test_pat" with type "test" omitted
+
+# Unsupported target "test_path" with type "test" omitted
+
+# Unsupported target "test_precedence" with type "test" omitted
+
+# Unsupported target "test_receiver" with type "test" omitted
+
+# Unsupported target "test_round_trip" with type "test" omitted
+
+# Unsupported target "test_shebang" with type "test" omitted
+
+# Unsupported target "test_should_parse" with type "test" omitted
+
+# Unsupported target "test_size" with type "test" omitted
+
+# Unsupported target "test_stmt" with type "test" omitted
+
+# Unsupported target "test_token_trees" with type "test" omitted
+
+# Unsupported target "test_ty" with type "test" omitted
+
+# Unsupported target "test_visibility" with type "test" omitted
+
+# Unsupported target "zzz_stable" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.textwrap-0.11.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.textwrap-0.11.0.bazel
@@ -1,0 +1,61 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "linear" with type "bench" omitted
+
+# Unsupported target "layout" with type "example" omitted
+
+# Unsupported target "termwidth" with type "example" omitted
+
+rust_library(
+    name = "textwrap",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.11.0",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__unicode_width__0_1_8//:unicode_width",
+    ],
+)
+
+# Unsupported target "version-numbers" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.tinytemplate-1.1.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.tinytemplate-1.1.0.bazel
@@ -1,0 +1,56 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "benchmarks" with type "bench" omitted
+
+rust_library(
+    name = "tinytemplate",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.1.0",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__serde__1_0_118//:serde",
+        "@rules_rust_examples_criterion_bench__serde_json__1_0_60//:serde_json",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.unicode-width-0.1.8.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.unicode-width-0.1.8.bazel
@@ -1,0 +1,53 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "unicode_width",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.8",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.unicode-xid-0.2.1.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.unicode-xid-0.2.1.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "unicode_xid",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "exhaustive_tests" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.walkdir-2.3.1.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.walkdir-2.3.1.bazel
@@ -1,0 +1,65 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "walkdir",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "2.3.1",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__same_file__1_0_6//:same_file",
+    ] + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@rules_rust_examples_criterion_bench__winapi__0_3_9//:winapi",
+            "@rules_rust_examples_criterion_bench__winapi_util__0_1_5//:winapi_util",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-0.2.69.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-0.2.69.bazel
@@ -1,0 +1,120 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "wasm_bindgen_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "spans",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.69",
+    visibility = ["//visibility:private"],
+    deps = [
+    ] + selects.with_or({
+        # cfg(target_arch = "wasm32")
+        (
+            "@io_bazel_rules_rust//rust/platform:wasm32-unknown-unknown",
+            "@io_bazel_rules_rust//rust/platform:wasm32-wasi",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+rust_library(
+    name = "wasm_bindgen",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "default",
+        "spans",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    proc_macro_deps = [
+        "@rules_rust_examples_criterion_bench__wasm_bindgen_macro__0_2_69//:wasm_bindgen_macro",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.69",
+    # buildifier: leave-alone
+    deps = [
+        ":wasm_bindgen_build_script",
+        "@rules_rust_examples_criterion_bench__cfg_if__1_0_0//:cfg_if",
+    ] + selects.with_or({
+        # cfg(target_arch = "wasm32")
+        (
+            "@io_bazel_rules_rust//rust/platform:wasm32-unknown-unknown",
+            "@io_bazel_rules_rust//rust/platform:wasm32-wasi",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "headless" with type "test" omitted
+
+# Unsupported target "must_use" with type "test" omitted
+
+# Unsupported target "non_wasm" with type "test" omitted
+
+# Unsupported target "std-crate-no-std-dep" with type "test" omitted
+
+# Unsupported target "unwrap_throw" with type "test" omitted
+
+# Unsupported target "wasm" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-backend-0.2.69.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-backend-0.2.69.bazel
@@ -1,0 +1,60 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "wasm_bindgen_backend",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "spans",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.69",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__bumpalo__3_4_0//:bumpalo",
+        "@rules_rust_examples_criterion_bench__lazy_static__1_4_0//:lazy_static",
+        "@rules_rust_examples_criterion_bench__log__0_4_11//:log",
+        "@rules_rust_examples_criterion_bench__proc_macro2__1_0_24//:proc_macro2",
+        "@rules_rust_examples_criterion_bench__quote__1_0_7//:quote",
+        "@rules_rust_examples_criterion_bench__syn__1_0_54//:syn",
+        "@rules_rust_examples_criterion_bench__wasm_bindgen_shared__0_2_69//:wasm_bindgen_shared",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-macro-0.2.69.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-macro-0.2.69.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "wasm_bindgen_macro",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "spans",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "proc-macro",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.69",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__quote__1_0_7//:quote",
+        "@rules_rust_examples_criterion_bench__wasm_bindgen_macro_support__0_2_69//:wasm_bindgen_macro_support",
+    ],
+)
+
+# Unsupported target "ui" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-macro-support-0.2.69.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-macro-support-0.2.69.bazel
@@ -1,0 +1,58 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "wasm_bindgen_macro_support",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "spans",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.69",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__proc_macro2__1_0_24//:proc_macro2",
+        "@rules_rust_examples_criterion_bench__quote__1_0_7//:quote",
+        "@rules_rust_examples_criterion_bench__syn__1_0_54//:syn",
+        "@rules_rust_examples_criterion_bench__wasm_bindgen_backend__0_2_69//:wasm_bindgen_backend",
+        "@rules_rust_examples_criterion_bench__wasm_bindgen_shared__0_2_69//:wasm_bindgen_shared",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-shared-0.2.69.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.wasm-bindgen-shared-0.2.69.bazel
@@ -1,0 +1,80 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "wasm_bindgen_shared_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.69",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "wasm_bindgen_shared",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.69",
+    # buildifier: leave-alone
+    deps = [
+        ":wasm_bindgen_shared_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.web-sys-0.3.46.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.web-sys-0.3.46.bazel
@@ -1,0 +1,76 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "web_sys",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "CanvasRenderingContext2d",
+        "Document",
+        "DomRect",
+        "DomRectReadOnly",
+        "Element",
+        "EventTarget",
+        "HtmlCanvasElement",
+        "HtmlElement",
+        "Node",
+        "Window",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.46",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_examples_criterion_bench__js_sys__0_3_46//:js_sys",
+        "@rules_rust_examples_criterion_bench__wasm_bindgen__0_2_69//:wasm_bindgen",
+    ] + selects.with_or({
+        # cfg(target_arch = "wasm32")
+        (
+            "@io_bazel_rules_rust//rust/platform:wasm32-unknown-unknown",
+            "@io_bazel_rules_rust//rust/platform:wasm32-wasi",
+        ): [
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# Unsupported target "wasm" with type "test" omitted

--- a/examples/criterion_bench/raze/remote/BUILD.winapi-0.3.9.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.winapi-0.3.9.bazel
@@ -1,0 +1,102 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "winapi_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "consoleapi",
+        "errhandlingapi",
+        "fileapi",
+        "minwinbase",
+        "minwindef",
+        "processenv",
+        "std",
+        "winbase",
+        "wincon",
+        "winerror",
+        "winnt",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.9",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "winapi",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "consoleapi",
+        "errhandlingapi",
+        "fileapi",
+        "minwinbase",
+        "minwindef",
+        "processenv",
+        "std",
+        "winbase",
+        "wincon",
+        "winerror",
+        "winnt",
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.3.9",
+    # buildifier: leave-alone
+    deps = [
+        ":winapi_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -1,0 +1,80 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "winapi_i686_pc_windows_gnu_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.0",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "winapi_i686_pc_windows_gnu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.0",
+    # buildifier: leave-alone
+    deps = [
+        ":winapi_i686_pc_windows_gnu_build_script",
+    ],
+)

--- a/examples/criterion_bench/raze/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.winapi-util-0.1.5.bazel
@@ -1,0 +1,63 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "unencumbered",  # Unlicense from expression "Unlicense OR MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "winapi_util",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.5",
+    # buildifier: leave-alone
+    deps = [
+    ] + selects.with_or({
+        # cfg(windows)
+        (
+            "@io_bazel_rules_rust//rust/platform:i686-pc-windows-msvc",
+            "@io_bazel_rules_rust//rust/platform:x86_64-pc-windows-msvc",
+        ): [
+            "@rules_rust_examples_criterion_bench__winapi__0_3_9//:winapi",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/examples/criterion_bench/raze/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/criterion_bench/raze/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -1,0 +1,80 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_test",
+)
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//criterion_bench/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets# buildifier: disable=load-on-top
+load(
+    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "winapi_x86_64_pc_windows_gnu_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.0",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
+
+rust_library(
+    name = "winapi_x86_64_pc_windows_gnu",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.4.0",
+    # buildifier: leave-alone
+    deps = [
+        ":winapi_x86_64_pc_windows_gnu_build_script",
+    ],
+)

--- a/examples/examples_deps.bzl
+++ b/examples/examples_deps.bzl
@@ -3,6 +3,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@examples//complex_sys:repositories.bzl", "rules_rust_examples_complex_sys_repositories")
+load("@examples//criterion_bench/raze:crates.bzl", "rules_rust_examples_criterion_bench_fetch_remote_crates")
 load("@examples//hello_sys/raze:crates.bzl", "rules_rust_examples_hello_sys_fetch_remote_crates")
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 load("@rules_rust//bindgen:repositories.bzl", "rust_bindgen_repositories")
@@ -39,6 +40,8 @@ def deps():
     rules_rust_examples_hello_sys_fetch_remote_crates()
 
     rules_rust_examples_complex_sys_repositories()
+
+    rules_rust_examples_criterion_bench_fetch_remote_crates()
 
     maybe(
         http_archive,

--- a/examples/fibonacci/BUILD.bazel
+++ b/examples/fibonacci/BUILD.bazel
@@ -25,6 +25,7 @@ rust_benchmark(
         "noci",
     ],
     deps = [":fibonacci"],
+    test_harness = True,
 )
 
 rust_doc(

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -473,11 +473,26 @@ def _rust_benchmark_impl(ctx):
     toolchain = find_toolchain(ctx)
 
     # Build the underlying benchmark binary.
-    bench_binary = ctx.actions.declare_file(
-        "{}_bin{}".format(ctx.label.name, toolchain.binary_ext),
-        sibling = ctx.configuration.bin_dir,
+    crate_name = ctx.label.name.replace("-", "_")
+    bench_binary = ctx.actions.declare_file(ctx.label.name + toolchain.binary_ext)
+    info = rustc_compile_action(
+        ctx = ctx,
+        toolchain = toolchain,
+        crate_info = CrateInfo(
+            name = crate_name,
+            type = "bin",
+            root = crate_root_src(ctx.attr, ctx.files.srcs, "bin"),
+            srcs = ctx.files.srcs,
+            deps = ctx.attr.deps,
+            proc_macro_deps = ctx.attr.proc_macro_deps,
+            aliases = ctx.attr.aliases,
+            output = bench_binary,
+            edition = get_edition(ctx.attr, toolchain),
+            rustc_env = ctx.attr.rustc_env,
+            is_test = False,
+        ),
+        rust_flags = ["--test"] if ctx.attr.test_harness else [],
     )
-    info = _rust_test_common(ctx, toolchain, bench_binary)
 
     if toolchain.exec_triple.find("windows") != -1:
         bench_script = ctx.actions.declare_file(
@@ -508,9 +523,9 @@ def _rust_benchmark_impl(ctx):
 
     return [
         DefaultInfo(
+            files = depset([bench_script, bench_binary]),
             runfiles = ctx.runfiles(
-                files = info.runfiles + [bench_binary],
-                collect_data = True,
+                files = [bench_binary] + ctx.attr.data,
             ),
             executable = bench_script,
         ),
@@ -719,6 +734,19 @@ _common_providers = [
     rust_common.dep_info,
     DefaultInfo,
 ]
+
+_rust_benchmark_attrs = {
+    "test_harness": attr.bool(
+        default = False,
+        mandatory = False,
+        doc = _tidy("""
+            Generate the test harness for this benchmark.
+
+            Criterion benchmarks do not use a test harness, but the nightly
+            #[bench] api does. Pass True if you have a #[bench] api test.
+        """),
+    ),
+}
 
 rust_library = rule(
     implementation = _rust_library_impl,
@@ -1232,7 +1260,7 @@ def rust_test_suite(name, srcs, **kwargs):
 
 rust_benchmark = rule(
     implementation = _rust_benchmark_impl,
-    attrs = _common_attrs,
+    attrs = dict(_common_attrs.items() + _rust_benchmark_attrs.items()),
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -478,7 +478,7 @@ def _rust_benchmark_impl(ctx):
     info = rustc_compile_action(
         ctx = ctx,
         toolchain = toolchain,
-        crate_info = CrateInfo(
+        crate_info = rust_common.crate_info(
             name = crate_name,
             type = "bin",
             root = crate_root_src(ctx.attr, ctx.files.srcs, "bin"),


### PR DESCRIPTION
I was just looking into fixing #231, but it doesn't seem like the current setup is well suited to criterion benchmarks (which I think has become the preferred method?). Specifically, when delegating to `_rust_test_common`, the criterion code doesn't seem to run at all because criterion wants to disable the test harness in favor of its own `main`.

Since this rule doesn't currently work, it's unlikely anyone depends on it. I propose we repurpose `rust_benchmark` to simply warn when the compilation mode != "opt" and delegate to a rust_binary with `--bench` which is more in line with how criterion expects to be invoked.
```
INFO: Build completed successfully, 60 total actions
Gnuplot not found, using plotters backend
fib 20                  time:   [36.696 us 37.153 us 37.602 us]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

This strategy can optionally be made to work for the nightly `#[bench]` attribute by passing the `--test` flag to rustc to generate the test harness. This is enabled with the `test_harness = True` option.

A test was added using criterion to prevent future bit-rot.