### PR TITLE
migration: include incompatible_use_toolchain_transition globally

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -243,6 +243,7 @@ _build_script_run = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
 )
 
 def cargo_build_script(

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -664,6 +664,7 @@ rust_library = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
     doc = _tidy("""\
         Builds a Rust library crate.
 
@@ -739,6 +740,7 @@ rust_static_library = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
     doc = _tidy("""\
         Builds a Rust static library.
 
@@ -761,6 +763,7 @@ rust_shared_library = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
     doc = _tidy("""\
         Builds a Rust shared library.
 
@@ -783,6 +786,7 @@ rust_proc_macro = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
     doc = _tidy("""\
         Builds a Rust proc-macro crate.
         """),
@@ -809,6 +813,7 @@ rust_binary = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
     doc = _tidy("""\
         Builds a Rust binary crate.
 
@@ -907,6 +912,7 @@ rust_test = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
     doc = _tidy("""\
         Builds a Rust test crate.
 
@@ -1055,6 +1061,7 @@ rust_test_binary = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
     doc = _tidy("""\
         Builds a Rust test binary, without marking this rule as a Bazel test.
 
@@ -1078,6 +1085,7 @@ rust_benchmark = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
     doc = _tidy("""\
         Builds a Rust benchmark test.
 


### PR DESCRIPTION
This is step 2 of
https://github.com/bazelbuild/proposals/blob/master/designs/2020-02-07-toolchain-transition-migration.md,
and was requested by someone at work. We'll eventually want to drop
this (see step 9), but for now this enables more-correct behavior
around toolchain transitions.