### PR TITLE
Fixed legacy-provider-syntax for wasm_bindgen

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,33 +1,47 @@
-load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 package(default_visibility = ["//visibility:private"])
 
 bzl_library(
-    name = "all_deps",
+    name = "docs_deps",
     srcs = [
         "@bazel_tools//tools:bzl_srcs",
+        "@build_bazel_rules_nodejs//internal/providers:bzl",
     ],
     deps = [
-        "@bazel_skylib//:workspace",
-        "@bazel_skylib//lib:unittest",
-        "@bazel_skylib//lib:versions",
+        "@rules_proto//proto:rules",
+    ],
+)
+
+bzl_library(
+    name = "all_docs",
+    deps = [
+        ":docs_deps",
         "@rules_rust//:rules",
         "@rules_rust//bindgen:rules",
         "@rules_rust//cargo:rules",
         "@rules_rust//proto:rules",
         "@rules_rust//rust:rules",
         "@rules_rust//wasm_bindgen:rules",
-        "@rules_proto//proto:rules",
     ],
 )
 
 PAGES = {
+    "cargo_build_script": [
+        "cargo_build_script",
+    ],
     "rust": [
         "rust_library",
         "rust_binary",
         "rust_benchmark",
         "rust_test",
+    ],
+    "rust_bindgen": [
+        "rust_bindgen_library",
+        "rust_bindgen_repositories",
+        "rust_bindgen_toolchain",
+        "rust_bindgen",
     ],
     "rust_doc": [
         "rust_doc",
@@ -39,26 +53,17 @@ PAGES = {
         "rust_proto_repositories",
         "rust_proto_toolchain",
     ],
-    "rust_bindgen": [
-        "rust_bindgen_library",
-        "rust_bindgen_repositories",
-        "rust_bindgen_toolchain",
-        "rust_bindgen",
-    ],
-    "rust_wasm_bindgen": [
-        "rust_wasm_bindgen_repositories",
-        "rust_wasm_bindgen_toolchain",
-        "rust_wasm_bindgen",
-    ],
-    "cargo_build_script": [
-        "cargo_build_script",
-    ],
     "rust_repositories": [
         "rust_repositories",
         "rust_repository_set",
         "rust_toolchain",
         "rust_toolchain_repository",
         "rust_toolchain_repository_proxy",
+    ],
+    "rust_wasm_bindgen": [
+        "rust_wasm_bindgen_repositories",
+        "rust_wasm_bindgen_toolchain",
+        "rust_wasm_bindgen",
     ],
 }
 
@@ -81,7 +86,7 @@ PAGES = {
         header_template = ":%s_header_vm" % k,
         input = ":all.bzl",
         symbol_names = PAGES[k],
-        deps = [":all_deps"],
+        deps = [":all_docs"],
     )
     for k in PAGES.keys()
 ]
@@ -101,5 +106,5 @@ stardoc(
     header_template = ":flatten_header_vm",
     input = ":all.bzl",
     symbol_names = [symbol for k in PAGES.keys() for symbol in PAGES[k]],
-    deps = [":all_deps"],
+    deps = [":all_docs"],
 )

--- a/docs/docs_deps.bzl
+++ b/docs/docs_deps.bzl
@@ -2,9 +2,12 @@
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
+load("@rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_repositories")
 
 def deps():
     """Define dependencies for `rules_rust` docs"""
     rust_repositories()
+
+    rust_wasm_bindgen_repositories()
 
     stardoc_repositories()

--- a/docs/docs_transitive_deps.bzl
+++ b/docs/docs_transitive_deps.bzl
@@ -1,6 +1,7 @@
 """Define transitive dependencies for `rules_rust` docs"""
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 
 def transitive_deps(is_top_level = False):
