### PR TITLE
rules_rust: make it possible to use non-staticlib rust_library targets in c++ deps

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -138,6 +138,10 @@ def _shortest_src_with_basename(srcs, basename):
 def _rust_library_impl(ctx):
     """The implementation of the `rust_library` rule.
 
+    This rule provides CcInfo, so it can be used everywhere Bazel
+    expects rules_cc, but care must be taken to have the correct
+    dependencies on an allocator and std implemetation as needed.
+
     Args:
         ctx (ctx): The rule's context object
 

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -643,8 +643,8 @@ _rust_test_attrs = {
     "env": attr.string_dict(
         mandatory = False,
         doc = _tidy("""
-            Specifies additional environment variables to set when the test is executed by bazel test. 
-            Values are subject to `$(execpath)` and 
+            Specifies additional environment variables to set when the test is executed by bazel test.
+            Values are subject to `$(execpath)` and
             ["Make variable"](https://docs.bazel.build/versions/master/be/make-variables.html) substitution.
         """),
     ),

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -149,6 +149,9 @@ def _rust_library_impl(ctx):
 def _rust_static_library_impl(ctx):
     """The implementation of the `rust_static_library` rule.
 
+    This rule provides CcInfo, so it can be used everywhere Bazel
+    expects rules_cc.
+
     Args:
         ctx (ctx): The rule's context object
 
@@ -159,6 +162,9 @@ def _rust_static_library_impl(ctx):
 
 def _rust_shared_library_impl(ctx):
     """The implementation of the `rust_shared_library` rule.
+
+    This rule provides CcInfo, so it can be used everywhere Bazel
+    expects rules_cc.
 
     Args:
         ctx (ctx): The rule's context object

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -667,6 +667,7 @@ def establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configur
             feature_configuration = feature_configuration,
             cc_toolchain = cc_toolchain,
             static_library = dot_a,
+            pic_static_library = dot_a,
         )
     elif crate_info.type == "cdylib":
         library_to_link = cc_common.create_library_to_link(

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -632,7 +632,7 @@ def rustc_compile_action(
     ]
 
 def establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configuration):
-    """If the produced crate is suitable yield a CcInfo to allow for interop with cc rules 
+    """If the produced crate is suitable yield a CcInfo to allow for interop with cc rules
 
     Args:
         ctx (ctx): The rule's context object

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -645,7 +645,7 @@ def establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configur
         list: A list containing the CcInfo provider
     """
 
-    if crate_info.is_test or crate_info.type not in ("staticlib", "cdylib") or getattr(ctx.attr, "out_binary", False):
+    if crate_info.is_test or crate_info.type not in ("staticlib", "cdylib", "rlib", "lib") or getattr(ctx.attr, "out_binary", False):
         return []
 
     if crate_info.type == "staticlib":
@@ -654,6 +654,19 @@ def establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configur
             feature_configuration = feature_configuration,
             cc_toolchain = cc_toolchain,
             static_library = crate_info.output,
+        )
+    elif crate_info.type in ("rlib", "lib"):
+        # bazel hard-codes a check for endswith((".a", ".pic.a",
+        # ".lib")) in create_library_to_link, so we work around that
+        # by creating a symlink to the .rlib with a .a extension.
+        dot_a = ctx.actions.declare_file(crate_info.name + ".a", sibling = crate_info.output)
+        ctx.actions.symlink(output = dot_a, target_file = crate_info.output)
+        # TODO(hlopko): handle PIC/NOPIC correctly
+        library_to_link = cc_common.create_library_to_link(
+            actions = ctx.actions,
+            feature_configuration = feature_configuration,
+            cc_toolchain = cc_toolchain,
+            static_library = dot_a,
         )
     elif crate_info.type == "cdylib":
         library_to_link = cc_common.create_library_to_link(


### PR DESCRIPTION
ld can handle .rlib archives, since they're really just standard ar(1)
archives like a .a file with some extra metadata. As a result, we can avoid
using staticlib crates when building mixed C++/Rust binaries.

This doesn't correctly handle libstd et al (yet), or deal with some generated
symbols that rustc produces when it drives the linking step, but it's a start.