### PR TITLE
Updated wasm-bindgen docs and added rust-analyzer docs 

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -58,6 +58,7 @@ PAGES = dict([
     ),
     page(
         name = "rust_analyzer",
+        header_template = ":rust_analyzer.vm",
         symbols = [
             "rust_analyzer",
             "rust_analyzer_aspect",

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -108,6 +108,7 @@ PAGES = dict([
     ),
     page(
         name = "rust_wasm_bindgen",
+        header_template = ":rust_wasm_bindgen.vm",
         symbols = [
             "rust_wasm_bindgen_repositories",
             "rust_wasm_bindgen_toolchain",

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -83,6 +83,7 @@ rust_analyzer(<a href="#rust_analyzer-name">name</a>, <a href="#rust_analyzer-ta
 
 Produces a rust-project.json for the given targets. Configure rust-analyzer to load the generated file via the linked projects mechanism.
 
+
 **ATTRIBUTES**
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,11 @@ supported in certain environments.
 
 You can also browse the [full API in one page](flatten.md).
 
+### Experimental rules
+
+- [crate_universe](crate_universe.md): A repository rule for fetching dependencies from a crate registry.
+- [rust_analyzer](rust_analyzer.md): rules for generating `rust-project.json` files for [rust-analyzer](https://rust-analyzer.github.io/)
+
 ## Specifying Rust version
 
 To build with a particular version of the Rust compiler, pass that version to [`rust_repositories`](flatten.md#rust_repositories):

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "e6d835ee673f388aa5b62dc23d82db8fc76497e93fa47d8a4afe97abaf09b10d",
-    strip_prefix = "rules_rust-f37b9d6a552e9412285e627f30cb124e709f4f7a",
+    sha256 = "18c0a02a007cd26c3f5b4d21dc26a80af776ef755460028a796bc61c649fdf3f",
+    strip_prefix = "rules_rust-467a301fd665db344803c1d8a2401ec2bf8c74ce",
     urls = [
-        # Master branch as of 2021-01-27
-        "https://github.com/bazelbuild/rules_rust/archive/f37b9d6a552e9412285e627f30cb124e709f4f7a.tar.gz",
+        # Master branch as of 2021-04-23
+        "https://github.com/bazelbuild/rules_rust/archive/467a301fd665db344803c1d8a2401ec2bf8c74ce.tar.gz",
     ],
 )
 
@@ -44,7 +44,7 @@ supported in certain environments.
 - [rust_proto](rust_proto.md): rules for generating [protobuf](https://developers.google.com/protocol-buffers).
   and [gRPC](https://grpc.io) stubs.
 - [rust_bindgen](rust_bindgen.md): rules for generating C++ bindings.
-- [rust_wasm_bindgen](rust_wasm_bindgen.md): rules for generating WebAssembly bindings, see the section about [WebAssembly](#webassembly).
+- [rust_wasm_bindgen](rust_wasm_bindgen.md): rules for generating [WebAssembly](https://www.rust-lang.org/what/wasm) bindings.
 - [cargo_build_script](cargo_build_script.md): a rule to run [`build.rs` script](https://doc.rust-lang.org/cargo/reference/build-scripts.html) from Bazel.
 
 You can also browse the [full API in one page](flatten.md).
@@ -76,22 +76,5 @@ rust_repositories(rustfmt_version = "1.51.0")
 
 ## External Dependencies
 
-Currently the most common approach to managing external dependencies is using
+Currently, the most common approach to managing external dependencies is using
 [cargo-raze](https://github.com/google/cargo-raze) to generate `BUILD` files for Cargo crates.
-
-## WebAssembly
-
-To build a `rust_binary` for `wasm32-unknown-unknown` target add the `--platforms=@rules_rust//rust/platform:wasm` flag.
-
-```command
-bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasm
-```
-
-To build a `rust_binary` for `wasm32-wasi` target add the `--platforms=@rules_rust//rust/platform:wasi` flag.
-
-```command
-bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasi
-```
-
-`rust_wasm_bindgen` will automatically transition to the `wasm` platform and can be used when
-building WebAssembly code for the host target.

--- a/docs/rust_analyzer.md
+++ b/docs/rust_analyzer.md
@@ -3,6 +3,84 @@
 * [rust_analyzer](#rust_analyzer)
 * [rust_analyzer_aspect](#rust_analyzer_aspect)
 
+
+## Overview
+
+For [non-Cargo projects](https://rust-analyzer.github.io/manual.html#non-cargo-based-projects),
+[rust-analyzer](https://rust-analyzer.github.io/) depends on a `rust-project.json` file at the
+root of the project that describes its structure. The `rust_analyzer` rule facilitates generating 
+such a file.
+
+### Setup
+
+First, add the following to the `WORKSPACE` file:
+
+```python
+load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_deps")
+
+rust_analyzer_deps()
+```
+
+Then, add a rule to the root `BUILD` file like the following.
+
+```python
+load("@rules_rust//rust:defs.bzl", "rust_analyzer")
+
+rust_analyzer(
+    name = "rust_analyzer",
+    targets = [
+        # all the binary/library targets you want in the rust-project.json
+    ],
+)
+```
+
+A list of `rust_analyzer` compatible targets can be found by usign the following query:
+
+```bash
+bazel query 'kind("rust_*library|rust_binary", //...:all)'
+```
+
+Note that visibility rules apply.
+
+Run `bazel run @rules_rust//tools/rust_analyzer:gen_rust_project` whenever
+dependencies change to regenerate the `rust-project.json` file. It should be
+added to `.gitignore` because it is effectively a build artifact. Once the
+`rust-project.json` has been generated in the project root, rust-analyzer can
+pick it up upon restart.
+
+#### VSCode
+
+To set this up using [VSCode](https://code.visualstudio.com/), users should first install the
+[rust_analyzer plugin](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer).
+With that in place, the following task can be added to the `.vscode/tasks.json` file of the workspace
+to ensure a `rust-project.json` file is created and up to date when the editor is opened.
+
+```json
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Generate rust-project.json",
+            "command": "bazel",
+            "args": ["run", "@rules_rust//tools/rust_analyzer:gen_rust_project"],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "problemMatcher": [],
+            "presentation": {
+                "reveal": "never",
+                "panel": "dedicated",
+            },
+            "runOptions": {
+                "runOn": "folderOpen"
+            }
+        },
+    ]
+}
+```
+
+
 <a id="#rust_analyzer"></a>
 
 ## rust_analyzer
@@ -12,6 +90,7 @@ rust_analyzer(<a href="#rust_analyzer-name">name</a>, <a href="#rust_analyzer-ta
 </pre>
 
 Produces a rust-project.json for the given targets. Configure rust-analyzer to load the generated file via the linked projects mechanism.
+
 
 **ATTRIBUTES**
 

--- a/docs/rust_analyzer.vm
+++ b/docs/rust_analyzer.vm
@@ -1,0 +1,77 @@
+#[[
+## Overview
+
+For [non-Cargo projects](https://rust-analyzer.github.io/manual.html#non-cargo-based-projects),
+[rust-analyzer](https://rust-analyzer.github.io/) depends on a `rust-project.json` file at the
+root of the project that describes its structure. The `rust_analyzer` rule facilitates generating 
+such a file.
+
+### Setup
+
+First, add the following to the `WORKSPACE` file:
+
+```python
+load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_deps")
+
+rust_analyzer_deps()
+```
+
+Then, add a rule to the root `BUILD` file like the following.
+
+```python
+load("@rules_rust//rust:defs.bzl", "rust_analyzer")
+
+rust_analyzer(
+    name = "rust_analyzer",
+    targets = [
+        # all the binary/library targets you want in the rust-project.json
+    ],
+)
+```
+
+A list of `rust_analyzer` compatible targets can be found by usign the following query:
+
+```bash
+bazel query 'kind("rust_*library|rust_binary", //...:all)'
+```
+
+Note that visibility rules apply.
+
+Run `bazel run @rules_rust//tools/rust_analyzer:gen_rust_project` whenever
+dependencies change to regenerate the `rust-project.json` file. It should be
+added to `.gitignore` because it is effectively a build artifact. Once the
+`rust-project.json` has been generated in the project root, rust-analyzer can
+pick it up upon restart.
+
+#### VSCode
+
+To set this up using [VSCode](https://code.visualstudio.com/), users should first install the
+[rust_analyzer plugin](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer).
+With that in place, the following task can be added to the `.vscode/tasks.json` file of the workspace
+to ensure a `rust-project.json` file is created and up to date when the editor is opened.
+
+```json
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Generate rust-project.json",
+            "command": "bazel",
+            "args": ["run", "@rules_rust//tools/rust_analyzer:gen_rust_project"],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "problemMatcher": [],
+            "presentation": {
+                "reveal": "never",
+                "panel": "dedicated",
+            },
+            "runOptions": {
+                "runOn": "folderOpen"
+            }
+        },
+    ]
+}
+```
+]]#

--- a/docs/rust_wasm_bindgen.md
+++ b/docs/rust_wasm_bindgen.md
@@ -4,6 +4,25 @@
 * [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
 * [rust_wasm_bindgen](#rust_wasm_bindgen)
 
+
+## Overview
+
+To build a `rust_binary` for `wasm32-unknown-unknown` target add the `--platforms=@rules_rust//rust/platform:wasm` flag.
+
+```command
+bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasm
+```
+
+To build a `rust_binary` for `wasm32-wasi` target add the `--platforms=@rules_rust//rust/platform:wasi` flag.
+
+```command
+bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasi
+```
+
+`rust_wasm_bindgen` will automatically transition to the `wasm` platform and can be used when
+building WebAssembly code for the host target.
+
+
 <a id="#rust_wasm_bindgen"></a>
 
 ## rust_wasm_bindgen

--- a/docs/rust_wasm_bindgen.vm
+++ b/docs/rust_wasm_bindgen.vm
@@ -1,0 +1,18 @@
+#[[
+## Overview
+
+To build a `rust_binary` for `wasm32-unknown-unknown` target add the `--platforms=@rules_rust//rust/platform:wasm` flag.
+
+```command
+bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasm
+```
+
+To build a `rust_binary` for `wasm32-wasi` target add the `--platforms=@rules_rust//rust/platform:wasi` flag.
+
+```command
+bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasi
+```
+
+`rust_wasm_bindgen` will automatically transition to the `wasm` platform and can be used when
+building WebAssembly code for the host target.
+]]#

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -171,7 +171,7 @@ def create_crate(ctx, info, crate_mapping):
 # cargo_build_script rules. This would require a genrule to actually construct
 # the JSON, rather than being able to build it completly in starlark.
 # TODO(djmarcin): Run the cargo_build_scripts to gather env vars correctly.
-def _rust_project_impl(ctx):
+def _rust_analyzer_impl(ctx):
     rust_toolchain = find_toolchain(ctx)
     sysroot_src = _exec_root_tmpl + rust_toolchain.rust_lib.label.workspace_root + "/lib/rustlib/src/library"
 
@@ -215,8 +215,10 @@ rust_analyzer = rule(
     outputs = {
         "filename": "rust-project.json",
     },
-    implementation = _rust_project_impl,
+    implementation = _rust_analyzer_impl,
     toolchains = [str(Label("//rust:toolchain"))],
     incompatible_use_toolchain_transition = True,
-    doc = "Produces a rust-project.json for the given targets. Configure rust-analyzer to load the generated file via the linked projects mechanism.",
+    doc = """\
+Produces a rust-project.json for the given targets. Configure rust-analyzer to load the generated file via the linked projects mechanism.
+""",
 )

--- a/tools/rust_analyzer/BUILD.bazel
+++ b/tools/rust_analyzer/BUILD.bazel
@@ -1,7 +1,4 @@
-load(
-    "//rust:rust.bzl",
-    "rust_binary",
-)
+load("//rust:defs.bzl", "rust_binary")
 
 rust_binary(
     name = "gen_rust_project",

--- a/tools/rust_analyzer/deps.bzl
+++ b/tools/rust_analyzer/deps.bzl
@@ -4,5 +4,8 @@ The dependencies for running the gen_rust_project binary.
 
 load("//tools/rust_analyzer/raze:crates.bzl", "rules_rust_tools_rust_analyzer_fetch_remote_crates")
 
-def gen_rust_project_dependencies():
+def rust_analyzer_deps():
     rules_rust_tools_rust_analyzer_fetch_remote_crates()
+
+# For legacy support
+gen_rust_project_dependencies = rust_analyzer_deps


### PR DESCRIPTION
Special thanks to @yagehu for writing the bulk of the `rust-analyzer` docs (https://github.com/bazelbuild/rules_rust/pull/649)!!

The changes here reduce the noise in the top landing page of the docs and move rule specific information into the page that covers them.