@@ -11,6 +12,8 @@ def transitive_deps(is_top_level = False):
             from the root WORKSPACE file of `rules_rust`. Defaults to False.
     """
     rust_proto_repositories()
+
+    node_repositories()
 
     # Rules proto does not declare a bzl_library, we stub it there for now.
     # TODO: Remove this hack if/when rules_proto adds a bzl_library.

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -864,11 +864,11 @@ See @rules_rust//rust:repositories.bzl for examples of defining the @rust_cpuX r
 | <a id="rust_toolchain-binary_ext"></a>binary_ext |  The extension for binaries created from rustc.   | String | required |  |
 | <a id="rust_toolchain-cargo"></a>cargo |  The location of the <code>cargo</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-clippy_driver"></a>clippy_driver |  The location of the <code>clippy-driver</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_toolchain-debug_info"></a>debug_info |  Rustc debug info levels per opt level   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"opt": "0", "dbg": "2", "fastbuild": "0"} |
+| <a id="rust_toolchain-debug_info"></a>debug_info |  Rustc debug info levels per opt level   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"dbg": "2", "fastbuild": "0", "opt": "0"} |
 | <a id="rust_toolchain-default_edition"></a>default_edition |  The edition to use for rust_* rules that don't specify an edition.   | String | optional | "2015" |
 | <a id="rust_toolchain-dylib_ext"></a>dylib_ext |  The extension for dynamic libraries created from rustc.   | String | required |  |
 | <a id="rust_toolchain-exec_triple"></a>exec_triple |  The platform triple for the toolchains execution environment. For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations   | String | optional | "" |
-| <a id="rust_toolchain-opt_level"></a>opt_level |  Rustc optimization levels.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"opt": "3", "dbg": "0", "fastbuild": "0"} |
+| <a id="rust_toolchain-opt_level"></a>opt_level |  Rustc optimization levels.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"dbg": "0", "fastbuild": "0", "opt": "3"} |
 | <a id="rust_toolchain-os"></a>os |  The operating system for the current toolchain   | String | required |  |
 | <a id="rust_toolchain-rust_doc"></a>rust_doc |  The location of the <code>rustdoc</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-rust_lib"></a>rust_lib |  The rust standard library.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |

--- a/docs/rust_repositories.md
+++ b/docs/rust_repositories.md
@@ -65,11 +65,11 @@ See @rules_rust//rust:repositories.bzl for examples of defining the @rust_cpuX r
 | <a id="rust_toolchain-binary_ext"></a>binary_ext |  The extension for binaries created from rustc.   | String | required |  |
 | <a id="rust_toolchain-cargo"></a>cargo |  The location of the <code>cargo</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-clippy_driver"></a>clippy_driver |  The location of the <code>clippy-driver</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_toolchain-debug_info"></a>debug_info |  Rustc debug info levels per opt level   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"opt": "0", "dbg": "2", "fastbuild": "0"} |
+| <a id="rust_toolchain-debug_info"></a>debug_info |  Rustc debug info levels per opt level   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"dbg": "2", "fastbuild": "0", "opt": "0"} |
 | <a id="rust_toolchain-default_edition"></a>default_edition |  The edition to use for rust_* rules that don't specify an edition.   | String | optional | "2015" |
 | <a id="rust_toolchain-dylib_ext"></a>dylib_ext |  The extension for dynamic libraries created from rustc.   | String | required |  |
 | <a id="rust_toolchain-exec_triple"></a>exec_triple |  The platform triple for the toolchains execution environment. For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations   | String | optional | "" |
-| <a id="rust_toolchain-opt_level"></a>opt_level |  Rustc optimization levels.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"opt": "3", "dbg": "0", "fastbuild": "0"} |
+| <a id="rust_toolchain-opt_level"></a>opt_level |  Rustc optimization levels.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"dbg": "0", "fastbuild": "0", "opt": "3"} |
 | <a id="rust_toolchain-os"></a>os |  The operating system for the current toolchain   | String | required |  |
 | <a id="rust_toolchain-rust_doc"></a>rust_doc |  The location of the <code>rustdoc</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-rust_lib"></a>rust_lib |  The rust standard library.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |

--- a/examples/examples_deps.bzl
+++ b/examples/examples_deps.bzl
@@ -2,7 +2,6 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 load("@examples//complex_sys:repositories.bzl", "rules_rust_examples_complex_sys_repositories")
 load("@examples//hello_sys/raze:crates.bzl", "rules_rust_examples_hello_sys_fetch_remote_crates")
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
@@ -36,8 +35,6 @@ def deps():
         },
         version = "1.46.0",
     )
-
-    node_repositories()
 
     rules_rust_examples_hello_sys_fetch_remote_crates()
 

--- a/examples/examples_repositories.bzl
+++ b/examples/examples_repositories.bzl
@@ -13,13 +13,6 @@ def repositories():
 
     maybe(
         http_archive,
-        name = "build_bazel_rules_nodejs",
-        sha256 = "4952ef879704ab4ad6729a29007e7094aef213ea79e9f2e94cbe1c9a753e63ef",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.2.0/rules_nodejs-2.2.0.tar.gz"],
-    )
-
-    maybe(
-        http_archive,
         name = "rules_proto",
         sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
         strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",

--- a/examples/examples_transitive_deps.bzl
+++ b/examples/examples_transitive_deps.bzl
@@ -5,6 +5,7 @@ dependencies. This file contains the required macros to pull these dependencies
 """
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 
 # buildifier: disable=unnamed-macro
@@ -33,3 +34,5 @@ def transitive_deps(is_top_level = False):
             name = "rules_rust_example_cargo_manifest_dir",
             path = "cargo_manifest_dir/external_crate",
         )
+
+    node_repositories()

--- a/wasm_bindgen/repositories.bzl
+++ b/wasm_bindgen/repositories.bzl
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//wasm_bindgen/raze:crates.bzl", "rules_rust_wasm_bindgen_fetch_remote_crates")
 
 # buildifier: disable=unnamed-macro
@@ -23,6 +25,13 @@ def rust_wasm_bindgen_repositories():
     repository. This makes the default toolchain `@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain` available. For \
     more information on `wasm_bindgen` toolchains, see [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain).
     """
+
+    maybe(
+        http_archive,
+        name = "build_bazel_rules_nodejs",
+        sha256 = "dd4dc46066e2ce034cba0c81aa3e862b27e8e8d95871f567359f7a534cccb666",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.1.0/rules_nodejs-3.1.0.tar.gz"],
+    )
 
     rules_rust_wasm_bindgen_fetch_remote_crates()
 


### PR DESCRIPTION
This does more or less the same thing as [@rules_nodejs//packages/labs/protobufjs:ts_proto_library.bzl](https://github.com/bazelbuild/rules_nodejs/blob/1689fa185f9006dba198c079d848be18dceec38c/packages/labs/protobufjs/ts_proto_library.bzl#L115-L149) but this change drops the legacy provider syntax.

closes https://github.com/bazelbuild/rules_rust/issues/443