### PR TITLE
`crate_universe` now renders json formatted lockfiles

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,7 +4,7 @@ load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories()
 
-load("@rules_rust//crate_universe:defs.bzl", "crate_universe_deps")
+load("@rules_rust//crate_universe:deps.bzl", "crate_universe_deps")
 
 crate_universe_deps()
 

--- a/crate_universe/Cargo.lock
+++ b/crate_universe/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 [[package]]
 name = "cargo-raze"
 version = "0.12.0"
-source = "git+https://github.com/UebelAndre/cargo-raze.git?rev=caaf8345046eee830ea89fc04771ee117bd835eb#caaf8345046eee830ea89fc04771ee117bd835eb"
+source = "git+https://github.com/UebelAndre/cargo-raze.git?rev=0ef1bc28252b7458f214cd69ea6adff0c22ab019#0ef1bc28252b7458f214cd69ea6adff0c22ab019"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -500,9 +500,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -559,9 +559,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "log"
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags",
 ]
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
+checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1142,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb278a72e426f291faf182cb0e0cb7d20241e8e9881046724ac874a83c62346"
+checksum = "2617ab2fb1de8587a988a761692e59895438bebf404725d4f2123251f60bf23e"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1201,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]

--- a/crate_universe/Cargo.toml
+++ b/crate_universe/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 anyhow = "1"
 cargo_metadata = "0.13.1"
 # Until https://github.com/google/cargo-raze/pull/407 is merged:
-cargo-raze = { git = "https://github.com/UebelAndre/cargo-raze.git", rev = "caaf8345046eee830ea89fc04771ee117bd835eb", default-features = false }
+cargo-raze = { git = "https://github.com/UebelAndre/cargo-raze.git", rev = "0ef1bc28252b7458f214cd69ea6adff0c22ab019", default-features = false }
 cfg-expr = "0.7.4"
 env_logger = "0.8"
 hex = "0.4"
@@ -39,3 +39,4 @@ assert_cmd = "1"
 maplit = "1"
 predicates = "1"
 spectral = "0.6"
+tempfile = "3.2.0"

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -203,8 +203,8 @@ def _crate_universe_resolve_impl(repository_ctx):
         resolver_path,
         "--input_path",
         input_path,
-        "--repository_dir",
-        repository_ctx.path("."),
+        "--output_path",
+        repository_ctx.path("defs.bzl"),
         "--repo-name",
         repository_ctx.attr.name,
     ]

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -1,26 +1,9 @@
 """A module defining the `crate_universe` rule"""
 
+load("//rust:repositories.bzl", "DEFAULT_TOOLCHAIN_TRIPLES")
 load(":deps.bzl", _crate_universe_deps = "crate_universe_deps")
 
-DEFAULT_REPOSITORY_TEMPLATE = "https://crates.io/api/v1/crates/{crate}/{version}/download"
-
-_INPUT_CONTENT_TEMPLATE = """{{
-  "repository_name": {name},
-  "packages": [
-      {packages}
-  ],
-  "cargo_toml_files": {{
-      {cargo_toml_files}
-  }},
-  "overrides": {{
-      {overrides}
-  }},
-  "repository_template": "{repository_template}",
-  "target_triples": [
-    {targets}
-  ],
-  "cargo": "{cargo}"
-}}"""
+DEFAULT_CRATE_REGISTRY_TEMPLATE = "https://crates.io/api/v1/crates/{crate}/{version}/download"
 
 _CPU_ARCH_ERROR_MSG = """\
 Command failed with exit code '{code}': {args}
@@ -29,6 +12,53 @@ Command failed with exit code '{code}': {args}
 ----------stderr:
 {stderr}
 """
+
+def _input_content_template(ctx, name, packages, cargo_toml_files, overrides, registry_template, targets, cargo_bin_label):
+    """Generate json encoded dependency info for the crate resolver.
+
+    Args:
+        ctx (repository_ctx): The repository rule's context object.
+        name (str): The name of the repository.
+        packages (list): A list of json encoded `crate.spec` entries.
+        cargo_toml_files (list): A list of `Label`s to Cargo manifests.
+        overrides (dict): A dict of crate name (`str`) to json encoded `crate.override` data.
+        registry_template (str): A crate registry url template
+        targets (list): A list of target platform triples
+        cargo_bin_label (Label): The label of a Cargo binary.
+
+    Returns:
+        str: Json encoded config data for the resolver
+    """
+
+    # packages are expected to be json encoded, so we decode them
+    # to ensure they are correctly re-encoded
+    dcoded_pkgs = [json.decode(artifact) for artifact in packages]
+
+    # Generate an easy to use map of `Cargo.toml` files
+    encodable_cargo_toml_files = dict()
+    for label in cargo_toml_files:
+        encodable_cargo_toml_files.update({str(label): str(ctx.path(label))})
+
+    # Overrides are passed as encoded json strings, so we decode
+    # them to ensure they are correctly re-encoded
+    encodable_overrides = dict()
+    for key, value in overrides.items():
+        encodable_overrides.update({key: json.decode(value)})
+
+    return "{}\n".format(
+        json.encode_indent(
+            struct(
+                cargo = str(ctx.path(cargo_bin_label)),
+                cargo_toml_files = encodable_cargo_toml_files,
+                crate_registry_template = registry_template,
+                overrides = encodable_overrides,
+                packages = dcoded_pkgs,
+                repository_name = name,
+                target_triples = targets,
+            ),
+            indent = " " * 4,
+        ),
+    )
 
 def _query_cpu_architecture(repository_ctx, expected_archs, is_windows = False):
     """Detect the host CPU architecture
@@ -120,11 +150,6 @@ def _crate_universe_resolve_impl(repository_ctx):
     - Call the Rust resolver script. It writes a `defs.bzl` file in this repo containing the
       transitive dependencies as repo rules in a `pinned_rust_install()` macro.
     - The user then calls defs.bzl%pinned_rust_install().
-
-    Environment Variables:
-        REPIN: Re-pin the lockfile if set (useful for repinning deps from multiple rulesets).
-        RULES_RUST_REPIN: Re-pin the lockfile if set (useful for only repinning Rust deps).
-        RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE: Override URL to use to download resolver binary - for local paths use a file:// URL.
     """
 
     # Get info about the current host's tool locations
@@ -160,25 +185,26 @@ def _crate_universe_resolve_impl(repository_ctx):
         lockfile_path = repository_ctx.path(repository_ctx.attr.lockfile)
 
     # Yay hand-crafted JSON serialisation...
