### PR TITLE
Split rust_library and add //rust:defs.bzl

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -31,9 +31,12 @@ PAGES = {
     "cargo_build_script": [
         "cargo_build_script",
     ],
-    "rust": [
-        "rust_library",
+    "defs": [
         "rust_binary",
+        "rust_library",
+        "rust_static_library",
+        "rust_shared_library",
+        "rust_proc_macro",
         "rust_benchmark",
         "rust_test",
     ],

--- a/docs/all.bzl
+++ b/docs/all.bzl
@@ -30,14 +30,7 @@ load(
     _rust_proto_toolchain = "rust_proto_toolchain",
 )
 load(
-    "@rules_rust//rust:repositories.bzl",
-    _rust_repositories = "rust_repositories",
-    _rust_repository_set = "rust_repository_set",
-    _rust_toolchain_repository = "rust_toolchain_repository",
-    _rust_toolchain_repository_proxy = "rust_toolchain_repository_proxy",
-)
-load(
-    "@rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:defs.bzl",
     _rust_analyzer = "rust_analyzer",
     _rust_benchmark = "rust_benchmark",
     _rust_binary = "rust_binary",
@@ -45,7 +38,17 @@ load(
     _rust_doc = "rust_doc",
     _rust_doc_test = "rust_doc_test",
     _rust_library = "rust_library",
+    _rust_proc_macro = "rust_proc_macro",
+    _rust_shared_library = "rust_shared_library",
+    _rust_static_library = "rust_static_library",
     _rust_test = "rust_test",
+)
+load(
+    "@rules_rust//rust:repositories.bzl",
+    _rust_repositories = "rust_repositories",
+    _rust_repository_set = "rust_repository_set",
+    _rust_toolchain_repository = "rust_toolchain_repository",
+    _rust_toolchain_repository_proxy = "rust_toolchain_repository_proxy",
 )
 load(
     "@rules_rust//rust:toolchain.bzl",
@@ -61,8 +64,11 @@ load(
     _rust_wasm_bindgen_toolchain = "rust_wasm_bindgen_toolchain",
 )
 
-rust_library = _rust_library
 rust_binary = _rust_binary
+rust_library = _rust_library
+rust_static_library = _rust_static_library
+rust_shared_library = _rust_shared_library
+rust_proc_macro = _rust_proc_macro
 rust_test = _rust_test
 rust_doc = _rust_doc
 rust_doc_test = _rust_doc_test

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -1,6 +1,9 @@
 # Rust rules
-* [rust_library](#rust_library)
 * [rust_binary](#rust_binary)
+* [rust_library](#rust_library)
+* [rust_static_library](#rust_static_library)
+* [rust_shared_library](#rust_shared_library)
+* [rust_proc_macro](#rust_proc_macro)
 * [rust_benchmark](#rust_benchmark)
 * [rust_test](#rust_test)
 
@@ -15,39 +18,39 @@ rust_benchmark(<a href="#rust_benchmark-name">name</a>, <a href="#rust_benchmark
 
 Builds a Rust benchmark test.
 
-**Warning**: This rule is currently experimental. [Rust Benchmark tests][rust-bench] require the `Bencher` interface in the unstable `libtest` crate, which is behind the `test` unstable feature gate. As a result, using this rule would require using a nightly binary release of Rust.
+**Warning**: This rule is currently experimental. [Rust Benchmark tests][rust-bench]         require the `Bencher` interface in the unstable `libtest` crate, which is behind the         `test` unstable feature gate. As a result, using this rule would require using a nightly         binary release of Rust.
 
 [rust-bench]: https://doc.rust-lang.org/book/benchmark-tests.html
 
 Example:
 
-Suppose you have the following directory structure for a Rust project with a library crate, `fibonacci` with benchmarks under the `benches/` directory:
+Suppose you have the following directory structure for a Rust project with a         library crate, `fibonacci` with benchmarks under the `benches/` directory:
 
 ```output
 [workspace]/
-  WORKSPACE
-  fibonacci/
-      BUILD
-      src/
-          lib.rs
-      benches/
-          fibonacci_bench.rs
+WORKSPACE
+fibonacci/
+BUILD
+src/
+lib.rs
+benches/
+fibonacci_bench.rs
 ```
 
 `fibonacci/src/lib.rs`:
 ```rust
 pub fn fibonacci(n: u64) -> u64 {
-    if n < 2 {
-        return n;
-    }
-    let mut n1: u64 = 0;
-    let mut n2: u64 = 1;
-    for _ in 1..n {
-        let sum = n1 + n2;
-        n1 = n2;
-        n2 = sum;
-    }
-    n2
+if n < 2 {
+return n;
+}
+let mut n1: u64 = 0;
+let mut n2: u64 = 1;
+for _ in 1..n {
+let sum = n1 + n2;
+n1 = n2;
+n2 = sum;
+}
+n2
 }
 ```
 
@@ -62,7 +65,7 @@ use test::Bencher;
 
 #[bench]
 fn bench_fibonacci(b: &mut Bencher) {
-    b.iter(|| fibonacci::fibonacci(40));
+b.iter(|| fibonacci::fibonacci(40));
 }
 ```
 
@@ -72,17 +75,17 @@ To build the benchmark test, add a `rust_benchmark` target:
 ```python
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_benchmark")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_benchmark")
 
 rust_library(
-  name = "fibonacci",
-  srcs = ["src/lib.rs"],
+name = "fibonacci",
+srcs = ["src/lib.rs"],
 )
 
 rust_benchmark(
-  name = "fibonacci_bench",
-  srcs = ["benches/fibonacci_bench.rs"],
-  deps = [":fibonacci"],
+name = "fibonacci_bench",
+srcs = ["benches/fibonacci_bench.rs"],
+deps = [":fibonacci"],
 )
 ```
 
@@ -116,9 +119,9 @@ Run the benchmark test using: `bazel run //fibonacci:fibonacci_bench`.
 ## rust_binary
 
 <pre>
-rust_binary(<a href="#rust_binary-name">name</a>, <a href="#rust_binary-aliases">aliases</a>, <a href="#rust_binary-compile_data">compile_data</a>, <a href="#rust_binary-crate_features">crate_features</a>, <a href="#rust_binary-crate_root">crate_root</a>, <a href="#rust_binary-crate_type">crate_type</a>, <a href="#rust_binary-data">data</a>, <a href="#rust_binary-deps">deps</a>,
-            <a href="#rust_binary-edition">edition</a>, <a href="#rust_binary-linker_script">linker_script</a>, <a href="#rust_binary-out_binary">out_binary</a>, <a href="#rust_binary-out_dir_tar">out_dir_tar</a>, <a href="#rust_binary-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_binary-rustc_env">rustc_env</a>,
-            <a href="#rust_binary-rustc_env_files">rustc_env_files</a>, <a href="#rust_binary-rustc_flags">rustc_flags</a>, <a href="#rust_binary-srcs">srcs</a>, <a href="#rust_binary-version">version</a>)
+rust_binary(<a href="#rust_binary-name">name</a>, <a href="#rust_binary-aliases">aliases</a>, <a href="#rust_binary-compile_data">compile_data</a>, <a href="#rust_binary-crate_features">crate_features</a>, <a href="#rust_binary-crate_root">crate_root</a>, <a href="#rust_binary-data">data</a>, <a href="#rust_binary-deps">deps</a>, <a href="#rust_binary-edition">edition</a>,
+            <a href="#rust_binary-linker_script">linker_script</a>, <a href="#rust_binary-out_binary">out_binary</a>, <a href="#rust_binary-out_dir_tar">out_dir_tar</a>, <a href="#rust_binary-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_binary-rustc_env">rustc_env</a>, <a href="#rust_binary-rustc_env_files">rustc_env_files</a>,
+            <a href="#rust_binary-rustc_flags">rustc_flags</a>, <a href="#rust_binary-srcs">srcs</a>, <a href="#rust_binary-version">version</a>)
 </pre>
 
 Builds a Rust binary crate.
@@ -131,31 +134,31 @@ library crate, `hello_lib`, and a binary crate, `hello_world` that uses the
 
 ```output
 [workspace]/
-    WORKSPACE
-    hello_lib/
-        BUILD
-        src/
-            lib.rs
-    hello_world/
-        BUILD
-        src/
-            main.rs
+WORKSPACE
+hello_lib/
+BUILD
+src/
+lib.rs
+hello_world/
+BUILD
+src/
+main.rs
 ```
 
 `hello_lib/src/lib.rs`:
 ```rust
 pub struct Greeter {
-    greeting: String,
+greeting: String,
 }
 
 impl Greeter {
-    pub fn new(greeting: &str) -> Greeter {
-        Greeter { greeting: greeting.to_string(), }
-    }
+pub fn new(greeting: &str) -> Greeter {
+Greeter { greeting: greeting.to_string(), }
+}
 
-    pub fn greet(&self, thing: &str) {
-        println!("{} {}", &self.greeting, thing);
-    }
+pub fn greet(&self, thing: &str) {
+println!("{} {}", &self.greeting, thing);
+}
 }
 ```
 
@@ -166,8 +169,8 @@ package(default_visibility = ["//visibility:public"])
 load("@rules_rust//rust:rust.bzl", "rust_library")
 
 rust_library(
-    name = "hello_lib",
-    srcs = ["src/lib.rs"],
+name = "hello_lib",
+srcs = ["src/lib.rs"],
 )
 ```
 
@@ -176,8 +179,8 @@ rust_library(
 extern crate hello_lib;
 
 fn main() {
-    let hello = hello_lib::Greeter::new("Hello");
-    hello.greet("world");
+let hello = hello_lib::Greeter::new("Hello");
+hello.greet("world");
 }
 ```
 
@@ -186,9 +189,9 @@ fn main() {
 load("@rules_rust//rust:rust.bzl", "rust_binary")
 
 rust_binary(
-    name = "hello_world",
-    srcs = ["src/main.rs"],
-    deps = ["//hello_lib"],
+name = "hello_world",
+srcs = ["src/main.rs"],
+deps = ["//hello_lib"],
 )
 ```
 
@@ -197,13 +200,12 @@ Build and run `hello_world`:
 $ bazel run //hello_world
 INFO: Found 1 target...
 Target //examples/rust/hello_world:hello_world up-to-date:
-  bazel-bin/examples/rust/hello_world/hello_world
+bazel-bin/examples/rust/hello_world/hello_world
 INFO: Elapsed time: 1.308s, Critical Path: 1.22s
 
 INFO: Running command line: bazel-bin/examples/rust/hello_world/hello_world
 Hello world
 ```
-
 
 **ATTRIBUTES**
 
@@ -215,7 +217,6 @@ Hello world
 | <a id="rust_binary-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_binary-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
 | <a id="rust_binary-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_binary-crate_type"></a>crate_type |  -   | String | optional | "bin" |
 | <a id="rust_binary-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_binary-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_binary-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
@@ -235,9 +236,8 @@ Hello world
 ## rust_library
 
 <pre>
-rust_library(<a href="#rust_library-name">name</a>, <a href="#rust_library-aliases">aliases</a>, <a href="#rust_library-compile_data">compile_data</a>, <a href="#rust_library-crate_features">crate_features</a>, <a href="#rust_library-crate_root">crate_root</a>, <a href="#rust_library-crate_type">crate_type</a>, <a href="#rust_library-data">data</a>, <a href="#rust_library-deps">deps</a>,
-             <a href="#rust_library-edition">edition</a>, <a href="#rust_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_library-rustc_env">rustc_env</a>, <a href="#rust_library-rustc_env_files">rustc_env_files</a>, <a href="#rust_library-rustc_flags">rustc_flags</a>, <a href="#rust_library-srcs">srcs</a>,
-             <a href="#rust_library-version">version</a>)
+rust_library(<a href="#rust_library-name">name</a>, <a href="#rust_library-aliases">aliases</a>, <a href="#rust_library-compile_data">compile_data</a>, <a href="#rust_library-crate_features">crate_features</a>, <a href="#rust_library-crate_root">crate_root</a>, <a href="#rust_library-data">data</a>, <a href="#rust_library-deps">deps</a>, <a href="#rust_library-edition">edition</a>,
+             <a href="#rust_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_library-rustc_env">rustc_env</a>, <a href="#rust_library-rustc_env_files">rustc_env_files</a>, <a href="#rust_library-rustc_flags">rustc_flags</a>, <a href="#rust_library-srcs">srcs</a>, <a href="#rust_library-version">version</a>)
 </pre>
 
 Builds a Rust library crate.
@@ -248,28 +248,28 @@ Suppose you have the following directory structure for a simple Rust library cra
 
 ```output
 [workspace]/
-    WORKSPACE
-    hello_lib/
-        BUILD
-        src/
-            greeter.rs
-            lib.rs
+WORKSPACE
+hello_lib/
+BUILD
+src/
+greeter.rs
+lib.rs
 ```
 
 `hello_lib/src/greeter.rs`:
 ```rust
 pub struct Greeter {
-    greeting: String,
+greeting: String,
 }
 
 impl Greeter {
-    pub fn new(greeting: &str) -> Greeter {
-        Greeter { greeting: greeting.to_string(), }
-    }
+pub fn new(greeting: &str) -> Greeter {
+Greeter { greeting: greeting.to_string(), }
+}
 
-    pub fn greet(&self, thing: &str) {
-        println!("{} {}", &self.greeting, thing);
-    }
+pub fn greet(&self, thing: &str) {
+println!("{} {}", &self.greeting, thing);
+}
 }
 ```
 
@@ -286,11 +286,11 @@ package(default_visibility = ["//visibility:public"])
 load("@rules_rust//rust:rust.bzl", "rust_library")
 
 rust_library(
-    name = "hello_lib",
-    srcs = [
-        "src/greeter.rs",
-        "src/lib.rs",
-    ],
+name = "hello_lib",
+srcs = [
+"src/greeter.rs",
+"src/lib.rs",
+],
 )
 ```
 
@@ -299,7 +299,7 @@ Build the library:
 $ bazel build //hello_lib
 INFO: Found 1 target...
 Target //examples/rust/hello_lib:hello_lib up-to-date:
-  bazel-bin/examples/rust/hello_lib/libhello_lib.rlib
+bazel-bin/examples/rust/hello_lib/libhello_lib.rlib
 INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 ```
 
@@ -314,7 +314,6 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_library-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
 | <a id="rust_library-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_library-crate_type"></a>crate_type |  The type of linkage to use for building this library. Options include <code>"lib"</code>, <code>"rlib"</code>, <code>"dylib"</code>, <code>"cdylib"</code>, <code>"staticlib"</code>, and <code>"proc-macro"</code>.<br><br>The exact output file will depend on the toolchain used.   | String | optional | "rlib" |
 | <a id="rust_library-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_library-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_library-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
@@ -325,6 +324,126 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+
+
+<a id="#rust_proc_macro"></a>
+
+## rust_proc_macro
+
+<pre>
+rust_proc_macro(<a href="#rust_proc_macro-name">name</a>, <a href="#rust_proc_macro-aliases">aliases</a>, <a href="#rust_proc_macro-compile_data">compile_data</a>, <a href="#rust_proc_macro-crate_features">crate_features</a>, <a href="#rust_proc_macro-crate_root">crate_root</a>, <a href="#rust_proc_macro-data">data</a>, <a href="#rust_proc_macro-deps">deps</a>, <a href="#rust_proc_macro-edition">edition</a>,
+                <a href="#rust_proc_macro-out_dir_tar">out_dir_tar</a>, <a href="#rust_proc_macro-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_proc_macro-rustc_env">rustc_env</a>, <a href="#rust_proc_macro-rustc_env_files">rustc_env_files</a>, <a href="#rust_proc_macro-rustc_flags">rustc_flags</a>, <a href="#rust_proc_macro-srcs">srcs</a>, <a href="#rust_proc_macro-version">version</a>)
+</pre>
+
+Builds a Rust proc-macro crate.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_proc_macro-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_proc_macro-aliases"></a>aliases |  Remap crates to a new name or moniker for linkage to this target<br><br>These are other <code>rust_library</code> targets and will be presented as the new name given.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
+| <a id="rust_proc_macro-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
+| <a id="rust_proc_macro-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_proc_macro-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
+| <a id="rust_proc_macro-out_dir_tar"></a>out_dir_tar |  __Deprecated__, do not use, see [#cargo_build_script] instead.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_proc_macro-proc_macro_deps"></a>proc_macro_deps |  List of <code>rust_library</code> targets with kind <code>proc-macro</code> used to help build this library target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="rust_proc_macro-rustc_env_files"></a>rustc_env_files |  Files containing additional environment variables to set for rustc.<br><br>These files should  contain a single variable per line, of format <code>NAME=value</code>, and newlines may be included in a value by ending a line with a trailing back-slash (<code>\</code>).<br><br>The order that these files will be processed is unspecified, so multiple definitions of a particular variable are discouraged.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
+| <a id="rust_proc_macro-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+
+
+<a id="#rust_shared_library"></a>
+
+## rust_shared_library
+
+<pre>
+rust_shared_library(<a href="#rust_shared_library-name">name</a>, <a href="#rust_shared_library-aliases">aliases</a>, <a href="#rust_shared_library-compile_data">compile_data</a>, <a href="#rust_shared_library-crate_features">crate_features</a>, <a href="#rust_shared_library-crate_root">crate_root</a>, <a href="#rust_shared_library-data">data</a>, <a href="#rust_shared_library-deps">deps</a>, <a href="#rust_shared_library-edition">edition</a>,
+                    <a href="#rust_shared_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_shared_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_shared_library-rustc_env">rustc_env</a>, <a href="#rust_shared_library-rustc_env_files">rustc_env_files</a>, <a href="#rust_shared_library-rustc_flags">rustc_flags</a>, <a href="#rust_shared_library-srcs">srcs</a>,
+                    <a href="#rust_shared_library-version">version</a>)
+</pre>
+
+Builds a Rust shared library.
+
+This shared library will contain all transitively reachable crates and native objects.
+It is meant to be used when producing an artifact that is then consumed by some other build system
+(for example to produce a shared library that Python program links against).
+
+This rule provides CcInfo, so it can be used everywhere Bazel expects `rules_cc`.
+
+When building the whole binary in Bazel, use `rust_library` instead.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_shared_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_shared_library-aliases"></a>aliases |  Remap crates to a new name or moniker for linkage to this target<br><br>These are other <code>rust_library</code> targets and will be presented as the new name given.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
+| <a id="rust_shared_library-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
+| <a id="rust_shared_library-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_shared_library-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
+| <a id="rust_shared_library-out_dir_tar"></a>out_dir_tar |  __Deprecated__, do not use, see [#cargo_build_script] instead.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_shared_library-proc_macro_deps"></a>proc_macro_deps |  List of <code>rust_library</code> targets with kind <code>proc-macro</code> used to help build this library target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="rust_shared_library-rustc_env_files"></a>rustc_env_files |  Files containing additional environment variables to set for rustc.<br><br>These files should  contain a single variable per line, of format <code>NAME=value</code>, and newlines may be included in a value by ending a line with a trailing back-slash (<code>\</code>).<br><br>The order that these files will be processed is unspecified, so multiple definitions of a particular variable are discouraged.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
+| <a id="rust_shared_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+
+
+<a id="#rust_static_library"></a>
+
+## rust_static_library
+
+<pre>
+rust_static_library(<a href="#rust_static_library-name">name</a>, <a href="#rust_static_library-aliases">aliases</a>, <a href="#rust_static_library-compile_data">compile_data</a>, <a href="#rust_static_library-crate_features">crate_features</a>, <a href="#rust_static_library-crate_root">crate_root</a>, <a href="#rust_static_library-data">data</a>, <a href="#rust_static_library-deps">deps</a>, <a href="#rust_static_library-edition">edition</a>,
+                    <a href="#rust_static_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_static_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_static_library-rustc_env">rustc_env</a>, <a href="#rust_static_library-rustc_env_files">rustc_env_files</a>, <a href="#rust_static_library-rustc_flags">rustc_flags</a>, <a href="#rust_static_library-srcs">srcs</a>,
+                    <a href="#rust_static_library-version">version</a>)
+</pre>
+
+Builds a Rust static library.
+
+This static library will contain all transitively reachable crates and native objects.
+It is meant to be used when producing an artifact that is then consumed by some other build system
+(for example to produce an archive that Python program links against).
+
+This rule provides CcInfo, so it can be used everywhere Bazel expects `rules_cc`.
+
+When building the whole binary in Bazel, use `rust_library` instead.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_static_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_static_library-aliases"></a>aliases |  Remap crates to a new name or moniker for linkage to this target<br><br>These are other <code>rust_library</code> targets and will be presented as the new name given.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
+| <a id="rust_static_library-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
+| <a id="rust_static_library-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_static_library-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
+| <a id="rust_static_library-out_dir_tar"></a>out_dir_tar |  __Deprecated__, do not use, see [#cargo_build_script] instead.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_static_library-proc_macro_deps"></a>proc_macro_deps |  List of <code>rust_library</code> targets with kind <code>proc-macro</code> used to help build this library target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="rust_static_library-rustc_env_files"></a>rustc_env_files |  Files containing additional environment variables to set for rustc.<br><br>These files should  contain a single variable per line, of format <code>NAME=value</code>, and newlines may be included in a value by ending a line with a trailing back-slash (<code>\</code>).<br><br>The order that these files will be processed is unspecified, so multiple definitions of a particular variable are discouraged.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
+| <a id="rust_static_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
 <a id="#rust_test"></a>
@@ -340,92 +459,92 @@ Builds a Rust test crate.
 
 Examples:
 
-Suppose you have the following directory structure for a Rust library crate with unit test code in the library sources:
+Suppose you have the following directory structure for a Rust library crate         with unit test code in the library sources:
 
 ```output
 [workspace]/
-    WORKSPACE
-    hello_lib/
-        BUILD
-        src/
-            lib.rs
+WORKSPACE
+hello_lib/
+BUILD
+src/
+lib.rs
 ```
 
 `hello_lib/src/lib.rs`:
 ```rust
 pub struct Greeter {
-    greeting: String,
+greeting: String,
 }
 
 impl Greeter {
-    pub fn new(greeting: &str) -> Greeter {
-        Greeter { greeting: greeting.to_string(), }
-    }
+pub fn new(greeting: &str) -> Greeter {
+Greeter { greeting: greeting.to_string(), }
+}
 
-    pub fn greet(&self, thing: &str) {
-        println!("{} {}", &self.greeting, thing);
-    }
+pub fn greet(&self, thing: &str) {
+println!("{} {}", &self.greeting, thing);
+}
 }
 
 #[cfg(test)]
 mod test {
-    use super::Greeter;
+use super::Greeter;
 
-    #[test]
-    fn test_greeting() {
-        let hello = Greeter::new("Hi");
-        assert_eq!("Hi Rust", hello.greet("Rust"));
-    }
+#[test]
+fn test_greeting() {
+let hello = Greeter::new("Hi");
+assert_eq!("Hi Rust", hello.greet("Rust"));
+}
 }
 ```
 
-To build and run the tests, simply add a `rust_test` rule with no `srcs` and only depends on the `hello_lib` `rust_library` target:
+To build and run the tests, simply add a `rust_test` rule with no `srcs` and         only depends on the `hello_lib` `rust_library` target:
 
 `hello_lib/BUILD`:
 ```python
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
-    name = "hello_lib",
-    srcs = ["src/lib.rs"],
+name = "hello_lib",
+srcs = ["src/lib.rs"],
 )
 
 rust_test(
-    name = "hello_lib_test",
-    deps = [":hello_lib"],
+name = "hello_lib_test",
+deps = [":hello_lib"],
 )
 ```
 
 Run the test with `bazel build //hello_lib:hello_lib_test`.
 
-To run a crate or lib with the `#[cfg(test)]` configuration, handling inline tests, you should specify the crate directly like so.
+To run a crate or lib with the `#[cfg(test)]` configuration, handling inline         tests, you should specify the crate directly like so.
 
 ```python
 rust_test(
-    name = "hello_lib_test",
-    crate = ":hello_lib",
-    # You may add other deps that are specific to the test configuration
-    deps = ["//some/dev/dep"],
+name = "hello_lib_test",
+crate = ":hello_lib",
+# You may add other deps that are specific to the test configuration
+deps = ["//some/dev/dep"],
 )
 ```
 
 ### Example: `test` directory
 
-Integration tests that live in the [`tests` directory][int-tests], they are essentially built as separate crates. Suppose you have the following directory structure where `greeting.rs` is an integration test for the `hello_lib` library crate:
+Integration tests that live in the [`tests` directory][int-tests], they are         essentially built as separate crates. Suppose you have the following directory         structure where `greeting.rs` is an integration test for the `hello_lib`         library crate:
 
 [int-tests]: http://doc.rust-lang.org/book/testing.html#the-tests-directory
 
 ```output
 [workspace]/
-    WORKSPACE
-    hello_lib/
-        BUILD
-        src/
-            lib.rs
-        tests/
-            greeting.rs
+WORKSPACE
+hello_lib/
+BUILD
+src/
+lib.rs
+tests/
+greeting.rs
 ```
 
 `hello_lib/tests/greeting.rs`:
@@ -436,8 +555,8 @@ use hello_lib;
 
 #[test]
 fn test_greeting() {
-    let hello = greeter::Greeter::new("Hello");
-    assert_eq!("Hello world", hello.greeting("world"));
+let hello = greeter::Greeter::new("Hello");
+assert_eq!("Hello world", hello.greeting("world"));
 }
 ```
 
@@ -448,22 +567,21 @@ with `greeting.rs` in `srcs` and a dependency on the `hello_lib` target:
 ```python
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
-    name = "hello_lib",
-    srcs = ["src/lib.rs"],
+name = "hello_lib",
+srcs = ["src/lib.rs"],
 )
 
 rust_test(
-    name = "greeting_test",
-    srcs = ["tests/greeting.rs"],
-    deps = [":hello_lib"],
+name = "greeting_test",
+srcs = ["tests/greeting.rs"],
+deps = [":hello_lib"],
 )
 ```
 
 Run the test with `bazel build //hello_lib:hello_lib_test`.
-
 
 **ATTRIBUTES**
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -15,11 +15,14 @@
 * [rust_doc_test](#rust_doc_test)
 * [rust_grpc_library](#rust_grpc_library)
 * [rust_library](#rust_library)
+* [rust_proc_macro](#rust_proc_macro)
 * [rust_proto_library](#rust_proto_library)
 * [rust_proto_repositories](#rust_proto_repositories)
 * [rust_proto_toolchain](#rust_proto_toolchain)
 * [rust_repositories](#rust_repositories)
 * [rust_repository_set](#rust_repository_set)
+* [rust_shared_library](#rust_shared_library)
+* [rust_static_library](#rust_static_library)
 * [rust_test](#rust_test)
 * [rust_toolchain](#rust_toolchain)
 * [rust_toolchain_repository](#rust_toolchain_repository)
@@ -59,39 +62,39 @@ rust_benchmark(<a href="#rust_benchmark-name">name</a>, <a href="#rust_benchmark
 
 Builds a Rust benchmark test.
 
-**Warning**: This rule is currently experimental. [Rust Benchmark tests][rust-bench] require the `Bencher` interface in the unstable `libtest` crate, which is behind the `test` unstable feature gate. As a result, using this rule would require using a nightly binary release of Rust.
+**Warning**: This rule is currently experimental. [Rust Benchmark tests][rust-bench]         require the `Bencher` interface in the unstable `libtest` crate, which is behind the         `test` unstable feature gate. As a result, using this rule would require using a nightly         binary release of Rust.
 
 [rust-bench]: https://doc.rust-lang.org/book/benchmark-tests.html
 
 Example:
 
-Suppose you have the following directory structure for a Rust project with a library crate, `fibonacci` with benchmarks under the `benches/` directory:
+Suppose you have the following directory structure for a Rust project with a         library crate, `fibonacci` with benchmarks under the `benches/` directory:
 
 ```output
 [workspace]/
-  WORKSPACE
-  fibonacci/
-      BUILD
-      src/
-          lib.rs
-      benches/
-          fibonacci_bench.rs
+WORKSPACE
+fibonacci/
+BUILD
+src/
+lib.rs
+benches/
+fibonacci_bench.rs
 ```
 
 `fibonacci/src/lib.rs`:
 ```rust
 pub fn fibonacci(n: u64) -> u64 {
-    if n < 2 {
-        return n;
-    }
-    let mut n1: u64 = 0;
-    let mut n2: u64 = 1;
-    for _ in 1..n {
-        let sum = n1 + n2;
-        n1 = n2;
-        n2 = sum;
-    }
-    n2
+if n < 2 {
+return n;
+}
+let mut n1: u64 = 0;
+let mut n2: u64 = 1;
+for _ in 1..n {
+let sum = n1 + n2;
+n1 = n2;
+n2 = sum;
+}
+n2
 }
 ```
 
@@ -106,7 +109,7 @@ use test::Bencher;
 
 #[bench]
 fn bench_fibonacci(b: &mut Bencher) {
-    b.iter(|| fibonacci::fibonacci(40));
+b.iter(|| fibonacci::fibonacci(40));
 }
 ```
 
@@ -116,17 +119,17 @@ To build the benchmark test, add a `rust_benchmark` target:
 ```python
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_benchmark")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_benchmark")
 
 rust_library(
-  name = "fibonacci",
-  srcs = ["src/lib.rs"],
+name = "fibonacci",
+srcs = ["src/lib.rs"],
 )
 
 rust_benchmark(
-  name = "fibonacci_bench",
-  srcs = ["benches/fibonacci_bench.rs"],
-  deps = [":fibonacci"],
+name = "fibonacci_bench",
+srcs = ["benches/fibonacci_bench.rs"],
+deps = [":fibonacci"],
 )
 ```
 
@@ -160,9 +163,9 @@ Run the benchmark test using: `bazel run //fibonacci:fibonacci_bench`.
 ## rust_binary
 
 <pre>
-rust_binary(<a href="#rust_binary-name">name</a>, <a href="#rust_binary-aliases">aliases</a>, <a href="#rust_binary-compile_data">compile_data</a>, <a href="#rust_binary-crate_features">crate_features</a>, <a href="#rust_binary-crate_root">crate_root</a>, <a href="#rust_binary-crate_type">crate_type</a>, <a href="#rust_binary-data">data</a>, <a href="#rust_binary-deps">deps</a>,
-            <a href="#rust_binary-edition">edition</a>, <a href="#rust_binary-linker_script">linker_script</a>, <a href="#rust_binary-out_binary">out_binary</a>, <a href="#rust_binary-out_dir_tar">out_dir_tar</a>, <a href="#rust_binary-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_binary-rustc_env">rustc_env</a>,
-            <a href="#rust_binary-rustc_env_files">rustc_env_files</a>, <a href="#rust_binary-rustc_flags">rustc_flags</a>, <a href="#rust_binary-srcs">srcs</a>, <a href="#rust_binary-version">version</a>)
+rust_binary(<a href="#rust_binary-name">name</a>, <a href="#rust_binary-aliases">aliases</a>, <a href="#rust_binary-compile_data">compile_data</a>, <a href="#rust_binary-crate_features">crate_features</a>, <a href="#rust_binary-crate_root">crate_root</a>, <a href="#rust_binary-data">data</a>, <a href="#rust_binary-deps">deps</a>, <a href="#rust_binary-edition">edition</a>,
+            <a href="#rust_binary-linker_script">linker_script</a>, <a href="#rust_binary-out_binary">out_binary</a>, <a href="#rust_binary-out_dir_tar">out_dir_tar</a>, <a href="#rust_binary-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_binary-rustc_env">rustc_env</a>, <a href="#rust_binary-rustc_env_files">rustc_env_files</a>,
+            <a href="#rust_binary-rustc_flags">rustc_flags</a>, <a href="#rust_binary-srcs">srcs</a>, <a href="#rust_binary-version">version</a>)
 </pre>
 
 Builds a Rust binary crate.
@@ -175,31 +178,31 @@ library crate, `hello_lib`, and a binary crate, `hello_world` that uses the
 
 ```output
 [workspace]/
-    WORKSPACE
-    hello_lib/
-        BUILD
-        src/
-            lib.rs
-    hello_world/
-        BUILD
-        src/
-            main.rs
+WORKSPACE
+hello_lib/
+BUILD
+src/
+lib.rs
+hello_world/
+BUILD
+src/
+main.rs
 ```
 
 `hello_lib/src/lib.rs`:
 ```rust
 pub struct Greeter {
-    greeting: String,
+greeting: String,
 }
 
 impl Greeter {
-    pub fn new(greeting: &str) -> Greeter {
-        Greeter { greeting: greeting.to_string(), }
-    }
+pub fn new(greeting: &str) -> Greeter {
+Greeter { greeting: greeting.to_string(), }
+}
 
-    pub fn greet(&self, thing: &str) {
-        println!("{} {}", &self.greeting, thing);
-    }
+pub fn greet(&self, thing: &str) {
+println!("{} {}", &self.greeting, thing);
+}
 }
 ```
 
@@ -210,8 +213,8 @@ package(default_visibility = ["//visibility:public"])
 load("@rules_rust//rust:rust.bzl", "rust_library")
 
 rust_library(
-    name = "hello_lib",
-    srcs = ["src/lib.rs"],
+name = "hello_lib",
+srcs = ["src/lib.rs"],
 )
 ```
 
@@ -220,8 +223,8 @@ rust_library(
 extern crate hello_lib;
 
 fn main() {
-    let hello = hello_lib::Greeter::new("Hello");
-    hello.greet("world");
+let hello = hello_lib::Greeter::new("Hello");
+hello.greet("world");
 }
 ```
 
@@ -230,9 +233,9 @@ fn main() {
 load("@rules_rust//rust:rust.bzl", "rust_binary")
 
 rust_binary(
-    name = "hello_world",
-    srcs = ["src/main.rs"],
-    deps = ["//hello_lib"],
+name = "hello_world",
+srcs = ["src/main.rs"],
+deps = ["//hello_lib"],
 )
 ```
 
@@ -241,13 +244,12 @@ Build and run `hello_world`:
 $ bazel run //hello_world
 INFO: Found 1 target...
 Target //examples/rust/hello_world:hello_world up-to-date:
-  bazel-bin/examples/rust/hello_world/hello_world
+bazel-bin/examples/rust/hello_world/hello_world
 INFO: Elapsed time: 1.308s, Critical Path: 1.22s
 
 INFO: Running command line: bazel-bin/examples/rust/hello_world/hello_world
 Hello world
 ```
-
 
 **ATTRIBUTES**
 
@@ -259,7 +261,6 @@ Hello world
 | <a id="rust_binary-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_binary-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
 | <a id="rust_binary-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_binary-crate_type"></a>crate_type |  -   | String | optional | "bin" |
 | <a id="rust_binary-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_binary-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_binary-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
@@ -535,9 +536,8 @@ rust_binary(
 ## rust_library
 
 <pre>
-rust_library(<a href="#rust_library-name">name</a>, <a href="#rust_library-aliases">aliases</a>, <a href="#rust_library-compile_data">compile_data</a>, <a href="#rust_library-crate_features">crate_features</a>, <a href="#rust_library-crate_root">crate_root</a>, <a href="#rust_library-crate_type">crate_type</a>, <a href="#rust_library-data">data</a>, <a href="#rust_library-deps">deps</a>,
-             <a href="#rust_library-edition">edition</a>, <a href="#rust_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_library-rustc_env">rustc_env</a>, <a href="#rust_library-rustc_env_files">rustc_env_files</a>, <a href="#rust_library-rustc_flags">rustc_flags</a>, <a href="#rust_library-srcs">srcs</a>,
-             <a href="#rust_library-version">version</a>)
+rust_library(<a href="#rust_library-name">name</a>, <a href="#rust_library-aliases">aliases</a>, <a href="#rust_library-compile_data">compile_data</a>, <a href="#rust_library-crate_features">crate_features</a>, <a href="#rust_library-crate_root">crate_root</a>, <a href="#rust_library-data">data</a>, <a href="#rust_library-deps">deps</a>, <a href="#rust_library-edition">edition</a>,
+             <a href="#rust_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_library-rustc_env">rustc_env</a>, <a href="#rust_library-rustc_env_files">rustc_env_files</a>, <a href="#rust_library-rustc_flags">rustc_flags</a>, <a href="#rust_library-srcs">srcs</a>, <a href="#rust_library-version">version</a>)
 </pre>
 
 Builds a Rust library crate.
@@ -548,28 +548,28 @@ Suppose you have the following directory structure for a simple Rust library cra
 
 ```output
 [workspace]/
-    WORKSPACE
-    hello_lib/
-        BUILD
-        src/
-            greeter.rs
-            lib.rs
+WORKSPACE
+hello_lib/
+BUILD
+src/
+greeter.rs
+lib.rs
 ```
 
 `hello_lib/src/greeter.rs`:
 ```rust
 pub struct Greeter {
-    greeting: String,
+greeting: String,
 }
 
 impl Greeter {
-    pub fn new(greeting: &str) -> Greeter {
-        Greeter { greeting: greeting.to_string(), }
-    }
+pub fn new(greeting: &str) -> Greeter {
+Greeter { greeting: greeting.to_string(), }
+}
 
-    pub fn greet(&self, thing: &str) {
-        println!("{} {}", &self.greeting, thing);
-    }
+pub fn greet(&self, thing: &str) {
+println!("{} {}", &self.greeting, thing);
+}
 }
 ```
 
@@ -586,11 +586,11 @@ package(default_visibility = ["//visibility:public"])
 load("@rules_rust//rust:rust.bzl", "rust_library")
 
 rust_library(
-    name = "hello_lib",
-    srcs = [
-        "src/greeter.rs",
-        "src/lib.rs",
-    ],
+name = "hello_lib",
+srcs = [
+"src/greeter.rs",
+"src/lib.rs",
+],
 )
 ```
 
@@ -599,7 +599,7 @@ Build the library:
 $ bazel build //hello_lib
 INFO: Found 1 target...
 Target //examples/rust/hello_lib:hello_lib up-to-date:
-  bazel-bin/examples/rust/hello_lib/libhello_lib.rlib
+bazel-bin/examples/rust/hello_lib/libhello_lib.rlib
 INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 ```
 
@@ -614,7 +614,6 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_library-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
 | <a id="rust_library-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_library-crate_type"></a>crate_type |  The type of linkage to use for building this library. Options include <code>"lib"</code>, <code>"rlib"</code>, <code>"dylib"</code>, <code>"cdylib"</code>, <code>"staticlib"</code>, and <code>"proc-macro"</code>.<br><br>The exact output file will depend on the toolchain used.   | String | optional | "rlib" |
 | <a id="rust_library-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_library-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_library-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
@@ -625,6 +624,40 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+
+
+<a id="#rust_proc_macro"></a>
+
+## rust_proc_macro
+
+<pre>
+rust_proc_macro(<a href="#rust_proc_macro-name">name</a>, <a href="#rust_proc_macro-aliases">aliases</a>, <a href="#rust_proc_macro-compile_data">compile_data</a>, <a href="#rust_proc_macro-crate_features">crate_features</a>, <a href="#rust_proc_macro-crate_root">crate_root</a>, <a href="#rust_proc_macro-data">data</a>, <a href="#rust_proc_macro-deps">deps</a>, <a href="#rust_proc_macro-edition">edition</a>,
+                <a href="#rust_proc_macro-out_dir_tar">out_dir_tar</a>, <a href="#rust_proc_macro-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_proc_macro-rustc_env">rustc_env</a>, <a href="#rust_proc_macro-rustc_env_files">rustc_env_files</a>, <a href="#rust_proc_macro-rustc_flags">rustc_flags</a>, <a href="#rust_proc_macro-srcs">srcs</a>, <a href="#rust_proc_macro-version">version</a>)
+</pre>
+
+Builds a Rust proc-macro crate.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_proc_macro-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_proc_macro-aliases"></a>aliases |  Remap crates to a new name or moniker for linkage to this target<br><br>These are other <code>rust_library</code> targets and will be presented as the new name given.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
+| <a id="rust_proc_macro-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
+| <a id="rust_proc_macro-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_proc_macro-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
+| <a id="rust_proc_macro-out_dir_tar"></a>out_dir_tar |  __Deprecated__, do not use, see [#cargo_build_script] instead.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_proc_macro-proc_macro_deps"></a>proc_macro_deps |  List of <code>rust_library</code> targets with kind <code>proc-macro</code> used to help build this library target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="rust_proc_macro-rustc_env_files"></a>rustc_env_files |  Files containing additional environment variables to set for rustc.<br><br>These files should  contain a single variable per line, of format <code>NAME=value</code>, and newlines may be included in a value by ending a line with a trailing back-slash (<code>\</code>).<br><br>The order that these files will be processed is unspecified, so multiple definitions of a particular variable are discouraged.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
+| <a id="rust_proc_macro-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_proc_macro-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
 <a id="#rust_proto_library"></a>
@@ -725,6 +758,92 @@ See @rules_rust//proto:BUILD for examples of defining the toolchain.
 | <a id="rust_proto_toolchain-protoc"></a>protoc |  The location of the <code>protoc</code> binary. It should be an executable target.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @com_google_protobuf//:protoc |
 
 
+<a id="#rust_shared_library"></a>
+
+## rust_shared_library
+
+<pre>
+rust_shared_library(<a href="#rust_shared_library-name">name</a>, <a href="#rust_shared_library-aliases">aliases</a>, <a href="#rust_shared_library-compile_data">compile_data</a>, <a href="#rust_shared_library-crate_features">crate_features</a>, <a href="#rust_shared_library-crate_root">crate_root</a>, <a href="#rust_shared_library-data">data</a>, <a href="#rust_shared_library-deps">deps</a>, <a href="#rust_shared_library-edition">edition</a>,
+                    <a href="#rust_shared_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_shared_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_shared_library-rustc_env">rustc_env</a>, <a href="#rust_shared_library-rustc_env_files">rustc_env_files</a>, <a href="#rust_shared_library-rustc_flags">rustc_flags</a>, <a href="#rust_shared_library-srcs">srcs</a>,
+                    <a href="#rust_shared_library-version">version</a>)
+</pre>
+
+Builds a Rust shared library.
+
+This shared library will contain all transitively reachable crates and native objects.
+It is meant to be used when producing an artifact that is then consumed by some other build system
+(for example to produce a shared library that Python program links against).
+
+This rule provides CcInfo, so it can be used everywhere Bazel expects `rules_cc`.
+
+When building the whole binary in Bazel, use `rust_library` instead.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_shared_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_shared_library-aliases"></a>aliases |  Remap crates to a new name or moniker for linkage to this target<br><br>These are other <code>rust_library</code> targets and will be presented as the new name given.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
+| <a id="rust_shared_library-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
+| <a id="rust_shared_library-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_shared_library-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
+| <a id="rust_shared_library-out_dir_tar"></a>out_dir_tar |  __Deprecated__, do not use, see [#cargo_build_script] instead.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_shared_library-proc_macro_deps"></a>proc_macro_deps |  List of <code>rust_library</code> targets with kind <code>proc-macro</code> used to help build this library target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="rust_shared_library-rustc_env_files"></a>rustc_env_files |  Files containing additional environment variables to set for rustc.<br><br>These files should  contain a single variable per line, of format <code>NAME=value</code>, and newlines may be included in a value by ending a line with a trailing back-slash (<code>\</code>).<br><br>The order that these files will be processed is unspecified, so multiple definitions of a particular variable are discouraged.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
+| <a id="rust_shared_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_shared_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+
+
+<a id="#rust_static_library"></a>
+
+## rust_static_library
+
+<pre>
+rust_static_library(<a href="#rust_static_library-name">name</a>, <a href="#rust_static_library-aliases">aliases</a>, <a href="#rust_static_library-compile_data">compile_data</a>, <a href="#rust_static_library-crate_features">crate_features</a>, <a href="#rust_static_library-crate_root">crate_root</a>, <a href="#rust_static_library-data">data</a>, <a href="#rust_static_library-deps">deps</a>, <a href="#rust_static_library-edition">edition</a>,
+                    <a href="#rust_static_library-out_dir_tar">out_dir_tar</a>, <a href="#rust_static_library-proc_macro_deps">proc_macro_deps</a>, <a href="#rust_static_library-rustc_env">rustc_env</a>, <a href="#rust_static_library-rustc_env_files">rustc_env_files</a>, <a href="#rust_static_library-rustc_flags">rustc_flags</a>, <a href="#rust_static_library-srcs">srcs</a>,
+                    <a href="#rust_static_library-version">version</a>)
+</pre>
+
+Builds a Rust static library.
+
+This static library will contain all transitively reachable crates and native objects.
+It is meant to be used when producing an artifact that is then consumed by some other build system
+(for example to produce an archive that Python program links against).
+
+This rule provides CcInfo, so it can be used everywhere Bazel expects `rules_cc`.
+
+When building the whole binary in Bazel, use `rust_library` instead.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_static_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_static_library-aliases"></a>aliases |  Remap crates to a new name or moniker for linkage to this target<br><br>These are other <code>rust_library</code> targets and will be presented as the new name given.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: Label -> String</a> | optional | {} |
+| <a id="rust_static_library-compile_data"></a>compile_data |  List of files used by this rule at compile time.<br><br>This attribute can be used to specify any data files that are embedded into the library, such as via the [<code>include_str!</code>](https://doc.rust-lang.org/std/macro.include_str!.html) macro.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-crate_features"></a>crate_features |  List of features to enable for this crate.<br><br>Features are defined in the code using the <code>#[cfg(feature = "foo")]</code> configuration option. The features listed here will be passed to <code>rustc</code> with <code>--cfg feature="${feature_name}"</code> flags.   | List of strings | optional | [] |
+| <a id="rust_static_library-crate_root"></a>crate_root |  The file that will be passed to <code>rustc</code> to be used for building this crate.<br><br>If <code>crate_root</code> is not set, then this rule will look for a <code>lib.rs</code> file (or <code>main.rs</code> for rust_binary) or the single file in <code>srcs</code> if <code>srcs</code> contains only one file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_static_library-data"></a>data |  List of files used by this rule at compile time and runtime.<br><br>If including data at compile time with include_str!() and similar, prefer <code>compile_data</code> over <code>data</code>, to prevent the data also being included in the runfiles.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-edition"></a>edition |  The rust edition to use for this crate. Defaults to the edition specified in the rust_toolchain.   | String | optional | "" |
+| <a id="rust_static_library-out_dir_tar"></a>out_dir_tar |  __Deprecated__, do not use, see [#cargo_build_script] instead.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_static_library-proc_macro_deps"></a>proc_macro_deps |  List of <code>rust_library</code> targets with kind <code>proc-macro</code> used to help build this library target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-rustc_env"></a>rustc_env |  Dictionary of additional <code>"key": "value"</code> environment variables to set for rustc.<br><br>rust_test()/rust_binary() rules can use $(rootpath //package:target) to pass in the location of a generated file or external tool. Cargo build scripts that wish to expand locations should use cargo_build_script()'s build_script_env argument instead, as build scripts are run in a different environment - see cargo_build_script()'s documentation for more.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="rust_static_library-rustc_env_files"></a>rustc_env_files |  Files containing additional environment variables to set for rustc.<br><br>These files should  contain a single variable per line, of format <code>NAME=value</code>, and newlines may be included in a value by ending a line with a trailing back-slash (<code>\</code>).<br><br>The order that these files will be processed is unspecified, so multiple definitions of a particular variable are discouraged.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
+| <a id="rust_static_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_static_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+
+
 <a id="#rust_test"></a>
 
 ## rust_test
@@ -738,92 +857,92 @@ Builds a Rust test crate.
 
 Examples:
 
-Suppose you have the following directory structure for a Rust library crate with unit test code in the library sources:
+Suppose you have the following directory structure for a Rust library crate         with unit test code in the library sources:
 
 ```output
 [workspace]/
-    WORKSPACE
-    hello_lib/
-        BUILD
-        src/
-            lib.rs
+WORKSPACE
+hello_lib/
+BUILD
+src/
+lib.rs
 ```
 
 `hello_lib/src/lib.rs`:
 ```rust
 pub struct Greeter {
-    greeting: String,
+greeting: String,
 }
 
 impl Greeter {
-    pub fn new(greeting: &str) -> Greeter {
-        Greeter { greeting: greeting.to_string(), }
-    }
+pub fn new(greeting: &str) -> Greeter {
+Greeter { greeting: greeting.to_string(), }
+}
 
-    pub fn greet(&self, thing: &str) {
-        println!("{} {}", &self.greeting, thing);
-    }
+pub fn greet(&self, thing: &str) {
+println!("{} {}", &self.greeting, thing);
+}
 }
 
 #[cfg(test)]
 mod test {
-    use super::Greeter;
+use super::Greeter;
 
-    #[test]
-    fn test_greeting() {
-        let hello = Greeter::new("Hi");
-        assert_eq!("Hi Rust", hello.greet("Rust"));
-    }
+#[test]
+fn test_greeting() {
+let hello = Greeter::new("Hi");
+assert_eq!("Hi Rust", hello.greet("Rust"));
+}
 }
 ```
 
-To build and run the tests, simply add a `rust_test` rule with no `srcs` and only depends on the `hello_lib` `rust_library` target:
+To build and run the tests, simply add a `rust_test` rule with no `srcs` and         only depends on the `hello_lib` `rust_library` target:
 
 `hello_lib/BUILD`:
 ```python
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
-    name = "hello_lib",
-    srcs = ["src/lib.rs"],
+name = "hello_lib",
+srcs = ["src/lib.rs"],
 )
 
 rust_test(
-    name = "hello_lib_test",
-    deps = [":hello_lib"],
+name = "hello_lib_test",
+deps = [":hello_lib"],
 )
 ```
 
 Run the test with `bazel build //hello_lib:hello_lib_test`.
 
-To run a crate or lib with the `#[cfg(test)]` configuration, handling inline tests, you should specify the crate directly like so.
+To run a crate or lib with the `#[cfg(test)]` configuration, handling inline         tests, you should specify the crate directly like so.
 
 ```python
 rust_test(
-    name = "hello_lib_test",
-    crate = ":hello_lib",
-    # You may add other deps that are specific to the test configuration
-    deps = ["//some/dev/dep"],
+name = "hello_lib_test",
+crate = ":hello_lib",
+# You may add other deps that are specific to the test configuration
+deps = ["//some/dev/dep"],
 )
 ```
 
 ### Example: `test` directory
 
-Integration tests that live in the [`tests` directory][int-tests], they are essentially built as separate crates. Suppose you have the following directory structure where `greeting.rs` is an integration test for the `hello_lib` library crate:
+Integration tests that live in the [`tests` directory][int-tests], they are         essentially built as separate crates. Suppose you have the following directory         structure where `greeting.rs` is an integration test for the `hello_lib`         library crate:
 
 [int-tests]: http://doc.rust-lang.org/book/testing.html#the-tests-directory
 
 ```output
 [workspace]/
-    WORKSPACE
-    hello_lib/
-        BUILD
-        src/
-            lib.rs
-        tests/
-            greeting.rs
+WORKSPACE
+hello_lib/
+BUILD
+src/
+lib.rs
+tests/
+greeting.rs
 ```
 
 `hello_lib/tests/greeting.rs`:
@@ -834,8 +953,8 @@ use hello_lib;
 
 #[test]
 fn test_greeting() {
-    let hello = greeter::Greeter::new("Hello");
-    assert_eq!("Hello world", hello.greeting("world"));
+let hello = greeter::Greeter::new("Hello");
+assert_eq!("Hello world", hello.greeting("world"));
 }
 ```
 
@@ -846,22 +965,21 @@ with `greeting.rs` in `srcs` and a dependency on the `hello_lib` target:
 ```python
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
-    name = "hello_lib",
-    srcs = ["src/lib.rs"],
+name = "hello_lib",
+srcs = ["src/lib.rs"],
 )
 
 rust_test(
-    name = "greeting_test",
-    srcs = ["tests/greeting.rs"],
-    deps = [":hello_lib"],
+name = "greeting_test",
+srcs = ["tests/greeting.rs"],
+deps = [":hello_lib"],
 )
 ```
 
 Run the test with `bazel build //hello_lib:hello_lib_test`.
-
 
 **ATTRIBUTES**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ supported in certain environments.
 
 ## Rules
 
-- [rust](rust.md): standard rust rules for building and testing libraries and binaries.
+- [defs](defs.md): standard rust rules for building and testing libraries and binaries.
 - [rust_doc](rust_doc.md): rules for generating and testing rust documentation.
 - [rust_proto](rust_proto.md): rules for generating [protobuf](https://developers.google.com/protocol-buffers).
   and [gRPC](https://grpc.io) stubs.

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -6,6 +6,7 @@ exports_files([
     "known_shas.bzl",
     "repositories.bzl",
     "rust.bzl",
+    "defs.bzl",
     "toolchain.bzl",
 ])
 

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -1,4 +1,4 @@
-# Copyright 2015 The Bazel Authors. All rights reserved.
+# Copyright 2021 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,51 +12,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Deprecated, please use //rust:defs.bzl."""
+"""Public entry point to all Rust rules and supported APIs."""
 
 load(
-    "//rust:defs.bzl",
-    _error_format = "error_format",
-    _rust_benchmark = "rust_benchmark",
-    _rust_binary = "rust_binary",
+    "//rust/private:clippy.bzl",
     _rust_clippy = "rust_clippy",
     _rust_clippy_aspect = "rust_clippy_aspect",
-    _rust_common = "rust_common",
-    _rust_doc = "rust_doc",
-    _rust_doc_test = "rust_doc_test",
+)
+load("//rust/private:common.bzl", _rust_common = "rust_common")
+load(
+    "//rust/private:rust.bzl",
+    _rust_benchmark = "rust_benchmark",
+    _rust_binary = "rust_binary",
     _rust_library = "rust_library",
     _rust_proc_macro = "rust_proc_macro",
     _rust_shared_library = "rust_shared_library",
     _rust_static_library = "rust_static_library",
     _rust_test = "rust_test",
     _rust_test_binary = "rust_test_binary",
+)
+load(
+    "//rust/private:rust_analyzer.bzl",
     _rust_analyzer = "rust_analyzer",
     _rust_analyzer_aspect = "rust_analyzer_aspect",
 )
+load(
+    "//rust/private:rustc.bzl",
+    _error_format = "error_format",
+)
+load(
+    "//rust/private:rustdoc.bzl",
+    _rust_doc = "rust_doc",
+)
+load(
+    "//rust/private:rustdoc_test.bzl",
+    _rust_doc_test = "rust_doc_test",
+)
 
-def rust_library(**args):
-    """Deprecated. Use the version from "@rules_rust//rust:defs.bzl" instead.
+rust_library = _rust_library
+# See @rules_rust//rust/private:rust.bzl for a complete description.
 
-    Args:
-        **args: args to pass to the relevant rule.
+rust_static_library = _rust_static_library
+# See @rules_rust//rust/private:rust.bzl for a complete description.
 
-    Returns:
-        a target.
-    """
-    if "crate_type" in args:
-        crate_type = args.pop("crate_type")
-        if crate_type in ["lib", "rlib", "dylib"]:
-            return _rust_library(**args)
-        elif crate_type == "cdylib":
-            return _rust_shared_library(**args)
-        elif crate_type == "staticlib":
-            return _rust_static_library(**args)
-        elif crate_type == "proc-macro":
-            return _rust_proc_macro(**args)
-        else:
-            fail("Unexpected crate_type: " + crate_type)
-    else:
-        return _rust_library(**args)
+rust_shared_library = _rust_shared_library
+# See @rules_rust//rust/private:rust.bzl for a complete description.
+
+rust_proc_macro = _rust_proc_macro
+# See @rules_rust//rust/private:rust.bzl for a complete description.
 
 rust_binary = _rust_binary
 # See @rules_rust//rust/private:rust.bzl for a complete description.
@@ -80,16 +83,16 @@ rust_clippy_aspect = _rust_clippy_aspect
 # See @rules_rust//rust/private:clippy.bzl for a complete description.
 
 rust_clippy = _rust_clippy
-# See @rules_rust//rust:private/clippy.bzl for a complete description.
-
-rust_analyzer_aspect = _rust_analyzer_aspect
-# See @rules_rust//rust:private/rust_analyzer.bzl for a complete description.
-
-rust_analyzer = _rust_analyzer
-# See @rules_rust//rust:private/rust_analyzer.bzl for a complete description.
+# See @rules_rust//rust/private:clippy.bzl for a complete description.
 
 error_format = _error_format
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 rust_common = _rust_common
 # See @rules_rust//rust/private:common.bzl for a complete description.
+
+rust_analyzer_aspect = _rust_analyzer_aspect
+# See @rules_rust//rust:private/rust_analyzer.bzl for a complete description.
+
+rust_analyzer = _rust_analyzer
+# See @rules_rust//rust:private/rust_analyzer.bzl for a complete description.

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -2,9 +2,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@rules_cc//cc:defs.bzl", "cc_library")
-
-# buildifier: disable=bzl-visibility
-load("//rust/private:rust.bzl", "rust_binary", "rust_library")
+load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_proc_macro", "rust_shared_library", "rust_static_library")
 
 def _assert_argv_contains_not(env, action, flag):
     asserts.true(
@@ -81,55 +79,35 @@ def _bin_has_native_libs_test_impl(ctx):
     _assert_argv_contains(env, action, "-lstatic=native_dep")
     return analysistest.end(env)
 
-lib_has_no_native_libs_test = analysistest.make(_lib_has_no_native_libs_test_impl)
 rlib_has_no_native_libs_test = analysistest.make(_rlib_has_no_native_libs_test_impl)
 staticlib_has_native_libs_test = analysistest.make(_staticlib_has_native_libs_test_impl)
-dylib_has_native_libs_test = analysistest.make(_dylib_has_native_libs_test_impl)
 cdylib_has_native_libs_test = analysistest.make(_cdylib_has_native_libs_test_impl)
 proc_macro_has_native_libs_test = analysistest.make(_proc_macro_has_native_libs_test_impl)
 bin_has_native_libs_test = analysistest.make(_bin_has_native_libs_test_impl)
 
 def _native_dep_test():
     rust_library(
-        name = "lib_has_no_native_dep",
-        srcs = ["lib_using_native_dep.rs"],
-        deps = [":native_dep"],
-        crate_type = "lib",
-    )
-
-    rust_library(
         name = "rlib_has_no_native_dep",
         srcs = ["lib_using_native_dep.rs"],
         deps = [":native_dep"],
-        crate_type = "rlib",
     )
 
-    rust_library(
+    rust_static_library(
         name = "staticlib_has_native_dep",
         srcs = ["lib_using_native_dep.rs"],
         deps = [":native_dep"],
-        crate_type = "staticlib",
     )
 
-    rust_library(
-        name = "dylib_has_native_dep",
-        srcs = ["lib_using_native_dep.rs"],
-        deps = [":native_dep"],
-        crate_type = "dylib",
-    )
-
-    rust_library(
+    rust_shared_library(
         name = "cdylib_has_native_dep",
         srcs = ["lib_using_native_dep.rs"],
         deps = [":native_dep"],
-        crate_type = "cdylib",
     )
 
-    rust_library(
+    rust_proc_macro(
         name = "proc_macro_has_native_dep",
         srcs = ["proc_macro_using_native_dep.rs"],
         deps = [":native_dep"],
-        crate_type = "proc-macro",
         edition = "2018",
     )
 
@@ -144,10 +122,6 @@ def _native_dep_test():
         srcs = ["native_dep.cc"],
     )
 
-    lib_has_no_native_libs_test(
-        name = "lib_has_no_native_libs_test",
-        target_under_test = ":lib_has_no_native_dep",
-    )
     rlib_has_no_native_libs_test(
         name = "rlib_has_no_native_libs_test",
         target_under_test = ":rlib_has_no_native_dep",
@@ -155,10 +129,6 @@ def _native_dep_test():
     staticlib_has_native_libs_test(
         name = "staticlib_has_native_libs_test",
         target_under_test = ":staticlib_has_native_dep",
-    )
-    dylib_has_native_libs_test(
-        name = "dylib_has_native_libs_test",
-        target_under_test = ":dylib_has_native_dep",
     )
     cdylib_has_native_libs_test(
         name = "cdylib_has_native_libs_test",
@@ -184,10 +154,8 @@ def native_deps_test_suite(name):
     native.test_suite(
         name = name,
         tests = [
-            ":lib_has_no_native_libs_test",
             ":rlib_has_no_native_libs_test",
             ":staticlib_has_native_libs_test",
-            ":dylib_has_native_libs_test",
             ":cdylib_has_native_libs_test",
             ":proc_macro_has_native_libs_test",
             ":bin_has_native_libs_test",


### PR DESCRIPTION
This PR splits rust_library into multiple smaller rules:

* rust_library: rust_library will represent a non-transitive library
  similar to how cc_library, java_library and others behave. It will
  always provide CrateInfo, and depending on it will always mean you can
  access the crate from source. Once we support dynamic linking we can
  consider producing both rlib and dylib from rust_library, but let's
  leave that for another discussion.
* rust_static_library: this will only provide CcInfo and it will
  represent an archive of all transitive objects, both Rustc-made and
  native.
* rust_shared_library: this will only provide CcInfo and it will
  represent an shared library of all transitive objects, both Rustc-made
  and native.
* rust_proc_macro: similar to rust_library, but with different
  crate_type passed to rustc and different validation logic for its
  attributes.

I this this makes sense based on these observations:
* Right now rust_library covers all possible crate types except `bin`.
* rust_library always provides CrateInfo, rust_libraries can depend on
  other rust_libraries.
* When the crate type is `cdylib` or `staticlib`, rust_library provides
  CcInfo.
* When the crate type is `cdylib` or `staticlib`, Rust code will not be
  able to access the crate by `extern crate Foo` in the source; the
  behavior will be similar to depending on a CcInfo providing rule.

I believe smaller rules will make them less confusing and
will allow us to have more focused implementations.

This PR is mostly backwards compatible. //rust:rust.bzl#rust_library is
a macro. If the crate_type attribute is present, macro dispatches to
the right new rule. If it's not present, macro will choose the new
rust_library. New rules are added, so people can migrate at
their own pace.

defs.bzl is the bzl file that we now expect people to load. Bazel docs
recommend to store public rules in defs.bzl
(https://docs.bazel.build/versions/master/skylark/deploying.html#repository-content).

This change was first socialized at
https://groups.google.com/g/rules_rust/c/kGMg6haEF44.

Progress towards https://github.com/bazelbuild/rules_rust/issues/591.