### PR TITLE
Added missing macros to rendered documentation

### DIFF
--- a/bindgen/BUILD
+++ b/bindgen/BUILD
@@ -7,7 +7,7 @@ toolchain_type(name = "bindgen_toolchain")
 
 bzl_library(
     name = "rules",
-    srcs = glob(["**/*.bzl"]),
+    srcs = glob(["**/*.bzl"]) + ["//bindgen/raze:crates.bzl"],
     deps = ["//rust:rules"],
 )
 

--- a/bindgen/raze/BUILD.bazel
+++ b/bindgen/raze/BUILD.bazel
@@ -40,3 +40,11 @@ alias(
         "manual",
     ],
 )
+
+# Export file for Stardoc support
+exports_files(
+    [
+        "crates.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bindgen/raze/remote/BUILD.bindgen-0.55.1.bazel
+++ b/bindgen/raze/remote/BUILD.bindgen-0.55.1.bazel
@@ -95,7 +95,6 @@ rust_binary(
     version = "0.55.1",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":bindgen",
         ":bindgen_build_script",
         "@rules_rust_bindgen__bitflags__1_2_1//:bitflags",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -34,18 +34,19 @@ PAGES = {
         "rust_doc_test",
     ],
     "rust_proto": [
-        "rust_proto_toolchain",
-        "rust_proto_library",
         "rust_grpc_library",
+        "rust_proto_library",
+        "rust_proto_repositories",
+        "rust_proto_toolchain",
     ],
     "rust_bindgen": [
-        "rust_bindgen_toolchain",
         "rust_bindgen_library",
+        "rust_bindgen_repositories",
+        "rust_bindgen_toolchain",
         "rust_bindgen",
     ],
     "rust_wasm_bindgen": [
-        # This cannot be included due to https://github.com/google/cargo-raze/issues/285
-        # "rust_wasm_bindgen_repositories",
+        "rust_wasm_bindgen_repositories",
         "rust_wasm_bindgen_toolchain",
         "rust_wasm_bindgen",
     ],

--- a/docs/all.bzl
+++ b/docs/all.bzl
@@ -9,6 +9,10 @@ load(
     _rust_bindgen_toolchain = "rust_bindgen_toolchain",
 )
 load(
+    "@io_bazel_rules_rust//bindgen:repositories.bzl",
+    _rust_bindgen_repositories = "rust_bindgen_repositories",
+)
+load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     _cargo_build_script = "cargo_build_script",
 )
@@ -16,6 +20,10 @@ load(
     "@io_bazel_rules_rust//proto:proto.bzl",
     _rust_grpc_library = "rust_grpc_library",
     _rust_proto_library = "rust_proto_library",
+)
+load(
+    "@io_bazel_rules_rust//proto:repositories.bzl",
+    _rust_proto_repositories = "rust_proto_repositories",
 )
 load(
     "@io_bazel_rules_rust//proto:toolchain.bzl",
@@ -41,11 +49,10 @@ load(
     "@io_bazel_rules_rust//rust:toolchain.bzl",
     _rust_toolchain = "rust_toolchain",
 )
-# This cannot be included due to https://github.com/google/cargo-raze/issues/285
-# load(
-#     "@io_bazel_rules_rust//wasm_bindgen:repositories.bzl",
-#     _rust_wasm_bindgen_repositories = "rust_wasm_bindgen_repositories",
-# )
+load(
+    "@io_bazel_rules_rust//wasm_bindgen:repositories.bzl",
+    _rust_wasm_bindgen_repositories = "rust_wasm_bindgen_repositories",
+)
 load(
     "@io_bazel_rules_rust//wasm_bindgen:wasm_bindgen.bzl",
     _rust_wasm_bindgen = "rust_wasm_bindgen",
@@ -65,16 +72,17 @@ rust_grpc_library = _rust_grpc_library
 rust_bindgen_toolchain = _rust_bindgen_toolchain
 rust_bindgen = _rust_bindgen
 rust_bindgen_library = _rust_bindgen_library
+rust_bindgen_repositories = _rust_bindgen_repositories
 
 rust_toolchain = _rust_toolchain
 rust_proto_toolchain = _rust_proto_toolchain
+rust_proto_repositories = _rust_proto_repositories
 
 cargo_build_script = _cargo_build_script
 
 rust_wasm_bindgen = _rust_wasm_bindgen
 rust_wasm_bindgen_toolchain = _rust_wasm_bindgen_toolchain
-# This cannot be included due to https://github.com/google/cargo-raze/issues/285
-# rust_wasm_bindgen_repositories = _rust_wasm_bindgen_repositories
+rust_wasm_bindgen_repositories = _rust_wasm_bindgen_repositories
 
 rust_repositories = _rust_repositories
 rust_repository_set = _rust_repository_set

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -5,12 +5,14 @@
 * [rust_binary](#rust_binary)
 * [rust_bindgen](#rust_bindgen)
 * [rust_bindgen_library](#rust_bindgen_library)
+* [rust_bindgen_repositories](#rust_bindgen_repositories)
 * [rust_bindgen_toolchain](#rust_bindgen_toolchain)
 * [rust_doc](#rust_doc)
 * [rust_doc_test](#rust_doc_test)
 * [rust_grpc_library](#rust_grpc_library)
 * [rust_library](#rust_library)
 * [rust_proto_library](#rust_proto_library)
+* [rust_proto_repositories](#rust_proto_repositories)
 * [rust_proto_toolchain](#rust_proto_toolchain)
 * [rust_repositories](#rust_repositories)
 * [rust_repository_set](#rust_repository_set)
@@ -19,6 +21,7 @@
 * [rust_toolchain_repository](#rust_toolchain_repository)
 * [rust_toolchain_repository_proxy](#rust_toolchain_repository_proxy)
 * [rust_wasm_bindgen](#rust_wasm_bindgen)
+* [rust_wasm_bindgen_repositories](#rust_wasm_bindgen_repositories)
 * [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
 
 
@@ -1120,6 +1123,30 @@ Arguments are the same as `rust_bindgen`, and `kwargs` are passed directly to ru
 | <a id="rust_bindgen_library-kwargs"></a>kwargs |  Arguments to forward to the underlying <code>rust_library</code> rule.   |  none |
 
 
+<a id="#rust_bindgen_repositories"></a>
+
+## rust_bindgen_repositories
+
+<pre>
+rust_bindgen_repositories()
+</pre>
+
+Declare dependencies needed for bindgen.
+
+
+
+<a id="#rust_proto_repositories"></a>
+
+## rust_proto_repositories
+
+<pre>
+rust_proto_repositories()
+</pre>
+
+Declare dependencies needed for proto compilation.
+
+
+
 <a id="#rust_repositories"></a>
 
 ## rust_repositories
@@ -1188,5 +1215,19 @@ N.B. A "proxy repository" is needed to allow for registering the toolchain (with
 | <a id="rust_repository_set-dev_components"></a>dev_components |  Whether to download the rustc-dev components.     Requires version to be "nightly". Defaults to False.   |  <code>False</code> |
 | <a id="rust_repository_set-sha256s"></a>sha256s |  A dict associating tool subdirectories to sha256 hashes. See     [rust_repositories](#rust_repositories) for more details.   |  <code>None</code> |
 | <a id="rust_repository_set-urls"></a>urls |  A list of mirror urls containing the tools from the Rust-lang static file server. These must contain the '{}' used to substitute the tool being fetched (using .format). Defaults to ['https://static.rust-lang.org/dist/{}.tar.gz']   |  <code>["https://static.rust-lang.org/dist/{}.tar.gz"]</code> |
+
+
+<a id="#rust_wasm_bindgen_repositories"></a>
+
+## rust_wasm_bindgen_repositories
+
+<pre>
+rust_wasm_bindgen_repositories()
+</pre>
+
+Declare dependencies needed for wasm-bindgen.
+
+This macro will load crate dependencies of `wasm-bindgen` that are generated using [cargo raze][raze] inside the rules_rust     repository. This makes the default toolchain `@io_bazel_rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain` available. For     more information on `wasm_bindgen` toolchains, see [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain).
+
 
 

--- a/docs/rust_bindgen.md
+++ b/docs/rust_bindgen.md
@@ -1,6 +1,7 @@
 # Rust rules
-* [rust_bindgen_toolchain](#rust_bindgen_toolchain)
 * [rust_bindgen_library](#rust_bindgen_library)
+* [rust_bindgen_repositories](#rust_bindgen_repositories)
+* [rust_bindgen_toolchain](#rust_bindgen_toolchain)
 * [rust_bindgen](#rust_bindgen)
 
 <a id="#rust_bindgen"></a>
@@ -72,5 +73,17 @@ Arguments are the same as `rust_bindgen`, and `kwargs` are passed directly to ru
 | <a id="rust_bindgen_library-bindgen_flags"></a>bindgen_flags |  Flags to pass directly to the bindgen executable. See https://rust-lang.github.io/rust-bindgen/ for details.   |  <code>None</code> |
 | <a id="rust_bindgen_library-clang_flags"></a>clang_flags |  Flags to pass directly to the clang executable.   |  <code>None</code> |
 | <a id="rust_bindgen_library-kwargs"></a>kwargs |  Arguments to forward to the underlying <code>rust_library</code> rule.   |  none |
+
+
+<a id="#rust_bindgen_repositories"></a>
+
+## rust_bindgen_repositories
+
+<pre>
+rust_bindgen_repositories()
+</pre>
+
+Declare dependencies needed for bindgen.
+
 
 

--- a/docs/rust_proto.md
+++ b/docs/rust_proto.md
@@ -1,7 +1,8 @@
 # Rust rules
-* [rust_proto_toolchain](#rust_proto_toolchain)
-* [rust_proto_library](#rust_proto_library)
 * [rust_grpc_library](#rust_grpc_library)
+* [rust_proto_library](#rust_proto_library)
+* [rust_proto_repositories](#rust_proto_repositories)
+* [rust_proto_toolchain](#rust_proto_toolchain)
 
 <a id="#rust_grpc_library"></a>
 
@@ -143,5 +144,17 @@ See @io_bazel_rules_rust//proto:BUILD for examples of defining the toolchain.
 | <a id="rust_proto_toolchain-grpc_plugin"></a>grpc_plugin |  The location of the Rust protobuf compiler plugin to generate rust gRPC stubs.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @io_bazel_rules_rust//proto:protoc_gen_rust_grpc |
 | <a id="rust_proto_toolchain-proto_plugin"></a>proto_plugin |  The location of the Rust protobuf compiler plugin used to generate rust sources.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @io_bazel_rules_rust//proto:protoc_gen_rust |
 | <a id="rust_proto_toolchain-protoc"></a>protoc |  The location of the <code>protoc</code> binary. It should be an executable target.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @com_google_protobuf//:protoc |
+
+
+<a id="#rust_proto_repositories"></a>
+
+## rust_proto_repositories
+
+<pre>
+rust_proto_repositories()
+</pre>
+
+Declare dependencies needed for proto compilation.
+
 
 

--- a/docs/rust_wasm_bindgen.md
+++ b/docs/rust_wasm_bindgen.md
@@ -1,4 +1,5 @@
 # Rust rules
+* [rust_wasm_bindgen_repositories](#rust_wasm_bindgen_repositories)
 * [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
 * [rust_wasm_bindgen](#rust_wasm_bindgen)
 
@@ -77,5 +78,19 @@ For additional information, see the [Bazel toolchains documentation](https://doc
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_wasm_bindgen_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_wasm_bindgen_toolchain-bindgen"></a>bindgen |  The label of a <code>wasm-bindgen</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+
+
+<a id="#rust_wasm_bindgen_repositories"></a>
+
+## rust_wasm_bindgen_repositories
+
+<pre>
+rust_wasm_bindgen_repositories()
+</pre>
+
+Declare dependencies needed for wasm-bindgen.
+
+This macro will load crate dependencies of `wasm-bindgen` that are generated using [cargo raze][raze] inside the rules_rust     repository. This makes the default toolchain `@io_bazel_rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain` available. For     more information on `wasm_bindgen` toolchains, see [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain).
+
 
 

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -32,5 +32,5 @@ rust_proto_toolchain(name = "default-proto-toolchain-impl")
 
 bzl_library(
     name = "rules",
-    srcs = glob(["**/*.bzl"]),
+    srcs = glob(["**/*.bzl"]) + ["//proto/raze:crates.bzl"],
 )

--- a/proto/raze/BUILD.bazel
+++ b/proto/raze/BUILD.bazel
@@ -96,3 +96,11 @@ alias(
         "manual",
     ],
 )
+
+# Export file for Stardoc support
+exports_files(
+    [
+        "crates.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/proto/raze/remote/BUILD.grpc-compiler-0.6.2.bazel
+++ b/proto/raze/remote/BUILD.grpc-compiler-0.6.2.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "0.6.2",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":grpc_compiler",
         "@rules_rust_proto__protobuf__2_8_2//:protobuf",
         "@rules_rust_proto__protobuf_codegen__2_8_2//:protobuf_codegen",

--- a/proto/raze/remote/BUILD.protobuf-codegen-2.8.2.bazel
+++ b/proto/raze/remote/BUILD.protobuf-codegen-2.8.2.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "2.8.2",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":protobuf_codegen",
         "@rules_rust_proto__protobuf__2_8_2//:protobuf",
     ],
@@ -76,7 +75,6 @@ rust_binary(
     version = "2.8.2",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":protobuf_codegen",
         "@rules_rust_proto__protobuf__2_8_2//:protobuf",
     ],

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -77,6 +77,7 @@ def get_lib_name(lib):
     Returns:
         str: The name of the library
     """
+
     # NB: The suffix may contain a version number like 'so.1.2.3'
     libname = lib.basename.split(".", 1)[0]
 

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -1,4 +1,4 @@
 sh_binary(
     name = "fetch_shas",
-    srcs = ["fetch_shas.sh"]
+    srcs = ["fetch_shas.sh"],
 )

--- a/wasm_bindgen/BUILD
+++ b/wasm_bindgen/BUILD
@@ -7,7 +7,7 @@ toolchain_type(name = "wasm_bindgen_toolchain")
 
 bzl_library(
     name = "rules",
-    srcs = glob(["**/*.bzl"]),
+    srcs = glob(["**/*.bzl"]) + ["//wasm_bindgen/raze:crates.bzl"],
     deps = ["//rust:rules"],
 )
 

--- a/wasm_bindgen/raze/BUILD.bazel
+++ b/wasm_bindgen/raze/BUILD.bazel
@@ -31,3 +31,11 @@ alias(
         "manual",
     ],
 )
+
+# Export file for Stardoc support
+exports_files(
+    [
+        "crates.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/wasm_bindgen/raze/remote/BUILD.assert_cmd-1.0.2.bazel
+++ b/wasm_bindgen/raze/remote/BUILD.assert_cmd-1.0.2.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "1.0.2",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":assert_cmd",
         "@rules_rust_wasm_bindgen__doc_comment__0_3_3//:doc_comment",
         "@rules_rust_wasm_bindgen__predicates__1_0_5//:predicates",

--- a/wasm_bindgen/raze/remote/BUILD.cc-1.0.66.bazel
+++ b/wasm_bindgen/raze/remote/BUILD.cc-1.0.66.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "1.0.66",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":cc",
     ],
 )

--- a/wasm_bindgen/raze/remote/BUILD.difference-2.0.0.bazel
+++ b/wasm_bindgen/raze/remote/BUILD.difference-2.0.0.bazel
@@ -51,7 +51,6 @@ rust_binary(
     version = "2.0.0",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":difference",
     ],
 )

--- a/wasm_bindgen/raze/remote/BUILD.docopt-1.1.0.bazel
+++ b/wasm_bindgen/raze/remote/BUILD.docopt-1.1.0.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "1.1.0",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":docopt",
         "@rules_rust_wasm_bindgen__lazy_static__1_4_0//:lazy_static",
         "@rules_rust_wasm_bindgen__regex__1_4_2//:regex",

--- a/wasm_bindgen/raze/remote/BUILD.leb128-0.2.4.bazel
+++ b/wasm_bindgen/raze/remote/BUILD.leb128-0.2.4.bazel
@@ -52,7 +52,6 @@ rust_binary(
     version = "0.2.4",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":leb128",
     ],
 )

--- a/wasm_bindgen/raze/remote/BUILD.multipart-0.15.4.bazel
+++ b/wasm_bindgen/raze/remote/BUILD.multipart-0.15.4.bazel
@@ -56,7 +56,6 @@ rust_binary(
     version = "0.15.4",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":multipart",
         "@rules_rust_wasm_bindgen__buf_redux__0_8_4//:buf_redux",
         "@rules_rust_wasm_bindgen__httparse__1_3_4//:httparse",

--- a/wasm_bindgen/raze/remote/BUILD.wait-timeout-0.2.0.bazel
+++ b/wasm_bindgen/raze/remote/BUILD.wait-timeout-0.2.0.bazel
@@ -52,7 +52,6 @@ rust_binary(
     version = "0.2.0",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":wait_timeout",
     ] + selects.with_or({
         # cfg(unix)
@@ -102,7 +101,6 @@ rust_binary(
     version = "0.2.0",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":wait_timeout",
     ] + selects.with_or({
         # cfg(unix)
@@ -152,7 +150,6 @@ rust_binary(
     version = "0.2.0",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":wait_timeout",
     ] + selects.with_or({
         # cfg(unix)

--- a/wasm_bindgen/raze/remote/BUILD.wit-schema-version-0.1.0.bazel
+++ b/wasm_bindgen/raze/remote/BUILD.wit-schema-version-0.1.0.bazel
@@ -50,7 +50,6 @@ rust_binary(
     version = "0.1.0",
     # buildifier: leave-alone
     deps = [
-        # Binaries get an implicit dependency on their crate's lib
         ":wit_schema_version",
     ],
 )

--- a/wasm_bindgen/repositories.bzl
+++ b/wasm_bindgen/repositories.bzl
@@ -18,7 +18,7 @@ load("//wasm_bindgen/raze:crates.bzl", "rules_rust_wasm_bindgen_fetch_remote_cra
 # buildifier: disable=unnamed-macro
 def rust_wasm_bindgen_repositories():
     """Declare dependencies needed for wasm-bindgen.
-    
+
     This macro will load crate dependencies of `wasm-bindgen` that are generated using [cargo raze][raze] inside the rules_rust \
     repository. This makes the default toolchain `@io_bazel_rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain` available. For \
     more information on `wasm_bindgen` toolchains, see [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain).


### PR DESCRIPTION
Due to the changes released in `cargo-raze 0.9.0`, we can now generate documentation for `.bzl` files that load a `crates.bzl` file generated by `cargo-raze`. This PR updates the `wasm-bindgen` outputs and the documentation.

edit: I expanded the scope of this change to also include the `*_repositories` macros from the `bindgen` and `proto` rules since the delta was small enough.