### PR TITLE
Add cpp toolchain requirement for rust_toolchain

### DIFF
--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -253,6 +253,10 @@ rust_toolchain = rule(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
     },
+    toolchains = [
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
+    incompatible_use_toolchain_transition = True,
     doc = """Declares a Rust toolchain for use.
 
 This is for declaring a custom toolchain, eg. for configuring a particular version of rust or supporting a new platform.


### PR DESCRIPTION
Part of the work on #635, but not sufficient to fix it.