### PR TITLE
Add generated docs for `crate_universe`

### DIFF
--- a/crate_universe/BUILD.bazel
+++ b/crate_universe/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ["//visibility:public"])
+
+bzl_library(
+    name = "rules",
+    srcs = glob(["**/*.bzl"]),
+    deps = ["//crate_universe/private:bzl_srcs"],
+)

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -232,6 +232,8 @@ crate_universe = repository_rule(
     doc = """\
 A rule for downloading Rust dependencies (crates).
 
+__WARNING__: This rule experimental and subject to change without warning.
+
 Environment Variables:
 - `REPIN`: Re-pin the lockfile if set (useful for repinning deps from multiple rulesets).
 - `RULES_RUST_REPIN`: Re-pin the lockfile if set (useful for only repinning Rust deps).
@@ -301,6 +303,8 @@ def _spec(
         features = None):
     """A simple crate definition for use in the `crate_universe` rule.
 
+    __WARNING__: This rule experimental and subject to change without warning.
+
     Example:
 
     ```python
@@ -340,6 +344,8 @@ def _override(
         extra_rustc_env_vars = None,
         features_to_remove = []):
     """A map of overrides for a particular crate
+
+    __WARNING__: This rule experimental and subject to change without warning.
 
     Example:
 

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -181,7 +181,6 @@ def _crate_universe_resolve_impl(repository_ctx):
     if repository_ctx.attr.lockfile:
         lockfile_path = repository_ctx.path(repository_ctx.attr.lockfile)
 
-    # Yay hand-crafted JSON serialisation...
     input_content = _input_content_template(
         ctx = repository_ctx,
         name = repository_ctx.attr.name,
@@ -236,70 +235,44 @@ A rule for downloading Rust dependencies (crates).
 Environment Variables:
 - `REPIN`: Re-pin the lockfile if set (useful for repinning deps from multiple rulesets).
 - `RULES_RUST_REPIN`: Re-pin the lockfile if set (useful for only repinning Rust deps).
-- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE`: Override URL to use to download resolver binary - for local paths use a `file://` URL.
-
-`override` Example:
-
-```python
-load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
-
-crate_universe(
-    name = "mylib",
-    # [...]
-    overrides = {
-        "tokio": crate.override(
-            extra_rust_env_vars = {
-                "MY_ENV_VAR": "MY_ENV_VALUE",
-            },
-            extra_build_script_env_vars = {
-                "MY_BUILD_SCRIPT_ENV_VAR": "MY_ENV_VALUE",
-            },
-            extra_bazel_deps = {
-                # Extra dependencies are per target. They are additive.
-                "cfg(unix)": ["@somerepo//:foo"],  # cfg() predicate.
-                "x86_64-apple-darwin": ["@somerepo//:bar"],  # Specific triple.
-                "cfg(all())": ["@somerepo//:baz"],  # Applies to all targets ("regular dependency").
-            },
-            extra_build_script_bazel_deps = {
-                # Extra dependencies are per target. They are additive.
-                "cfg(unix)": ["@buildscriptdep//:foo"],
-                "x86_64-apple-darwin": ["@buildscriptdep//:bar"],
-                "cfg(all())": ["@buildscriptdep//:baz"],
-            },
-            extra_bazel_data_deps = {
-                # ...
-            },
-            extra_build_script_bazel_data_deps = {
-                # ...
-            },
-        ),
-    },
-)
-```
+- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE`: Override URL to use to download resolver binary 
+    - for local paths use a `file://` URL.
+- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE_SHA256`: An optional sha256 value for the binary at the override url location.
 """,
     implementation = _crate_universe_resolve_impl,
     attrs = {
         "cargo_toml_files": attr.label_list(
-            doc = "",
+            doc = "A list of Cargo manifests (`Cargo.toml` files).",
+            allow_files = True,
         ),
         "crate_registry_template": attr.string(
-            doc = "A Crate registry url template. This must contain `{version}` and `{crate}` templates",
+            doc = "A Crate registry url template. This must contain `{version}` and `{crate}` templates.",
             default = DEFAULT_CRATE_REGISTRY_TEMPLATE,
         ),
         "lockfile": attr.label(
-            doc = "",
+            doc = (
+                "The path to a file which stores pinned information about the generate dependency graph. " +
+                "this target must be a file and will be updated by the repository rule when the `REPIN` " +
+                "environment variable is set."
+            ),
             allow_single_file = True,
             mandatory = False,
         ),
         "overrides": attr.string_dict(
-            doc = "Mapping of crate name to `crate.override(...)` entries)",
+            doc = (
+                "Mapping of crate name to specification overrides. See [crate.override](#crateoverride) " +
+                " for more details."
+            ),
         ),
         "packages": attr.string_list(
-            doc = "",
+            doc = "A list of crate specifications. See [crate.spec](#cratespec) for more details.",
             allow_empty = True,
         ),
         "resolver_download_url_template": attr.string(
-            doc = "URL template from which to download the resolver binary. {host_triple} and {extension} will be filled in according to the host platform.",
+            doc = (
+                "URL template from which to download the resolver binary. {host_triple} and {extension} will be " +
+                "filled in according to the host platform."
+            ),
             default = DEFAULT_URL_TEMPLATE,
         ),
         "resolver_sha256s": attr.string_dict(
@@ -307,7 +280,10 @@ crate_universe(
             default = DEFAULT_SHA256_CHECKSUMS,
         ),
         "supported_targets": attr.string_list(
-            doc = "",
+            doc = (
+                "A list of supported [platform triples](https://doc.rust-lang.org/nightly/rustc/platform-support.html) " +
+                "to consider when resoliving dependencies."
+            ),
             allow_empty = False,
             default = DEFAULT_TOOLCHAIN_TRIPLES.keys(),
         ),
@@ -322,20 +298,108 @@ def _spec(
         name,
         semver,
         features = None):
+    """A simple crate definition
+
+    example:
+
+    ```python
+    load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
+
+    crate_universe(
+        name = "spec_example",
+        packages = [
+            crate.spec(
+                name = "lazy_static",
+                semver = "=1.4",
+            ),
+        ],
+    )
+    ```
+
+    Args:
+        name (str): The name of the crate as it would appear in a crate registry.
+        semver (str): The desired version ([semver](https://semver.org/)) of the crate
+        features (list, optional): A list of desired [features](https://doc.rust-lang.org/cargo/reference/features.html).
+
+    Returns:
+        str: A json encoded struct of crate info
+    """
     return json.encode(struct(
         name = name,
         semver = semver,
-        features = features if features else [],
+        features = features or [],
     ))
 
 def _override(
-        extra_rust_env_vars = None,
-        extra_build_script_env_vars = None,
-        extra_bazel_deps = None,
-        extra_build_script_bazel_deps = None,
         extra_bazel_data_deps = None,
+        extra_bazel_deps = None,
         extra_build_script_bazel_data_deps = None,
+        extra_build_script_bazel_deps = None,
+        extra_build_script_env_vars = None,
+        extra_rustc_env_vars = None,
         features_to_remove = []):
+    """A map of overrides for a particular crate
+
+    example:
+
+    ```python
+    load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
+
+    crate_universe(
+        name = "override_example",
+        # [...]
+        overrides = {
+            "tokio": crate.override(
+                extra_rustc_env_vars = {
+                    "MY_ENV_VAR": "MY_ENV_VALUE",
+                },
+                extra_build_script_env_vars = {
+                    "MY_BUILD_SCRIPT_ENV_VAR": "MY_ENV_VALUE",
+                },
+                extra_bazel_deps = {
+                    # Extra dependencies are per target. They are additive.
+                    "cfg(unix)": ["@somerepo//:foo"],  # cfg() predicate.
+                    "x86_64-apple-darwin": ["@somerepo//:bar"],  # Specific triple.
+                    "cfg(all())": ["@somerepo//:baz"],  # Applies to all targets ("regular dependency").
+                },
+                extra_build_script_bazel_deps = {
+                    # Extra dependencies are per target. They are additive.
+                    "cfg(unix)": ["@buildscriptdep//:foo"],
+                    "x86_64-apple-darwin": ["@buildscriptdep//:bar"],
+                    "cfg(all())": ["@buildscriptdep//:baz"],
+                },
+                extra_bazel_data_deps = {
+                    # ...
+                },
+                extra_build_script_bazel_data_deps = {
+                    # ...
+                },
+            ),
+        },
+    )
+    ```
+
+    Args:
+        extra_bazel_data_deps (dict, optional): Targets to add to the `data` attribute
+            of the generated target (eg: [rust_library.data](./defs.md#rust_library-data)).
+        extra_bazel_deps (dict, optional): Targets to add to the `deps` attribute
+            of the generated target (eg: [rust_library.deps](./defs.md#rust_library-data)).
+        extra_rustc_env_vars (dict, optional): Environment variables to add to the `rustc_env`
+            attribute for the generated target (eg: [rust_library.rustc_env](./defs.md#rust_library-rustc_env)).
+        extra_build_script_bazel_data_deps (dict, optional): Targets to add to the
+            [data](./cargo_build_script.md#cargo_build_script-data) attribute of the generated
+            `cargo_build_script` target.
+        extra_build_script_bazel_deps (dict, optional): Targets to add to the
+            [deps](./cargo_build_script.md#cargo_build_script-deps) attribute of the generated
+            `cargo_build_script` target.
+        extra_build_script_env_vars (dict, optional): Environment variables to add to the
+            [build_script_env](./cargo_build_script.md#cargo_build_script-build_script_env)
+            attribute of the generated `cargo_build_script` target.
+        features_to_remove (list, optional): A list of features to remove from a generated target.
+
+    Returns:
+        str: A json encoded struct of crate overrides
+    """
     for (dep_key, dep_val) in [
         (extra_bazel_deps, extra_bazel_deps),
         (extra_build_script_bazel_deps, extra_build_script_bazel_deps),
@@ -351,12 +415,12 @@ def _override(
                     fail("The {} values should be lists of strings".format(dep_key))
 
     return json.encode(struct(
-        extra_rust_env_vars = extra_rust_env_vars if extra_rust_env_vars else {},
-        extra_build_script_env_vars = extra_build_script_env_vars if extra_build_script_env_vars else {},
-        extra_bazel_deps = extra_bazel_deps if extra_bazel_deps else {},
-        extra_build_script_bazel_deps = extra_build_script_bazel_deps if extra_build_script_bazel_deps else {},
-        extra_bazel_data_deps = extra_bazel_data_deps if extra_bazel_data_deps else {},
-        extra_build_script_bazel_data_deps = extra_build_script_bazel_data_deps if extra_build_script_bazel_data_deps else {},
+        extra_rustc_env_vars = extra_rustc_env_vars or {},
+        extra_build_script_env_vars = extra_build_script_env_vars or {},
+        extra_bazel_deps = extra_bazel_deps or {},
+        extra_build_script_bazel_deps = extra_build_script_bazel_deps or {},
+        extra_bazel_data_deps = extra_bazel_data_deps or {},
+        extra_build_script_bazel_data_deps = extra_build_script_bazel_data_deps or {},
         features_to_remove = features_to_remove,
     ))
 

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -251,9 +251,10 @@ Environment Variables:
         ),
         "lockfile": attr.label(
             doc = (
-                "The path to a file which stores pinned information about the generate dependency graph. " +
+                "The path to a file which stores pinned information about the generated dependency graph. " +
                 "this target must be a file and will be updated by the repository rule when the `REPIN` " +
-                "environment variable is set."
+                "environment variable is set.\n" +
+                "If this is not set, dependencies will be re-resolved more often, setting this allows caching resolves, but will error if the cache is stale.
             ),
             allow_single_file = True,
             mandatory = False,
@@ -298,9 +299,9 @@ def _spec(
         name,
         semver,
         features = None):
-    """A simple crate definition
+    """A simple crate definition for use in the `crate_universe` rule.
 
-    example:
+    Example:
 
     ```python
     load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
@@ -340,7 +341,7 @@ def _override(
         features_to_remove = []):
     """A map of overrides for a particular crate
 
-    example:
+    Example:
 
     ```python
     load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -253,8 +253,8 @@ Environment Variables:
             doc = (
                 "The path to a file which stores pinned information about the generated dependency graph. " +
                 "this target must be a file and will be updated by the repository rule when the `REPIN` " +
-                "environment variable is set.\n" +
-                "If this is not set, dependencies will be re-resolved more often, setting this allows caching resolves, but will error if the cache is stale.
+                "environment variable is set. If this is not set, dependencies will be re-resolved more " +
+                "often, setting this allows caching resolves, but will error if the cache is stale."
             ),
             allow_single_file = True,
             mandatory = False,

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -246,7 +246,7 @@ Environment Variables:
             allow_files = True,
         ),
         "crate_registry_template": attr.string(
-            doc = "A Crate registry url template. This must contain `{version}` and `{crate}` templates.",
+            doc = "A template for where to download crates from for the default crate registry. This must contain `{version}` and `{crate}` templates.",
             default = DEFAULT_CRATE_REGISTRY_TEMPLATE,
         ),
         "lockfile": attr.label(

--- a/crate_universe/private/BUILD.bazel
+++ b/crate_universe/private/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ["//visibility:public"])
+
+bzl_library(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+)

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -25,7 +25,7 @@ pub struct Package {
 #[serde(deny_unknown_fields)]
 pub struct Override {
     // Mapping of environment variables key -> value.
-    pub extra_rust_env_vars: BTreeMap<String, String>,
+    pub extra_rustc_env_vars: BTreeMap<String, String>,
     // Mapping of environment variables key -> value.
     pub extra_build_script_env_vars: BTreeMap<String, String>,
     // Mapping of target triple or spec -> extra bazel target dependencies.
@@ -81,7 +81,7 @@ impl Config {
                 (
                     krate,
                     ConsolidatorOverride {
-                        extra_rust_env_vars: overryde.extra_rust_env_vars,
+                        extra_rustc_env_vars: overryde.extra_rustc_env_vars,
                         extra_build_script_env_vars: overryde.extra_build_script_env_vars,
                         extra_bazel_deps: overryde.extra_bazel_deps,
                         extra_build_script_bazel_deps: overryde.extra_build_script_bazel_deps,

--- a/crate_universe/src/consolidator.rs
+++ b/crate_universe/src/consolidator.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct ConsolidatorOverride {
     // Mapping of environment variables key -> value.
-    pub extra_rust_env_vars: BTreeMap<String, String>,
+    pub extra_rustc_env_vars: BTreeMap<String, String>,
     // Mapping of environment variables key -> value.
     pub extra_build_script_env_vars: BTreeMap<String, String>,
     // Mapping of target triple or spec -> extra bazel target dependencies.
@@ -239,7 +239,7 @@ impl Consolidator {
                 // Add extra environment variables.
                 pkg.raze_settings
                     .additional_env
-                    .extend(overryde.extra_rust_env_vars.into_iter());
+                    .extend(overryde.extra_rustc_env_vars.into_iter());
                 // Add extra build script environment variables.
                 pkg.raze_settings
                     .buildrs_additional_environment_variables

--- a/crate_universe/src/resolver.rs
+++ b/crate_universe/src/resolver.rs
@@ -138,7 +138,7 @@ impl Resolver {
             for (
                 crate_name,
                 ConsolidatorOverride {
-                    extra_rust_env_vars,
+                    extra_rustc_env_vars,
                     extra_build_script_env_vars,
                     extra_bazel_deps,
                     extra_bazel_data_deps,
@@ -150,7 +150,7 @@ impl Resolver {
             {
                 hasher.update(crate_name);
                 hasher.update(b"\0");
-                for (env_key, env_val) in extra_rust_env_vars {
+                for (env_key, env_val) in extra_rustc_env_vars {
                     hasher.update(env_key);
                     hasher.update(b"\0");
                     hasher.update(env_val);

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -21,6 +21,7 @@ bzl_library(
         "@rules_rust//:rules",
         "@rules_rust//bindgen:rules",
         "@rules_rust//cargo:rules",
+        "@rules_rust//crate_universe:rules",
         "@rules_rust//proto:rules",
         "@rules_rust//rust:rules",
         "@rules_rust//wasm_bindgen:rules",
@@ -30,6 +31,10 @@ bzl_library(
 PAGES = {
     "cargo_build_script": [
         "cargo_build_script",
+    ],
+    "crate_universe": [
+        "crate_universe",
+        "crate",
     ],
     "defs": [
         "rust_binary",

--- a/docs/all.bzl
+++ b/docs/all.bzl
@@ -17,6 +17,11 @@ load(
     _cargo_build_script = "cargo_build_script",
 )
 load(
+    "@rules_rust//crate_universe:defs.bzl",
+    _crate = "crate",
+    _crate_universe = "crate_universe",
+)
+load(
     "@rules_rust//proto:proto.bzl",
     _rust_grpc_library = "rust_grpc_library",
     _rust_proto_library = "rust_proto_library",
@@ -101,3 +106,6 @@ rust_toolchain_repository_proxy = _rust_toolchain_repository_proxy
 
 rust_clippy = _rust_clippy
 rust_analyzer = _rust_analyzer
+
+crate_universe = _crate_universe
+crate = _crate

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -13,6 +13,8 @@ crate_universe(<a href="#crate_universe-name">name</a>, <a href="#crate_universe
 
 A rule for downloading Rust dependencies (crates).
 
+__WARNING__: This rule experimental and subject to change without warning.
+
 Environment Variables:
 - `REPIN`: Re-pin the lockfile if set (useful for repinning deps from multiple rulesets).
 - `RULES_RUST_REPIN`: Re-pin the lockfile if set (useful for only repinning Rust deps).
@@ -47,6 +49,8 @@ crate.spec(<a href="#crate.spec-name">name</a>, <a href="#crate.spec-semver">sem
 </pre>
 
 A simple crate definition for use in the `crate_universe` rule.
+
+__WARNING__: This rule experimental and subject to change without warning.
 
 Example:
 
@@ -86,6 +90,8 @@ crate.override(<a href="#crate.override-extra_bazel_data_deps">extra_bazel_data_
 </pre>
 
 A map of overrides for a particular crate
+
+__WARNING__: This rule experimental and subject to change without warning.
 
 Example:
 

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -28,8 +28,8 @@ Environment Variables:
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="crate_universe-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="crate_universe-cargo_toml_files"></a>cargo_toml_files |  A list of Cargo manifests (<code>Cargo.toml</code> files).   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="crate_universe-crate_registry_template"></a>crate_registry_template |  A Crate registry url template. This must contain <code>{version}</code> and <code>{crate}</code> templates.   | String | optional | "https://crates.io/api/v1/crates/{crate}/{version}/download" |
-| <a id="crate_universe-lockfile"></a>lockfile |  The path to a file which stores pinned information about the generate dependency graph. this target must be a file and will be updated by the repository rule when the <code>REPIN</code> environment variable is set.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="crate_universe-crate_registry_template"></a>crate_registry_template |  A template for where to download crates from for the default crate registry. This must contain <code>{version}</code> and <code>{crate}</code> templates.   | String | optional | "https://crates.io/api/v1/crates/{crate}/{version}/download" |
+| <a id="crate_universe-lockfile"></a>lockfile |  The path to a file which stores pinned information about the generated dependency graph. this target must be a file and will be updated by the repository rule when the <code>REPIN</code> environment variable is set. If this is not set, dependencies will be re-resolved more often, setting this allows caching resolves, but will error if the cache is stale.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="crate_universe-overrides"></a>overrides |  Mapping of crate name to specification overrides. See [crate.override](#crateoverride)  for more details.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="crate_universe-packages"></a>packages |  A list of crate specifications. See [crate.spec](#cratespec) for more details.   | List of strings | optional | [] |
 | <a id="crate_universe-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
@@ -46,9 +46,9 @@ Environment Variables:
 crate.spec(<a href="#crate.spec-name">name</a>, <a href="#crate.spec-semver">semver</a>, <a href="#crate.spec-features">features</a>)
 </pre>
 
-A simple crate definition
+A simple crate definition for use in the `crate_universe` rule.
 
-example:
+Example:
 
 ```python
 load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
@@ -87,7 +87,7 @@ crate.override(<a href="#crate.override-extra_bazel_data_deps">extra_bazel_data_
 
 A map of overrides for a particular crate
 
-example:
+Example:
 
 ```python
 load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -1,0 +1,143 @@
+# Rust rules
+* [crate_universe](#crate_universe)
+* [crate](#crate)
+
+<a id="#crate_universe"></a>
+
+## crate_universe
+
+<pre>
+crate_universe(<a href="#crate_universe-name">name</a>, <a href="#crate_universe-cargo_toml_files">cargo_toml_files</a>, <a href="#crate_universe-crate_registry_template">crate_registry_template</a>, <a href="#crate_universe-lockfile">lockfile</a>, <a href="#crate_universe-overrides">overrides</a>, <a href="#crate_universe-packages">packages</a>,
+               <a href="#crate_universe-repo_mapping">repo_mapping</a>, <a href="#crate_universe-resolver_download_url_template">resolver_download_url_template</a>, <a href="#crate_universe-resolver_sha256s">resolver_sha256s</a>, <a href="#crate_universe-supported_targets">supported_targets</a>)
+</pre>
+
+A rule for downloading Rust dependencies (crates).
+
+Environment Variables:
+- `REPIN`: Re-pin the lockfile if set (useful for repinning deps from multiple rulesets).
+- `RULES_RUST_REPIN`: Re-pin the lockfile if set (useful for only repinning Rust deps).
+- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE`: Override URL to use to download resolver binary 
+    - for local paths use a `file://` URL.
+- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE_SHA256`: An optional sha256 value for the binary at the override url location.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="crate_universe-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="crate_universe-cargo_toml_files"></a>cargo_toml_files |  A list of Cargo manifests (<code>Cargo.toml</code> files).   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="crate_universe-crate_registry_template"></a>crate_registry_template |  A Crate registry url template. This must contain <code>{version}</code> and <code>{crate}</code> templates.   | String | optional | "https://crates.io/api/v1/crates/{crate}/{version}/download" |
+| <a id="crate_universe-lockfile"></a>lockfile |  The path to a file which stores pinned information about the generate dependency graph. this target must be a file and will be updated by the repository rule when the <code>REPIN</code> environment variable is set.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="crate_universe-overrides"></a>overrides |  Mapping of crate name to specification overrides. See [crate.override](#crateoverride)  for more details.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="crate_universe-packages"></a>packages |  A list of crate specifications. See [crate.spec](#cratespec) for more details.   | List of strings | optional | [] |
+| <a id="crate_universe-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| <a id="crate_universe-resolver_download_url_template"></a>resolver_download_url_template |  URL template from which to download the resolver binary. {host_triple} and {extension} will be filled in according to the host platform.   | String | optional | "{bin}" |
+| <a id="crate_universe-resolver_sha256s"></a>resolver_sha256s |  Dictionary of host_triple -&gt; sha256 for resolver binary.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"aarch64-apple-darwin": "{aarch64-apple-darwin--sha256}", "aarch64-unknown-linux-gnu": "{aarch64-unknown-linux-gnu--sha256}", "x86_64-apple-darwin": "{x86_64-apple-darwin--sha256}", "x86_64-pc-windows-gnu": "{x86_64-pc-windows-gnu--sha256}", "x86_64-unknown-linux-gnu": "{x86_64-unknown-linux-gnu--sha256}"} |
+| <a id="crate_universe-supported_targets"></a>supported_targets |  A list of supported [platform triples](https://doc.rust-lang.org/nightly/rustc/platform-support.html) to consider when resoliving dependencies.   | List of strings | optional | ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-freebsd", "x86_64-unknown-linux-gnu"] |
+
+
+<a id="#crate.spec"></a>
+
+## crate.spec
+
+<pre>
+crate.spec(<a href="#crate.spec-name">name</a>, <a href="#crate.spec-semver">semver</a>, <a href="#crate.spec-features">features</a>)
+</pre>
+
+A simple crate definition
+
+example:
+
+```python
+load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
+
+crate_universe(
+    name = "spec_example",
+    packages = [
+        crate.spec(
+            name = "lazy_static",
+            semver = "=1.4",
+        ),
+    ],
+)
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="crate.spec-name"></a>name |  The name of the crate as it would appear in a crate registry.   |  none |
+| <a id="crate.spec-semver"></a>semver |  The desired version ([semver](https://semver.org/)) of the crate   |  none |
+| <a id="crate.spec-features"></a>features |  A list of desired [features](https://doc.rust-lang.org/cargo/reference/features.html).   |  <code>None</code> |
+
+
+<a id="#crate.override"></a>
+
+## crate.override
+
+<pre>
+crate.override(<a href="#crate.override-extra_bazel_data_deps">extra_bazel_data_deps</a>, <a href="#crate.override-extra_bazel_deps">extra_bazel_deps</a>, <a href="#crate.override-extra_build_script_bazel_data_deps">extra_build_script_bazel_data_deps</a>,
+               <a href="#crate.override-extra_build_script_bazel_deps">extra_build_script_bazel_deps</a>, <a href="#crate.override-extra_build_script_env_vars">extra_build_script_env_vars</a>, <a href="#crate.override-extra_rustc_env_vars">extra_rustc_env_vars</a>,
+               <a href="#crate.override-features_to_remove">features_to_remove</a>)
+</pre>
+
+A map of overrides for a particular crate
+
+example:
+
+```python
+load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
+
+crate_universe(
+    name = "override_example",
+    # [...]
+    overrides = {
+        "tokio": crate.override(
+            extra_rustc_env_vars = {
+                "MY_ENV_VAR": "MY_ENV_VALUE",
+            },
+            extra_build_script_env_vars = {
+                "MY_BUILD_SCRIPT_ENV_VAR": "MY_ENV_VALUE",
+            },
+            extra_bazel_deps = {
+                # Extra dependencies are per target. They are additive.
+                "cfg(unix)": ["@somerepo//:foo"],  # cfg() predicate.
+                "x86_64-apple-darwin": ["@somerepo//:bar"],  # Specific triple.
+                "cfg(all())": ["@somerepo//:baz"],  # Applies to all targets ("regular dependency").
+            },
+            extra_build_script_bazel_deps = {
+                # Extra dependencies are per target. They are additive.
+                "cfg(unix)": ["@buildscriptdep//:foo"],
+                "x86_64-apple-darwin": ["@buildscriptdep//:bar"],
+                "cfg(all())": ["@buildscriptdep//:baz"],
+            },
+            extra_bazel_data_deps = {
+                # ...
+            },
+            extra_build_script_bazel_data_deps = {
+                # ...
+            },
+        ),
+    },
+)
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="crate.override-extra_bazel_data_deps"></a>extra_bazel_data_deps |  Targets to add to the <code>data</code> attribute of the generated target (eg: [rust_library.data](./defs.md#rust_library-data)).   |  <code>None</code> |
+| <a id="crate.override-extra_bazel_deps"></a>extra_bazel_deps |  Targets to add to the <code>deps</code> attribute of the generated target (eg: [rust_library.deps](./defs.md#rust_library-data)).   |  <code>None</code> |
+| <a id="crate.override-extra_build_script_bazel_data_deps"></a>extra_build_script_bazel_data_deps |  Targets to add to the [data](./cargo_build_script.md#cargo_build_script-data) attribute of the generated <code>cargo_build_script</code> target.   |  <code>None</code> |
+| <a id="crate.override-extra_build_script_bazel_deps"></a>extra_build_script_bazel_deps |  Targets to add to the [deps](./cargo_build_script.md#cargo_build_script-deps) attribute of the generated <code>cargo_build_script</code> target.   |  <code>None</code> |
+| <a id="crate.override-extra_build_script_env_vars"></a>extra_build_script_env_vars |  Environment variables to add to the [build_script_env](./cargo_build_script.md#cargo_build_script-build_script_env) attribute of the generated <code>cargo_build_script</code> target.   |  <code>None</code> |
+| <a id="crate.override-extra_rustc_env_vars"></a>extra_rustc_env_vars |  Environment variables to add to the <code>rustc_env</code> attribute for the generated target (eg: [rust_library.rustc_env](./defs.md#rust_library-rustc_env)).   |  <code>None</code> |
+| <a id="crate.override-features_to_remove"></a>features_to_remove |  A list of features to remove from a generated target.   |  <code>[]</code> |
+
+

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -681,6 +681,6 @@ rust_test_suite(
 | :------------- | :------------- | :------------- |
 | <a id="rust_test_suite-name"></a>name |  The name of the <code>test_suite</code>.   |  none |
 | <a id="rust_test_suite-srcs"></a>srcs |  All test sources, typically <code>glob(["tests/**/*.rs"])</code>.   |  none |
-| <a id="rust_test_suite-kwargs"></a>kwargs |  Additional keyword arguments for the underyling [rust_test](#rust_test) targets. The     <code>tags</code> argument is also passed to the generated <code>test_suite</code> target.   |  none |
+| <a id="rust_test_suite-kwargs"></a>kwargs |  Additional keyword arguments for the underyling [rust_test](#rust_test) targets. The <code>tags</code> argument is also passed to the generated <code>test_suite</code> target.   |  none |
 
 

--- a/docs/docs_repositories.bzl
+++ b/docs/docs_repositories.bzl
@@ -20,8 +20,8 @@ def repositories(is_top_level = False):
         http_archive,
         name = "io_bazel_stardoc",
         urls = [
-            "https://github.com/bazelbuild/stardoc/archive/a0f330bcbae44ffc59d50a86a830a661b8d18acc.zip",
+            "https://github.com/bazelbuild/stardoc/archive/d93ee5347e2d9c225ad315094507e018364d5a67.zip",
         ],
-        sha256 = "e12831c6c414325c99325726dd26dabd8ed4c9efa7b4f27b4d1d9594ec7dfc40",
-        strip_prefix = "stardoc-a0f330bcbae44ffc59d50a86a830a661b8d18acc",
+        sha256 = "ff10a8b1503f5606fab5aa5bc9ae267272c023af7789f03caef95b5ab3fe0df2",
+        strip_prefix = "stardoc-d93ee5347e2d9c225ad315094507e018364d5a67",
     )

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1,6 +1,8 @@
 # Rust rules
 
 * [cargo_build_script](#cargo_build_script)
+* [crate](#crate)
+* [crate_universe](#crate_universe)
 * [rust_analyzer](#rust_analyzer)
 * [rust_analyzer_aspect](#rust_analyzer_aspect)
 * [rust_benchmark](#rust_benchmark)
@@ -31,6 +33,42 @@
 * [rust_wasm_bindgen](#rust_wasm_bindgen)
 * [rust_wasm_bindgen_repositories](#rust_wasm_bindgen_repositories)
 * [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
+
+
+<a id="#crate_universe"></a>
+
+## crate_universe
+
+<pre>
+crate_universe(<a href="#crate_universe-name">name</a>, <a href="#crate_universe-cargo_toml_files">cargo_toml_files</a>, <a href="#crate_universe-crate_registry_template">crate_registry_template</a>, <a href="#crate_universe-lockfile">lockfile</a>, <a href="#crate_universe-overrides">overrides</a>, <a href="#crate_universe-packages">packages</a>,
+               <a href="#crate_universe-repo_mapping">repo_mapping</a>, <a href="#crate_universe-resolver_download_url_template">resolver_download_url_template</a>, <a href="#crate_universe-resolver_sha256s">resolver_sha256s</a>, <a href="#crate_universe-supported_targets">supported_targets</a>)
+</pre>
+
+A rule for downloading Rust dependencies (crates).
+
+Environment Variables:
+- `REPIN`: Re-pin the lockfile if set (useful for repinning deps from multiple rulesets).
+- `RULES_RUST_REPIN`: Re-pin the lockfile if set (useful for only repinning Rust deps).
+- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE`: Override URL to use to download resolver binary 
+    - for local paths use a `file://` URL.
+- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE_SHA256`: An optional sha256 value for the binary at the override url location.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="crate_universe-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="crate_universe-cargo_toml_files"></a>cargo_toml_files |  A list of Cargo manifests (<code>Cargo.toml</code> files).   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="crate_universe-crate_registry_template"></a>crate_registry_template |  A Crate registry url template. This must contain <code>{version}</code> and <code>{crate}</code> templates.   | String | optional | "https://crates.io/api/v1/crates/{crate}/{version}/download" |
+| <a id="crate_universe-lockfile"></a>lockfile |  The path to a file which stores pinned information about the generate dependency graph. this target must be a file and will be updated by the repository rule when the <code>REPIN</code> environment variable is set.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="crate_universe-overrides"></a>overrides |  Mapping of crate name to specification overrides. See [crate.override](#crateoverride)  for more details.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="crate_universe-packages"></a>packages |  A list of crate specifications. See [crate.spec](#cratespec) for more details.   | List of strings | optional | [] |
+| <a id="crate_universe-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| <a id="crate_universe-resolver_download_url_template"></a>resolver_download_url_template |  URL template from which to download the resolver binary. {host_triple} and {extension} will be filled in according to the host platform.   | String | optional | "{bin}" |
+| <a id="crate_universe-resolver_sha256s"></a>resolver_sha256s |  Dictionary of host_triple -&gt; sha256 for resolver binary.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {"aarch64-apple-darwin": "{aarch64-apple-darwin--sha256}", "aarch64-unknown-linux-gnu": "{aarch64-unknown-linux-gnu--sha256}", "x86_64-apple-darwin": "{x86_64-apple-darwin--sha256}", "x86_64-pc-windows-gnu": "{x86_64-pc-windows-gnu--sha256}", "x86_64-unknown-linux-gnu": "{x86_64-unknown-linux-gnu--sha256}"} |
+| <a id="crate_universe-supported_targets"></a>supported_targets |  A list of supported [platform triples](https://doc.rust-lang.org/nightly/rustc/platform-support.html) to consider when resoliving dependencies.   | List of strings | optional | ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-freebsd", "x86_64-unknown-linux-gnu"] |
 
 
 <a id="#rust_analyzer"></a>
@@ -1321,6 +1359,109 @@ The `hello_lib` target will be build with the flags and the environment variable
 | <a id="cargo_build_script-kwargs"></a>kwargs |  Forwards to the underlying <code>rust_binary</code> rule.   |  none |
 
 
+<a id="#crate.spec"></a>
+
+## crate.spec
+
+<pre>
+crate.spec(<a href="#crate.spec-name">name</a>, <a href="#crate.spec-semver">semver</a>, <a href="#crate.spec-features">features</a>)
+</pre>
+
+A simple crate definition
+
+example:
+
+```python
+load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
+
+crate_universe(
+    name = "spec_example",
+    packages = [
+        crate.spec(
+            name = "lazy_static",
+            semver = "=1.4",
+        ),
+    ],
+)
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="crate.spec-name"></a>name |  The name of the crate as it would appear in a crate registry.   |  none |
+| <a id="crate.spec-semver"></a>semver |  The desired version ([semver](https://semver.org/)) of the crate   |  none |
+| <a id="crate.spec-features"></a>features |  A list of desired [features](https://doc.rust-lang.org/cargo/reference/features.html).   |  <code>None</code> |
+
+
+<a id="#crate.override"></a>
+
+## crate.override
+
+<pre>
+crate.override(<a href="#crate.override-extra_bazel_data_deps">extra_bazel_data_deps</a>, <a href="#crate.override-extra_bazel_deps">extra_bazel_deps</a>, <a href="#crate.override-extra_build_script_bazel_data_deps">extra_build_script_bazel_data_deps</a>,
+               <a href="#crate.override-extra_build_script_bazel_deps">extra_build_script_bazel_deps</a>, <a href="#crate.override-extra_build_script_env_vars">extra_build_script_env_vars</a>, <a href="#crate.override-extra_rustc_env_vars">extra_rustc_env_vars</a>,
+               <a href="#crate.override-features_to_remove">features_to_remove</a>)
+</pre>
+
+A map of overrides for a particular crate
+
+example:
+
+```python
+load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
+
+crate_universe(
+    name = "override_example",
+    # [...]
+    overrides = {
+        "tokio": crate.override(
+            extra_rustc_env_vars = {
+                "MY_ENV_VAR": "MY_ENV_VALUE",
+            },
+            extra_build_script_env_vars = {
+                "MY_BUILD_SCRIPT_ENV_VAR": "MY_ENV_VALUE",
+            },
+            extra_bazel_deps = {
+                # Extra dependencies are per target. They are additive.
+                "cfg(unix)": ["@somerepo//:foo"],  # cfg() predicate.
+                "x86_64-apple-darwin": ["@somerepo//:bar"],  # Specific triple.
+                "cfg(all())": ["@somerepo//:baz"],  # Applies to all targets ("regular dependency").
+            },
+            extra_build_script_bazel_deps = {
+                # Extra dependencies are per target. They are additive.
+                "cfg(unix)": ["@buildscriptdep//:foo"],
+                "x86_64-apple-darwin": ["@buildscriptdep//:bar"],
+                "cfg(all())": ["@buildscriptdep//:baz"],
+            },
+            extra_bazel_data_deps = {
+                # ...
+            },
+            extra_build_script_bazel_data_deps = {
+                # ...
+            },
+        ),
+    },
+)
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="crate.override-extra_bazel_data_deps"></a>extra_bazel_data_deps |  Targets to add to the <code>data</code> attribute of the generated target (eg: [rust_library.data](./defs.md#rust_library-data)).   |  <code>None</code> |
+| <a id="crate.override-extra_bazel_deps"></a>extra_bazel_deps |  Targets to add to the <code>deps</code> attribute of the generated target (eg: [rust_library.deps](./defs.md#rust_library-data)).   |  <code>None</code> |
+| <a id="crate.override-extra_build_script_bazel_data_deps"></a>extra_build_script_bazel_data_deps |  Targets to add to the [data](./cargo_build_script.md#cargo_build_script-data) attribute of the generated <code>cargo_build_script</code> target.   |  <code>None</code> |
+| <a id="crate.override-extra_build_script_bazel_deps"></a>extra_build_script_bazel_deps |  Targets to add to the [deps](./cargo_build_script.md#cargo_build_script-deps) attribute of the generated <code>cargo_build_script</code> target.   |  <code>None</code> |
+| <a id="crate.override-extra_build_script_env_vars"></a>extra_build_script_env_vars |  Environment variables to add to the [build_script_env](./cargo_build_script.md#cargo_build_script-build_script_env) attribute of the generated <code>cargo_build_script</code> target.   |  <code>None</code> |
+| <a id="crate.override-extra_rustc_env_vars"></a>extra_rustc_env_vars |  Environment variables to add to the <code>rustc_env</code> attribute for the generated target (eg: [rust_library.rustc_env](./defs.md#rust_library-rustc_env)).   |  <code>None</code> |
+| <a id="crate.override-features_to_remove"></a>features_to_remove |  A list of features to remove from a generated target.   |  <code>[]</code> |
+
+
 <a id="#rust_bindgen_library"></a>
 
 ## rust_bindgen_library
@@ -1374,7 +1515,7 @@ Declare dependencies needed for proto compilation.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain)     (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies     that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
+| <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain) (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
 
 
 <a id="#rust_repositories"></a>
@@ -1438,12 +1579,12 @@ N.B. A "proxy repository" is needed to allow for registering the toolchain (with
 | <a id="rust_repository_set-name"></a>name |  The name of the generated repository   |  none |
 | <a id="rust_repository_set-version"></a>version |  The version of the tool among "nightly", "beta', or an exact version.   |  none |
 | <a id="rust_repository_set-exec_triple"></a>exec_triple |  The Rust-style target that this compiler runs on   |  none |
-| <a id="rust_repository_set-extra_target_triples"></a>extra_target_triples |  Additional rust-style targets that this set of     toolchains should support. Defaults to [].   |  <code>[]</code> |
+| <a id="rust_repository_set-extra_target_triples"></a>extra_target_triples |  Additional rust-style targets that this set of toolchains should support. Defaults to [].   |  <code>[]</code> |
 | <a id="rust_repository_set-iso_date"></a>iso_date |  The date of the tool. Defaults to None.   |  <code>None</code> |
-| <a id="rust_repository_set-rustfmt_version"></a>rustfmt_version |  The version of rustfmt to be associated with the     toolchain. Defaults to None.   |  <code>None</code> |
+| <a id="rust_repository_set-rustfmt_version"></a>rustfmt_version |  The version of rustfmt to be associated with the toolchain. Defaults to None.   |  <code>None</code> |
 | <a id="rust_repository_set-edition"></a>edition |  The rust edition to be used by default (2015 (if None) or 2018).   |  <code>None</code> |
-| <a id="rust_repository_set-dev_components"></a>dev_components |  Whether to download the rustc-dev components.     Requires version to be "nightly". Defaults to False.   |  <code>False</code> |
-| <a id="rust_repository_set-sha256s"></a>sha256s |  A dict associating tool subdirectories to sha256 hashes. See     [rust_repositories](#rust_repositories) for more details.   |  <code>None</code> |
+| <a id="rust_repository_set-dev_components"></a>dev_components |  Whether to download the rustc-dev components. Requires version to be "nightly". Defaults to False.   |  <code>False</code> |
+| <a id="rust_repository_set-sha256s"></a>sha256s |  A dict associating tool subdirectories to sha256 hashes. See [rust_repositories](#rust_repositories) for more details.   |  <code>None</code> |
 | <a id="rust_repository_set-urls"></a>urls |  A list of mirror urls containing the tools from the Rust-lang static file server. These must contain the '{}' used to substitute the tool being fetched (using .format). Defaults to ['https://static.rust-lang.org/dist/{}.tar.gz']   |  <code>["https://static.rust-lang.org/dist/{}.tar.gz"]</code> |
 
 
@@ -1508,7 +1649,7 @@ rust_test_suite(
 | :------------- | :------------- | :------------- |
 | <a id="rust_test_suite-name"></a>name |  The name of the <code>test_suite</code>.   |  none |
 | <a id="rust_test_suite-srcs"></a>srcs |  All test sources, typically <code>glob(["tests/**/*.rs"])</code>.   |  none |
-| <a id="rust_test_suite-kwargs"></a>kwargs |  Additional keyword arguments for the underyling [rust_test](#rust_test) targets. The     <code>tags</code> argument is also passed to the generated <code>test_suite</code> target.   |  none |
+| <a id="rust_test_suite-kwargs"></a>kwargs |  Additional keyword arguments for the underyling [rust_test](#rust_test) targets. The <code>tags</code> argument is also passed to the generated <code>test_suite</code> target.   |  none |
 
 
 <a id="#rust_wasm_bindgen_repositories"></a>
@@ -1526,6 +1667,6 @@ Declare dependencies needed for [rust_wasm_bindgen](#rust_wasm_bindgen).
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="rust_wasm_bindgen_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)     (<code>@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain</code>) is registered. This toolchain requires a set of dependencies     that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
+| <a id="rust_wasm_bindgen_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain) (<code>@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
 
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -61,8 +61,8 @@ Environment Variables:
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="crate_universe-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="crate_universe-cargo_toml_files"></a>cargo_toml_files |  A list of Cargo manifests (<code>Cargo.toml</code> files).   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="crate_universe-crate_registry_template"></a>crate_registry_template |  A Crate registry url template. This must contain <code>{version}</code> and <code>{crate}</code> templates.   | String | optional | "https://crates.io/api/v1/crates/{crate}/{version}/download" |
-| <a id="crate_universe-lockfile"></a>lockfile |  The path to a file which stores pinned information about the generate dependency graph. this target must be a file and will be updated by the repository rule when the <code>REPIN</code> environment variable is set.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="crate_universe-crate_registry_template"></a>crate_registry_template |  A template for where to download crates from for the default crate registry. This must contain <code>{version}</code> and <code>{crate}</code> templates.   | String | optional | "https://crates.io/api/v1/crates/{crate}/{version}/download" |
+| <a id="crate_universe-lockfile"></a>lockfile |  The path to a file which stores pinned information about the generated dependency graph. this target must be a file and will be updated by the repository rule when the <code>REPIN</code> environment variable is set. If this is not set, dependencies will be re-resolved more often, setting this allows caching resolves, but will error if the cache is stale.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="crate_universe-overrides"></a>overrides |  Mapping of crate name to specification overrides. See [crate.override](#crateoverride)  for more details.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="crate_universe-packages"></a>packages |  A list of crate specifications. See [crate.spec](#cratespec) for more details.   | List of strings | optional | [] |
 | <a id="crate_universe-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
@@ -1367,9 +1367,9 @@ The `hello_lib` target will be build with the flags and the environment variable
 crate.spec(<a href="#crate.spec-name">name</a>, <a href="#crate.spec-semver">semver</a>, <a href="#crate.spec-features">features</a>)
 </pre>
 
-A simple crate definition
+A simple crate definition for use in the `crate_universe` rule.
 
-example:
+Example:
 
 ```python
 load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")
@@ -1408,7 +1408,7 @@ crate.override(<a href="#crate.override-extra_bazel_data_deps">extra_bazel_data_
 
 A map of overrides for a particular crate
 
-example:
+Example:
 
 ```python
 load("@rules_rust//crate_universe:defs.bzl", "crate_universe", "crate")

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -46,6 +46,8 @@ crate_universe(<a href="#crate_universe-name">name</a>, <a href="#crate_universe
 
 A rule for downloading Rust dependencies (crates).
 
+__WARNING__: This rule experimental and subject to change without warning.
+
 Environment Variables:
 - `REPIN`: Re-pin the lockfile if set (useful for repinning deps from multiple rulesets).
 - `RULES_RUST_REPIN`: Re-pin the lockfile if set (useful for only repinning Rust deps).
@@ -1369,6 +1371,8 @@ crate.spec(<a href="#crate.spec-name">name</a>, <a href="#crate.spec-semver">sem
 
 A simple crate definition for use in the `crate_universe` rule.
 
+__WARNING__: This rule experimental and subject to change without warning.
+
 Example:
 
 ```python
@@ -1407,6 +1411,8 @@ crate.override(<a href="#crate.override-extra_bazel_data_deps">extra_bazel_data_
 </pre>
 
 A map of overrides for a particular crate
+
+__WARNING__: This rule experimental and subject to change without warning.
 
 Example:
 

--- a/docs/rust_proto.md
+++ b/docs/rust_proto.md
@@ -162,6 +162,6 @@ Declare dependencies needed for proto compilation.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain)     (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies     that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
+| <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain) (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
 
 

--- a/docs/rust_repositories.md
+++ b/docs/rust_repositories.md
@@ -201,12 +201,12 @@ N.B. A "proxy repository" is needed to allow for registering the toolchain (with
 | <a id="rust_repository_set-name"></a>name |  The name of the generated repository   |  none |
 | <a id="rust_repository_set-version"></a>version |  The version of the tool among "nightly", "beta', or an exact version.   |  none |
 | <a id="rust_repository_set-exec_triple"></a>exec_triple |  The Rust-style target that this compiler runs on   |  none |
-| <a id="rust_repository_set-extra_target_triples"></a>extra_target_triples |  Additional rust-style targets that this set of     toolchains should support. Defaults to [].   |  <code>[]</code> |
+| <a id="rust_repository_set-extra_target_triples"></a>extra_target_triples |  Additional rust-style targets that this set of toolchains should support. Defaults to [].   |  <code>[]</code> |
 | <a id="rust_repository_set-iso_date"></a>iso_date |  The date of the tool. Defaults to None.   |  <code>None</code> |
-| <a id="rust_repository_set-rustfmt_version"></a>rustfmt_version |  The version of rustfmt to be associated with the     toolchain. Defaults to None.   |  <code>None</code> |
+| <a id="rust_repository_set-rustfmt_version"></a>rustfmt_version |  The version of rustfmt to be associated with the toolchain. Defaults to None.   |  <code>None</code> |
 | <a id="rust_repository_set-edition"></a>edition |  The rust edition to be used by default (2015 (if None) or 2018).   |  <code>None</code> |
-| <a id="rust_repository_set-dev_components"></a>dev_components |  Whether to download the rustc-dev components.     Requires version to be "nightly". Defaults to False.   |  <code>False</code> |
-| <a id="rust_repository_set-sha256s"></a>sha256s |  A dict associating tool subdirectories to sha256 hashes. See     [rust_repositories](#rust_repositories) for more details.   |  <code>None</code> |
+| <a id="rust_repository_set-dev_components"></a>dev_components |  Whether to download the rustc-dev components. Requires version to be "nightly". Defaults to False.   |  <code>False</code> |
+| <a id="rust_repository_set-sha256s"></a>sha256s |  A dict associating tool subdirectories to sha256 hashes. See [rust_repositories](#rust_repositories) for more details.   |  <code>None</code> |
 | <a id="rust_repository_set-urls"></a>urls |  A list of mirror urls containing the tools from the Rust-lang static file server. These must contain the '{}' used to substitute the tool being fetched (using .format). Defaults to ['https://static.rust-lang.org/dist/{}.tar.gz']   |  <code>["https://static.rust-lang.org/dist/{}.tar.gz"]</code> |
 
 

--- a/docs/rust_wasm_bindgen.md
+++ b/docs/rust_wasm_bindgen.md
@@ -102,6 +102,6 @@ Declare dependencies needed for [rust_wasm_bindgen](#rust_wasm_bindgen).
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="rust_wasm_bindgen_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)     (<code>@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain</code>) is registered. This toolchain requires a set of dependencies     that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
+| <a id="rust_wasm_bindgen_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain) (<code>@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
 
 


### PR DESCRIPTION
Additionally, this renames `crate.override.extra_rust_env_vars` to `crate.override.extra_rustc_env_vars` to be more consistent with the behavior of that field