### PR TITLE
Add Missing link definition in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-This repository provides rules for building [Rust][rust] projects with [Bazel](https://bazel.build/).
+This repository provides rules for building [Rust](https://www.rust-lang.org/) projects with [Bazel](https://bazel.build/).
 
 ## Community
 


### PR DESCRIPTION
Fix markdown syntax for the Rust programming language.

The link was using a link definition without link.
Since all other links use inline style, this commit also follows this style.