### PR TITLE
Persistent worker in C++

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,3 +90,18 @@ bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:w
 
 `rust_wasm_bindgen` will automatically transition to the `wasm` platform and can be used when
 building WebAssembly code for the host target.
+
+## Persistent Worker support
+
+The rules ship with a persistent worker implementation that uses Rust's [incremental compilation](https://doc.rust-lang.org/edition-guide/rust-2018/the-compiler/incremental-compilation-for-faster-compiles.html) for faster build times when iterating on code.
+
+To enable this:
+
+Enable the protobuf rules by adding this to your WORKSPACE
+
+```
+load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
+rust_proto_repositories()
+```
+
+In your build command, use the flag `--@rules_rust//rust:experimental-use-worker`. Optionally you can add this flag to your `.bazelrc` to always use this.

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,4 +22,9 @@ bzl_library(
         "//rust/platform:rules",
         "//rust/private:rules",
     ],
+)
+
+bool_flag(
+    name = "use-worker",
+    build_setting_default = False,
 )

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -25,6 +25,6 @@ bzl_library(
 )
 
 bool_flag(
-    name = "use-worker",
+    name = "experimental-use-worker",
     build_setting_default = False,
 )

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -659,7 +659,7 @@ _common_attrs = {
         allow_single_file = True,
         cfg = "exec",
     ),
