### PR TITLE
Fix test target on macOS with Bazel@HEAD

### DIFF
--- a/examples/ffi/rust_calling_c/c/BUILD
+++ b/examples/ffi/rust_calling_c/c/BUILD
@@ -20,9 +20,9 @@ cc_test(
 
 ## Do the same as above, but with a dynamic c library.
 
-cc_library(
+cc_import(
     name = "native_matrix_so",
-    srcs = [":libnative_matrix_so.so"],
+    shared_library = ":libnative_matrix_so.so",
     hdrs = ["matrix.h"],
 )
 

--- a/examples/ffi/rust_calling_c/c/BUILD
+++ b/examples/ffi/rust_calling_c/c/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library", "cc_test")
 
 package(default_visibility = ["//ffi/rust_calling_c:__subpackages__"])
 


### PR DESCRIPTION
Avoid build artifacts name conflict after `supports_dynamic_linker` feature was removed from cc toolchain for macOS
Context: https://github.com/bazelbuild/bazel/issues/4341#issuecomment-762576370
