### PR TITLE
Respect `crate_name` attribute when setting CARGO_CRATE_NAME.

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -20,11 +20,11 @@ load(
 load("//rust/private:common.bzl", "rust_common")
 load(
     "//rust/private:utils.bzl",
+    "crate_name_from_attr",
     "expand_locations",
     "find_cc_toolchain",
     "get_lib_name",
     "get_preferred_artifact",
-    "name_to_crate_name",
     "relativize",
 )
 
@@ -73,8 +73,7 @@ def _get_rustc_env(attr, toolchain):
     return {
         "CARGO_CFG_TARGET_ARCH": toolchain.target_arch,
         "CARGO_CFG_TARGET_OS": toolchain.os,
-        # TODO(martinboehme): Respect a `crate_name` attribute if present.
-        "CARGO_CRATE_NAME": name_to_crate_name(attr.name),
+        "CARGO_CRATE_NAME": crate_name_from_attr(attr),
         "CARGO_PKG_AUTHORS": "",
         "CARGO_PKG_DESCRIPTION": "",
         "CARGO_PKG_HOMEPAGE": "",

--- a/test/build_env/BUILD.bazel
+++ b/test/build_env/BUILD.bazel
@@ -30,6 +30,13 @@ rust_test(
     deps = [":cargo_build_script_env-vars_build_script"],
 )
 
+rust_test(
+    name = "cargo-env-vars-custom-crate-name-test",
+    crate_name = "custom_crate_name",
+    srcs = ["tests/custom_crate_name.rs"],
+    deps = [":cargo_build_script_env-vars_build_script"],
+)
+
 cargo_build_script(
     name = "cargo_build_script_env-vars_build_script",
     srcs = ["src/build.rs"],

--- a/test/build_env/tests/custom_crate_name.rs
+++ b/test/build_env/tests/custom_crate_name.rs
@@ -1,0 +1,5 @@
+#[test]
+fn cargo_env_vars() {
+    assert_eq!(env!("CARGO_PKG_NAME"), "cargo-env-vars-custom-crate-name-test");
+    assert_eq!(env!("CARGO_CRATE_NAME"), "custom_crate_name");
+}


### PR DESCRIPTION
As part of this change, I've moved the formerly private `_crate_name` function from rust.bzl to utils.bzl and renamed it to `crate_name_from_attr`.

I've also had to add a `hasattr(attr, "crate_name")` check to this function because `rustc_compile_action` (which calls through to `_get_rustc_env`) gets called from the implementation of the Rust proto rules, and those don't have a `crate_name` attribute (and it wouldn't make sense to add one either).