-    "_use_worker": attr.label(default = Label("//rust:use-worker")),
+    "_use_worker": attr.label(default = Label("//rust:experimental-use-worker")),
 }
 
 _rust_test_attrs = {

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -653,6 +653,13 @@ _common_attrs = {
         allow_single_file = True,
         cfg = "exec",
     ),
+    "_persistent_worker": attr.label(
+        default = Label("//util/worker"),
+        executable = True,
+        allow_single_file = True,
+        cfg = "exec",
+    ),
+    "_use_worker": attr.label(default = Label("//rust:use-worker")),
 }
 
 _rust_test_attrs = {

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -28,6 +28,7 @@ load(
     "relativize",
     "rule_attrs",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 BuildInfo = provider(
     doc = "A provider containing `rustc` build settings for a given Crate.",
@@ -54,6 +55,9 @@ ErrorFormatInfo = provider(
     doc = "Set the --error-format flag for all rustc invocations",
     fields = {"error_format": "(string) [" + ", ".join(_error_format_values) + "]"},
 )
+
+def _use_worker(ctx):
+    return ctx.attr._use_worker[BuildSettingInfo].value
 
 def _get_rustc_env(ctx, toolchain):
     """Gathers rustc environment variables
@@ -355,6 +359,9 @@ def construct_arguments(
 
     # Wrapper args first
     args = ctx.actions.args()
+    if _use_worker(ctx):
+        args.set_param_file_format("multiline")
+        args.use_param_file("@%s", use_always = True)
 
     for build_env_file in build_env_files:
         args.add("--env-file", build_env_file)
@@ -554,8 +561,17 @@ def rustc_compile_action(
     else:
         formatted_version = ""
 
+    executable = ctx.executable._process_wrapper
+    execution_requirements = {}
+    if _use_worker(ctx):
+        executable = ctx.executable._persistent_worker
+        execution_requirements = {
+            "supports-workers": "1",
+            "requires-worker-protocol": "proto"
+        }
+
     ctx.actions.run(
-        executable = ctx.executable._process_wrapper,
+        executable = executable,
         inputs = compile_inputs,
         outputs = [crate_info.output],
         env = env,
@@ -567,6 +583,7 @@ def rustc_compile_action(
             formatted_version,
             len(crate_info.srcs.to_list()),
         ),
+        execution_requirements = execution_requirements,
     )
 
     dylibs = [get_preferred_artifact(lib) for linker_input in dep_info.transitive_noncrates.to_list() for lib in linker_input.libraries if _is_dylib(lib)]

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -565,8 +565,11 @@ def rustc_compile_action(
     arguments = [args]
     execution_requirements = {}
     if _use_worker(ctx):
-        # Pass the "compiler" to the worker.
-        arguments = ["--compiler", executable.path, args]
+        arguments = [
+            "--compiler", executable.path,
+            "--compilation_mode", ctx.var["COMPILATION_MODE"],
+            args,
+        ]
         executable = ctx.executable._persistent_worker
         execution_requirements = {
             "supports-workers": "1",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -562,9 +562,11 @@ def rustc_compile_action(
         formatted_version = ""
 
     executable = ctx.executable._process_wrapper
+    tools = []
     arguments = [args]
     execution_requirements = {}
     if _use_worker(ctx):
+        tools = [executable]
         arguments = [
             "--compiler", executable.path,
             "--compilation_mode", ctx.var["COMPILATION_MODE"],
@@ -581,6 +583,7 @@ def rustc_compile_action(
         inputs = compile_inputs,
         outputs = [crate_info.output],
         env = env,
+        tools = tools,
         arguments = arguments,
         mnemonic = "Rustc",
         progress_message = "Compiling Rust {} {}{} ({} files)".format(

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -562,12 +562,15 @@ def rustc_compile_action(
         formatted_version = ""
 
     executable = ctx.executable._process_wrapper
+    arguments = [args]
     execution_requirements = {}
     if _use_worker(ctx):
+        # Pass the "compiler" to the worker.
+        arguments = ["--compiler", executable.path, args]
         executable = ctx.executable._persistent_worker
         execution_requirements = {
             "supports-workers": "1",
-            "requires-worker-protocol": "proto"
+            "requires-worker-protocol": "proto",
         }
 
     ctx.actions.run(
@@ -575,7 +578,7 @@ def rustc_compile_action(
         inputs = compile_inputs,
         outputs = [crate_info.output],
         env = env,
-        arguments = [args],
+        arguments = arguments,
         mnemonic = "Rustc",
         progress_message = "Compiling Rust {} {}{} ({} files)".format(
             crate_info.type,

--- a/util/worker/BUILD
+++ b/util/worker/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_proto//proto:defs.bzl", "proto_library");
 
 cc_binary(
     name = "worker",
@@ -15,6 +16,7 @@ cc_binary(
             "//util/process_wrapper:system_posix.cc",
         ],
     }),
+    deps = [":worker_cc_proto"],
     defines = [] + select({
         "@bazel_tools//src/conditions:host_windows": [
             "UNICODE",
@@ -23,4 +25,14 @@ cc_binary(
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "worker_cc_proto",
+    deps = [":worker_protocol"],
+)
+
+proto_library(
+    name = "worker_protocol",
+    srcs = ["worker_protocol.proto"],
 )

--- a/util/worker/BUILD
+++ b/util/worker/BUILD
@@ -1,18 +1,18 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 cc_binary(
-    name = "process_wrapper",
+    name = "worker",
     srcs = [
-        "process_wrapper.cc",
-        "system.h",
-        "utils.h",
-        "utils.cc",
+        "worker.cc",
+        "//util/process_wrapper:system.h",
+        "//util/process_wrapper:utils.h",
+        "//util/process_wrapper:utils.cc",
     ] + select({
         "@bazel_tools//src/conditions:host_windows": [
-            "system_windows.cc",
+            "//util/process_wrapper:system_windows.cc",
         ],
         "//conditions:default": [
-            "system_posix.cc",
+            "//util/process_wrapper:system_posix.cc",
         ],
     }),
     defines = [] + select({
@@ -24,11 +24,3 @@ cc_binary(
     }),
     visibility = ["//visibility:public"],
 )
-
-exports_files([
-    "utils.h",
-    "utils.cc",
-    "system.h",
-    "system_windows.cc",
-    "system_posix.cc",
-])

--- a/util/worker/worker.cc
+++ b/util/worker/worker.cc
@@ -72,8 +72,14 @@ bool HandleRequest(
   arguments.reserve(request.arguments_size() + 2);
 
   auto request_args = request.arguments();
+  std::string target;
   for (int i = 0; i < request.arguments_size(); i++) {
-      arguments.push_back(request.arguments(i));
+      auto argument = request.arguments(i);
+      // Starts with
+      if (argument.rfind("--target=", 0) != std::string::npos) {
+          target = argument.substr(9) + '/';
+      }
+      arguments.push_back(argument);
   }
 
   // Considering
@@ -83,7 +89,7 @@ bool HandleRequest(
   // That prevents the GC phase from clearing the cache of a debug build when running an opt build.
   arguments.push_back("--codegen");
   // TODO: Can be shared across requests to avoid concatenation.
-  arguments.push_back("incremental=" + System::GetWorkingDirectory() + "/rustc-target-" + compilation_mode + "/incremental");
+  arguments.push_back("incremental=" + System::GetWorkingDirectory() + "/rustc-target/" + target + compilation_mode + "/incremental");
 
   // Since the worker is not multiplexed, we can always log to the same file and overwrite on the next request.
   System::StrType stdout_file = System::GetWorkingDirectory() + "/stdout.log";

--- a/util/worker/worker.cc
+++ b/util/worker/worker.cc
@@ -1,0 +1,197 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <utility>
+
+#include "util/process_wrapper/system.h"
+#include "util/process_wrapper/utils.h"
+
+using CharType = process_wrapper::System::StrType::value_type;
+
+// Simple process wrapper allowing us to not depend on the shell to run a
+// process to perform basic operations like capturing the output or having
+// the $pwd used in command line arguments or environment variables
+int PW_MAIN(int argc, const CharType* argv[], const CharType* envp[]) {
+  using namespace process_wrapper;
+
+  System::EnvironmentBlock environment_block;
+  // Taking all environment variables from the current process
+  // and sending them down to the child process
+  for (int i = 0; envp[i] != nullptr; ++i) {
+    environment_block.push_back(envp[i]);
+  }
+
+  using Subst = std::pair<System::StrType, System::StrType>;
+
+  System::StrType exec_path;
+  std::vector<Subst> subst_mappings;
+  System::StrType stdout_file;
+  System::StrType stderr_file;
+  System::StrType touch_file;
+  System::StrType copy_source;
+  System::StrType copy_dest;
+  System::Arguments arguments;
+  System::Arguments file_arguments;
+
+  // Processing current process argument list until -- is encountered
+  // everthing after gets sent down to the child process
+  for (int i = 1; i < argc; ++i) {
+    System::StrType arg = argv[i];
+    if (++i == argc) {
+      std::cerr << "process wrapper error: argument \"" << ToUtf8(arg)
+                << "\" missing parameter.\n";
+      return -1;
+    }
+    if (arg == PW_SYS_STR("--subst")) {
+      System::StrType subst = argv[i];
+      size_t equal_pos = subst.find('=');
+      if (equal_pos == std::string::npos) {
+        std::cerr << "process wrapper error: wrong substituion format for \""
+                  << ToUtf8(subst) << "\".\n";
+        return -1;
+      }
+      System::StrType key = subst.substr(0, equal_pos);
+      if (key.empty()) {
+        std::cerr << "process wrapper error: empty key for substituion \""
+                  << ToUtf8(subst) << "\".\n";
+        return -1;
+      }
+      System::StrType value = subst.substr(equal_pos + 1, subst.size());
+      if (value == PW_SYS_STR("${pwd}")) {
+        value = System::GetWorkingDirectory();
+      }
+      subst_mappings.push_back({std::move(key), std::move(value)});
+    } else if (arg == PW_SYS_STR("--env-file")) {
+      if (!ReadFileToArray(argv[i], environment_block)) {
+        return -1;
+      }
+    } else if (arg == PW_SYS_STR("--arg-file")) {
+      if (!ReadFileToArray(argv[i], file_arguments)) {
+        return -1;
+      }
+    } else if (arg == PW_SYS_STR("--touch-file")) {
+      if (!touch_file.empty()) {
+        std::cerr << "process wrapper error: \"--touch-file\" can only appear "
+                     "once.\n";
+        return -1;
+      }
+      touch_file = argv[i];
+    } else if (arg == PW_SYS_STR("--copy-output")) {
+      // i is already at the first arg position, accountint we need another arg
+      // and then -- executable_name.
+      if (i + 1 > argc) {
+        std::cerr
+            << "process wrapper error: \"--copy-output\" needs 2 parameters.\n";
+        return -1;
+      }
+      if (!copy_source.empty() || !copy_dest.empty()) {
+        std::cerr << "process wrapper error: \"--copy-output\" can only appear "
+                     "once.\n";
+        return -1;
+      }
+      copy_source = argv[i];
+      copy_dest = argv[++i];
+      if (copy_source == copy_dest) {
+        std::cerr << "process wrapper error: \"--copy-output\" source and dest "
+                     "need to be different.\n";
+        return -1;
+      }
+    } else if (arg == PW_SYS_STR("--stdout-file")) {
+      if (!stdout_file.empty()) {
+        std::cerr << "process wrapper error: \"--stdout-file\" can only appear "
+                     "once.\n";
+        return -1;
+      }
+      stdout_file = argv[i];
+    } else if (arg == PW_SYS_STR("--stderr-file")) {
+      if (!stderr_file.empty()) {
+        std::cerr << "process wrapper error: \"--stderr-file\" can only appear "
+                     "once.\n";
+        return -1;
+      }
+      stderr_file = argv[i];
+    } else if (arg == PW_SYS_STR("--")) {
+      exec_path = argv[i];
+      for (++i; i < argc; ++i) {
+        arguments.push_back(argv[i]);
+      }
+      // after we consume all arguments we append the files arguments
+      for (const System::StrType& file_arg : file_arguments) {
+        arguments.push_back(file_arg);
+      }
+    } else {
+      std::cerr << "process wrapper error: unknow argument \"" << ToUtf8(arg)
+                << "\"." << '\n';
+      return -1;
+    }
+  }
+
+  if (subst_mappings.size()) {
+    for (const Subst& subst : subst_mappings) {
+      System::StrType token = PW_SYS_STR("${");
+      token += subst.first;
+      token.push_back('}');
+      for (System::StrType& arg : arguments) {
+        ReplaceToken(arg, token, subst.second);
+      }
+
+      for (System::StrType& env : environment_block) {
+        ReplaceToken(env, token, subst.second);
+      }
+    }
+  }
+
+  std::cerr << "NIKHILM HELLO\n";
+  return 1;
+
+  // Have the last values added take precedence over the first.
+  // This is simpler than needing to track duplicates and explicitly override them.
+  std::reverse(environment_block.begin(), environment_block.end());
+
+  int exit_code = System::Exec(exec_path, arguments, environment_block,
+                               stdout_file, stderr_file);
+  if (exit_code == 0) {
+    if (!touch_file.empty()) {
+      std::ofstream file(touch_file);
+      if (file.fail()) {
+        std::cerr << "process wrapper error: failed to create touch file: \""
+                  << ToUtf8(touch_file) << "\"\n";
+        return -1;
+      }
+      file.close();
+    }
+
+    // we perform a copy of the output if necessary
+    if (!copy_source.empty() && !copy_dest.empty()) {
+      std::ifstream source(copy_source, std::ios::binary);
+      if (source.fail()) {
+        std::cerr << "process wrapper error: failed to open copy source: \""
+                  << ToUtf8(copy_source) << "\"\n";
+        return -1;
+      }
+      std::ofstream dest(copy_dest, std::ios::binary);
+      if (dest.fail()) {
+        std::cerr << "process wrapper error: failed to open copy dest: \""
+                  << ToUtf8(copy_dest) << "\"\n";
+        return -1;
+      }
+      dest << source.rdbuf();
+    }
+  }
+  return exit_code;
+}

--- a/util/worker/worker.cc
+++ b/util/worker/worker.cc
@@ -18,10 +18,42 @@
 #include <string>
 #include <utility>
 
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+
 #include "util/process_wrapper/system.h"
 #include "util/process_wrapper/utils.h"
+#include "util/worker/worker_protocol.pb.h"
+
+// TODO: Library and app split.
+using blaze::worker::WorkRequest;
+using google::protobuf::io::CodedInputStream;
+using google::protobuf::io::FileInputStream;
 
 using CharType = process_wrapper::System::StrType::value_type;
+
+bool ReadRequest(CodedInputStream *stream, WorkRequest *request)
+{
+  uint32_t req_len;
+  if (!stream->ReadVarint32(&req_len)) {
+    std::cerr << "Unable to read message length\n";
+    return false;
+  }
+
+  CodedInputStream::Limit limit = stream->PushLimit(req_len);
+  if (!request->MergeFromCodedStream(stream)) {
+    std::cerr << "Unable to merge from stream\n";
+    return false;
+  }
+
+  if (!stream->ConsumedEntireMessage()) {
+    std::cerr << "Did not consume entire message\n";
+    return false;
+  }
+
+  stream->PopLimit(limit);
+  return true;
+}
 
 // Simple process wrapper allowing us to not depend on the shell to run a
 // process to perform basic operations like capturing the output or having
@@ -38,6 +70,9 @@ int PW_MAIN(int argc, const CharType* argv[], const CharType* envp[]) {
 
   using Subst = std::pair<System::StrType, System::StrType>;
 
+  // This will need support for understanding param file argument.
+  // As well as parsing other flags generally.
+
   System::StrType exec_path;
   std::vector<Subst> subst_mappings;
   System::StrType stdout_file;
@@ -48,116 +83,38 @@ int PW_MAIN(int argc, const CharType* argv[], const CharType* envp[]) {
   System::Arguments arguments;
   System::Arguments file_arguments;
 
+  bool as_worker = false;
+
   // Processing current process argument list until -- is encountered
   // everthing after gets sent down to the child process
   for (int i = 1; i < argc; ++i) {
     System::StrType arg = argv[i];
-    if (++i == argc) {
-      std::cerr << "process wrapper error: argument \"" << ToUtf8(arg)
-                << "\" missing parameter.\n";
-      return -1;
-    }
-    if (arg == PW_SYS_STR("--subst")) {
-      System::StrType subst = argv[i];
-      size_t equal_pos = subst.find('=');
-      if (equal_pos == std::string::npos) {
-        std::cerr << "process wrapper error: wrong substituion format for \""
-                  << ToUtf8(subst) << "\".\n";
-        return -1;
-      }
-      System::StrType key = subst.substr(0, equal_pos);
-      if (key.empty()) {
-        std::cerr << "process wrapper error: empty key for substituion \""
-                  << ToUtf8(subst) << "\".\n";
-        return -1;
-      }
-      System::StrType value = subst.substr(equal_pos + 1, subst.size());
-      if (value == PW_SYS_STR("${pwd}")) {
-        value = System::GetWorkingDirectory();
-      }
-      subst_mappings.push_back({std::move(key), std::move(value)});
-    } else if (arg == PW_SYS_STR("--env-file")) {
-      if (!ReadFileToArray(argv[i], environment_block)) {
-        return -1;
-      }
-    } else if (arg == PW_SYS_STR("--arg-file")) {
-      if (!ReadFileToArray(argv[i], file_arguments)) {
-        return -1;
-      }
-    } else if (arg == PW_SYS_STR("--touch-file")) {
-      if (!touch_file.empty()) {
-        std::cerr << "process wrapper error: \"--touch-file\" can only appear "
-                     "once.\n";
-        return -1;
-      }
-      touch_file = argv[i];
-    } else if (arg == PW_SYS_STR("--copy-output")) {
-      // i is already at the first arg position, accountint we need another arg
-      // and then -- executable_name.
-      if (i + 1 > argc) {
-        std::cerr
-            << "process wrapper error: \"--copy-output\" needs 2 parameters.\n";
-        return -1;
-      }
-      if (!copy_source.empty() || !copy_dest.empty()) {
-        std::cerr << "process wrapper error: \"--copy-output\" can only appear "
-                     "once.\n";
-        return -1;
-      }
-      copy_source = argv[i];
-      copy_dest = argv[++i];
-      if (copy_source == copy_dest) {
-        std::cerr << "process wrapper error: \"--copy-output\" source and dest "
-                     "need to be different.\n";
-        return -1;
-      }
-    } else if (arg == PW_SYS_STR("--stdout-file")) {
-      if (!stdout_file.empty()) {
-        std::cerr << "process wrapper error: \"--stdout-file\" can only appear "
-                     "once.\n";
-        return -1;
-      }
-      stdout_file = argv[i];
-    } else if (arg == PW_SYS_STR("--stderr-file")) {
-      if (!stderr_file.empty()) {
-        std::cerr << "process wrapper error: \"--stderr-file\" can only appear "
-                     "once.\n";
-        return -1;
-      }
-      stderr_file = argv[i];
-    } else if (arg == PW_SYS_STR("--")) {
-      exec_path = argv[i];
-      for (++i; i < argc; ++i) {
-        arguments.push_back(argv[i]);
-      }
-      // after we consume all arguments we append the files arguments
-      for (const System::StrType& file_arg : file_arguments) {
-        arguments.push_back(file_arg);
-      }
+    if (arg == PW_SYS_STR("--persistent_worker")) {
+        as_worker = true;
     } else {
-      std::cerr << "process wrapper error: unknow argument \"" << ToUtf8(arg)
+      std::cerr << "worker wrapper error: unknown argument \"" << ToUtf8(arg)
                 << "\"." << '\n';
       return -1;
     }
   }
 
-  if (subst_mappings.size()) {
-    for (const Subst& subst : subst_mappings) {
-      System::StrType token = PW_SYS_STR("${");
-      token += subst.first;
-      token.push_back('}');
-      for (System::StrType& arg : arguments) {
-        ReplaceToken(arg, token, subst.second);
-      }
-
-      for (System::StrType& env : environment_block) {
-        ReplaceToken(env, token, subst.second);
-      }
-    }
+  if (!as_worker) {
+    std::cerr << "Don't know how to run as non-worker yet\n";
+    return -1;
   }
 
-  std::cerr << "NIKHILM HELLO\n";
-  return 1;
+  CodedInputStream *stream = new CodedInputStream(new FileInputStream(0));
+  while (true) {
+    WorkRequest request;
+    if (!ReadRequest(stream, &request)) {
+      return 1;
+    }
+    for (int i = 0; i < request.arguments_size(); i++) {
+      std::cerr << request.arguments(i) << " ";
+    }
+    std::cerr << "\n";
+    return 1;
+  }
 
   // Have the last values added take precedence over the first.
   // This is simpler than needing to track duplicates and explicitly override them.

--- a/util/worker/worker_protocol.proto
+++ b/util/worker/worker_protocol.proto
@@ -1,0 +1,62 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package blaze.worker;
+
+option java_package = "com.google.devtools.build.lib.worker";
+
+// An input file.
+message Input {
+  // The path in the file system where to read this input artifact from. This is
+  // either a path relative to the execution root (the worker process is
+  // launched with the working directory set to the execution root), or an
+  // absolute path.
+  string path = 1;
+
+  // A hash-value of the contents. The format of the contents is unspecified and
+  // the digest should be treated as an opaque token.
+  bytes digest = 2;
+}
+
+// This represents a single work unit that Blaze sends to the worker.
+message WorkRequest {
+  repeated string arguments = 1;
+
+  // The inputs that the worker is allowed to read during execution of this
+  // request.
+  repeated Input inputs = 2;
+
+  // To support multiplex worker, each WorkRequest must have an unique ID. This
+  // ID should be attached unchanged to the WorkResponse.
+  int32 request_id = 3;
+}
+
+// The worker sends this message to Blaze when it finished its work on the
+// WorkRequest message.
+message WorkResponse {
+  int32 exit_code = 1;
+
+  // This is printed to the user after the WorkResponse has been received and is
+  // supposed to contain compiler warnings / errors etc. - thus we'll use a
+  // string type here, which gives us UTF-8 encoding.
+  string output = 2;
+
+  // To support multiplex worker, each WorkResponse must have an unique ID.
+  // Since worker processes which support multiplex worker will handle multiple
+  // WorkRequests in parallel, this ID will be used to determined which
+  // WorkerProxy does this WorkResponse belong to.
+  int32 request_id = 3;
+}


### PR DESCRIPTION
This supersedes #421. I finally had the motivation to just switch to using C++ and fortunately it wasn't as bad as I expected.

Improvements
- Written in C++ so it can be built from source on all platforms
- Don't have to worry about the bootstrap problem
- Much easier to use, including on a per-command basis, just by using a build settings flag.
- Incorporates target triple as well as compilation mode in the incremental compilation directory path to match [Cargo's directory structure](https://github.com/rust-lang/cargo/blob/58a961314437258065e23cb6316dfc121d96fb71/src/cargo/core/compiler/layout.rs). See the request in https://github.com/bazelbuild/rules_rust/pull/517#issuecomment-809991674.

Currently untested:
- If this even builds on macOS/Windows, as I don't have access to those platforms.

@dae would you mind trying this out?