### PR TITLE
Re-add support for building Wasm libraries as executables.

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -789,13 +789,6 @@ rust_proc_macro = rule(
 )
 
 _rust_binary_attrs = {
-    "linker_script": attr.label(
-        doc = _tidy("""
-            Link script to forward into linker via rustc options.
-        """),
-        cfg = "exec",
-        allow_single_file = True,
-    ),
     "crate_type": attr.string(
         doc = _tidy("""
             Crate type that will be passed to `rustc` to be used for building this crate.
@@ -804,6 +797,13 @@ _rust_binary_attrs = {
             for WebAssembly targets (//rust/platform:wasi and //rust/platform:wasm).
         """),
         default = "bin",
+    ),
+    "linker_script": attr.label(
+        doc = _tidy("""
+            Link script to forward into linker via rustc options.
+        """),
+        cfg = "exec",
+        allow_single_file = True,
     ),
     "out_binary": attr.bool(),
 }

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -255,11 +255,11 @@ def _rust_binary_impl(ctx):
     return rustc_compile_action(
         ctx = ctx,
         toolchain = toolchain,
-        crate_type = "bin",
+        crate_type = ctx.attr.crate_type,
         crate_info = rust_common.crate_info(
             name = crate_name,
-            type = "bin",
-            root = crate_root_src(ctx.attr, ctx.files.srcs, crate_type = "bin"),
+            type = ctx.attr.crate_type,
+            root = crate_root_src(ctx.attr, ctx.files.srcs, ctx.attr.crate_type),
             srcs = ctx.files.srcs,
             deps = ctx.attr.deps,
             proc_macro_deps = ctx.attr.proc_macro_deps,
@@ -795,6 +795,15 @@ _rust_binary_attrs = {
         """),
         cfg = "exec",
         allow_single_file = True,
+    ),
+    "crate_type": attr.string(
+        doc = _tidy("""
+            Crate type that will be passed to `rustc` to be used for building this crate.
+
+            This option is a temporary workaround and should be used only when building
+            for WebAssembly targets (//rust/platform:wasi and //rust/platform:wasm).
+        """),
+        default = "bin",
     ),
     "out_binary": attr.bool(),
 }


### PR DESCRIPTION
The ability to build Wasm libraries as executables is needed to support
WASI reactors (Wasm executables with multiple entrypoints).

This is a temporary workaround, and we should be able to use crate-type
"bin" when a proper support for WASI reactors (rust-lang/rust#79997) is
stabilised is Rust.

This feature was added in #312, and most recently broken in #592.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>