-    input_content = _INPUT_CONTENT_TEMPLATE.format(
-        name = "\"{}\"".format(repository_ctx.attr.name),
-        packages = ",\n".join([artifact for artifact in repository_ctx.attr.packages]),
-        cargo_toml_files = ",\n".join(['"{}": "{}"'.format(ct, repository_ctx.path(ct)) for ct in repository_ctx.attr.cargo_toml_files]),
-        overrides = ",\n".join(["\"{}\": {}".format(oname, ovalue) for (oname, ovalue) in repository_ctx.attr.overrides.items()]),
-        repository_template = repository_ctx.attr.repository_template,
-        targets = ",\n".join(['"{}"'.format(target) for target in repository_ctx.attr.supported_targets]),
-        cargo = repository_ctx.path(cargo_label),
+    input_content = _input_content_template(
+        ctx = repository_ctx,
+        name = repository_ctx.attr.name,
+        packages = repository_ctx.attr.packages,
+        cargo_toml_files = repository_ctx.attr.cargo_toml_files,
+        overrides = repository_ctx.attr.overrides,
+        registry_template = repository_ctx.attr.crate_registry_template,
+        targets = repository_ctx.attr.supported_targets,
+        cargo_bin_label = cargo_label,
     )
 
-    input_path = "_{name}.json".format(name = repository_ctx.attr.name)
+    input_path = "{name}.resolver_config.json".format(name = repository_ctx.attr.name)
     repository_ctx.file(input_path, content = input_content)
 
     args = [
         resolver_path,
         "--input_path",
         input_path,
-        "--output_path",
-        repository_ctx.path("defs.bzl"),
+        "--repository_dir",
+        repository_ctx.path("."),
         "--repo-name",
         repository_ctx.attr.name,
     ]
@@ -189,20 +215,16 @@ def _crate_universe_resolve_impl(repository_ctx):
     if "RULES_RUST_REPIN" in env_var_names or "REPIN" in env_var_names:
         args.append("--update-lockfile")
 
-    path_binaries = [
-        repository_ctx.path(rustc_label),
-    ]
-
     result = repository_ctx.execute(
         args,
         environment = {
             # The resolver invokes `cargo metadata` which relies on `rustc` being on the $PATH
             # See https://github.com/rust-lang/cargo/issues/8219
-            "PATH": ":".join([str(b.dirname) for b in path_binaries]),
+            "CARGO": str(repository_ctx.path(cargo_label)),
+            "RUSTC": str(repository_ctx.path(rustc_label)),
             "RUST_LOG": "info",
         },
     )
-    repository_ctx.delete(input_path)
     if result.stderr:
         print("Output from resolver: " + result.stderr)  # buildifier: disable=print
     if result.return_code != 0:
@@ -210,51 +232,62 @@ def _crate_universe_resolve_impl(repository_ctx):
 
     repository_ctx.file("BUILD.bazel")
 
-_crate_universe_resolve = repository_rule(
+crate_universe = repository_rule(
     doc = """\
 A rule for downloading Rust dependencies (crates).
 
+Environment Variables:
+- `REPIN`: Re-pin the lockfile if set (useful for repinning deps from multiple rulesets).
+- `RULES_RUST_REPIN`: Re-pin the lockfile if set (useful for only repinning Rust deps).
+- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE`: Override URL to use to download resolver binary - for local paths use a `file://` URL.
+
 `override` Example:
 
-    load("@rules_rust//crate_universe:defs.bzl", "rust_library", "crate")
+```python
+load("@rules_rust//crate_universe:defs.bzl", "rust_library", "crate")
 
-    rust_library(
-        name = "mylib",
-        # [...]
-        overrides = {
-            "tokio": crate.override(
-                extra_rust_env_vars = {
-                    "MY_ENV_VAR": "MY_ENV_VALUE",
-                },
-                extra_build_script_env_vars = {
-                    "MY_BUILD_SCRIPT_ENV_VAR": "MY_ENV_VALUE",
-                },
-                extra_bazel_deps = {
-                    # Extra dependencies are per target. They are additive.
-                    "cfg(unix)": ["@somerepo//:foo"],  # cfg() predicate.
-                    "x86_64-apple-darwin": ["@somerepo//:bar"],  # Specific triple.
-                    "cfg(all())": ["@somerepo//:baz"],  # Applies to all targets ("regular dependency").
-                },
-                extra_build_script_bazel_deps = {
-                    # Extra dependencies are per target. They are additive.
-                    "cfg(unix)": ["@buildscriptdep//:foo"],
-                    "x86_64-apple-darwin": ["@buildscriptdep//:bar"],
-                    "cfg(all())": ["@buildscriptdep//:baz"],
-                },
-                extra_bazel_data_deps = {
-                    # ...
-                },
-                extra_build_script_bazel_data_deps = {
-                    # ...
-                },
-            ),
-        },
-    )
+rust_library(
+    name = "mylib",
+    # [...]
+    overrides = {
+        "tokio": crate.override(
+            extra_rust_env_vars = {
+                "MY_ENV_VAR": "MY_ENV_VALUE",
+            },
+            extra_build_script_env_vars = {
+                "MY_BUILD_SCRIPT_ENV_VAR": "MY_ENV_VALUE",
+            },
+            extra_bazel_deps = {
+                # Extra dependencies are per target. They are additive.
+                "cfg(unix)": ["@somerepo//:foo"],  # cfg() predicate.
+                "x86_64-apple-darwin": ["@somerepo//:bar"],  # Specific triple.
+                "cfg(all())": ["@somerepo//:baz"],  # Applies to all targets ("regular dependency").
+            },
+            extra_build_script_bazel_deps = {
+                # Extra dependencies are per target. They are additive.
+                "cfg(unix)": ["@buildscriptdep//:foo"],
+                "x86_64-apple-darwin": ["@buildscriptdep//:bar"],
+                "cfg(all())": ["@buildscriptdep//:baz"],
+            },
+            extra_bazel_data_deps = {
+                # ...
+            },
+            extra_build_script_bazel_data_deps = {
+                # ...
+            },
+        ),
+    },
+)
+```
 """,
     implementation = _crate_universe_resolve_impl,
     attrs = {
         "cargo_toml_files": attr.label_list(
             doc = "",
+        ),
+        "crate_registry_template": attr.string(
+            doc = "A Crate registry url template. This must contain `{version}` and `{crate}` templates",
+            default = DEFAULT_CRATE_REGISTRY_TEMPLATE,
         ),
         "lockfile": attr.label(
             doc = "",
@@ -268,12 +301,10 @@ A rule for downloading Rust dependencies (crates).
             doc = "",
             allow_empty = True,
         ),
-        "repository_template": attr.string(
-            doc = "",
-        ),
         "supported_targets": attr.string_list(
             doc = "",
             allow_empty = False,
+            default = DEFAULT_TOOLCHAIN_TRIPLES.keys(),
         ),
         "_resolvers": attr.label_list(
             doc = "A list of resolver binaries for various platforms",
@@ -292,48 +323,15 @@ A rule for downloading Rust dependencies (crates).
     ],
 )
 
-def crate_universe(
-        name,
-        packages = [],
-        cargo_toml_files = [],
-        overrides = {},
-        repository_template = None,
-        supported_targets = [],
-        lockfile = None):
-    """Resolve crates from a cargo repository which can be consumed as dependencies by targets using rules_rust.
-
-    This is currently highly experimental, and subject to breaking API changes without notice.
-
-    In order to actually use this rule, you will need to make available a built version of the rust binary in `cargo/crate_universe_resolver`
-    as an http_file with the name crate_universe_resolver_linux or crate_universe_resolver_darwin (whichever is appropriate for your platform).
-    """
-
-    _crate_universe_resolve(
-        name = name,
-        packages = [package.to_json() for package in packages],
-        cargo_toml_files = [_absolutify(label) for label in cargo_toml_files],
-        overrides = dict([(k, v.to_json()) for (k, v) in overrides.items()]),
-        repository_template = repository_template if repository_template else DEFAULT_REPOSITORY_TEMPLATE,
-        supported_targets = supported_targets,
-        lockfile = lockfile,
-    )
-
-def _absolutify(label):
-    if label.startswith("//") or label.startswith("@"):
-        return label
-    if label.startswith(":"):
-        return "//" + native.package_name() + label
-    return "//" + native.package_name() + ":" + label
-
 def _spec(
         name,
         semver,
         features = None):
-    return struct(
+    return json.encode(struct(
         name = name,
         semver = semver,
         features = features if features else [],
-    )
+    ))
 
 def _override(
         extra_rust_env_vars = None,
@@ -357,7 +355,7 @@ def _override(
                 if not type(deps) == "list" or any([type(x) != "string" for x in deps]):
                     fail("The {} values should be lists of strings".format(dep_key))
 
-    return struct(
+    return json.encode(struct(
         extra_rust_env_vars = extra_rust_env_vars if extra_rust_env_vars else {},
         extra_build_script_env_vars = extra_build_script_env_vars if extra_build_script_env_vars else {},
         extra_bazel_deps = extra_bazel_deps if extra_bazel_deps else {},
@@ -365,7 +363,7 @@ def _override(
         extra_bazel_data_deps = extra_bazel_data_deps if extra_bazel_data_deps else {},
         extra_build_script_bazel_data_deps = extra_build_script_bazel_data_deps if extra_build_script_bazel_data_deps else {},
         features_to_remove = features_to_remove,
-    )
+    ))
 
 crate = struct(
     spec = _spec,

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -244,9 +244,9 @@ Environment Variables:
 `override` Example:
 
 ```python
-load("@rules_rust//crate_universe:defs.bzl", "rust_library", "crate")
+load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
 
-rust_library(
+crate_universe(
     name = "mylib",
     # [...]
     overrides = {

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -1,14 +1,18 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::path::PathBuf;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    path::PathBuf,
+};
 
 use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::consolidator::{ConsolidatorConfig, ConsolidatorOverride};
-use crate::parser::merge_cargo_tomls;
-use crate::renderer::RenderConfig;
-use crate::resolver::{Resolver, ResolverConfig};
+use crate::{
+    consolidator::{ConsolidatorConfig, ConsolidatorOverride},
+    parser::merge_cargo_tomls,
+    renderer::RenderConfig,
+    resolver::{Resolver, ResolverConfig},
+};
 
 #[derive(Debug, Deserialize, Serialize, Ord, Eq, PartialOrd, PartialEq)]
 pub struct Package {

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -56,8 +56,7 @@ pub struct Config {
     /// Template of the URL from which to download crates, which are assumed to be gzip'd tar files.
     /// This string may contain arbitrarily many instances of {crate} and {version} which will be
     /// replaced by crate names and versions.
-    #[serde(default = "default_repository_template")]
-    pub repository_template: String,
+    pub crate_registry_template: String,
 
     pub target_triples: Vec<String>,
     pub cargo: PathBuf,
@@ -104,7 +103,7 @@ impl Config {
             ConsolidatorConfig { overrides },
             RenderConfig {
                 repo_rule_name: self.repository_name.clone(),
-                repository_template: self.repository_template.clone(),
+                crate_registry_template: self.crate_registry_template.clone(),
                 rules_rust_workspace_name: self.rust_rules_workspace_name.clone(),
             },
             self.target_triples,
@@ -142,8 +141,4 @@ pub fn default_rules_rust_workspace_name() -> String {
 
 pub fn default_index_url() -> Url {
     Url::parse("https://github.com/rust-lang/crates.io-index").expect("Invalid default index URL")
-}
-
-fn default_repository_template() -> String {
-    String::from("https://crates.io/api/v1/crates/{crate}/{version}/download")
 }

--- a/crate_universe/src/consolidator.rs
+++ b/crate_universe/src/consolidator.rs
@@ -4,13 +4,15 @@ use anyhow::anyhow;
 use cargo_raze::context::{
     BuildableDependency, CrateContext, CrateDependencyContext, CrateTargetedDepContext,
 };
+use cargo_raze::util::{generate_bazel_conditions, get_matching_bazel_triples};
+use cfg_expr::targets::get_builtin_target_by_triple;
 use itertools::Itertools;
 use semver::Version;
 
-use crate::renderer::{RenderConfig, Renderer};
-use crate::resolver::Dependencies;
-use cargo_raze::util::{generate_bazel_conditions, get_matching_bazel_triples};
-use cfg_expr::targets::get_builtin_target_by_triple;
+use crate::{
+    renderer::{RenderConfig, Renderer},
+    resolver::Dependencies,
+};
 
 #[derive(Debug, Default)]
 pub struct ConsolidatorOverride {

--- a/crate_universe/src/main.rs
+++ b/crate_universe/src/main.rs
@@ -1,10 +1,8 @@
-use std::{
-    io::{BufRead, BufReader},
-    path::PathBuf,
-};
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context};
-use crate_universe_resolver::config::Config;
+use crate_universe_resolver::{config::Config, renderer::Renderer};
+use indoc::indoc;
 use log::*;
 use structopt::StructOpt;
 
@@ -19,7 +17,9 @@ struct Opt {
     #[structopt(long = "input_path", parse(from_os_str))]
     input_path: PathBuf,
     #[structopt(long = "output_path", parse(from_os_str))]
-    output_path: PathBuf,
+    output_path: Option<PathBuf>,
+    #[structopt(long = "repository_dir", parse(from_os_str))]
+    repository_dir: PathBuf,
     #[structopt(long = "lockfile", parse(from_os_str))]
     lockfile: Option<PathBuf>,
     #[structopt(long = "update-lockfile")]
@@ -30,7 +30,6 @@ fn main() -> anyhow::Result<()> {
     env_logger::init();
 
     let opt = Opt::from_args();
-
     trace!("Parsing config from {:?}", opt.input_path);
 
     let config: Config = {
@@ -39,49 +38,55 @@ fn main() -> anyhow::Result<()> {
         serde_json::from_reader(config_file)
             .with_context(|| format!("Failed to parse config file {:?}", opt.input_path))?
     };
-    let lockfile = opt.lockfile;
-    let repo_name = opt.repo_name;
-    let output_path = opt.output_path;
 
+    let lockfile = &opt.lockfile;
+    if opt.update_lockfile {
+        if lockfile.is_none() {
+            eprintln!("Not updating lockfile for `crate_universe` repository with name \"{}\" because it has no `lockfile` attribute.", opt.repo_name);
+        }
+    } else if let Some(lockfile) = lockfile {
+        return reuse_lockfile(config, &lockfile, &opt);
+    }
+
+    generate_dependencies(config, &opt)
+}
+
+fn reuse_lockfile(config: Config, lockfile: &Path, opt: &Opt) -> anyhow::Result<()> {
     trace!("Preprocessing config");
     let mut resolver = config.preprocess()?;
 
-    if opt.update_lockfile {
-        if lockfile.is_none() {
-            eprintln!("Not updating lockfile for `crate_universe` repository with name \"{}\" because it has no `lockfile` attribute.", repo_name);
-        }
-    } else if let Some(lockfile) = lockfile {
-        let mut lockfile_format_version_line = String::new();
-        let mut lockfile_hash_line = String::new();
-        {
-            std::fs::File::open(&lockfile)
-                .map(BufReader::new)
-                .and_then(|mut f| {
-                    f.read_line(&mut lockfile_format_version_line)?;
-                    f.read_line(&mut lockfile_hash_line)?;
-                    Ok(())
-                })
-                .with_context(|| format!("Failed to read lockfile header from {:?}", lockfile))?;
-        }
-        if lockfile_format_version_line != "# rules_rust crate_universe file format 1\n" {
-            return Err(anyhow!("Unrecognized lockfile format"));
-        }
-        if let Some(lockfile_hash) = lockfile_hash_line.strip_prefix("# config hash ") {
-            if resolver.digest()? == lockfile_hash.trim() {
-                std::fs::copy(&lockfile, &output_path).with_context(|| {
-                    format!(
-                        "Failed to copy lockfile from {:?} to {:?}",
-                        lockfile, output_path
-                    )
-                })?;
-                return Ok(());
-            } else {
-                return Err(anyhow!("rules_rust_external: Lockfile at {} is out of date, please either:\n1. Re-run bazel with the environment variable `RULES_RUST_UPDATE_CRATE_UNIVERSE_LOCKFILE=true`, to update the lockfile\n2. Remove the `lockfile` attribute from the `crate_universe` repository rule with name \"{}\" to use floating dependency versions", lockfile.display(), repo_name));
-            }
-        } else {
-            return Err(anyhow!("Invalid lockfile"));
-        }
+    let renderer = Renderer::new_from_lockfile(lockfile)?;
+
+    // TODO: Add lockfile versioning and check that here
+
+    if !renderer.matches_digest(&resolver.digest()?) {
+        return Err(anyhow!(indoc! { r#"
+            "rules_rust_external: Lockfile at {} is out of date, please either:
+            1. Re-run bazel with the environment variable `RULES_RUST_UPDATE_CRATE_UNIVERSE_LOCKFILE=true`, to update the lockfile
+            2. Remove the `lockfile` attribute from the `crate_universe` repository rule with name \"{}\" to use floating dependency versions", lockfile.display(), opt.repo_name
+        "# }));
     }
+
+    // TODO: Instead of explicitly passing a single file, allow a directory to be passed
+    // so each dependency can render it's own build file and we can avoid monolithic
+    // outputs. `output_path` should be removed in the future.
+    if let Some(output_path) = &opt.output_path {
+        let mut output_file = std::fs::File::create(&output_path)
+            .with_context(|| format!("Could not create output file {:?}", output_path))?;
+
+        renderer.render(&mut output_file)
+    } else {
+        let def_bzl_path = opt.repository_dir.join("defs.bzl");
+        let mut def_bzl_file = std::fs::File::create(&def_bzl_path)
+            .with_context(|| format!("Could not create output file {:?}", def_bzl_path))?;
+
+        renderer.render(&mut def_bzl_file)
+    }
+}
+
+fn generate_dependencies(config: Config, opt: &Opt) -> anyhow::Result<()> {
+    trace!("Preprocessing config");
+    let resolver = config.preprocess()?;
 
     // This will contain the mapping of the workspace member (i.e. toplevel) packages' direct
     // dependencies package names to their package Bazel repository name (e.g. `bzip2 ->
@@ -92,21 +97,31 @@ fn main() -> anyhow::Result<()> {
     trace!("Consolidating overrides");
     let renderer = consolidator.consolidate()?;
 
-    trace!("Rendering output to: {:?}", output_path);
-    let mut output_file = std::fs::File::create(&output_path)
-        .with_context(|| format!("Could not create output file {:?}", output_path))?;
-    renderer
-        .render(&mut output_file)
-        .context("Could not render deps")?;
+    // TODO: Instead of explicitly passing a single file, allow a directory to be passed
+    // so each dependency can render it's own build file and we can avoid monolithic
+    // outputs. `output_path` should be removed in the future.
+    if let Some(output_path) = &opt.output_path {
+        let mut output_file = std::fs::File::create(&output_path)
+            .with_context(|| format!("Could not create output file {:?}", output_path))?;
+
+        trace!("Rendering output to: {}", &output_path.display());
+        renderer.render(&mut output_file)?;
+    } else {
+        let def_bzl_path = opt.repository_dir.join("defs.bzl");
+        let mut def_bzl_file = std::fs::File::create(&def_bzl_path)
+            .with_context(|| format!("Could not create output file {:?}", def_bzl_path))?;
+
+        trace!("Rendering output to: {}", &def_bzl_path.display());
+        renderer.render(&mut def_bzl_file)?;
+    }
+
+    let lockfile = &opt.lockfile;
 
     if opt.update_lockfile {
         if let Some(lockfile) = lockfile.as_ref() {
-            std::fs::copy(&output_path, lockfile).with_context(|| {
-                format!(
-                    "Error updating lockfile at {:?} from {:?}",
-                    lockfile, output_path
-                )
-            })?;
+            renderer
+                .render_lockfile(lockfile)
+                .context("Failed to update lockfile")?;
         }
     }
 

--- a/crate_universe/src/main.rs
+++ b/crate_universe/src/main.rs
@@ -62,7 +62,7 @@ fn reuse_lockfile(config: Config, lockfile: &Path, opt: &Opt) -> anyhow::Result<
     if !renderer.matches_digest(&resolver.digest()?) {
         return Err(anyhow!(indoc! { r#"
             "rules_rust_external: Lockfile at {} is out of date, please either:
-            1. Re-run bazel with the environment variable `RULES_RUST_UPDATE_CRATE_UNIVERSE_LOCKFILE=true`, to update the lockfile
+            1. Re-run bazel with the environment variable `RULES_RUST_REPIN=true`, to update the lockfile
             2. Remove the `lockfile` attribute from the `crate_universe` repository rule with name \"{}\" to use floating dependency versions", lockfile.display(), opt.repo_name
         "# }));
     }

--- a/crate_universe/src/main.rs
+++ b/crate_universe/src/main.rs
@@ -1,8 +1,11 @@
+use std::{
+    io::{BufRead, BufReader},
+    path::PathBuf,
+};
+
 use anyhow::{anyhow, Context};
 use crate_universe_resolver::config::Config;
 use log::*;
-use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
 use structopt::StructOpt;
 
 // Options which don't affect the contents of the generated should be on this struct.

--- a/crate_universe/src/parser.rs
+++ b/crate_universe/src/parser.rs
@@ -1,14 +1,18 @@
-use crate::config::Package as AdditionalPackage;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::{TryFrom, TryInto},
+    fs::read_to_string,
+    path::PathBuf,
+};
+
 use anyhow::{anyhow, Context};
 use indoc::indoc;
 use log::*;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Deserializer};
-use std::collections::{BTreeMap, BTreeSet};
-use std::convert::{TryFrom, TryInto};
-use std::fs::read_to_string;
-use std::path::PathBuf;
 use toml::Value;
+
+use crate::config::Package as AdditionalPackage;
 
 #[derive(Debug, Deserialize)]
 // We deny unknown fields so that when new fields are encountered, we need to explicitly decide

--- a/crate_universe/src/renderer.rs
+++ b/crate_universe/src/renderer.rs
@@ -1,29 +1,37 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    io::Write,
+    fs::File,
+    io::{BufReader, Write},
     path::Path,
 };
 
+use anyhow::Context;
 use cargo_raze::context::{CrateContext, CrateDependencyContext, CrateTargetedDepContext};
 use semver::Version;
-use serde::Serialize;
-use tera::{self, Context, Tera};
+use serde::{Deserialize, Serialize};
+use tera::{self, Tera};
 
 use crate::{config, resolver::Dependencies};
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct RenderConfig {
     pub repo_rule_name: String,
-    pub repository_template: String,
+    pub crate_registry_template: String,
     pub rules_rust_workspace_name: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+struct RenderContext {
+    pub config: RenderConfig,
+    pub hash: String,
+    pub transitive_renderable_packages: Vec<RenderablePackage>,
+    pub member_packages_version_mapping: Dependencies,
+    pub label_to_crates: BTreeMap<String, BTreeSet<String>>,
+}
+
 pub struct Renderer {
-    config: RenderConfig,
-    hash: String,
+    context: RenderContext,
     internal_renderer: Tera,
-    transitive_renderable_packages: Vec<RenderablePackage>,
-    member_packages_version_mapping: Dependencies,
-    label_to_crates: BTreeMap<String, BTreeSet<String>>,
 }
 
 // Get default and targeted metadata, collated per Bazel condition (which corresponds to a triple).
@@ -144,13 +152,7 @@ fn empty_deps_context() -> CrateDependencyContext {
 }
 
 impl Renderer {
-    pub fn new(
-        config: RenderConfig,
-        hash: String,
-        transitive_packages: Vec<CrateContext>,
-        member_packages_version_mapping: Dependencies,
-        label_to_crates: BTreeMap<String, BTreeSet<String>>,
-    ) -> Renderer {
+    fn new_tera() -> Tera {
         let mut internal_renderer = Tera::new("src/not/a/dir/*").unwrap();
 
         internal_renderer.register_function(
@@ -244,6 +246,16 @@ impl Renderer {
             ])
             .unwrap();
 
+        internal_renderer
+    }
+
+    pub fn new(
+        config: RenderConfig,
+        hash: String,
+        transitive_packages: Vec<CrateContext>,
+        member_packages_version_mapping: Dependencies,
+        label_to_crates: BTreeMap<String, BTreeSet<String>>,
+    ) -> Renderer {
         let transitive_renderable_packages = transitive_packages
             .into_iter()
             .map(|mut crate_context| {
@@ -282,28 +294,56 @@ impl Renderer {
             .collect();
 
         Self {
-            config,
-            hash,
-            internal_renderer,
-            transitive_renderable_packages,
-            member_packages_version_mapping,
-            label_to_crates,
+            context: RenderContext {
+                config,
+                hash,
+                transitive_renderable_packages,
+                member_packages_version_mapping,
+                label_to_crates,
+            },
+            internal_renderer: Renderer::new_tera(),
         }
+    }
+
+    pub fn new_from_lockfile(lockfile: &Path) -> anyhow::Result<Renderer> {
+        // Open the file in read-only mode with buffer.
+        let file = File::open(lockfile)?;
+        let reader = BufReader::new(file);
+
+        Ok(Self {
+            context: serde_json::from_reader(reader)?,
+            internal_renderer: Renderer::new_tera(),
+        })
     }
 
     pub fn render<Out: Write>(&self, output: &mut Out) -> anyhow::Result<()> {
         self.render_workspaces(output)?;
         writeln!(output, "")?;
-        self.render_helper_functions(output)
+        self.render_helper_functions(output)?;
+
+        Ok(())
     }
 
-    // Visible for testing
+    pub fn render_lockfile(&self, lockfile_path: &Path) -> anyhow::Result<()> {
+        let mut lockfile_file = std::fs::File::create(lockfile_path)
+            .with_context(|| format!("Could not create lockfile file: {:?}", lockfile_path))?;
+        let content = serde_json::to_string_pretty(&self.context)
+            .with_context(|| format!("Could not seralize render context: {:?}", self.context))?;
+        write!(lockfile_file, "{}\n", &content)?;
+
+        Ok(())
+    }
+
+    // TODO: Public for `tests/renderer.rs`, unit tests should added here instead
     pub fn render_workspaces<Out: Write>(&self, output: &mut Out) -> anyhow::Result<()> {
-        let mut context = Context::new();
-        context.insert("lockfile_hash", &self.hash);
-        context.insert("crates", &self.transitive_renderable_packages);
-        context.insert("repo_rule_name", &self.config.repo_rule_name);
-        context.insert("repository_http_template", &self.config.repository_template);
+        let mut context = tera::Context::new();
+        context.insert("lockfile_hash", &self.context.hash);
+        context.insert("crates", &self.context.transitive_renderable_packages);
+        context.insert("repo_rule_name", &self.context.config.repo_rule_name);
+        context.insert(
+            "repository_http_template",
+            &self.context.config.crate_registry_template,
+        );
         let rendered_repository_rules = self
             .internal_renderer
             .render("templates/lockfile.template", &context)?;
@@ -313,14 +353,15 @@ impl Renderer {
         Ok(())
     }
 
-    // Visible for testing
+    // TODO: Public for `tests/renderer.rs`, unit tests should added here instead
     pub fn render_helper_functions<Out: Write>(&self, output: &mut Out) -> anyhow::Result<()> {
         let mut crate_repo_names_inner = BTreeMap::new();
-        crate_repo_names_inner.extend(&self.member_packages_version_mapping.normal);
-        crate_repo_names_inner.extend(&self.member_packages_version_mapping.build);
-        crate_repo_names_inner.extend(&self.member_packages_version_mapping.dev);
+        crate_repo_names_inner.extend(&self.context.member_packages_version_mapping.normal);
+        crate_repo_names_inner.extend(&self.context.member_packages_version_mapping.build);
+        crate_repo_names_inner.extend(&self.context.member_packages_version_mapping.dev);
 
         let renderable_packages: Vec<_> = self
+            .context
             .transitive_renderable_packages
             .iter()
             .filter(|krate| {
@@ -330,15 +371,19 @@ impl Renderer {
             .collect();
 
         let (proc_macro_crates, default_crates): (Vec<_>, Vec<_>) = self
+            .context
             .member_packages_version_mapping
             .normal
             .iter()
             .partition(|(name, version)| {
-                self.transitive_renderable_packages.iter().any(|package| {
-                    *package.crate_context.pkg_name == **name
-                        && package.crate_context.pkg_version == **version
-                        && package.is_proc_macro
-                })
+                self.context
+                    .transitive_renderable_packages
+                    .iter()
+                    .any(|package| {
+                        *package.crate_context.pkg_name == **name
+                            && package.crate_context.pkg_version == **version
+                            && package.is_proc_macro
+                    })
             });
 
         let mut kind_to_labels_to_crate_names = BTreeMap::new();
@@ -346,20 +391,34 @@ impl Renderer {
             .insert(Kind::Normal, self.label_to_crate_names(&default_crates));
         kind_to_labels_to_crate_names.insert(
             Kind::Dev,
-            self.label_to_crate_names(&self.member_packages_version_mapping.dev.iter().collect()),
+            self.label_to_crate_names(
+                &self
+                    .context
+                    .member_packages_version_mapping
+                    .dev
+                    .iter()
+                    .collect(),
+            ),
         );
         kind_to_labels_to_crate_names.insert(
             Kind::Build,
-            self.label_to_crate_names(&self.member_packages_version_mapping.build.iter().collect()),
+            self.label_to_crate_names(
+                &self
+                    .context
+                    .member_packages_version_mapping
+                    .build
+                    .iter()
+                    .collect(),
+            ),
         );
         kind_to_labels_to_crate_names.insert(
             Kind::ProcMacro,
             self.label_to_crate_names(&proc_macro_crates),
         );
 
-        let mut context = Context::new();
+        let mut context = tera::Context::new();
         context.insert("crates", &renderable_packages);
-        context.insert("repo_rule_name", &self.config.repo_rule_name);
+        context.insert("repo_rule_name", &self.context.config.repo_rule_name);
         context.insert(
             "kind_to_labels_to_crate_names",
             &kind_to_labels_to_crate_names,
@@ -378,7 +437,8 @@ impl Renderer {
         crates: &Vec<(&String, &Version)>,
     ) -> BTreeMap<String, Vec<String>> {
         let crate_names: HashSet<&String> = crates.iter().map(|(name, _)| *name).collect();
-        self.label_to_crates
+        self.context
+            .label_to_crates
             .iter()
             .map(|(label, all_crates)| {
                 let value = all_crates
@@ -389,6 +449,10 @@ impl Renderer {
                 (label.clone(), value)
             })
             .collect()
+    }
+
+    pub fn matches_digest(&self, digest: &str) -> bool {
+        self.context.hash == digest
     }
 }
 
@@ -407,7 +471,7 @@ fn string_arg<'a, 'b>(
     })
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 struct RenderablePackage {
     crate_context: CrateContext,
     per_triple_metadata: BTreeMap<String, CrateTargetedDepContext>,

--- a/crate_universe/src/renderer.rs
+++ b/crate_universe/src/renderer.rs
@@ -1,13 +1,15 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    io::Write,
+    path::Path,
+};
+
 use cargo_raze::context::{CrateContext, CrateDependencyContext, CrateTargetedDepContext};
 use semver::Version;
 use serde::Serialize;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::io::Write;
 use tera::{self, Context, Tera};
 
-use crate::config;
-use crate::resolver::Dependencies;
-use std::path::Path;
+use crate::{config, resolver::Dependencies};
 
 pub struct RenderConfig {
     pub repo_rule_name: String,

--- a/crate_universe/src/resolver.rs
+++ b/crate_universe/src/resolver.rs
@@ -1,22 +1,28 @@
-use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    path::{Path, PathBuf},
+    process::Stdio,
+};
 
+use anyhow::Context;
 use cargo_metadata::{DependencyKind, Metadata, MetadataCommand};
-use cargo_raze::context::CrateContext;
-use cargo_raze::metadata::RazeMetadataFetcher;
-use cargo_raze::planning::{BuildPlanner, BuildPlannerImpl};
-use cargo_raze::settings::{GenMode, RazeSettings};
+use cargo_raze::{
+    context::CrateContext,
+    metadata::RazeMetadataFetcher,
+    planning::{BuildPlanner, BuildPlannerImpl},
+    settings::{GenMode, RazeSettings},
+};
 use log::trace;
 use semver::{Version, VersionReq};
 use sha2::{Digest, Sha256};
-
-use crate::consolidator::{Consolidator, ConsolidatorConfig, ConsolidatorOverride};
-use crate::renderer::RenderConfig;
-use crate::NamedTempFile;
-use anyhow::Context;
 use url::Url;
+
+use crate::{
+    consolidator::{Consolidator, ConsolidatorConfig, ConsolidatorOverride},
+    renderer::RenderConfig,
+    NamedTempFile,
+};
 
 pub struct ResolverConfig {
     pub cargo: PathBuf,

--- a/crate_universe/src/resolver.rs
+++ b/crate_universe/src/resolver.rs
@@ -15,6 +15,7 @@ use cargo_raze::{
 };
 use log::trace;
 use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use url::Url;
 
@@ -47,7 +48,7 @@ pub struct ResolvedArtifactsWithMetadata {
     pub member_packages_version_mapping: HashMap<String, Version>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Dependencies {
     pub normal: BTreeMap<String, Version>,
     pub build: BTreeMap<String, Version>,
@@ -93,7 +94,7 @@ impl Resolver {
                 render_config:
                     RenderConfig {
                         repo_rule_name,
-                        repository_template,
+                        crate_registry_template,
                         rules_rust_workspace_name,
                     },
                 consolidator_config: ConsolidatorConfig { overrides },
@@ -107,7 +108,7 @@ impl Resolver {
 
             hasher.update(repo_rule_name.as_str().as_bytes());
             hasher.update(b"\0");
-            hasher.update(repository_template.as_str().as_bytes());
+            hasher.update(crate_registry_template.as_str().as_bytes());
             hasher.update(b"\0");
             hasher.update(rules_rust_workspace_name.as_bytes());
             hasher.update(b"\0");
@@ -189,6 +190,12 @@ impl Resolver {
                 if env_name == "CARGO_HOME" {
                     continue;
                 }
+                if env_name == "CARGO" {
+                    continue;
+                }
+                if env_name == "RUSTC" {
+                    continue;
+                }
                 // We hope that other env vars don't cause problems...
                 if env_name.starts_with("CARGO") && env_name != "CARGO_NET_GIT_FETCH_WITH_CLI" {
                     eprintln!("Warning: You have the {} environment variable set - this may affect your crate_universe output", env_name);
@@ -218,11 +225,11 @@ impl Resolver {
         // RazeMetadataFetcher only uses the scheme+host+port of this URL.
         // If it used the path, we'd run into issues escaping the {s and }s from the template,
         // but the scheme+host+port should be fine.
-        let repository_template_url = Url::parse(&self.render_config.repository_template)
+        let crate_registry_template_url = Url::parse(&self.render_config.crate_registry_template)
             .context("Parsing repository template URL")?;
         let md_fetcher = RazeMetadataFetcher::new(
             &self.resolver_config.cargo,
-            repository_template_url,
+            crate_registry_template_url,
             self.resolver_config.index_url.clone(),
         );
         let metadata = md_fetcher
@@ -242,7 +249,7 @@ impl Resolver {
             crates: HashMap::default(),
             output_buildfile_suffix: "".to_string(),
             default_gen_buildrs: true,
-            registry: self.render_config.repository_template.clone(),
+            registry: self.render_config.crate_registry_template.clone(),
             index_url: self.resolver_config.index_url.as_str().to_owned(),
             rust_rules_workspace_name: self.render_config.rules_rust_workspace_name.clone(),
             vendor_dir: "".to_string(),

--- a/crate_universe/src/serde_utils.rs
+++ b/crate_universe/src/serde_utils.rs
@@ -1,10 +1,11 @@
+use std::{collections::BTreeSet, fmt, path::PathBuf, str::FromStr};
+
+use serde::{
+    de::{self, Error, MapAccess, Visitor},
+    Deserialize,
+};
+
 use crate::parser::{DepSpec, VersionSpec};
-use serde::de::{Error, MapAccess, Visitor};
-use serde::{de, Deserialize};
-use std::collections::BTreeSet;
-use std::fmt;
-use std::path::PathBuf;
-use std::str::FromStr;
 
 // Work around https://github.com/serde-rs/serde/issues/368
 const fn always_true() -> bool {

--- a/crate_universe/tests/integration.rs
+++ b/crate_universe/tests/integration.rs
@@ -31,7 +31,7 @@ lazy_static = "=1.4.0"
         repository_name: "beep".to_owned(),
         cargo_toml_files: btreemap! { String::from("//some:Cargo.toml") => cargo_toml_file.path().to_path_buf() },
         overrides: Default::default(),
-        repository_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
+        crate_registry_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
         target_triples: vec!["x86_64-apple-darwin".to_owned()],
         packages: vec![],
         cargo: PathBuf::from(env!("CARGO")),
@@ -293,7 +293,7 @@ path = "src/main.rs"
         repository_name: "beep".to_owned(),
         cargo_toml_files: btreemap! { String::from("//some:Cargo.toml") => cargo_toml_file.path().to_path_buf() },
         overrides,
-        repository_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
+        crate_registry_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
         target_triples: vec![
             "x86_64-apple-darwin".to_owned(),
             "x86_64-unknown-linux-gnu".to_owned(),
@@ -1482,7 +1482,7 @@ plist = "=1.0.0"
         repository_name: "hurrah".to_owned(),
         cargo_toml_files: btreemap! { String::from("//some:Cargo.toml") => cargo_toml_file.path().to_path_buf() },
         overrides: Default::default(),
-        repository_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
+        crate_registry_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
         target_triples: vec!["x86_64-apple-darwin".to_owned()],
         packages: vec![],
         cargo: PathBuf::from(env!("CARGO")),
@@ -1533,7 +1533,7 @@ prost-types = { git = "https://github.com/danburkert/prost.git", rev = "4ded4a98
         repository_name: "yep".to_owned(),
         cargo_toml_files: btreemap! { String::from("//some:Cargo.toml") => cargo_toml_file.path().to_path_buf() },
         overrides: Default::default(),
-        repository_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
+        crate_registry_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
         target_triples: vec!["x86_64-apple-darwin".to_owned()],
         packages: vec![],
         cargo: PathBuf::from(env!("CARGO")),
@@ -1944,7 +1944,7 @@ path = "lib.rs"
         repository_name: "another".to_owned(),
         cargo_toml_files: btreemap! { String::from("//some/other:Cargo.toml") => workspace_cargo_toml },
         overrides: Default::default(),
-        repository_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
+        crate_registry_template: "https://crates-io.s3-us-west-1.amazonaws.com/crates/crates/{crate}/{crate}-{version}.crate".to_owned(),
         target_triples: vec!["x86_64-apple-darwin".to_owned()],
         packages: vec![],
         cargo: PathBuf::from(env!("CARGO")),
@@ -2029,12 +2029,16 @@ rust_library(
 }
 
 fn test(config: &Config) -> Assert {
+    let temp_repository_dir = tempfile::TempDir::new().unwrap();
+
     Command::cargo_bin(env!("CARGO_PKG_NAME"))
         .unwrap()
         .arg("--input_path")
         .arg("/dev/stdin")
         .arg("--output_path")
         .arg("/dev/stdout")
+        .arg("--repository_dir")
+        .arg(temp_repository_dir.as_ref())
         .arg("--repo-name")
         .arg("whatever")
         .write_stdin(serde_json::to_string(&config).unwrap())

--- a/crate_universe/tests/renderer.rs
+++ b/crate_universe/tests/renderer.rs
@@ -12,7 +12,7 @@ fn single_git_repository() {
     let renderer = Renderer::new(
         RenderConfig {
             repo_rule_name: String::from("rule_prefix"),
-            repository_template: String::from(
+            crate_registry_template: String::from(
                 "https://crates.io/api/v1/crates/{crate}/{version}/download",
             ),
             rules_rust_workspace_name: String::from("rules_rust"),
@@ -63,7 +63,7 @@ fn single_http_archive() {
     let renderer = Renderer::new(
         RenderConfig {
             repo_rule_name: String::from("rule_prefix"),
-            repository_template: String::from(
+            crate_registry_template: String::from(
                 "https://crates.io/api/v1/crates/{crate}/{version}/download",
             ),
             rules_rust_workspace_name: String::from("rules_rust"),
@@ -122,7 +122,7 @@ fn crate_helper_function_mapping() {
     let renderer = Renderer::new(
         RenderConfig {
             repo_rule_name: String::from("rule_prefix"),
-            repository_template: String::from(
+            crate_registry_template: String::from(
                 "https://crates.io/api/v1/crates/{crate}/{version}/download",
             ),
             rules_rust_workspace_name: String::from("rules_rust"),
@@ -254,6 +254,7 @@ fn lazy_static_crate_context(git: bool) -> CrateContext {
         workspace_path_to_crate: String::from("UNUSED"),
         workspace_member_dependents: vec![],
         workspace_member_dev_dependents: vec![],
+        workspace_member_build_dependents: vec![],
         is_workspace_member_dependency: false,
         is_binary_dependency: false,
         targets: vec![BuildableTarget {

--- a/examples/crate_universe/uses_sys_crate/lockfile.lock
+++ b/examples/crate_universe/uses_sys_crate/lockfile.lock
@@ -1,545 +1,603 @@
-# rules_rust crate_universe file format 1
-# config hash b916e44c6b9880f343f36afe6306a62a91143212d5a24f94ad1170df9b5f6a9e
-
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-def pinned_rust_install():
-    http_archive(
-        name = "uses_sys_crate_deps__bzip2__0_3_3",
-        # TODO: Allow configuring where rust_library comes from
-        build_file_content = """# buildifier: disable=load
-load(
-    "@rules_rust//rust:defs.bzl",
-    "rust_binary",
-    "rust_library",
-    "rust_proc_macro",
-    "rust_test",
-)
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
-package(default_visibility = [
-    "//visibility:public",
-])
-
-licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
-])
-
-# Generated targets
-
-# buildifier: leave-alone
-rust_library(
-    name = "bzip2",
-    deps = [
-        "@uses_sys_crate_deps__bzip2_sys__0_1_10_1_0_8//:bzip2_sys",
-        "@uses_sys_crate_deps__libc__0_2_76//:libc",
-    ],
-    srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    data = glob(["**"], exclude=[
-        # These can be manually added with overrides if needed.
-
-        # If you run `cargo build` in this dir, the target dir can get very big very quick.
-        "target/**",
-
-        # These are not vendored from the crate - we exclude them to avoid busting caches
-        # when we change how we generate BUILD files and such.
-        "BUILD.bazel",
-        "WORKSPACE.bazel",
-        "WORKSPACE",
-    ]),
-    version = "0.3.3",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    crate_features = [
-    ],
-    aliases = select({
-        # Default
-        "//conditions:default": {
+{
+  "config": {
+    "repo_rule_name": "uses_sys_crate_deps",
+    "crate_registry_template": "https://crates.io/api/v1/crates/{crate}/{version}/download",
+    "rules_rust_workspace_name": "rules_rust"
+  },
+  "hash": "b916e44c6b9880f343f36afe6306a62a91143212d5a24f94ad1170df9b5f6a9e",
+  "transitive_renderable_packages": [
+    {
+      "crate_context": {
+        "pkg_name": "bzip2",
+        "pkg_version": "0.3.3",
+        "edition": "2015",
+        "raze_settings": {
+          "additional_deps": [],
+          "skipped_deps": [],
+          "extra_aliased_targets": [],
+          "additional_flags": [],
+          "additional_env": {},
+          "gen_buildrs": null,
+          "data_attr": null,
+          "data_dependencies": [],
+          "compile_data_attr": null,
+          "build_data_dependencies": [],
+          "buildrs_additional_environment_variables": {},
+          "buildrs_additional_deps": [],
+          "patch_args": [],
+          "patch_cmds": [],
+          "patch_cmds_win": [],
+          "patch_tool": null,
+          "patches": [],
+          "additional_build_file": null
         },
-    }),
-)
-# Unsupported target "tokio" with type "test" omitted
-""",
-        strip_prefix = "bzip2-0.3.3",
-        type = "tar.gz",
-        url = "https://crates.io/api/v1/crates/bzip2/0.3.3/download",
-    )
-
-    http_archive(
-        name = "uses_sys_crate_deps__bzip2_sys__0_1_10_1_0_8",
-        # TODO: Allow configuring where rust_library comes from
-        build_file_content = """# buildifier: disable=load
-load(
-    "@rules_rust//rust:defs.bzl",
-    "rust_binary",
-    "rust_library",
-    "rust_proc_macro",
-    "rust_test",
-)
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
-package(default_visibility = [
-    "//visibility:public",
-])
-
-licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
-])
-
-# Generated targets
-# buildifier: disable=load-on-top
-load(
-    "@rules_rust//cargo:cargo_build_script.bzl",
-    "cargo_build_script",
-)
-
-# buildifier: leave-alone
-cargo_build_script(
-    name = "bzip2_sys_build_script",
-    srcs = glob(["**/*.rs"]),
-    crate_root = "build.rs",
-    edition = "2015",
-    deps = [
-        "@uses_sys_crate_deps__cc__1_0_67//:cc",
-        "@uses_sys_crate_deps__pkg_config__0_3_19//:pkg_config",
-    ],
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    crate_features = [
-    ],
-    build_script_env = {
+        "canonical_additional_build_file": null,
+        "default_deps": {
+          "dependencies": [
+            {
+              "buildable_target": "@uses_sys_crate_deps__bzip2_sys__0_1_10_1_0_8//:bzip2_sys",
+              "name": "bzip2-sys",
+              "version": "0.1.10+1.0.8",
+              "is_proc_macro": false
+            },
+            {
+              "buildable_target": "@uses_sys_crate_deps__libc__0_2_76//:libc",
+              "name": "libc",
+              "version": "0.2.76",
+              "is_proc_macro": false
+            }
+          ],
+          "proc_macro_dependencies": [],
+          "data_dependencies": [],
+          "build_dependencies": [
+            {
+              "buildable_target": "@uses_sys_crate_deps__bzip2_sys__0_1_10_1_0_8//:bzip2_sys",
+              "name": "bzip2-sys",
+              "version": "0.1.10+1.0.8",
+              "is_proc_macro": false
+            }
+          ],
+          "build_proc_macro_dependencies": [],
+          "build_data_dependencies": [],
+          "dev_dependencies": [],
+          "aliased_dependencies": []
+        },
+        "targeted_deps": [],
+        "license": {
+          "name": "MIT from expression \"MIT OR Apache-2.0\"",
+          "rating": "notice"
+        },
+        "features": [],
+        "workspace_path_to_crate": "@uses_sys_crate_deps__bzip2__0_3_3//",
+        "workspace_member_dependents": [
+          ""
+        ],
+        "workspace_member_dev_dependents": [],
+        "workspace_member_build_dependents": [],
+        "is_workspace_member_dependency": true,
+        "is_binary_dependency": false,
+        "targets": [
+          {
+            "kind": "lib",
+            "name": "bzip2",
+            "path": "src/lib.rs",
+            "edition": "2015"
+          },
+          {
+            "kind": "test",
+            "name": "tokio",
+            "path": "tests/tokio.rs",
+            "edition": "2015"
+          }
+        ],
+        "build_script_target": null,
+        "links": null,
+        "source_details": {
+          "git_data": null
+        },
+        "sha256": "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b",
+        "registry_url": "https://crates.io/api/v1/crates/bzip2/0.3.3/download",
+        "expected_build_path": "remote/BUILD.bzip2-0.3.3.bazel",
+        "lib_target_name": "bzip2",
+        "is_proc_macro": false
+      },
+      "per_triple_metadata": {
+        "//conditions:default": {
+          "target": "Default",
+          "deps": {
+            "dependencies": [
+              {
+                "buildable_target": "@uses_sys_crate_deps__bzip2_sys__0_1_10_1_0_8//:bzip2_sys",
+                "name": "bzip2-sys",
+                "version": "0.1.10+1.0.8",
+                "is_proc_macro": false
+              },
+              {
+                "buildable_target": "@uses_sys_crate_deps__libc__0_2_76//:libc",
+                "name": "libc",
+                "version": "0.2.76",
+                "is_proc_macro": false
+              }
+            ],
+            "proc_macro_dependencies": [],
+            "data_dependencies": [],
+            "build_dependencies": [
+              {
+                "buildable_target": "@uses_sys_crate_deps__bzip2_sys__0_1_10_1_0_8//:bzip2_sys",
+                "name": "bzip2-sys",
+                "version": "0.1.10+1.0.8",
+                "is_proc_macro": false
+              }
+            ],
+            "build_proc_macro_dependencies": [],
+            "build_data_dependencies": [],
+            "dev_dependencies": [],
+            "aliased_dependencies": []
+          },
+          "conditions": [
+            "//conditions:default"
+          ]
+        }
+      },
+      "is_proc_macro": false
     },
-    links = "bzip2",
-    data = glob(["**"], exclude=[
-        # These can be manually added with overrides if needed.
-
-        # If you run `cargo build` in this dir, the target dir can get very big very quick.
-        "target/**",
-
-        # These are not vendored from the crate - we exclude them to avoid busting caches
-        # when we change how we generate BUILD files and such.
-        "BUILD.bazel",
-        "WORKSPACE.bazel",
-        "WORKSPACE",
-    ]),
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    version = "0.1.10+1.0.8",
-    visibility = ["//visibility:private"],
-)
-
-
-# buildifier: leave-alone
-rust_library(
-    name = "bzip2_sys",
-    deps = [
-        ":bzip2_sys_build_script",
-        "@uses_sys_crate_deps__libc__0_2_76//:libc",
-    ],
-    srcs = glob(["**/*.rs"]),
-    crate_root = "lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    data = glob(["**"], exclude=[
-        # These can be manually added with overrides if needed.
-
-        # If you run `cargo build` in this dir, the target dir can get very big very quick.
-        "target/**",
-
-        # These are not vendored from the crate - we exclude them to avoid busting caches
-        # when we change how we generate BUILD files and such.
-        "BUILD.bazel",
-        "WORKSPACE.bazel",
-        "WORKSPACE",
-    ]),
-    version = "0.1.10+1.0.8",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    crate_features = [
-    ],
-    aliases = select({
-        # Default
-        "//conditions:default": {
+    {
+      "crate_context": {
+        "pkg_name": "bzip2-sys",
+        "pkg_version": "0.1.10+1.0.8",
+        "edition": "2015",
+        "raze_settings": {
+          "additional_deps": [],
+          "skipped_deps": [],
+          "extra_aliased_targets": [],
+          "additional_flags": [],
+          "additional_env": {},
+          "gen_buildrs": null,
+          "data_attr": null,
+          "data_dependencies": [],
+          "compile_data_attr": null,
+          "build_data_dependencies": [],
+          "buildrs_additional_environment_variables": {},
+          "buildrs_additional_deps": [],
+          "patch_args": [],
+          "patch_cmds": [],
+          "patch_cmds_win": [],
+          "patch_tool": null,
+          "patches": [],
+          "additional_build_file": null
         },
-    }),
-)
-""",
-        strip_prefix = "bzip2-sys-0.1.10+1.0.8",
-        type = "tar.gz",
-        url = "https://crates.io/api/v1/crates/bzip2-sys/0.1.10+1.0.8/download",
-    )
-
-    http_archive(
-        name = "uses_sys_crate_deps__cc__1_0_67",
-        # TODO: Allow configuring where rust_library comes from
-        build_file_content = """# buildifier: disable=load
-load(
-    "@rules_rust//rust:defs.bzl",
-    "rust_binary",
-    "rust_library",
-    "rust_proc_macro",
-    "rust_test",
-)
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
-package(default_visibility = [
-    "//visibility:public",
-])
-
-licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
-])
-
-# Generated targets
-
-# buildifier: leave-alone
-rust_binary(
-    # Prefix bin name to disambiguate from (probable) collision with lib name
-    # N.B.: The exact form of this is subject to change.
-    name = "cargo_bin_gcc_shim",
-    deps = [
-        # Binaries get an implicit dependency on their crate's lib
-        ":cc",
-    ],
-    srcs = glob(["**/*.rs"]),
-    crate_root = "src/bin/gcc-shim.rs",
-    edition = "2018",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    data = glob(["**"], exclude=[
-        # These can be manually added with overrides if needed.
-
-        # If you run `cargo build` in this dir, the target dir can get very big very quick.
-        "target/**",
-
-        # These are not vendored from the crate - we exclude them to avoid busting caches
-        # when we change how we generate BUILD files and such.
-        "BUILD.bazel",
-        "WORKSPACE.bazel",
-        "WORKSPACE",
-    ]),
-    version = "1.0.67",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    crate_features = [
-    ],
-    aliases = select({
-        # Default
-        "//conditions:default": {
+        "canonical_additional_build_file": null,
+        "default_deps": {
+          "dependencies": [
+            {
+              "buildable_target": "@uses_sys_crate_deps__libc__0_2_76//:libc",
+              "name": "libc",
+              "version": "0.2.76",
+              "is_proc_macro": false
+            }
+          ],
+          "proc_macro_dependencies": [],
+          "data_dependencies": [],
+          "build_dependencies": [
+            {
+              "buildable_target": "@uses_sys_crate_deps__cc__1_0_67//:cc",
+              "name": "cc",
+              "version": "1.0.67",
+              "is_proc_macro": false
+            },
+            {
+              "buildable_target": "@uses_sys_crate_deps__pkg_config__0_3_19//:pkg_config",
+              "name": "pkg-config",
+              "version": "0.3.19",
+              "is_proc_macro": false
+            }
+          ],
+          "build_proc_macro_dependencies": [],
+          "build_data_dependencies": [],
+          "dev_dependencies": [],
+          "aliased_dependencies": []
         },
-    }),
-)
-
-# buildifier: leave-alone
-rust_library(
-    name = "cc",
-    deps = [
-    ],
-    srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2018",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    data = glob(["**"], exclude=[
-        # These can be manually added with overrides if needed.
-
-        # If you run `cargo build` in this dir, the target dir can get very big very quick.
-        "target/**",
-
-        # These are not vendored from the crate - we exclude them to avoid busting caches
-        # when we change how we generate BUILD files and such.
-        "BUILD.bazel",
-        "WORKSPACE.bazel",
-        "WORKSPACE",
-    ]),
-    version = "1.0.67",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    crate_features = [
-    ],
-    aliases = select({
-        # Default
-        "//conditions:default": {
+        "targeted_deps": [],
+        "license": {
+          "name": "MIT from expression \"MIT OR Apache-2.0\"",
+          "rating": "notice"
         },
-    }),
-)
-# Unsupported target "cc_env" with type "test" omitted
-# Unsupported target "cflags" with type "test" omitted
-# Unsupported target "cxxflags" with type "test" omitted
-# Unsupported target "test" with type "test" omitted
-""",
-        strip_prefix = "cc-1.0.67",
-        type = "tar.gz",
-        url = "https://crates.io/api/v1/crates/cc/1.0.67/download",
-    )
-
-    http_archive(
-        name = "uses_sys_crate_deps__libc__0_2_76",
-        # TODO: Allow configuring where rust_library comes from
-        build_file_content = """# buildifier: disable=load
-load(
-    "@rules_rust//rust:defs.bzl",
-    "rust_binary",
-    "rust_library",
-    "rust_proc_macro",
-    "rust_test",
-)
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
-package(default_visibility = [
-    "//visibility:public",
-])
-
-licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
-])
-
-# Generated targets
-# buildifier: disable=load-on-top
-load(
-    "@rules_rust//cargo:cargo_build_script.bzl",
-    "cargo_build_script",
-)
-
-# buildifier: leave-alone
-cargo_build_script(
-    name = "libc_build_script",
-    srcs = glob(["**/*.rs"]),
-    crate_root = "build.rs",
-    edition = "2015",
-    deps = [
-    ],
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    crate_features = [
-      "default",
-      "std",
-    ],
-    build_script_env = {
+        "features": [],
+        "workspace_path_to_crate": "@uses_sys_crate_deps__bzip2_sys__0_1_10_1_0_8//",
+        "workspace_member_dependents": [],
+        "workspace_member_dev_dependents": [],
+        "workspace_member_build_dependents": [],
+        "is_workspace_member_dependency": false,
+        "is_binary_dependency": false,
+        "targets": [
+          {
+            "kind": "lib",
+            "name": "bzip2_sys",
+            "path": "lib.rs",
+            "edition": "2015"
+          }
+        ],
+        "build_script_target": {
+          "kind": "custom-build",
+          "name": "build-script-build",
+          "path": "build.rs",
+          "edition": "2015"
+        },
+        "links": "bzip2",
+        "source_details": {
+          "git_data": null
+        },
+        "sha256": "17fa3d1ac1ca21c5c4e36a97f3c3eb25084576f6fc47bf0139c1123434216c6c",
+        "registry_url": "https://crates.io/api/v1/crates/bzip2-sys/0.1.10+1.0.8/download",
+        "expected_build_path": "remote/BUILD.bzip2-sys-0.1.10+1.0.8.bazel",
+        "lib_target_name": "bzip2_sys",
+        "is_proc_macro": false
+      },
+      "per_triple_metadata": {
+        "//conditions:default": {
+          "target": "Default",
+          "deps": {
+            "dependencies": [
+              {
+                "buildable_target": "@uses_sys_crate_deps__libc__0_2_76//:libc",
+                "name": "libc",
+                "version": "0.2.76",
+                "is_proc_macro": false
+              }
+            ],
+            "proc_macro_dependencies": [],
+            "data_dependencies": [],
+            "build_dependencies": [
+              {
+                "buildable_target": "@uses_sys_crate_deps__cc__1_0_67//:cc",
+                "name": "cc",
+                "version": "1.0.67",
+                "is_proc_macro": false
+              },
+              {
+                "buildable_target": "@uses_sys_crate_deps__pkg_config__0_3_19//:pkg_config",
+                "name": "pkg-config",
+                "version": "0.3.19",
+                "is_proc_macro": false
+              }
+            ],
+            "build_proc_macro_dependencies": [],
+            "build_data_dependencies": [],
+            "dev_dependencies": [],
+            "aliased_dependencies": []
+          },
+          "conditions": [
+            "//conditions:default"
+          ]
+        }
+      },
+      "is_proc_macro": false
     },
-    data = glob(["**"], exclude=[
-        # These can be manually added with overrides if needed.
-
-        # If you run `cargo build` in this dir, the target dir can get very big very quick.
-        "target/**",
-
-        # These are not vendored from the crate - we exclude them to avoid busting caches
-        # when we change how we generate BUILD files and such.
-        "BUILD.bazel",
-        "WORKSPACE.bazel",
-        "WORKSPACE",
-    ]),
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    version = "0.2.76",
-    visibility = ["//visibility:private"],
-)
-
-
-# buildifier: leave-alone
-rust_library(
-    name = "libc",
-    deps = [
-        ":libc_build_script",
-    ],
-    srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    data = glob(["**"], exclude=[
-        # These can be manually added with overrides if needed.
-
-        # If you run `cargo build` in this dir, the target dir can get very big very quick.
-        "target/**",
-
-        # These are not vendored from the crate - we exclude them to avoid busting caches
-        # when we change how we generate BUILD files and such.
-        "BUILD.bazel",
-        "WORKSPACE.bazel",
-        "WORKSPACE",
-    ]),
-    version = "0.2.76",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    crate_features = [
-        "default",
-        "std",
-    ],
-    aliases = select({
-        # Default
-        "//conditions:default": {
+    {
+      "crate_context": {
+        "pkg_name": "cc",
+        "pkg_version": "1.0.67",
+        "edition": "2018",
+        "raze_settings": {
+          "additional_deps": [],
+          "skipped_deps": [],
+          "extra_aliased_targets": [],
+          "additional_flags": [],
+          "additional_env": {},
+          "gen_buildrs": null,
+          "data_attr": null,
+          "data_dependencies": [],
+          "compile_data_attr": null,
+          "build_data_dependencies": [],
+          "buildrs_additional_environment_variables": {},
+          "buildrs_additional_deps": [],
+          "patch_args": [],
+          "patch_cmds": [],
+          "patch_cmds_win": [],
+          "patch_tool": null,
+          "patches": [],
+          "additional_build_file": null
         },
-    }),
-)
-# Unsupported target "const_fn" with type "test" omitted
-""",
-        strip_prefix = "libc-0.2.76",
-        type = "tar.gz",
-        url = "https://crates.io/api/v1/crates/libc/0.2.76/download",
-    )
-
-    http_archive(
-        name = "uses_sys_crate_deps__pkg_config__0_3_19",
-        # TODO: Allow configuring where rust_library comes from
-        build_file_content = """# buildifier: disable=load
-load(
-    "@rules_rust//rust:defs.bzl",
-    "rust_binary",
-    "rust_library",
-    "rust_proc_macro",
-    "rust_test",
-)
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
-package(default_visibility = [
-    "//visibility:public",
-])
-
-licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
-])
-
-# Generated targets
-
-# buildifier: leave-alone
-rust_library(
-    name = "pkg_config",
-    deps = [
-    ],
-    srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    data = glob(["**"], exclude=[
-        # These can be manually added with overrides if needed.
-
-        # If you run `cargo build` in this dir, the target dir can get very big very quick.
-        "target/**",
-
-        # These are not vendored from the crate - we exclude them to avoid busting caches
-        # when we change how we generate BUILD files and such.
-        "BUILD.bazel",
-        "WORKSPACE.bazel",
-        "WORKSPACE",
-    ]),
-    version = "0.3.19",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    crate_features = [
-    ],
-    aliases = select({
-        # Default
-        "//conditions:default": {
+        "canonical_additional_build_file": null,
+        "default_deps": {
+          "dependencies": [],
+          "proc_macro_dependencies": [],
+          "data_dependencies": [],
+          "build_dependencies": [],
+          "build_proc_macro_dependencies": [],
+          "build_data_dependencies": [],
+          "dev_dependencies": [],
+          "aliased_dependencies": []
         },
-    }),
-)
-# Unsupported target "test" with type "test" omitted
-""",
-        strip_prefix = "pkg-config-0.3.19",
-        type = "tar.gz",
-        url = "https://crates.io/api/v1/crates/pkg-config/0.3.19/download",
-    )
-
-
-CRATE_TARGET_NAMES = {
-    "bzip2": "@uses_sys_crate_deps__bzip2__0_3_3//:bzip2",
-    "libc": "@uses_sys_crate_deps__libc__0_2_76//:libc",
+        "targeted_deps": [],
+        "license": {
+          "name": "MIT from expression \"MIT OR Apache-2.0\"",
+          "rating": "notice"
+        },
+        "features": [],
+        "workspace_path_to_crate": "@uses_sys_crate_deps__cc__1_0_67//",
+        "workspace_member_dependents": [],
+        "workspace_member_dev_dependents": [],
+        "workspace_member_build_dependents": [],
+        "is_workspace_member_dependency": false,
+        "is_binary_dependency": false,
+        "targets": [
+          {
+            "kind": "bin",
+            "name": "gcc-shim",
+            "path": "src/bin/gcc-shim.rs",
+            "edition": "2018"
+          },
+          {
+            "kind": "lib",
+            "name": "cc",
+            "path": "src/lib.rs",
+            "edition": "2018"
+          },
+          {
+            "kind": "test",
+            "name": "cc_env",
+            "path": "tests/cc_env.rs",
+            "edition": "2018"
+          },
+          {
+            "kind": "test",
+            "name": "cflags",
+            "path": "tests/cflags.rs",
+            "edition": "2018"
+          },
+          {
+            "kind": "test",
+            "name": "cxxflags",
+            "path": "tests/cxxflags.rs",
+            "edition": "2018"
+          },
+          {
+            "kind": "test",
+            "name": "test",
+            "path": "tests/test.rs",
+            "edition": "2018"
+          }
+        ],
+        "build_script_target": null,
+        "links": null,
+        "source_details": {
+          "git_data": null
+        },
+        "sha256": "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd",
+        "registry_url": "https://crates.io/api/v1/crates/cc/1.0.67/download",
+        "expected_build_path": "remote/BUILD.cc-1.0.67.bazel",
+        "lib_target_name": "cc",
+        "is_proc_macro": false
+      },
+      "per_triple_metadata": {
+        "//conditions:default": {
+          "target": "Default",
+          "deps": {
+            "dependencies": [],
+            "proc_macro_dependencies": [],
+            "data_dependencies": [],
+            "build_dependencies": [],
+            "build_proc_macro_dependencies": [],
+            "build_data_dependencies": [],
+            "dev_dependencies": [],
+            "aliased_dependencies": []
+          },
+          "conditions": [
+            "//conditions:default"
+          ]
+        }
+      },
+      "is_proc_macro": false
+    },
+    {
+      "crate_context": {
+        "pkg_name": "libc",
+        "pkg_version": "0.2.76",
+        "edition": "2015",
+        "raze_settings": {
+          "additional_deps": [],
+          "skipped_deps": [],
+          "extra_aliased_targets": [],
+          "additional_flags": [],
+          "additional_env": {},
+          "gen_buildrs": null,
+          "data_attr": null,
+          "data_dependencies": [],
+          "compile_data_attr": null,
+          "build_data_dependencies": [],
+          "buildrs_additional_environment_variables": {},
+          "buildrs_additional_deps": [],
+          "patch_args": [],
+          "patch_cmds": [],
+          "patch_cmds_win": [],
+          "patch_tool": null,
+          "patches": [],
+          "additional_build_file": null
+        },
+        "canonical_additional_build_file": null,
+        "default_deps": {
+          "dependencies": [],
+          "proc_macro_dependencies": [],
+          "data_dependencies": [],
+          "build_dependencies": [],
+          "build_proc_macro_dependencies": [],
+          "build_data_dependencies": [],
+          "dev_dependencies": [],
+          "aliased_dependencies": []
+        },
+        "targeted_deps": [],
+        "license": {
+          "name": "MIT from expression \"MIT OR Apache-2.0\"",
+          "rating": "notice"
+        },
+        "features": [
+          "default",
+          "std"
+        ],
+        "workspace_path_to_crate": "@uses_sys_crate_deps__libc__0_2_76//",
+        "workspace_member_dependents": [
+          ""
+        ],
+        "workspace_member_dev_dependents": [],
+        "workspace_member_build_dependents": [],
+        "is_workspace_member_dependency": true,
+        "is_binary_dependency": false,
+        "targets": [
+          {
+            "kind": "lib",
+            "name": "libc",
+            "path": "src/lib.rs",
+            "edition": "2015"
+          },
+          {
+            "kind": "test",
+            "name": "const_fn",
+            "path": "tests/const_fn.rs",
+            "edition": "2015"
+          }
+        ],
+        "build_script_target": {
+          "kind": "custom-build",
+          "name": "build-script-build",
+          "path": "build.rs",
+          "edition": "2015"
+        },
+        "links": null,
+        "source_details": {
+          "git_data": null
+        },
+        "sha256": "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3",
+        "registry_url": "https://crates.io/api/v1/crates/libc/0.2.76/download",
+        "expected_build_path": "remote/BUILD.libc-0.2.76.bazel",
+        "lib_target_name": "libc",
+        "is_proc_macro": false
+      },
+      "per_triple_metadata": {
+        "//conditions:default": {
+          "target": "Default",
+          "deps": {
+            "dependencies": [],
+            "proc_macro_dependencies": [],
+            "data_dependencies": [],
+            "build_dependencies": [],
+            "build_proc_macro_dependencies": [],
+            "build_data_dependencies": [],
+            "dev_dependencies": [],
+            "aliased_dependencies": []
+          },
+          "conditions": [
+            "//conditions:default"
+          ]
+        }
+      },
+      "is_proc_macro": false
+    },
+    {
+      "crate_context": {
+        "pkg_name": "pkg-config",
+        "pkg_version": "0.3.19",
+        "edition": "2015",
+        "raze_settings": {
+          "additional_deps": [],
+          "skipped_deps": [],
+          "extra_aliased_targets": [],
+          "additional_flags": [],
+          "additional_env": {},
+          "gen_buildrs": null,
+          "data_attr": null,
+          "data_dependencies": [],
+          "compile_data_attr": null,
+          "build_data_dependencies": [],
+          "buildrs_additional_environment_variables": {},
+          "buildrs_additional_deps": [],
+          "patch_args": [],
+          "patch_cmds": [],
+          "patch_cmds_win": [],
+          "patch_tool": null,
+          "patches": [],
+          "additional_build_file": null
+        },
+        "canonical_additional_build_file": null,
+        "default_deps": {
+          "dependencies": [],
+          "proc_macro_dependencies": [],
+          "data_dependencies": [],
+          "build_dependencies": [],
+          "build_proc_macro_dependencies": [],
+          "build_data_dependencies": [],
+          "dev_dependencies": [],
+          "aliased_dependencies": []
+        },
+        "targeted_deps": [],
+        "license": {
+          "name": "MIT from expression \"MIT OR Apache-2.0\"",
+          "rating": "notice"
+        },
+        "features": [],
+        "workspace_path_to_crate": "@uses_sys_crate_deps__pkg_config__0_3_19//",
+        "workspace_member_dependents": [],
+        "workspace_member_dev_dependents": [],
+        "workspace_member_build_dependents": [],
+        "is_workspace_member_dependency": false,
+        "is_binary_dependency": false,
+        "targets": [
+          {
+            "kind": "lib",
+            "name": "pkg-config",
+            "path": "src/lib.rs",
+            "edition": "2015"
+          },
+          {
+            "kind": "test",
+            "name": "test",
+            "path": "tests/test.rs",
+            "edition": "2015"
+          }
+        ],
+        "build_script_target": null,
+        "links": null,
+        "source_details": {
+          "git_data": null
+        },
+        "sha256": "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c",
+        "registry_url": "https://crates.io/api/v1/crates/pkg-config/0.3.19/download",
+        "expected_build_path": "remote/BUILD.pkg-config-0.3.19.bazel",
+        "lib_target_name": "pkg-config",
+        "is_proc_macro": false
+      },
+      "per_triple_metadata": {
+        "//conditions:default": {
+          "target": "Default",
+          "deps": {
+            "dependencies": [],
+            "proc_macro_dependencies": [],
+            "data_dependencies": [],
+            "build_dependencies": [],
+            "build_proc_macro_dependencies": [],
+            "build_data_dependencies": [],
+            "dev_dependencies": [],
+            "aliased_dependencies": []
+          },
+          "conditions": [
+            "//conditions:default"
+          ]
+        }
+      },
+      "is_proc_macro": false
+    }
+  ],
+  "member_packages_version_mapping": {
+    "normal": {
+      "bzip2": "0.3.3",
+      "libc": "0.2.76"
+    },
+    "build": {},
+    "dev": {}
+  },
+  "label_to_crates": {
+    "//uses_sys_crate:Cargo.toml": [
+      "bzip2"
+    ]
+  }
 }
-
-def crate(crate_name):
-    """Return the name of the target for the given crate.
-    """
-    target_name = CRATE_TARGET_NAMES.get(crate_name)
-    if target_name == None:
-        fail("Unknown crate name: {}".format(crate_name))
-    return target_name
-
-def all_deps():
-    """Return all standard dependencies explicitly listed in the Cargo.toml or packages list."""
-    return [
-        crate(crate_name) for crate_name in [
-            "bzip2",
-            "libc",
-        ]
-    ]
-
-def all_proc_macro_deps():
-    """Return all proc-macro dependencies explicitly listed in the Cargo.toml or packages list."""
-    return [
-        crate(crate_name) for crate_name in [
-        ]
-    ]
-
-def crates_from(label):
-    mapping = {
-        "//uses_sys_crate:Cargo.toml": [crate("bzip2")],
-    }
-    return mapping[_absolutify(label)]
-
-def dev_crates_from(label):
-    mapping = {
-        "//uses_sys_crate:Cargo.toml": [],
-    }
-    return mapping[_absolutify(label)]
-
-def build_crates_from(label):
-    mapping = {
-        "//uses_sys_crate:Cargo.toml": [],
-    }
-    return mapping[_absolutify(label)]
-
-def proc_macro_crates_from(label):
-    mapping = {
-        "//uses_sys_crate:Cargo.toml": [],
-    }
-    return mapping[_absolutify(label)]
-
-def _absolutify(label):
-    if label.startswith("//") or label.startswith("@"):
-        return label
-    if label.startswith(":"):
-        return "//" + native.package_name() + label
-    return "//" + native.package_name() + ":" + label

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -14,6 +14,14 @@ load(":known_shas.bzl", "FILE_KEY_TO_SHA")
 
 DEFAULT_TOOLCHAIN_NAME_PREFIX = "toolchain_for"
 DEFAULT_STATIC_RUST_URL_TEMPLATES = ["https://static.rust-lang.org/dist/{}.tar.gz"]
+DEFAULT_TOOLCHAIN_TRIPLES = {
+    "aarch64-apple-darwin": "rust_darwin_aarch64",
+    "aarch64-unknown-linux-gnu": "rust_linux_aarch64",
+    "x86_64-apple-darwin": "rust_darwin_x86_64",
+    "x86_64-pc-windows-msvc": "rust_windows_x86_64",
+    "x86_64-unknown-freebsd": "rust_freebsd_x86_64",
+    "x86_64-unknown-linux-gnu": "rust_linux_x86_64",
+}
 
 # Note: Code in `.github/workflows/crate_universe.yaml` looks for this line, if you remove it or change its format, you will also need to update that code.
 DEFAULT_RUST_VERSION = "1.51.0"
@@ -80,82 +88,19 @@ def rust_repositories(
         ],
     )
 
-    rust_repository_set(
-        name = "rust_linux_x86_64",
-        exec_triple = "x86_64-unknown-linux-gnu",
-        extra_target_triples = ["wasm32-unknown-unknown", "wasm32-wasi"],
-        version = version,
-        iso_date = iso_date,
-        rustfmt_version = rustfmt_version,
-        edition = edition,
-        dev_components = dev_components,
-        sha256s = sha256s,
-        urls = urls,
-    )
-
-    rust_repository_set(
-        name = "rust_linux_aarch64",
-        exec_triple = "aarch64-unknown-linux-gnu",
-        extra_target_triples = ["wasm32-unknown-unknown", "wasm32-wasi"],
-        version = version,
-        iso_date = iso_date,
-        rustfmt_version = rustfmt_version,
-        edition = edition,
-        dev_components = dev_components,
-        sha256s = sha256s,
-        urls = urls,
-    )
-
-    rust_repository_set(
-        name = "rust_darwin_x86_64",
-        exec_triple = "x86_64-apple-darwin",
-        extra_target_triples = ["wasm32-unknown-unknown", "wasm32-wasi"],
-        version = version,
-        iso_date = iso_date,
-        rustfmt_version = rustfmt_version,
-        edition = edition,
-        dev_components = dev_components,
-        sha256s = sha256s,
-        urls = urls,
-    )
-
-    rust_repository_set(
-        name = "rust_darwin_aarch64",
-        exec_triple = "aarch64-apple-darwin",
-        extra_target_triples = ["wasm32-unknown-unknown", "wasm32-wasi"],
-        version = version,
-        iso_date = iso_date,
-        rustfmt_version = rustfmt_version,
-        edition = edition,
-        dev_components = dev_components,
-        sha256s = sha256s,
-        urls = urls,
-    )
-
-    rust_repository_set(
-        name = "rust_freebsd_x86_64",
-        exec_triple = "x86_64-unknown-freebsd",
-        extra_target_triples = ["wasm32-unknown-unknown", "wasm32-wasi"],
-        version = version,
-        iso_date = iso_date,
-        rustfmt_version = rustfmt_version,
-        edition = edition,
-        dev_components = dev_components,
-        sha256s = sha256s,
-        urls = urls,
-    )
-
-    rust_repository_set(
-        name = "rust_windows_x86_64",
-        exec_triple = "x86_64-pc-windows-msvc",
-        extra_target_triples = ["wasm32-unknown-unknown", "wasm32-wasi"],
-        version = version,
-        iso_date = iso_date,
-        rustfmt_version = rustfmt_version,
-        sha256s = sha256s,
-        edition = edition,
-        urls = urls,
-    )
+    for exec_triple, name in DEFAULT_TOOLCHAIN_TRIPLES.items():
+        rust_repository_set(
+            name = name,
+            exec_triple = exec_triple,
+            extra_target_triples = ["wasm32-unknown-unknown", "wasm32-wasi"],
+            version = version,
+            iso_date = iso_date,
+            rustfmt_version = rustfmt_version,
+            edition = edition,
+            dev_components = dev_components,
+            sha256s = sha256s,
+            urls = urls,
+        )
 
 def _check_version_valid(version, iso_date, param_prefix = ""):
     """Verifies that the provided rust version and iso_date make sense."""


### PR DESCRIPTION
Notable changes in this PR:
- `crate_universe` `lockfile` attributes are now rendered as json files instead of starlark dumps
- `crate_universe_resolver` now accepts a `repository_dir` argument for the path to the new repository. This should be preferable to a single output file for all dependencies.
- The `cargo-raze` dependenciy has been updated to a pin which implements the required sorting and de-serialization.
- Formatted `use` declarations
- Updated dependencies
- `CARGO` and `RUSTC` environment variables are now ignored in determining the digest. This should be safe given that `cargo version` is an input to generating the lockfile hash.
- `repository_template` has been renamed to `crate_registry_template`, which is more correct.
- The [json](https://docs.bazel.build/versions/master/skylark/lib/json.html) module is now used to handle generating the config `.json` file