### PR TITLE
Run basic crate_universe example on Windows

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -145,17 +145,18 @@ tasks:
     environment:
       RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP: true
     working_directory: examples/crate_universe
+    build_flags:
+      - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts
     crate_universe_windows_targets: &crate_universe_windows_targets
       - "//..."
       # TODO: There are windows specific build issues in the generated
-      # depednencies. This should be fixed and all testing enabled.
-      - "-//basic:test"
+      # dependencies. This should be fixed and all testing enabled.
       - "-//has_aliased_deps/..."
       - "-//uses_proc_macro/..."
       - "-//uses_sys_crate/..."
     build_targets: *crate_universe_windows_targets
     # TODO: fix test targets in `crate_universe_windows_targets`
-    # test_targets: *crate_universe_windows_targets
+    test_targets: *crate_universe_windows_targets
 buildifier:
   version: latest
   warnings: "all"


### PR DESCRIPTION
We already disable all sys crates from our tests, so this is keeping in
that fashion. Looks like the issues here aren't crate_universe specific.