### PR TITLE
fix: change test for `greet` method, instead of `greeting`

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -368,9 +368,9 @@ mod test {
     use super::Greeter;
 
     #[test]
-    fn test_greeting() {
+    fn test_greet() {
         let hello = Greeter::new("Hi");
-        assert_eq!("Hi Rust", hello.greeting("Rust"));
+        assert_eq!("Hi Rust", hello.greet("Rust"));
     }
 }
 ```


### PR DESCRIPTION
This PR is related to #482.

I fixed a minor mistakes in the sample code.