### PR TITLE
Add //rust/private/BUILD (therefore create a package there)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 
 # npm
 **/node_modules/
+
+# vscode
+.vscode
+*.code-workspace

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//rust:private/rustc.bzl", "error_format")
+load("//rust/private:rustc.bzl", "error_format")
 
 bzl_library(
     name = "rules",

--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("//rust:private/utils.bzl", "find_toolchain", "get_libs_for_static_executable")
 load("//rust:rust.bzl", "rust_library")
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:utils.bzl", "find_toolchain", "get_libs_for_static_executable")
 
 def rust_bindgen_library(
         name,

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -1,10 +1,16 @@
 # buildifier: disable=module-docstring
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("//rust:private/rust.bzl", "name_to_crate_name")
-load("//rust:private/rustc.bzl", "BuildInfo", "DepInfo", "get_cc_toolchain", "get_compilation_mode_opts", "get_linker_and_args")
-load("//rust:private/utils.bzl", "expand_locations", "find_toolchain")
 load("//rust:rust.bzl", "rust_binary")
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:rust.bzl", "name_to_crate_name")
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:rustc.bzl", "BuildInfo", "DepInfo", "get_cc_toolchain", "get_compilation_mode_opts", "get_linker_and_args")
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:utils.bzl", "expand_locations", "find_toolchain")
 
 def get_cc_compile_env(cc_toolchain, feature_configuration):
     """Gather cc environment variables from the given `cc_toolchain`

--- a/examples/cargo/BUILD
+++ b/examples/cargo/BUILD
@@ -1,11 +1,11 @@
 load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+load(
     "@rules_rust//rust:rust.bzl",
     "rust_library",
     "rust_test",
-)
-load(
-    "@rules_rust//cargo:cargo_build_script.bzl",
-    "cargo_build_script",
 )
 
 cargo_build_script(

--- a/examples/env_locations/BUILD
+++ b/examples/env_locations/BUILD
@@ -1,8 +1,8 @@
+load("@rules_rust//cargo:cargo_build_script.bzl", "cargo_build_script")
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_test",
 )
-load("@rules_rust//cargo:cargo_build_script.bzl", "cargo_build_script")
 
 # generate a file
 genrule(
@@ -25,10 +25,10 @@ cargo_build_script(
     name = "build",
     srcs = ["build.rs"],
     build_script_env = {
-        # both execpath and location should work
-        "SOURCE_FILE": "$(execpath source.file)",
         "GENERATED_DATA": "$(location generated.data)",
         "SOME_TOOL": "$(execpath @com_google_protobuf//:protoc)",
+        # both execpath and location should work
+        "SOURCE_FILE": "$(execpath source.file)",
     },
     data = _data,
 )
@@ -41,10 +41,10 @@ rust_test(
     data = _data,
     edition = "2018",
     rustc_env = {
-        "SOURCE_FILE": "$(rootpath source.file)",
-        "GENERATED_DATA_ROOT": "$(rootpath generated.data)",
         "GENERATED_DATA_ABS": "$(execpath generated.data)",
+        "GENERATED_DATA_ROOT": "$(rootpath generated.data)",
         "SOME_TOOL": "$(rootpath @com_google_protobuf//:protoc)",
+        "SOURCE_FILE": "$(rootpath source.file)",
     },
     deps = [
         ":build",

--- a/examples/ffi/rust_calling_c/c/BUILD
+++ b/examples/ffi/rust_calling_c/c/BUILD
@@ -22,8 +22,8 @@ cc_test(
 
 cc_import(
     name = "native_matrix_so",
-    shared_library = ":libnative_matrix_so.so",
     hdrs = ["matrix.h"],
+    shared_library = ":libnative_matrix_so.so",
 )
 
 cc_binary(

--- a/examples/ffi/rust_calling_c/simple/BUILD
+++ b/examples/ffi/rust_calling_c/simple/BUILD
@@ -1,6 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rust//bindgen:bindgen.bzl", "rust_bindgen_library")
 load("@rules_rust//rust:rust.bzl", "rust_binary", "rust_test")
-load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "simple",

--- a/examples/proto/helloworld/greeter_client/BUILD
+++ b/examples/proto/helloworld/greeter_client/BUILD
@@ -1,5 +1,5 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
 load("@rules_rust//proto:toolchain.bzl", "GRPC_COMPILE_DEPS")
+load("@rules_rust//rust:rust.bzl", "rust_binary")
 
 rust_binary(
     name = "greeter_client",

--- a/examples/proto/helloworld/greeter_server/BUILD
+++ b/examples/proto/helloworld/greeter_server/BUILD
@@ -1,5 +1,5 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
 load("@rules_rust//proto:toolchain.bzl", "GRPC_COMPILE_DEPS")
+load("@rules_rust//rust:rust.bzl", "rust_binary")
 
 rust_binary(
     name = "greeter_server",

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -40,8 +40,13 @@ load(
     _generate_proto = "rust_generate_proto",
     _generated_file_stem = "generated_file_stem",
 )
-load("//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
-load("//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
+load("//rust:common.bzl", "CrateInfo")
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:rustc.bzl", "rustc_compile_action")
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:utils.bzl", "determine_output_hash", "find_toolchain")
 
 RustProtoInfo = provider(
     doc = "Rust protobuf provider info",

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -14,7 +14,8 @@
 
 """Toolchain for compiling rust stubs from protobuf and gRPC."""
 
-load("//rust:private/rust.bzl", "name_to_crate_name")
+# buildifier: disable=bzl-visibility
+load("//rust/private:rust.bzl", "name_to_crate_name")
 
 def generated_file_stem(f):
     basename = f.rsplit("/", 2)[-1]

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -18,5 +18,6 @@ bzl_library(
     srcs = glob(["**/*.bzl"]),
     deps = [
         "//rust/platform:rules",
+        "//rust/private:rules",
     ],
 )

--- a/rust/common.bzl
+++ b/rust/common.bzl
@@ -1,0 +1,32 @@
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module with Rust definitions required to write custom Rust rules."""
+
+CrateInfo = provider(
+    doc = "A provider containing general Crate information.",
+    fields = {
+        "aliases": "Dict[Label, String]: Renamed and aliased crates",
+        "deps": "List[Provider]: This crate's (rust or cc) dependencies' providers.",
+        "edition": "str: The edition of this crate.",
+        "is_test": "bool: If the crate is being compiled in a test context",
+        "name": "str: The name of this crate.",
+        "output": "File: The output File that will be produced, depends on crate type.",
+        "proc_macro_deps": "List[CrateInfo]: This crate's rust proc_macro dependencies' providers.",
+        "root": "File: The source File entrypoint to this crate, eg. lib.rs",
+        "rustc_env": "Dict[String, String]: Additional `\"key\": \"value\"` environment variables to set for rustc.",
+        "srcs": "List[File]: All source Files that are part of the crate.",
+        "type": "str: The type of this crate. eg. lib or bin",
+    },
+)

--- a/rust/platform/BUILD
+++ b/rust/platform/BUILD
@@ -1,5 +1,5 @@
-load(":platform.bzl", "declare_config_settings")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":platform.bzl", "declare_config_settings")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -15,5 +15,5 @@ package_group(
 bzl_library(
     name = "rules",
     srcs = glob(["**/*.bzl"]),
-    visibility = ["//rust:__pkg__"],
+    visibility = ["//rust:__subpackages__"],
 )

--- a/rust/private/BUILD
+++ b/rust/private/BUILD
@@ -1,0 +1,12 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "rules",
+    srcs = glob(
+        ["**/*.bzl"],
+    ),
+    visibility = ["//rust:__subpackages__"],
+    deps = [
+        "//rust/platform:rules",
+    ],
+)

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
+load("//rust:common.bzl", "CrateInfo")
 load(
-    "//rust:private/rust.bzl",
+    "//rust/private:rust.bzl",
     "crate_root_src",
 )
 load(
-    "//rust:private/rustc.bzl",
-    "CrateInfo",
+    "//rust/private:rustc.bzl",
     "collect_deps",
     "collect_inputs",
     "construct_arguments",
     "get_cc_toolchain",
 )
-load("//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
+load("//rust/private:utils.bzl", "determine_output_hash", "find_toolchain")
 
 _rust_extensions = [
     "rs",

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("//rust:private/rustc.bzl", "CrateInfo", "rustc_compile_action")
-load("//rust:private/utils.bzl", "determine_output_hash", "find_toolchain")
+load("//rust:common.bzl", "CrateInfo")
+load("//rust/private:rustc.bzl", "rustc_compile_action")
+load("//rust/private:utils.bzl", "determine_output_hash", "find_toolchain")
 
 # TODO(marco): Separate each rule into its own file.
 
@@ -355,7 +356,7 @@ def _tidy(doc_string):
     """
     return "\n".join([line.strip() for line in doc_string.splitlines()])
 
-_rust_common_attrs = {
+_common_attrs = {
     "aliases": attr.label_keyed_string_dict(
         doc = _tidy("""
             Remap crates to a new name or moniker for linkage to this target
@@ -501,7 +502,7 @@ _rust_test_attrs = {
 
 rust_library = rule(
     implementation = _rust_library_impl,
-    attrs = dict(_rust_common_attrs.items() +
+    attrs = dict(_common_attrs.items() +
                  _rust_library_attrs.items()),
     fragments = ["cpp"],
     host_fragments = ["cpp"],
@@ -591,7 +592,7 @@ _rust_binary_attrs = {
 
 rust_binary = rule(
     implementation = _rust_binary_impl,
-    attrs = dict(_rust_common_attrs.items() + _rust_binary_attrs.items()),
+    attrs = dict(_common_attrs.items() + _rust_binary_attrs.items()),
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],
@@ -687,7 +688,7 @@ Hello world
 
 rust_test = rule(
     implementation = _rust_test_impl,
-    attrs = dict(_rust_common_attrs.items() +
+    attrs = dict(_common_attrs.items() +
                  _rust_test_attrs.items()),
     executable = True,
     fragments = ["cpp"],
@@ -836,7 +837,7 @@ Run the test with `bazel build //hello_lib:hello_lib_test`.
 
 rust_test_binary = rule(
     implementation = _rust_test_impl,
-    attrs = dict(_rust_common_attrs.items() +
+    attrs = dict(_common_attrs.items() +
                  _rust_test_attrs.items()),
     executable = True,
     fragments = ["cpp"],
@@ -860,7 +861,7 @@ See `rust_test` for example usage.
 
 rust_benchmark = rule(
     implementation = _rust_benchmark_impl,
-    attrs = _rust_common_attrs,
+    attrs = _common_attrs,
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -18,30 +18,14 @@ load(
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
 )
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("//rust:common.bzl", "CrateInfo")
 load(
-    "//rust:private/utils.bzl",
+    "//rust/private:utils.bzl",
     "expand_locations",
     "get_lib_name",
     "get_libs_for_static_executable",
     "relativize",
     "rule_attrs",
-)
-
-CrateInfo = provider(
-    doc = "A provider containing general Crate information.",
-    fields = {
-        "aliases": "Dict[Label, String]: Renamed and aliased crates",
-        "deps": "List[Provider]: This crate's (rust or cc) dependencies' providers.",
-        "edition": "str: The edition of this crate.",
-        "is_test": "bool: If the crate is being compiled in a test context",
-        "name": "str: The name of this crate.",
-        "output": "File: The output File that will be produced, depends on crate type.",
-        "proc_macro_deps": "List[CrateInfo]: This crate's rust proc_macro dependencies' providers.",
-        "root": "File: The source File entrypoint to this crate, eg. lib.rs",
-        "rustc_env": "Dict[String, String]: Additional `\"key\": \"value\"` environment variables to set for rustc.",
-        "srcs": "List[File]: All source Files that are part of the crate.",
-        "type": "str: The type of this crate. eg. lib or bin",
-    },
 )
 
 BuildInfo = provider(

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("//rust:private/rustc.bzl", "CrateInfo", "DepInfo", "add_crate_link_flags", "add_edition_flags")
-load("//rust:private/utils.bzl", "find_toolchain")
+load("//rust:common.bzl", "CrateInfo")
+load("//rust/private:rustc.bzl", "DepInfo", "add_crate_link_flags", "add_edition_flags")
+load("//rust/private:utils.bzl", "find_toolchain")
 
 _rust_doc_doc = """Generates code documentation.
 

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("//rust:private/rustc.bzl", "CrateInfo", "DepInfo")
-load("//rust:private/utils.bzl", "find_toolchain", "get_lib_name")
+load("//rust:common.bzl", "CrateInfo")
+load("//rust/private:rustc.bzl", "DepInfo")
+load("//rust/private:utils.bzl", "find_toolchain", "get_lib_name")
 
 def _rust_doc_test_impl(ctx):
     """The implementation for the `rust_doc_test` rule

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -14,12 +14,12 @@
 
 # buildifier: disable=module-docstring
 load(
-    "//rust:private/clippy.bzl",
+    "//rust/private:clippy.bzl",
     _rust_clippy = "rust_clippy",
     _rust_clippy_aspect = "rust_clippy_aspect",
 )
 load(
-    "//rust:private/rust.bzl",
+    "//rust/private:rust.bzl",
     _rust_benchmark = "rust_benchmark",
     _rust_binary = "rust_binary",
     _rust_library = "rust_library",
@@ -27,37 +27,37 @@ load(
     _rust_test_binary = "rust_test_binary",
 )
 load(
-    "//rust:private/rustdoc.bzl",
+    "//rust/private:rustdoc.bzl",
     _rust_doc = "rust_doc",
 )
 load(
-    "//rust:private/rustdoc_test.bzl",
+    "//rust/private:rustdoc_test.bzl",
     _rust_doc_test = "rust_doc_test",
 )
 
 rust_library = _rust_library
-# See @rules_rust//rust:private/rust.bzl for a complete description.
+# See @rules_rust//rust/private:rust.bzl for a complete description.
 
 rust_binary = _rust_binary
-# See @rules_rust//rust:private/rust.bzl for a complete description.
+# See @rules_rust//rust/private:rust.bzl for a complete description.
 
 rust_test = _rust_test
-# See @rules_rust//rust:private/rust.bzl for a complete description.
+# See @rules_rust//rust/private:rust.bzl for a complete description.
 
 rust_test_binary = _rust_test_binary
-# See @rules_rust//rust:private/rust.bzl for a complete description.
+# See @rules_rust//rust/private:rust.bzl for a complete description.
 
 rust_benchmark = _rust_benchmark
-# See @rules_rust//rust:private/rust.bzl for a complete description.
+# See @rules_rust//rust/private:rust.bzl for a complete description.
 
 rust_doc = _rust_doc
-# See @rules_rust//rust:private/rustdoc.bzl for a complete description.
+# See @rules_rust//rust/private:rustdoc.bzl for a complete description.
 
 rust_doc_test = _rust_doc_test
-# See @rules_rust//rust:private/rustdoc_test.bzl for a complete description.
+# See @rules_rust//rust/private:rustdoc_test.bzl for a complete description.
 
 rust_clippy_aspect = _rust_clippy_aspect
-# See @rules_rust//rust:private/clippy.bzl for a complete description.
+# See @rules_rust//rust/private:clippy.bzl for a complete description.
 
 rust_clippy = _rust_clippy
-# See @rules_rust//rust:private/clippy.bzl for a complete description.
+# See @rules_rust//rust/private:clippy.bzl for a complete description.

--- a/test/process_wrapper/BUILD
+++ b/test/process_wrapper/BUILD
@@ -1,6 +1,6 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//test/process_wrapper:process_wrapper_tester.bzl", "process_wrapper_tester")
 
 cc_binary(

--- a/test/rustfmt/rustfmt_generator.bzl
+++ b/test/rustfmt/rustfmt_generator.bzl
@@ -1,5 +1,6 @@
 # buildifier: disable=module-docstring
-load("//rust:private/utils.bzl", "find_toolchain")
+# buildifier: disable=bzl-visibility
+load("//rust/private:utils.bzl", "find_toolchain")
 
 def _rustfmt_generator_impl(ctx):
     toolchain = find_toolchain(ctx)

--- a/wasm_bindgen/wasm_bindgen.bzl
+++ b/wasm_bindgen/wasm_bindgen.bzl
@@ -20,7 +20,9 @@ load(
     "JSModuleInfo",
     "JSNamedModuleInfo",
 )
-load("//rust:private/transitions.bzl", "wasm_bindgen_transition")
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:transitions.bzl", "wasm_bindgen_transition")
 
 _WASM_BINDGEN_DOC = """\
 Generates javascript and typescript bindings for a webassembly module.


### PR DESCRIPTION
This PR achieves the following:
* buildifier bzl-visibility check was not detecting violations as it assumes `private` package, not just a directory
* adds `//rust:common.bzl` file where all the publicly available and supported API for writing custom rules interacting with Rust will reside
* the private package now sets the stability expectations, and it forces us to think about API layering and abstractions.

This turned out to be much bigger PR than expected :(