### PR TITLE
Added `//rust/platform:macos` alias

### DIFF
--- a/rust/platform/platform.bzl
+++ b/rust/platform/platform.bzl
@@ -81,6 +81,12 @@ def declare_config_settings():
         actual = ":darwin",
     )
 
+    # Add alias for OSX to "macos" to match the modern name for the OS.
+    native.alias(
+        name = "macos",
+        actual = ":darwin",
+    )
+
     all_supported_triples = _SUPPORTED_T1_PLATFORM_TRIPLES + _SUPPORTED_T2_PLATFORM_TRIPLES
     for triple in all_supported_triples:
         native.config_setting(

--- a/rust/platform/platform.bzl
+++ b/rust/platform/platform.bzl
@@ -81,7 +81,8 @@ def declare_config_settings():
         actual = ":darwin",
     )
 
-    # Add alias for OSX to "macos" to match the modern name for the OS.
+    # Add alias for OSX to "macos" to be consistent with the long-term
+    # direction of `@platforms` in using the OS's modern name.
     native.alias(
         name = "macos",
         actual = ":darwin",


### PR DESCRIPTION
Add alias for OSX to "macos" to match the modern name for the OS.