### PR TITLE
Export the LICENSE file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//rust/private:rustc.bzl", "error_format")
 
+exports_files(["LICENSE"])
+
 bzl_library(
     name = "rules",
     srcs = [


### PR DESCRIPTION
This is required for Google internal workflows, hopefully it won't bother other users.