### PR TITLE
Change transitive_libs in DepInfo to a depset

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -165,7 +165,7 @@ def collect_deps(label, deps, proc_macro_deps, aliases, toolchain):
                 transitive = transitive_noncrates,
                 order = "topological",  # dylib link flag ordering matters.
             ),
-            transitive_libs = transitive_libs.to_list(),
+            transitive_libs = transitive_libs,
             transitive_build_infos = depset(transitive = transitive_build_infos),
             dep_env = build_info.dep_env if build_info else None,
         ),
@@ -283,7 +283,6 @@ def collect_inputs(
     compile_inputs = depset(
         getattr(files, "data", []) +
         getattr(files, "compile_data", []) +
-        dep_info.transitive_libs +
         [toolchain.rustc] +
         toolchain.crosstool_files +
         ([build_info.rustc_env, build_info.flags] if build_info else []) +
@@ -293,6 +292,7 @@ def collect_inputs(
             toolchain.rust_lib.files,
             linker_depset,
             crate_info.srcs,
+            dep_info.transitive_libs,
         ],
     )
     build_env_files = getattr(files, "rustc_env_files", [])

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -45,12 +45,12 @@ def _rust_doc_test_impl(ctx):
     # The test script compiles the crate and runs it, so it needs both compile and runtime inputs.
     compile_inputs = depset(
         [crate.output] +
-        dep_info.transitive_libs +
         [toolchain.rust_doc] +
         [toolchain.rustc] +
         toolchain.crosstool_files,
         transitive = [
             crate.srcs,
+            dep_info.transitive_libs,
             toolchain.rustc_lib.files,
             toolchain.rust_lib.files,
         ],


### PR DESCRIPTION
It appears to already be a depset, just happens to be flattened.  It's
not a part of the external API, so, in theory, this should have an
effect.