### PR TITLE
Updated tag message for crate_universe releases

### DIFF
--- a/.github/workflows/crate_universe.yaml
+++ b/.github/workflows/crate_universe.yaml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   build:
-    if: ${{ github.repository_owner == bazelbuild }}
+    if: ${{ github.repository_owner == 'bazelbuild' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -80,7 +80,7 @@ jobs:
           path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/${{ matrix.env.TARGET }}
           if-no-files-found: error
   release:
-    if: ${{ github.repository_owner == bazelbuild }}
+    if: ${{ github.repository_owner == 'bazelbuild' }}
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -94,6 +94,46 @@ jobs:
       - run: |
           # Ensure all files are executable
           chmod +x ${{ github.workspace }}/crate_universe/private/bootstrap/bin/*/release/*
+      - run: |
+          # Write new defaults.bzl file
+          # Copy the new template
+          cp ${{ github.workspace }}/crate_universe/private/defaults.bzl.template ${{ github.workspace }}/crate_universe/private/defaults.bzl
+
+          # Replace the url
+          url="$(echo $URL | sed 's|releases/tag/|releases/download/|')/{bin}"
+          sed -i "s|{DEFAULT_URL_TEMPLATE}|${url}|" ${{ github.workspace }}/crate_universe/private/defaults.bzl
+
+          # Populate all sha256 values
+          TARGETS=(
+            aarch64-apple-darwin
+            aarch64-unknown-linux-gnu
+            x86_64-apple-darwin
+            x86_64-pc-windows-gnu
+            x86_64-unknown-linux-gnu
+          )
+          for triple in ${TARGETS[@]}; do
+            if [[ "${triple}" == *"windows"* ]]; then
+                bin_name=crate_universe_resolver.exe
+            else
+                bin_name=crate_universe_resolver
+            fi
+            sha256="$(shasum --algorithm 256 ${{ github.workspace }}/crate_universe/private/bootstrap/bin/${triple}/release/${bin_name} | awk '{ print $1 }')"
+            sed -i "s|{${triple}--sha256}|${sha256}|" ${{ github.workspace }}/crate_universe/private/defaults.bzl
+          done
+
+          cat << EOF > ${{ github.workspace }}/tag_message.txt
+          From commit: ${GITHUB_SHA}
+
+          \`crate_universe_defaults.bzl\`:
+
+          \`\`\`python
+          $(cat ${{ github.workspace }}/crate_universe/private/defaults.bzl)
+          \`\`\`
+          EOF
+        env:
+          # This url should match ${{ steps.crate_universe_release.outputs.html_url }} but because this step runs before
+          # `crate_universe_release` we hard code the url to be what we expect the release URL to be.
+          URL: https://github.com/bazelbuild/rules_rust/releases/download/crate_universe-${{ github.run_number }}
       - uses: actions/create-release@v1
         id: crate_universe_release
         env:
@@ -102,8 +142,7 @@ jobs:
           prerelease: true
           tag_name: crate_universe-${{ github.run_number }}
           release_name: crate_universe-${{ github.run_number }}
-          body: |
-            From commit: ${{ github.sha }}
+          body_path: ${{ github.workspace }}/tag_message.txt
       # There must be a upload action for each platform triple we create
       - name: "Upload aarch64-apple-darwin"
         uses: actions/upload-release-asset@v1
@@ -150,33 +189,3 @@ jobs:
           asset_name: crate_universe_resolver-x86_64-unknown-linux-gnu
           asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/x86_64-unknown-linux-gnu/release/crate_universe_resolver
           asset_content_type: application/octet-stream
-      - run: |
-          # Write new defaults.bzl file
-          # Copy the new template
-          cp ${{ github.workspace }}/crate_universe/private/defaults.bzl.template ${{ github.workspace }}/crate_universe/private/defaults.bzl
-
-          # Replace the url
-          url="$(echo $URL | sed 's|releases/tag/|releases/download/|')/{bin}"
-          sed -i "s|{DEFAULT_URL_TEMPLATE}|${url}|" ${{ github.workspace }}/crate_universe/private/defaults.bzl
-
-          # Populate all sha256 values
-          TARGETS=(
-            aarch64-apple-darwin
-            aarch64-unknown-linux-gnu
-            x86_64-apple-darwin
-            x86_64-pc-windows-gnu
-            x86_64-unknown-linux-gnu
-          )
-          for triple in ${TARGETS[@]}; do
-            if [[ "${triple}" == *"windows"* ]]; then
-                bin_name=crate_universe_resolver.exe
-            else
-                bin_name=crate_universe_resolver
-            fi
-            sha256="$(shasum --algorithm 256 ${{ github.workspace }}/crate_universe/private/bootstrap/bin/${triple}/release/${bin_name} | awk '{ print $1 }')"
-            sed -i "s|{${triple}--sha256}|${sha256}|" ${{ github.workspace }}/crate_universe/private/defaults.bzl
-          done
-          echo "Generated crate_universe/private/defaults.bzl file:"
-          cat ${{ github.workspace }}/crate_universe/private/defaults.bzl
-        env:
-          URL: ${{ steps.crate_universe_release.outputs.html_url }}

--- a/crate_universe/README.md
+++ b/crate_universe/README.md
@@ -1,0 +1,20 @@
+# Crate Universe
+
+## How to use
+
+Find the most up-to-date `crate_universe` release at https://github.com/bazelbuild/rules_rust/releases
+and add the `crate_universe_defaults.bzl` file to your workspace (eg
+`./3rdparty/rules_rust/crate_universe_defaults.bzl).
+
+With this in place, the following can be added to your `WORKSPACE.bazel` file.
+
+```python
+load("//3rdparty/rules_rust:crate_universe_defaults.bzl", "DEFAULT_URL_TEMPLATE", "DEFAULT_SHA256_CHECKSUMS")
+
+load("@rules_rust//crate_universe:deps.bzl", "crate_universe_deps")
+
+crate_universe_deps(url_template = DEFAULT_URL_TEMPLATE, sha256s = DEFAULT_SHA256_CHECKSUMS)
+```
+
+The `crate_universe` macro can now be used within your workspace. See the [examples](../examples/crate_universe) for
+more context.

--- a/crate_universe/README.md
+++ b/crate_universe/README.md
@@ -2,6 +2,8 @@
 
 ## How to use
 
+**Note**: `crate_universe` is experimental, and may have breaking API changes at any time. These instructions may also change without notice.
+
 Find the most up-to-date `crate_universe` release at https://github.com/bazelbuild/rules_rust/releases
 and add the `crate_universe_defaults.bzl` file to your workspace (eg
 `./3rdparty/rules_rust/crate_universe_defaults.bzl).

--- a/crate_universe/deps.bzl
+++ b/crate_universe/deps.bzl
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//crate_universe/private:defaults.bzl", "DEFAULT_SHA256_CHECKSUMS", "DEFAULT_URL_TEMPLATE")
 
-def crate_universe_bins(url_template = DEFAULT_URL_TEMPLATE, sha256s = DEFAULT_SHA256_CHECKSUMS):
-    """Defines repositories for crate universe binaries
+def crate_universe_deps(url_template = DEFAULT_URL_TEMPLATE, sha256s = DEFAULT_SHA256_CHECKSUMS):
+    """Define all dependencies for the crate_universe repository rule
 
     Args:
         url_template (str, optional): A template url for downloading binaries.
@@ -33,7 +33,3 @@ def crate_universe_bins(url_template = DEFAULT_URL_TEMPLATE, sha256s = DEFAULT_S
             sha256 = sha256s.get(triple),
             urls = [url_template.format(bin = "crate_universe_resolver-{}{}".format(triple, extension))],
         )
-
-def crate_universe_deps():
-    """Define all dependencies for the crate_universe repository rule"""
-    crate_universe_bins()


### PR DESCRIPTION
This creates a pre-release with the following message
<img width="1238" alt="Screen Shot 2021-04-08 at 6 36 46 PM" src="https://user-images.githubusercontent.com/26427366/114116383-76792080-9899-11eb-9ca1-035295b4517d.png">


I've also added a `README` to explain to users how to use the rule in it's current state.