### PR TITLE
Update link in README.md

### DIFF
--- a/bindgen/README.md
+++ b/bindgen/README.md
@@ -16,7 +16,7 @@ These rules are for using [Bindgen][bindgen] to generate [Rust][rust] bindings t
 [rust]: http://www.rust-lang.org/
 [bindgen]: https://github.com/rust-lang/rust-bindgen
 
-See the [bindgen example](../examples/ffi/rust_calling_c/simple/BUILD#L9) for a more complete example of use.
+See the [bindgen example](../examples/ffi/rust_calling_c/simple/BUILD.bazel#L9) for a more complete example of use.
 
 ### Setup
 


### PR DESCRIPTION
The link was broken by the recent `BUILD` -> `BUILD.bazel` rename.