### PR TITLE
Moved proto deps into toolchain to avoid confusing boiler plate code

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -505,7 +505,6 @@ Example:
 
 ```python
 load("//proto:proto.bzl", "rust_grpc_library")
-load("//proto:toolchain.bzl", "GRPC_COMPILE_DEPS")
 
 proto_library(
     name = "my_proto",
@@ -520,7 +519,7 @@ rust_grpc_library(
 rust_binary(
     name = "my_service",
     srcs = ["my_service.rs"],
-    deps = [":rust"] + GRPC_COMPILE_DEPS,
+    deps = [":rust"],
 )
 ```
 
@@ -532,7 +531,7 @@ rust_binary(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_grpc_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_grpc_library-deps"></a>deps |  List of proto_library dependencies that will be built. One crate for each proto_library will be created with the corresponding gRPC stubs.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
-| <a id="rust_grpc_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [Label("//proto/raze:protobuf"), Label("//proto/raze:grpc"), Label("//proto/raze:tls_api"), Label("//proto/raze:tls_api_stub")] |
+| <a id="rust_grpc_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#rust_library"></a>
@@ -682,7 +681,6 @@ Example:
 
 ```python
 load("@rules_rust//proto:proto.bzl", "rust_proto_library")
-load("@rules_rust//proto:toolchain.bzl", "PROTO_COMPILE_DEPS")
 
 proto_library(
     name = "my_proto",
@@ -697,7 +695,7 @@ proto_rust_library(
 rust_binary(
     name = "my_proto_binary",
     srcs = ["my_proto_binary.rs"],
-    deps = [":rust"] + PROTO_COMPILE_DEPS,
+    deps = [":rust"],
 )
 ```
 
@@ -709,7 +707,7 @@ rust_binary(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_proto_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_proto_library-deps"></a>deps |  List of proto_library dependencies that will be built. One crate for each proto_library will be created with the corresponding stubs.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
-| <a id="rust_proto_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [Label("//proto/raze:protobuf")] |
+| <a id="rust_proto_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#rust_proto_toolchain"></a>
@@ -717,7 +715,8 @@ rust_binary(
 ## rust_proto_toolchain
 
 <pre>
-rust_proto_toolchain(<a href="#rust_proto_toolchain-name">name</a>, <a href="#rust_proto_toolchain-edition">edition</a>, <a href="#rust_proto_toolchain-grpc_plugin">grpc_plugin</a>, <a href="#rust_proto_toolchain-proto_plugin">proto_plugin</a>, <a href="#rust_proto_toolchain-protoc">protoc</a>)
+rust_proto_toolchain(<a href="#rust_proto_toolchain-name">name</a>, <a href="#rust_proto_toolchain-edition">edition</a>, <a href="#rust_proto_toolchain-grpc_compile_deps">grpc_compile_deps</a>, <a href="#rust_proto_toolchain-grpc_plugin">grpc_plugin</a>, <a href="#rust_proto_toolchain-proto_compile_deps">proto_compile_deps</a>,
+                     <a href="#rust_proto_toolchain-proto_plugin">proto_plugin</a>, <a href="#rust_proto_toolchain-protoc">protoc</a>)
 </pre>
 
 Declares a Rust Proto toolchain for use.
@@ -761,7 +760,9 @@ See @rules_rust//proto:BUILD for examples of defining the toolchain.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_proto_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_proto_toolchain-edition"></a>edition |  The edition used by the generated rust source.   | String | optional | "2015" |
+| <a id="rust_proto_toolchain-grpc_compile_deps"></a>grpc_compile_deps |  The crates the generated grpc libraries depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [Label("//proto/raze:protobuf"), Label("//proto/raze:grpc"), Label("//proto/raze:tls_api"), Label("//proto/raze:tls_api_stub")] |
 | <a id="rust_proto_toolchain-grpc_plugin"></a>grpc_plugin |  The location of the Rust protobuf compiler plugin to generate rust gRPC stubs.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //proto:protoc_gen_rust_grpc |
+| <a id="rust_proto_toolchain-proto_compile_deps"></a>proto_compile_deps |  The crates the generated protobuf libraries depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [Label("//proto/raze:protobuf")] |
 | <a id="rust_proto_toolchain-proto_plugin"></a>proto_plugin |  The location of the Rust protobuf compiler plugin used to generate rust sources.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //proto:protoc_gen_rust |
 | <a id="rust_proto_toolchain-protoc"></a>protoc |  The location of the <code>protoc</code> binary. It should be an executable target.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @com_google_protobuf//:protoc |
 
@@ -1362,11 +1363,17 @@ Declare dependencies needed for bindgen.
 ## rust_proto_repositories
 
 <pre>
-rust_proto_repositories()
+rust_proto_repositories(<a href="#rust_proto_repositories-register_default_toolchain">register_default_toolchain</a>)
 </pre>
 
 Declare dependencies needed for proto compilation.
 
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain)     (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies     that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
 
 
 <a id="#rust_repositories"></a>

--- a/docs/rust_proto.md
+++ b/docs/rust_proto.md
@@ -18,7 +18,6 @@ Example:
 
 ```python
 load("//proto:proto.bzl", "rust_grpc_library")
-load("//proto:toolchain.bzl", "GRPC_COMPILE_DEPS")
 
 proto_library(
     name = "my_proto",
@@ -33,7 +32,7 @@ rust_grpc_library(
 rust_binary(
     name = "my_service",
     srcs = ["my_service.rs"],
-    deps = [":rust"] + GRPC_COMPILE_DEPS,
+    deps = [":rust"],
 )
 ```
 
@@ -45,7 +44,7 @@ rust_binary(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_grpc_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_grpc_library-deps"></a>deps |  List of proto_library dependencies that will be built. One crate for each proto_library will be created with the corresponding gRPC stubs.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
-| <a id="rust_grpc_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [Label("//proto/raze:protobuf"), Label("//proto/raze:grpc"), Label("//proto/raze:tls_api"), Label("//proto/raze:tls_api_stub")] |
+| <a id="rust_grpc_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#rust_proto_library"></a>
@@ -62,7 +61,6 @@ Example:
 
 ```python
 load("@rules_rust//proto:proto.bzl", "rust_proto_library")
-load("@rules_rust//proto:toolchain.bzl", "PROTO_COMPILE_DEPS")
 
 proto_library(
     name = "my_proto",
@@ -77,7 +75,7 @@ proto_rust_library(
 rust_binary(
     name = "my_proto_binary",
     srcs = ["my_proto_binary.rs"],
-    deps = [":rust"] + PROTO_COMPILE_DEPS,
+    deps = [":rust"],
 )
 ```
 
@@ -89,7 +87,7 @@ rust_binary(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_proto_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_proto_library-deps"></a>deps |  List of proto_library dependencies that will be built. One crate for each proto_library will be created with the corresponding stubs.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
-| <a id="rust_proto_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [Label("//proto/raze:protobuf")] |
+| <a id="rust_proto_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#rust_proto_toolchain"></a>
@@ -97,7 +95,8 @@ rust_binary(
 ## rust_proto_toolchain
 
 <pre>
-rust_proto_toolchain(<a href="#rust_proto_toolchain-name">name</a>, <a href="#rust_proto_toolchain-edition">edition</a>, <a href="#rust_proto_toolchain-grpc_plugin">grpc_plugin</a>, <a href="#rust_proto_toolchain-proto_plugin">proto_plugin</a>, <a href="#rust_proto_toolchain-protoc">protoc</a>)
+rust_proto_toolchain(<a href="#rust_proto_toolchain-name">name</a>, <a href="#rust_proto_toolchain-edition">edition</a>, <a href="#rust_proto_toolchain-grpc_compile_deps">grpc_compile_deps</a>, <a href="#rust_proto_toolchain-grpc_plugin">grpc_plugin</a>, <a href="#rust_proto_toolchain-proto_compile_deps">proto_compile_deps</a>,
+                     <a href="#rust_proto_toolchain-proto_plugin">proto_plugin</a>, <a href="#rust_proto_toolchain-protoc">protoc</a>)
 </pre>
 
 Declares a Rust Proto toolchain for use.
@@ -141,7 +140,9 @@ See @rules_rust//proto:BUILD for examples of defining the toolchain.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_proto_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_proto_toolchain-edition"></a>edition |  The edition used by the generated rust source.   | String | optional | "2015" |
+| <a id="rust_proto_toolchain-grpc_compile_deps"></a>grpc_compile_deps |  The crates the generated grpc libraries depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [Label("//proto/raze:protobuf"), Label("//proto/raze:grpc"), Label("//proto/raze:tls_api"), Label("//proto/raze:tls_api_stub")] |
 | <a id="rust_proto_toolchain-grpc_plugin"></a>grpc_plugin |  The location of the Rust protobuf compiler plugin to generate rust gRPC stubs.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //proto:protoc_gen_rust_grpc |
+| <a id="rust_proto_toolchain-proto_compile_deps"></a>proto_compile_deps |  The crates the generated protobuf libraries depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [Label("//proto/raze:protobuf")] |
 | <a id="rust_proto_toolchain-proto_plugin"></a>proto_plugin |  The location of the Rust protobuf compiler plugin used to generate rust sources.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //proto:protoc_gen_rust |
 | <a id="rust_proto_toolchain-protoc"></a>protoc |  The location of the <code>protoc</code> binary. It should be an executable target.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @com_google_protobuf//:protoc |
 
@@ -151,10 +152,16 @@ See @rules_rust//proto:BUILD for examples of defining the toolchain.
 ## rust_proto_repositories
 
 <pre>
-rust_proto_repositories()
+rust_proto_repositories(<a href="#rust_proto_repositories-register_default_toolchain">register_default_toolchain</a>)
 </pre>
 
 Declare dependencies needed for proto compilation.
 
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain)     (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies     that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
 
 

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -35,8 +35,6 @@ rust_proto_repositories()
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load(
     "//proto:toolchain.bzl",
-    "GRPC_COMPILE_DEPS",
-    "PROTO_COMPILE_DEPS",
     _generate_proto = "rust_generate_proto",
     _generated_file_stem = "generated_file_stem",
 )
@@ -214,6 +212,12 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
         output_hash,
     ))
 
+    # Gather all dependencies for compilation
+    compile_action_deps = depset(
+        compile_deps +
+        proto_toolchain.grpc_compile_deps if is_grpc else proto_toolchain.proto_compile_deps,
+    )
+
     return rustc_compile_action(
         ctx = ctx,
         toolchain = find_toolchain(ctx),
@@ -223,7 +227,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
             type = "rlib",
             root = lib_rs,
             srcs = depset(srcs),
-            deps = depset(compile_deps),
+            deps = compile_action_deps,
             proc_macro_deps = depset([]),
             aliases = {},
             output = rust_lib,
@@ -286,7 +290,6 @@ rust_proto_library = rule(
         ),
         "rust_deps": attr.label_list(
             doc = "The crates the generated library depends on.",
-            default = PROTO_COMPILE_DEPS,
         ),
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
@@ -310,6 +313,8 @@ rust_proto_library = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    # TODO: Remove once (bazelbuild/bazel#11584) is closed and the rules use
+    # the version of Bazel that issue was closed on as the min supported version
     incompatible_use_toolchain_transition = True,
     doc = """\
 Builds a Rust library crate from a set of `proto_library`s.
@@ -318,7 +323,6 @@ Example:
 
 ```python
 load("@rules_rust//proto:proto.bzl", "rust_proto_library")
-load("@rules_rust//proto:toolchain.bzl", "PROTO_COMPILE_DEPS")
 
 proto_library(
     name = "my_proto",
@@ -333,7 +337,7 @@ proto_rust_library(
 rust_binary(
     name = "my_proto_binary",
     srcs = ["my_proto_binary.rs"],
-    deps = [":rust"] + PROTO_COMPILE_DEPS,
+    deps = [":rust"],
 )
 ```
 """,
@@ -364,7 +368,6 @@ rust_grpc_library = rule(
         ),
         "rust_deps": attr.label_list(
             doc = "The crates the generated library depends on.",
-            default = GRPC_COMPILE_DEPS,
         ),
         "_cc_toolchain": attr.label(
             default = "@bazel_tools//tools/cpp:current_cc_toolchain",
@@ -388,6 +391,9 @@ rust_grpc_library = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    # TODO: Remove once (bazelbuild/bazel#11584) is closed and the rules use
+    # the version of Bazel that issue was closed on as the min supported version
+    incompatible_use_toolchain_transition = True,
     doc = """\
 Builds a Rust library crate from a set of `proto_library`s suitable for gRPC.
 
@@ -395,7 +401,6 @@ Example:
 
 ```python
 load("//proto:proto.bzl", "rust_grpc_library")
-load("//proto:toolchain.bzl", "GRPC_COMPILE_DEPS")
 
 proto_library(
     name = "my_proto",
@@ -410,7 +415,7 @@ rust_grpc_library(
 rust_binary(
     name = "my_service",
     srcs = ["my_service.rs"],
-    deps = [":rust"] + GRPC_COMPILE_DEPS,
+    deps = [":rust"],
 )
 ```
 """,

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -18,8 +18,14 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//proto/raze:crates.bzl", "rules_rust_proto_fetch_remote_crates")
 
 # buildifier: disable=unnamed-macro
-def rust_proto_repositories():
-    """Declare dependencies needed for proto compilation."""
+def rust_proto_repositories(register_default_toolchain = True):
+    """Declare dependencies needed for proto compilation.
+
+    Args:
+        register_default_toolchain (bool, optional): If True, the default [rust_proto_toolchain](#rust_proto_toolchain)
+            (`@rules_rust//proto:default-proto-toolchain`) is registered. This toolchain requires a set of dependencies
+            that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.
+    """
     maybe(
         http_archive,
         name = "com_google_protobuf",
@@ -69,4 +75,5 @@ def rust_proto_repositories():
     rules_rust_proto_fetch_remote_crates()
 
     # Register toolchains
-    native.register_toolchains(str(Label("//proto:default-proto-toolchain")))
+    if register_default_toolchain:
+        native.register_toolchains(str(Label("//proto:default-proto-toolchain")))

--- a/wasm_bindgen/repositories.bzl
+++ b/wasm_bindgen/repositories.bzl
@@ -22,7 +22,7 @@ def rust_wasm_bindgen_repositories(register_default_toolchain = True):
     """Declare dependencies needed for [rust_wasm_bindgen](#rust_wasm_bindgen).
 
     Args:
-        register_default_toolchain (Label, optional): If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
+        register_default_toolchain (bool, optional): If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
             (`@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain`) is registered. This toolchain requires a set of dependencies
             that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.
     """


### PR DESCRIPTION
Users looking to register their own toolchain sometimes stumble over the fact that every use of `rust_grpc_library` or `rust_proto_library` now requires them to also add the appropriate targets to the `rust_deps` attributes. This is easily missed and not necessary. Instead, these dependencies should be added to the `@rules_rust//proto:toolchain` being used so there's a single source of truth for all the dependencies required by these rules.

Additionally, this allows users to optionally __not__ register the default toolchain in cases where they want to define their own but would like to ensure other dependencies are brought in.

closes https://github.com/bazelbuild/rules_rust/issues/483