### PR TITLE
Don't apply `name_to_crate_name` to test binary names.

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -357,9 +357,9 @@ def _create_test_launcher(ctx, toolchain, output, providers):
     # This should be investigated but for now, we generally assume if the target environment is windows,
     # the execution environment is windows.
     if toolchain.os == "windows":
-        launcher = ctx.actions.declare_file(name_to_crate_name(ctx.label.name + ".launcher.exe"))
+        launcher = ctx.actions.declare_file(ctx.label.name + ".launcher.exe")
     else:
-        launcher = ctx.actions.declare_file(name_to_crate_name(ctx.label.name + ".launcher"))
+        launcher = ctx.actions.declare_file(ctx.label.name + ".launcher")
 
     # Because returned executables must be created from the same rule, the
     # launcher target is simply symlinked and exposed.
@@ -491,7 +491,7 @@ def _rust_test_impl(ctx):
     toolchain = find_toolchain(ctx)
 
     output = ctx.actions.declare_file(
-        name_to_crate_name(ctx.label.name) + toolchain.binary_ext,
+        ctx.label.name + toolchain.binary_ext,
     )
 
     return _rust_test_common(ctx, toolchain, output)


### PR DESCRIPTION
Normal `rust_binary` targets don't do this, so for consistency, don't do it in tests either.

An additional motivation for this change is that I'm trying to whittle down the number of uses of the `name_to_crate_name` function, as it doesn't take a possible `crate_name` attribute into account. For context, see also the changes and discussion in

https://github.com/bazelbuild/rules_rust/pull/645