### PR TITLE
support clippy aspect in unit tests as well

### DIFF
--- a/examples/cargo/lib.rs
+++ b/examples/cargo/lib.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// theoretically this should be safe, as unit tests are built without
+// optimizations
+#![allow(clippy::assertions_on_constants)]
 mod test {
     #[test]
     fn test_env_contents() {

--- a/examples/ffi/rust_calling_c/src/matrix.rs
+++ b/examples/ffi/rust_calling_c/src/matrix.rs
@@ -117,34 +117,26 @@ mod test {
 
     #[test]
     fn test_size() {
-        let matrix = Matrix::new(2, 4, &vec![11, 12, 13, 14,
-                                             21, 22, 23, 24]);
+        let matrix = Matrix::new(2, 4, &[11, 12, 13, 14, 21, 22, 23, 24]);
         assert_eq!(2, matrix.rows());
         assert_eq!(4, matrix.cols());
     }
 
     #[test]
     fn test_equal() {
-        let matrix_a = Matrix::new(2, 4, &vec![11, 12, 13, 14,
-                                               21, 22, 23, 24]);
-        let matrix_b = Matrix::new(2, 4, &vec![11, 12, 13, 14,
-                                               21, 22, 23, 24]);
+        let matrix_a = Matrix::new(2, 4, &[11, 12, 13, 14, 21, 22, 23, 24]);
+        let matrix_b = Matrix::new(2, 4, &[11, 12, 13, 14, 21, 22, 23, 24]);
         assert!(matrix_a.equal(&matrix_b));
 
-        let matrix_c = Matrix::new(2, 4, &vec![12, 13, 14, 15,
-                                               23, 24, 25, 26]);
+        let matrix_c = Matrix::new(2, 4, &[12, 13, 14, 15, 23, 24, 25, 26]);
         assert!(!matrix_a.equal(&matrix_c));
     }
 
     #[test]
     fn test_transpose() {
-        let mut matrix = Matrix::new(2, 4, &vec![11, 12, 13, 14,
-                                                 21, 22, 23, 24]);
+        let mut matrix = Matrix::new(2, 4, &[11, 12, 13, 14, 21, 22, 23, 24]);
         matrix.transpose();
-        let expected = Matrix::new(4, 2, &vec![11, 21,
-                                               12, 22,
-                                               13, 23,
-                                               14, 24]);
+        let expected = Matrix::new(4, 2, &[11, 21, 12, 22, 13, 23, 14, 24]);
         assert!(matrix.equal(&expected));
     }
 }

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -46,12 +46,17 @@ def _clippy_aspect_impl(target, ctx):
     if CrateInfo not in target:
         return []
     rust_srcs = _rust_sources(target, ctx.rule)
-    if rust_srcs == []:
-        return []
 
     toolchain = find_toolchain(ctx)
     crate_info = target[CrateInfo]
-    root = crate_root_src(ctx.rule.attr, rust_srcs, crate_info.type)
+
+    if crate_info.is_test:
+        root = crate_info.root
+    else:
+        if rust_srcs == []:
+            # nothing to do
+            return []
+        root = crate_root_src(ctx.rule.attr, rust_srcs, crate_info.type)
 
     dep_info, build_info = collect_deps(
         ctx.label,


### PR DESCRIPTION
Unit tests with a 'crate = ...' argument have no rust_srcs, so
clippy was not running for them.