### PR TITLE
construct_arguments: Always use correct attributes in an aspect context.

### DIFF
--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -84,6 +84,7 @@ def _clippy_aspect_impl(target, ctx):
 
     args, env = construct_arguments(
         ctx,
+        ctx.rule.attr,
         ctx.file,
         toolchain,
         toolchain.clippy_driver.path,
@@ -98,7 +99,6 @@ def _clippy_aspect_impl(target, ctx):
         build_env_files = build_env_files,
         build_flags_files = build_flags_files,
         maker_path = clippy_marker.path,
-        aspect = True,
         emit = ["dep-info", "metadata"],
     )
 

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -135,23 +135,6 @@ def get_preferred_artifact(library_to_link):
         library_to_link.dynamic_library
     )
 
-def rule_attrs(ctx, aspect):
-    """Gets a rule's attributes.
-
-    As per https://docs.bazel.build/versions/master/skylark/aspects.html when we're executing from an
-    aspect we need to get attributes of a rule differently to if we're not in an aspect.
-
-    Args:
-        ctx (ctx): A rule's context object
-        aspect (bool): Whether we're running in an aspect
-
-    Returns:
-        struct: A struct to access the values of the attributes for a
-            [rule_attributes](https://docs.bazel.build/versions/master/skylark/lib/rule_attributes.html#modules.rule_attributes)
-            object.
-    """
-    return ctx.rule.attr if aspect else ctx.attr
-
 def _expand_location(ctx, env, data):
     """A trivial helper for `_expand_locations`
 


### PR DESCRIPTION
`construct_arguments` was already using the `rule_attrs` helper function in some places to access `ctx.rule.attr` instead of `ctx.attr`, but it wasn't doing this consistently.

I've chosen to eliminate the boolean `aspect` parameter of `construct_arguments` and pass in the correct attributes directly
instead. This also eliminates the need for the `rule_attrs` helper function. Since this function was only being used here, I have eliminated it entirely.

Finally, I have changed `_get_rustc_env` to take only the attributes instead of the entire context.

All tests continue to pass. I haven't added any tests that would break without this change, but in an upcoming PR, I will change `_get_rustc_env` to respect the `crate_name` attribute, and this would break without the changes in this PR.