### PR TITLE
Use relative labels and `Label` macro wherever possible

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@io_bazel_rules_rust//rust:private/rustc.bzl", "error_format")
+load("//rust:private/rustc.bzl", "error_format")
 
 bzl_library(
     name = "rules",

--- a/bindgen/BUILD
+++ b/bindgen/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_rust//bindgen:bindgen.bzl", "rust_bindgen_toolchain")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//bindgen:bindgen.bzl", "rust_bindgen_toolchain")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,18 +8,18 @@ toolchain_type(name = "bindgen_toolchain")
 bzl_library(
     name = "rules",
     srcs = glob(["**/*.bzl"]),
-    deps = ["@io_bazel_rules_rust//rust:rules"],
+    deps = ["//rust:rules"],
 )
 
 rust_bindgen_toolchain(
     name = "default_bindgen_toolchain_impl",
     bindgen = "//bindgen/raze:cargo_bin_bindgen",
     clang = select({
-        "@io_bazel_rules_rust//rust/platform:osx": "@bindgen_clang_osx//:clang",
+        "//rust/platform:osx": "@bindgen_clang_osx//:clang",
         "//conditions:default": "@bindgen_clang_linux//:clang",
     }),
     libclang = select({
-        "@io_bazel_rules_rust//rust/platform:osx": "@bindgen_clang_osx//:libclang.so",
+        "//rust/platform:osx": "@bindgen_clang_osx//:libclang.so",
         "//conditions:default": "@bindgen_clang_linux//:libclang.so",
     }),
     libstdcxx = "@local_libstdcpp//:libstdc++",
@@ -28,5 +28,5 @@ rust_bindgen_toolchain(
 toolchain(
     name = "default_bindgen_toolchain",
     toolchain = "default_bindgen_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_rust//bindgen:bindgen_toolchain",
+    toolchain_type = "//bindgen:bindgen_toolchain",
 )

--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain", "get_libs_for_static_executable")
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_library")
+load("//rust:private/utils.bzl", "find_toolchain", "get_libs_for_static_executable")
+load("//rust:rust.bzl", "rust_library")
 
 def rust_bindgen_library(
         name,
@@ -61,7 +61,7 @@ def _rust_bindgen_impl(ctx):
     if header not in cc_header_list:
         fail("Header {} is not in {}'s transitive headers.".format(ctx.attr.header, cc_lib), "header")
 
-    toolchain = ctx.toolchains["@io_bazel_rules_rust//bindgen:bindgen_toolchain"]
+    toolchain = ctx.toolchains[Label("//bindgen:bindgen_toolchain")]
     bindgen_bin = toolchain.bindgen
     rustfmt_bin = toolchain.rustfmt or rust_toolchain.rustfmt
     clang_bin = toolchain.clang
@@ -168,7 +168,7 @@ rust_bindgen = rule(
             doc = "Flags to pass directly to the clang executable.",
         ),
         "_process_wrapper": attr.label(
-            default = "@io_bazel_rules_rust//util/process_wrapper",
+            default = Label("//util/process_wrapper"),
             executable = True,
             allow_single_file = True,
             cfg = "exec",
@@ -176,8 +176,8 @@ rust_bindgen = rule(
     },
     outputs = {"out": "%{name}.rs"},
     toolchains = [
-        "@io_bazel_rules_rust//bindgen:bindgen_toolchain",
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//bindgen:bindgen_toolchain")),
+        str(Label("//rust:toolchain")),
     ],
 )
 

--- a/bindgen/repositories.bzl
+++ b/bindgen/repositories.bzl
@@ -31,7 +31,7 @@ def rust_bindgen_repositories():
 
     rules_rust_bindgen_fetch_remote_crates()
 
-    native.register_toolchains("@io_bazel_rules_rust//bindgen:default_bindgen_toolchain")
+    native.register_toolchains(str(Label("//bindgen:default_bindgen_toolchain")))
 
 _COMMON_WORKSPACE = """\
 workspace(name = "{}")

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -1,10 +1,10 @@
 # buildifier: disable=module-docstring
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@io_bazel_rules_rust//rust:private/rust.bzl", "name_to_crate_name")
-load("@io_bazel_rules_rust//rust:private/rustc.bzl", "BuildInfo", "DepInfo", "get_cc_toolchain", "get_compilation_mode_opts", "get_linker_and_args")
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "expand_locations", "find_toolchain")
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary")
+load("//rust:private/rust.bzl", "name_to_crate_name")
+load("//rust:private/rustc.bzl", "BuildInfo", "DepInfo", "get_cc_toolchain", "get_compilation_mode_opts", "get_linker_and_args")
+load("//rust:private/utils.bzl", "expand_locations", "find_toolchain")
+load("//rust:rust.bzl", "rust_binary")
 
 def get_cc_compile_env(cc_toolchain, feature_configuration):
     """Gather cc environment variables from the given `cc_toolchain`
@@ -232,7 +232,7 @@ _build_script_run = rule(
     },
     fragments = ["cpp"],
     toolchains = [
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
 )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -25,7 +25,7 @@ rust_binary(
 toolchain(
     name = "default-proto-toolchain",
     toolchain = ":default-proto-toolchain-impl",
-    toolchain_type = "@io_bazel_rules_rust//proto:toolchain",
+    toolchain_type = "//proto:toolchain",
 )
 
 rust_proto_toolchain(name = "default-proto-toolchain-impl")

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -26,22 +26,22 @@ To use the Rust proto rules, add the following to your `WORKSPACE` file to add t
 external repositories for the Rust proto toolchain (in addition to the [rust rules setup](..)):
 
 ```python
-load("@io_bazel_rules_rust//proto:repositories.bzl", "rust_proto_repositories")
+load("//proto:repositories.bzl", "rust_proto_repositories")
 
 rust_proto_repositories()
 ```
 """
 
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load(
-    "@io_bazel_rules_rust//proto:toolchain.bzl",
+    "//proto:toolchain.bzl",
     "GRPC_COMPILE_DEPS",
     "PROTO_COMPILE_DEPS",
     _generate_proto = "rust_generate_proto",
     _generated_file_stem = "generated_file_stem",
 )
-load("@io_bazel_rules_rust//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
-load("@rules_proto//proto:defs.bzl", "ProtoInfo")
+load("//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
+load("//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
 
 RustProtoInfo = provider(
     doc = "Rust protobuf provider info",
@@ -182,7 +182,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
     """
 
     # Create all the source in a specific folder
-    proto_toolchain = ctx.toolchains["@io_bazel_rules_rust//proto:toolchain"]
+    proto_toolchain = ctx.toolchains[Label("//proto:toolchain")]
     output_dir = "%s.%s.rust" % (crate_name, "grpc" if is_grpc else "proto")
 
     # Generate the proto stubs
@@ -283,10 +283,10 @@ rust_proto_library = rule(
             default = PROTO_COMPILE_DEPS,
         ),
         "_cc_toolchain": attr.label(
-            default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
         "_process_wrapper": attr.label(
-            default = "@io_bazel_rules_rust//util/process_wrapper",
+            default = Label("//util/process_wrapper"),
             executable = True,
             allow_single_file = True,
             cfg = "exec",
@@ -294,16 +294,14 @@ rust_proto_library = rule(
         "_optional_output_wrapper": attr.label(
             executable = True,
             cfg = "exec",
-            default = Label(
-                "@io_bazel_rules_rust//proto:optional_output_wrapper",
-            ),
+            default = Label("//proto:optional_output_wrapper"),
         ),
     },
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        "@io_bazel_rules_rust//proto:toolchain",
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//proto:toolchain")),
+        str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     doc = """\
@@ -365,7 +363,7 @@ rust_grpc_library = rule(
             default = "@bazel_tools//tools/cpp:current_cc_toolchain",
         ),
         "_process_wrapper": attr.label(
-            default = "@io_bazel_rules_rust//util/process_wrapper",
+            default = Label("//util/process_wrapper"),
             executable = True,
             allow_single_file = True,
             cfg = "exec",
@@ -373,16 +371,14 @@ rust_grpc_library = rule(
         "_optional_output_wrapper": attr.label(
             executable = True,
             cfg = "exec",
-            default = Label(
-                "@io_bazel_rules_rust//proto:optional_output_wrapper",
-            ),
+            default = Label("//proto:optional_output_wrapper"),
         ),
     },
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        "@io_bazel_rules_rust//proto:toolchain",
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//proto:toolchain")),
+        str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     doc = """\
@@ -391,8 +387,8 @@ Builds a Rust library crate from a set of `proto_library`s suitable for gRPC.
 Example:
 
 ```python
-load("@io_bazel_rules_rust//proto:proto.bzl", "rust_grpc_library")
-load("@io_bazel_rules_rust//proto:toolchain.bzl", "GRPC_COMPILE_DEPS")
+load("//proto:proto.bzl", "rust_grpc_library")
+load("//proto:toolchain.bzl", "GRPC_COMPILE_DEPS")
 
 proto_library(
     name = "my_proto",

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -69,6 +69,4 @@ def rust_proto_repositories():
     rules_rust_proto_fetch_remote_crates()
 
     # Register toolchains
-    native.register_toolchains(
-        "@io_bazel_rules_rust//proto:default-proto-toolchain",
-    )
+    native.register_toolchains(str(Label("//proto:default-proto-toolchain")))

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -14,7 +14,7 @@
 
 """Toolchain for compiling rust stubs from protobuf and gRPC."""
 
-load("@io_bazel_rules_rust//rust:private/rust.bzl", "name_to_crate_name")
+load("//rust:private/rust.bzl", "name_to_crate_name")
 
 def generated_file_stem(f):
     basename = f.rsplit("/", 2)[-1]
@@ -113,14 +113,14 @@ def _rust_proto_toolchain_impl(ctx):
 
 # Default dependencies needed to compile protobuf stubs.
 PROTO_COMPILE_DEPS = [
-    "@io_bazel_rules_rust//proto/raze:protobuf",
+    Label("//proto/raze:protobuf"),
 ]
 
 # Default dependencies needed to compile gRPC stubs.
 GRPC_COMPILE_DEPS = PROTO_COMPILE_DEPS + [
-    "@io_bazel_rules_rust//proto/raze:grpc",
-    "@io_bazel_rules_rust//proto/raze:tls_api",
-    "@io_bazel_rules_rust//proto/raze:tls_api_stub",
+    Label("//proto/raze:grpc"),
+    Label("//proto/raze:tls_api"),
+    Label("//proto/raze:tls_api_stub"),
 ]
 
 # TODO(damienmg): Once bazelbuild/bazel#6889 is fixed, reintroduce
@@ -139,17 +139,13 @@ rust_proto_toolchain = rule(
             doc = "The location of the Rust protobuf compiler plugin used to generate rust sources.",
             allow_single_file = True,
             cfg = "exec",
-            default = Label(
-                "@io_bazel_rules_rust//proto:protoc_gen_rust",
-            ),
+            default = Label("//proto:protoc_gen_rust"),
         ),
         "grpc_plugin": attr.label(
             doc = "The location of the Rust protobuf compiler plugin to generate rust gRPC stubs.",
             allow_single_file = True,
             cfg = "exec",
-            default = Label(
-                "@io_bazel_rules_rust//proto:protoc_gen_rust_grpc",
-            ),
+            default = Label("//proto:protoc_gen_rust_grpc"),
         ),
         "edition": attr.string(
             doc = "The edition used by the generated rust source.",

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -17,6 +17,6 @@ bzl_library(
     name = "rules",
     srcs = glob(["**/*.bzl"]),
     deps = [
-        "@io_bazel_rules_rust//rust/platform:rules",
+        "//rust/platform:rules",
     ],
 )

--- a/rust/platform/BUILD
+++ b/rust/platform/BUILD
@@ -15,5 +15,5 @@ package_group(
 bzl_library(
     name = "rules",
     srcs = glob(["**/*.bzl"]),
-    visibility = ["@io_bazel_rules_rust//rust:__pkg__"],
+    visibility = ["//rust:__pkg__"],
 )

--- a/rust/platform/platform.bzl
+++ b/rust/platform/platform.bzl
@@ -91,16 +91,16 @@ def declare_config_settings():
     native.platform(
         name = "wasm",
         constraint_values = [
-            "@io_bazel_rules_rust//rust/platform/cpu:wasm32",
-            "@io_bazel_rules_rust//rust/platform/os:unknown",
+            str(Label("//rust/platform/cpu:wasm32")),
+            str(Label("//rust/platform/os:unknown")),
         ],
     )
 
     native.platform(
         name = "wasi",
         constraint_values = [
-            "@io_bazel_rules_rust//rust/platform/cpu:wasm32",
-            "@io_bazel_rules_rust//rust/platform/os:wasi",
+            str(Label("//rust/platform/cpu:wasm32")),
+            str(Label("//rust/platform/os:wasi")),
         ],
     )
 

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -186,9 +186,15 @@ def triple_to_constraint_set(triple):
         list: A list of constraints (each represented by a list of strings)
     """
     if triple == "wasm32-wasi":
-        return ["@io_bazel_rules_rust//rust/platform/cpu:wasm32", "@io_bazel_rules_rust//rust/platform/os:wasi"]
+        return [
+            "@io_bazel_rules_rust//rust/platform/cpu:wasm32",
+            "@io_bazel_rules_rust//rust/platform/os:wasi",
+        ]
     if triple == "wasm32-unknown-unknown":
-        return ["@io_bazel_rules_rust//rust/platform/cpu:wasm32", "@io_bazel_rules_rust//rust/platform/os:unknown"]
+        return [
+            "@io_bazel_rules_rust//rust/platform/cpu:wasm32",
+            "@io_bazel_rules_rust//rust/platform/os:unknown",
+        ]
 
     component_parts = triple.split("-")
     if len(component_parts) < 3:

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -14,7 +14,7 @@
 
 # buildifier: disable=module-docstring
 load(
-    "@io_bazel_rules_rust//rust:private/rustc.bzl",
+    "//rust:private/rustc.bzl",
     "CrateInfo",
     "collect_deps",
     "collect_inputs",
@@ -22,10 +22,10 @@ load(
     "get_cc_toolchain",
 )
 load(
-    "@io_bazel_rules_rust//rust:private/rust.bzl",
+    "//rust:private/rust.bzl",
     "crate_root_src",
 )
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
+load("//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
 
 _rust_extensions = [
     "rs",
@@ -144,7 +144,7 @@ rust_clippy_aspect = aspect(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
         "_process_wrapper": attr.label(
-            default = "@io_bazel_rules_rust//util/process_wrapper",
+            default = Label("//util/process_wrapper"),
             executable = True,
             allow_single_file = True,
             cfg = "exec",
@@ -152,7 +152,7 @@ rust_clippy_aspect = aspect(
         "_error_format": attr.label(default = "//:error_format"),
     },
     toolchains = [
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     implementation = _clippy_aspect_impl,

--- a/rust/private/dummy_cc_toolchain/BUILD
+++ b/rust/private/dummy_cc_toolchain/BUILD
@@ -7,7 +7,7 @@ dummy_cc_toolchain(name = "dummy_cc_wasm32")
 # TODO(jedmonds@spotify.com): Need to support linking C code to rust code when compiling for wasm32.
 toolchain(
     name = "dummy_cc_wasm32_toolchain",
-    target_compatible_with = ["@io_bazel_rules_rust//rust/platform/cpu:wasm32"],
+    target_compatible_with = ["//rust/platform/cpu:wasm32"],
     toolchain = ":dummy_cc_wasm32",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("@io_bazel_rules_rust//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
+load("//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
+load("//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
 
 # TODO(marco): Separate each rule into its own file.
 
@@ -467,7 +467,7 @@ _rust_common_attrs = {
         default = "@bazel_tools//tools/cpp:current_cc_toolchain",
     ),
     "_process_wrapper": attr.label(
-        default = "@io_bazel_rules_rust//util/process_wrapper",
+        default = Label("//util/process_wrapper"),
         executable = True,
         allow_single_file = True,
         cfg = "exec",
@@ -506,7 +506,7 @@ rust_library = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     doc = """\
@@ -596,7 +596,7 @@ rust_binary = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     doc = """\
@@ -694,7 +694,7 @@ rust_test = rule(
     host_fragments = ["cpp"],
     test = True,
     toolchains = [
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     doc = """\
@@ -842,7 +842,7 @@ rust_test_binary = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     doc = """\
@@ -865,7 +865,7 @@ rust_benchmark = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     doc = """\

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -19,7 +19,7 @@ load(
 )
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
-    "@io_bazel_rules_rust//rust:private/utils.bzl",
+    "//rust:private/utils.bzl",
     "expand_locations",
     "get_lib_name",
     "get_libs_for_static_executable",

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("@io_bazel_rules_rust//rust:private/rustc.bzl", "CrateInfo", "DepInfo", "add_crate_link_flags", "add_edition_flags")
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain")
+load("//rust:private/rustc.bzl", "CrateInfo", "DepInfo", "add_crate_link_flags", "add_edition_flags")
+load("//rust:private/utils.bzl", "find_toolchain")
 
 _rust_doc_doc = """Generates code documentation.
 
@@ -174,5 +174,5 @@ rust_doc = rule(
     outputs = {
         "rust_doc_zip": "%{name}.zip",
     },
-    toolchains = ["@io_bazel_rules_rust//rust:toolchain"],
+    toolchains = [str(Label("//rust:toolchain"))],
 )

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("@io_bazel_rules_rust//rust:private/rustc.bzl", "CrateInfo", "DepInfo")
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain", "get_lib_name")
+load("//rust:private/rustc.bzl", "CrateInfo", "DepInfo")
+load("//rust:private/utils.bzl", "find_toolchain", "get_lib_name")
 
 def _rust_doc_test_impl(ctx):
     """The implementation for the `rust_doc_test` rule
@@ -197,7 +197,7 @@ rust_doc_test = rule(
     },
     executable = True,
     test = True,
-    toolchains = ["@io_bazel_rules_rust//rust:toolchain"],
+    toolchains = [str(Label("//rust:toolchain"))],
     doc = """Runs Rust documentation tests.
 
 Example:

--- a/rust/private/transitions.bzl
+++ b/rust/private/transitions.bzl
@@ -11,7 +11,7 @@ def _wasm_bindgen_transition(settings, attr):
     Returns:
         dict: A dict of new build settings values to apply
     """
-    return {"//command_line_option:platforms": "@io_bazel_rules_rust//rust/platform:wasm"}
+    return {"//command_line_option:platforms": str(Label("//rust/platform:wasm"))}
 
 wasm_bindgen_transition = transition(
     implementation = _wasm_bindgen_transition,

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -23,7 +23,7 @@ def find_toolchain(ctx):
     Returns:
         rust_toolchain: A Rust toolchain context.
     """
-    return ctx.toolchains["@io_bazel_rules_rust//rust:toolchain"]
+    return ctx.toolchains[Label("//rust:toolchain")]
 
 # TODO: Replace with bazel-skylib's `path.dirname`. This requires addressing some
 # dependency issues or generating docs will break.

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -609,8 +609,8 @@ def _rust_toolchain_repository_impl(ctx):
         if ctx.attr.dev_components and target_triple not in ctx.attr.extra_target_triples:
             _load_rustc_dev_nightly(ctx, target_triple)
 
-    ctx.file("WORKSPACE", "")
-    ctx.file("BUILD", "\n".join(build_components))
+    ctx.file("WORKSPACE.bazel", "")
+    ctx.file("BUILD.bazel", "\n".join(build_components))
 
 def _rust_toolchain_repository_proxy_impl(ctx):
     build_components = []
@@ -625,8 +625,8 @@ def _rust_toolchain_repository_proxy_impl(ctx):
             target_triple = target_triple,
         ))
 
-    ctx.file("WORKSPACE", "")
-    ctx.file("BUILD", "\n".join(build_components))
+    ctx.file("WORKSPACE.bazel", "")
+    ctx.file("BUILD.bazel", "\n".join(build_components))
 
 rust_toolchain_repository = repository_rule(
     doc = (
@@ -767,4 +767,4 @@ def rust_repository_set(
 
     # Register toolchains
     native.register_toolchains(*all_toolchain_names)
-    native.register_toolchains("@io_bazel_rules_rust//rust/private/dummy_cc_toolchain:dummy_cc_wasm32_toolchain")
+    native.register_toolchains(str(Label("//rust/private/dummy_cc_toolchain:dummy_cc_wasm32_toolchain")))

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -14,7 +14,7 @@
 
 # buildifier: disable=module-docstring
 load(
-    "@io_bazel_rules_rust//rust:private/rust.bzl",
+    "//rust:private/rust.bzl",
     _rust_benchmark = "rust_benchmark",
     _rust_binary = "rust_binary",
     _rust_library = "rust_library",
@@ -22,15 +22,15 @@ load(
     _rust_test_binary = "rust_test_binary",
 )
 load(
-    "@io_bazel_rules_rust//rust:private/rustdoc.bzl",
+    "//rust:private/rustdoc.bzl",
     _rust_doc = "rust_doc",
 )
 load(
-    "@io_bazel_rules_rust//rust:private/rustdoc_test.bzl",
+    "//rust:private/rustdoc_test.bzl",
     _rust_doc_test = "rust_doc_test",
 )
 load(
-    "@io_bazel_rules_rust//rust:private/clippy.bzl",
+    "//rust:private/clippy.bzl",
     _rust_clippy = "rust_clippy",
     _rust_clippy_aspect = "rust_clippy_aspect",
 )

--- a/test/process_wrapper/process_wrapper_tester.bzl
+++ b/test/process_wrapper/process_wrapper_tester.bzl
@@ -82,7 +82,7 @@ process_wrapper_tester = rule(
             cfg = "exec",
         ),
         "_process_wrapper": attr.label(
-            default = "@io_bazel_rules_rust//util/process_wrapper",
+            default = Label("//util/process_wrapper"),
             executable = True,
             allow_single_file = True,
             cfg = "exec",

--- a/test/rustfmt/rustfmt_generator.bzl
+++ b/test/rustfmt/rustfmt_generator.bzl
@@ -1,5 +1,5 @@
 # buildifier: disable=module-docstring
-load("@io_bazel_rules_rust//rust:private/utils.bzl", "find_toolchain")
+load("//rust:private/utils.bzl", "find_toolchain")
 
 def _rustfmt_generator_impl(ctx):
     toolchain = find_toolchain(ctx)
@@ -32,7 +32,7 @@ rustfmt_generator = rule(
             allow_single_file = True,
         ),
         "_process_wrapper": attr.label(
-            default = "@io_bazel_rules_rust//util/process_wrapper",
+            default = Label("//util/process_wrapper"),
             executable = True,
             allow_single_file = True,
             cfg = "exec",
@@ -40,6 +40,6 @@ rustfmt_generator = rule(
     },
     outputs = {"out": "%{name}.rs"},
     toolchains = [
-        "@io_bazel_rules_rust//rust:toolchain",
+        str(Label("//rust:toolchain")),
     ],
 )

--- a/test/transitive_lib/BUILD
+++ b/test/transitive_lib/BUILD
@@ -1,8 +1,5 @@
-load(
-    "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
-    "cargo_build_script",
-)
-load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary", "rust_library")
+load("//cargo:cargo_build_script.bzl", "cargo_build_script")
+load("//rust:rust.bzl", "rust_binary", "rust_library")
 
 # sets link alias
 cargo_build_script(

--- a/test/versioned_dylib/BUILD
+++ b/test/versioned_dylib/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@io_bazel_rules_rust//rust:rust.bzl",
+    "//rust:rust.bzl",
     "rust_binary",
     "rust_test",
 )

--- a/tools/runfiles/BUILD
+++ b/tools/runfiles/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@io_bazel_rules_rust//rust:rust.bzl",
+    "//rust:rust.bzl",
     "rust_doc_test",
     "rust_library",
     "rust_test",

--- a/wasm_bindgen/BUILD
+++ b/wasm_bindgen/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_rust//wasm_bindgen:wasm_bindgen.bzl", "rust_wasm_bindgen_toolchain")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//wasm_bindgen:wasm_bindgen.bzl", "rust_wasm_bindgen_toolchain")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,7 +8,7 @@ toolchain_type(name = "wasm_bindgen_toolchain")
 bzl_library(
     name = "rules",
     srcs = glob(["**/*.bzl"]),
-    deps = ["@io_bazel_rules_rust//rust:rules"],
+    deps = ["//rust:rules"],
 )
 
 rust_wasm_bindgen_toolchain(
@@ -19,5 +19,5 @@ rust_wasm_bindgen_toolchain(
 toolchain(
     name = "default_wasm_bindgen_toolchain",
     toolchain = "default_wasm_bindgen_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_rust//wasm_bindgen:wasm_bindgen_toolchain",
+    toolchain_type = "//wasm_bindgen:wasm_bindgen_toolchain",
 )

--- a/wasm_bindgen/repositories.bzl
+++ b/wasm_bindgen/repositories.bzl
@@ -26,4 +26,4 @@ def rust_wasm_bindgen_repositories():
 
     rules_rust_wasm_bindgen_fetch_remote_crates()
 
-    native.register_toolchains("@io_bazel_rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain")
+    native.register_toolchains(str(Label("//wasm_bindgen:default_wasm_bindgen_toolchain")))

--- a/wasm_bindgen/wasm_bindgen.bzl
+++ b/wasm_bindgen/wasm_bindgen.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("@io_bazel_rules_rust//rust:private/transitions.bzl", "wasm_bindgen_transition")
+load("//rust:private/transitions.bzl", "wasm_bindgen_transition")
 
 _WASM_BINDGEN_DOC = """\
 Generates javascript and typescript bindings for a webassembly module.
@@ -60,7 +60,7 @@ For additional information, see the [Bazel toolchains documentation](https://doc
 """
 
 def _rust_wasm_bindgen_impl(ctx):
-    toolchain = ctx.toolchains["@io_bazel_rules_rust//wasm_bindgen:wasm_bindgen_toolchain"]
+    toolchain = ctx.toolchains[Label("//wasm_bindgen:wasm_bindgen_toolchain")]
     bindgen_bin = toolchain.bindgen
 
     args = ctx.actions.args()
@@ -141,7 +141,7 @@ rust_wasm_bindgen = rule(
             doc = "Flags to pass directly to the bindgen executable. See https://github.com/rustwasm/wasm-bindgen/ for details.",
         ),
         "_whitelist_function_transition": attr.label(
-            default = "//tools/whitelists/function_transition_whitelist",
+            default = Label("//tools/whitelists/function_transition_whitelist"),
         ),
     },
     outputs = {
@@ -152,7 +152,7 @@ rust_wasm_bindgen = rule(
         "typescript_bindings": "%{name}.d.ts",
     },
     toolchains = [
-        "@io_bazel_rules_rust//wasm_bindgen:wasm_bindgen_toolchain",
+        str(Label("//wasm_bindgen:wasm_bindgen_toolchain")),
     ],
 )
 


### PR DESCRIPTION
This PR updates changes the explicit use of `@io_bazel_rules_rust//...` to `//...` and adds the use of [Label](https://docs.bazel.build/versions/master/skylark/lib/Label.html) wherever possible. This should currently have no functional but it provides some better type guarantees.