### PR TITLE
Pass C++ runtime lib when C++ toolchain declares it

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -7,10 +7,10 @@ load("//rust:rust.bzl", "rust_binary")
 load("//rust/private:rust.bzl", "name_to_crate_name")
 
 # buildifier: disable=bzl-visibility
-load("//rust/private:rustc.bzl", "BuildInfo", "DepInfo", "get_cc_toolchain", "get_compilation_mode_opts", "get_linker_and_args")
+load("//rust/private:rustc.bzl", "BuildInfo", "DepInfo", "get_compilation_mode_opts", "get_linker_and_args")
 
 # buildifier: disable=bzl-visibility
-load("//rust/private:utils.bzl", "expand_locations", "find_toolchain")
+load("//rust/private:utils.bzl", "expand_locations", "find_cc_toolchain", "find_toolchain")
 
 def get_cc_compile_env(cc_toolchain, feature_configuration):
     """Gather cc environment variables from the given `cc_toolchain`
@@ -98,7 +98,7 @@ def _build_script_impl(ctx):
 
     # Pull in env vars which may be required for the cc_toolchain to work (e.g. on OSX, the SDK version).
     # We hope that the linker env is sufficient for the whole cc_toolchain.
-    cc_toolchain, feature_configuration = get_cc_toolchain(ctx)
+    cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
     _, _, linker_env = get_linker_and_args(ctx, cc_toolchain, feature_configuration, None)
     env.update(**linker_env)
 

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -23,9 +23,8 @@ load(
     "collect_deps",
     "collect_inputs",
     "construct_arguments",
-    "get_cc_toolchain",
 )
-load("//rust/private:utils.bzl", "determine_output_hash", "find_toolchain")
+load("//rust/private:utils.bzl", "determine_output_hash", "find_cc_toolchain", "find_toolchain")
 
 _rust_extensions = [
     "rs",
@@ -48,6 +47,7 @@ def _clippy_aspect_impl(target, ctx):
     rust_srcs = _rust_sources(target, ctx.rule)
 
     toolchain = find_toolchain(ctx)
+    cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
     crate_info = target[rust_common.crate_info]
     crate_type = crate_info.type
 
@@ -72,6 +72,7 @@ def _clippy_aspect_impl(target, ctx):
         ctx.rule.file,
         ctx.rule.files,
         toolchain,
+        cc_toolchain,
         crate_info,
         dep_info,
         build_info,
@@ -80,8 +81,6 @@ def _clippy_aspect_impl(target, ctx):
     # A marker file indicating clippy has executed successfully.
     # This file is necessary because "ctx.actions.run" mandates an output.
     clippy_marker = ctx.actions.declare_file(ctx.label.name + "_clippy.ok")
-
-    cc_toolchain, feature_configuration = get_cc_toolchain(ctx)
 
     args, env = construct_arguments(
         ctx,

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -14,6 +14,8 @@
 
 """Utility functions not specific to the rust toolchain."""
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", find_rules_cc_toolchain = "find_cpp_toolchain")
+
 def find_toolchain(ctx):
     """Finds the first rust toolchain that is configured.
 
@@ -24,6 +26,25 @@ def find_toolchain(ctx):
         rust_toolchain: A Rust toolchain context.
     """
     return ctx.toolchains[Label("//rust:toolchain")]
+
+def find_cc_toolchain(ctx):
+    """Extracts a CcToolchain from the current target's context
+
+    Args:
+        ctx (ctx): The current target's rule context object
+
+    Returns:
+        tuple: A tuple of (CcToolchain, FeatureConfiguration)
+    """
+    cc_toolchain = find_rules_cc_toolchain(ctx)
+
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    return cc_toolchain, feature_configuration
 
 # TODO: Replace with bazel-skylib's `path.dirname`. This requires addressing some
 # dependency issues or generating docs will break.


### PR DESCRIPTION
Currently `rules_rust` won't link against the C++ standard library in case
C++ toolchain is the `static_link_cpp_runtimes` feature (therefore when
it uses `cc_toolchain.static_runtime_lib` and `cc_toolchain.dynamic_runtime_lib`
attributes to declare which version of C++ static library should be
linked into the final binary).

This PR modifies `add_native_link_flags` to also look into the
C++ toolchain and depend on C++ standard library from there.

While there, I moved the `get_cc_toolchain` function to the `utils.rs`,
to be consistent with the handling of the Rust toolchain.