### PR TITLE
Added github actions for performing releases

### DIFF
--- a/.github/workflows/release_begin.yaml
+++ b/.github/workflows/release_begin.yaml
@@ -1,20 +1,18 @@
 ---
-name: Crate Universe CI+CD
+name: Release
 on:
-  push:
-    branches:
-      - main
-    paths:
-      # Only run these jobs if rust code has changed since they're time consuming
-      - ".github/workflows/crate_universe.yaml"
-      - "crate_universe/**"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The new version to release"
+        required: true
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  build:
+  crate_universe_builds:
     if: ${{ github.repository_owner == 'bazelbuild' }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -43,6 +41,8 @@ jobs:
               EXTENSION: ""
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: "${{ github.base_ref }}"
       - run: |
           # Install cross
           if [[ "${RUNNER_OS}" == "macOS" ]]; then
@@ -81,27 +81,36 @@ jobs:
           if-no-files-found: error
   release:
     if: ${{ github.repository_owner == 'bazelbuild' }}
-    needs: build
+    needs: crate_universe_builds
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
-          # Save the git credentials so we can commit back to the repo
-          persist-credentials: true
+          ref: main
+      - run: |
+          # Write new releases file
+          cat << EOF > ${{ github.workspace }}/version.bzl
+          """The version of rules_rust."""
+
+          VERSION = "${{ github.event.inputs.version }}"
+          EOF
+      - run: |
+          # Get release candidate number
+          git fetch origin &> /dev/null
+          num_tags="$(git tag -l | grep "${{ github.event.inputs.version }}" | wc -l | xargs || true)"
+          echo "RELEASE_CANDIDATE_NUMBER=$( echo "${num_tags}" | python3 -c 'import sys; print(int(sys.stdin.read().strip()) + 1)')" >> $GITHUB_ENV
       - uses: actions/download-artifact@v2
         with:
           path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin
       - run: |
-          # Ensure all files are executable
-          chmod +x ${{ github.workspace }}/crate_universe/private/bootstrap/bin/*/release/*
-      - run: |
-          # Write new defaults.bzl file
+          # Write new crate_universe defaults.bzl file
           # Copy the new template
           cp ${{ github.workspace }}/crate_universe/private/defaults.bzl.template ${{ github.workspace }}/crate_universe/private/defaults.bzl
 
-          # Replace the url
-          url="$(echo $URL | sed 's|releases/tag/|releases/download/|')/crate_universe_resolver-{host_triple}{extension}"
+          # Generate the release URL
+          url="${URL_PREFIX}/crate_universe_resolver-{host_triple}{extension}"
           sed -i "s|{DEFAULT_URL_TEMPLATE}|${url}|" ${{ github.workspace }}/crate_universe/private/defaults.bzl
+          sed -i "s|{rc}|${RELEASE_CANDIDATE_NUMBER}|" ${{ github.workspace }}/crate_universe/private/defaults.bzl
 
           # Populate all sha256 values
           TARGETS=(
@@ -120,36 +129,25 @@ jobs:
             sha256="$(shasum --algorithm 256 ${{ github.workspace }}/crate_universe/private/bootstrap/bin/${triple}/release/${bin_name} | awk '{ print $1 }')"
             sed -i "s|{${triple}--sha256}|${sha256}|" ${{ github.workspace }}/crate_universe/private/defaults.bzl
           done
-
-          cat << EOF > ${{ github.workspace }}/tag_message.txt
-          From commit: ${GITHUB_SHA}
-
-          \`crate_universe_defaults.bzl\`:
-
-          \`\`\`python
-          $(cat ${{ github.workspace }}/crate_universe/private/defaults.bzl)
-          \`\`\`
-          EOF
         env:
-          # This url should match ${{ steps.crate_universe_release.outputs.html_url }} but because this step runs before
-          # `crate_universe_release` we hard code the url to be what we expect the release URL to be.
-          URL: https://github.com/bazelbuild/rules_rust/releases/download/crate_universe-${{ github.run_number }}
+          URL_PREFIX: https://github.com/${{ github.repository_owner }}/rules_rust/releases/download/${{ github.event.inputs.version }}
       - uses: actions/create-release@v1
-        id: crate_universe_release
+        id: rules_rust_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prerelease: true
-          tag_name: crate_universe-${{ github.run_number }}
-          release_name: crate_universe-${{ github.run_number }}
-          body_path: ${{ github.workspace }}/tag_message.txt
+          tag_name: ${{ github.event.inputs.version }}rc-${{ env.RELEASE_CANDIDATE_NUMBER }}
+          release_name: ${{ github.event.inputs.version }}rc-${{ env.RELEASE_CANDIDATE_NUMBER }}
+          body: ${{ github.event.inputs.version }}rc-${{ env.RELEASE_CANDIDATE_NUMBER }}
+          commitish: main
       # There must be a upload action for each platform triple we create
       - name: "Upload aarch64-apple-darwin"
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.crate_universe_release.outputs.upload_url }}
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
           asset_name: crate_universe_resolver-aarch64-apple-darwin
           asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/aarch64-apple-darwin/release/crate_universe_resolver
           asset_content_type: application/octet-stream
@@ -158,7 +156,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.crate_universe_release.outputs.upload_url }}
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
           asset_name: crate_universe_resolver-aarch64-unknown-linux-gnu
           asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/aarch64-unknown-linux-gnu/release/crate_universe_resolver
           asset_content_type: application/octet-stream
@@ -167,7 +165,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.crate_universe_release.outputs.upload_url }}
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
           asset_name: crate_universe_resolver-x86_64-apple-darwin
           asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/x86_64-apple-darwin/release/crate_universe_resolver
           asset_content_type: application/octet-stream
@@ -176,7 +174,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.crate_universe_release.outputs.upload_url }}
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
           asset_name: crate_universe_resolver-x86_64-pc-windows-gnu.exe
           asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/x86_64-pc-windows-gnu/release/crate_universe_resolver.exe
           asset_content_type: application/octet-stream
@@ -185,7 +183,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.crate_universe_release.outputs.upload_url }}
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
           asset_name: crate_universe_resolver-x86_64-unknown-linux-gnu
           asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/x86_64-unknown-linux-gnu/release/crate_universe_resolver
           asset_content_type: application/octet-stream
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          title: Release ${{ github.event.inputs.version }}
+          commit-message: release ${{ github.event.inputs.version }}
+          branch: release/${{ github.event.inputs.version }}
+          delete-branch: true
+          body: Release ${{ github.event.inputs.version }}

--- a/.github/workflows/release_finish.yaml
+++ b/.github/workflows/release_finish.yaml
@@ -1,0 +1,122 @@
+---
+name: Release Finalize
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Only trigger for new releases
+      - "version.bzl"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    if: ${{ github.repository_owner == 'bazelbuild' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          # Get current release version
+          git fetch origin &> /dev/null
+          RELEASE_VERSION=$(cat version.bzl | grep VERSION | sed 's/VERSION = "//' | sed 's/"//')
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+
+          # Get release candidate number
+          echo "RELEASE_CANDIDATE_NUMBER=$(git tag -l | grep "${RELEASE_VERSION}" | wc -l | xargs || true)" >> $GITHUB_ENV
+      - run: |
+          # Ensure there is at least 1 release candidate in the environment
+          if [[ -z "${RELEASE_CANDIDATE_NUMBER}" ]]; then
+            exit 1
+          elif [[ "${RELEASE_CANDIDATE_NUMBER}" -eq "0" ]]; then
+            exit 1
+          fi
+      - run: |
+          # Download all artifacts from the release candidate
+          TARGETS=(
+            aarch64-apple-darwin
+            aarch64-unknown-linux-gnu
+            x86_64-apple-darwin
+            x86_64-pc-windows-gnu
+            x86_64-unknown-linux-gnu
+          )
+
+          for triple in ${TARGETS[@]}; do
+            if [[ "${triple}" == *"windows"* ]]; then
+                ext=".exe"
+            else
+                ext=""
+            fi
+            resolver="${ARTIFACT_DIR}/${triple}/release/crate_universe_resolver${ext}"
+            mkdir -p "$(dirname "${resolver}")"
+            url="${ARTIFACT_URL}/crate_universe_resolver-${triple}${ext}"
+            echo "Downloading '${url}' to '${resolver}'"
+            curl --fail -Lo "${resolver}" "${url}"
+            sha256="$(shasum --algorithm 256 "${resolver}" | awk '{ print $1 }')"
+
+            if [[ -z "$(grep ${sha256} ${{ github.workspace }}/crate_universe/private/defaults.bzl)" ]]; then
+              echo "Unexpected sha256 value from `${url}`: got ${sha256}, expected value in `defaults.bzl`"
+              exit 1
+            fi
+          done
+        env:
+          ARTIFACT_URL: https://github.com/${{ github.repository_owner }}/rules_rust/releases/download/${{env.RELEASE_VERSION}}rc-${{ env.RELEASE_CANDIDATE_NUMBER }}
+          ARTIFACT_DIR: ${{ github.workspace }}/crate_universe/private/bootstrap/bin
+      - uses: actions/create-release@v1
+        id: rules_rust_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          prerelease: true
+          tag_name: ${{env.RELEASE_VERSION}}
+          release_name: ${{env.RELEASE_VERSION}}
+          body: ${{env.RELEASE_VERSION}}
+          commitish: ${{ github.base_ref }}
+      # There must be a upload action for each platform triple we create
+      - name: "Upload aarch64-apple-darwin"
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
+          asset_name: crate_universe_resolver-aarch64-apple-darwin
+          asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/aarch64-apple-darwin/release/crate_universe_resolver
+          asset_content_type: application/octet-stream
+      - name: "Upload aarch64-unknown-linux-gnu"
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
+          asset_name: crate_universe_resolver-aarch64-unknown-linux-gnu
+          asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/aarch64-unknown-linux-gnu/release/crate_universe_resolver
+          asset_content_type: application/octet-stream
+      - name: "Upload x86_64-apple-darwin"
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
+          asset_name: crate_universe_resolver-x86_64-apple-darwin
+          asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/x86_64-apple-darwin/release/crate_universe_resolver
+          asset_content_type: application/octet-stream
+      - name: "Upload x86_64-pc-windows-gnu"
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
+          asset_name: crate_universe_resolver-x86_64-pc-windows-gnu.exe
+          asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/x86_64-pc-windows-gnu/release/crate_universe_resolver.exe
+          asset_content_type: application/octet-stream
+      - name: "Upload x86_64-unknown-linux-gnu"
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
+          asset_name: crate_universe_resolver-x86_64-unknown-linux-gnu
+          asset_path: ${{ github.workspace }}/crate_universe/private/bootstrap/bin/x86_64-unknown-linux-gnu/release/crate_universe_resolver
+          asset_content_type: application/octet-stream

--- a/crate_universe/private/defaults.bzl
+++ b/crate_universe/private/defaults.bzl
@@ -1,10 +1,11 @@
-"""A helper module defining generated information about crate_universe dependencies"""
+"""A module defining generated information about crate_universe dependencies"""
 
 # This global should match the current release of `crate_unvierse`.
-DEFAULT_URL_TEMPLATE = "{bin}"
+DEFAULT_URL_TEMPLATE = "{host_triple}{extension}"
 
 # Note that if any additional platforms are added here, the pipeline defined
-# by `create_universe.yaml` should also be updated
+# by `pre-release.yaml` should also be updated. The current shas are from
+# release canddidate {rc}
 DEFAULT_SHA256_CHECKSUMS = {
     "aarch64-apple-darwin": "{aarch64-apple-darwin--sha256}",
     "aarch64-unknown-linux-gnu": "{aarch64-unknown-linux-gnu--sha256}",

--- a/crate_universe/private/defaults.bzl.template
+++ b/crate_universe/private/defaults.bzl.template
@@ -1,10 +1,11 @@
-"""A helper module defining generated information about crate_universe dependencies"""
+"""A module defining generated information about crate_universe dependencies"""
 
 # This global should match the current release of `crate_unvierse`.
 DEFAULT_URL_TEMPLATE = "{DEFAULT_URL_TEMPLATE}"
 
 # Note that if any additional platforms are added here, the pipeline defined
-# by `create_universe.yaml` should also be updated
+# by `pre-release.yaml` should also be updated. The current shas are from
+# release canddidate {rc}
 DEFAULT_SHA256_CHECKSUMS = {
     "aarch64-apple-darwin": "{aarch64-apple-darwin--sha256}",
     "aarch64-unknown-linux-gnu": "{aarch64-unknown-linux-gnu--sha256}",


### PR DESCRIPTION
This PR adds a workflow for performing releases.

To run the workflow/perform a release, maintainers can manually trigger it
<img width="792" alt="Screen Shot 2021-04-28 at 11 16 33 PM" src="https://user-images.githubusercontent.com/26427366/116510237-73aa9380-a879-11eb-8e14-5326d5e8a499.png">

This then kicks off some builds which produce build artifacts associated with a release candidate pre-release
<img width="1126" alt="Screen Shot 2021-04-28 at 11 24 46 PM" src="https://user-images.githubusercontent.com/26427366/116510400-b2d8e480-a879-11eb-8830-ffa92663c190.png">
<img width="923" alt="Screen Shot 2021-04-28 at 11 31 39 PM" src="https://user-images.githubusercontent.com/26427366/116510535-eae02780-a879-11eb-8e47-d38e0b761c7a.png">

This is done so produced artifacts can be cached and reviewed before the final release is cut.

To finish the release, the pull request that's created just needs to be merged
<img width="1058" alt="Screen Shot 2021-04-28 at 11 25 22 PM" src="https://user-images.githubusercontent.com/26427366/116510669-1f53e380-a87a-11eb-9be5-a9d6407a9db3.png">

This then runs the `Release Finalize` workflow which fetches artifacts from the latest release candidate and uploads them to the new, official release
<img width="905" alt="Screen Shot 2021-04-28 at 11 26 49 PM" src="https://user-images.githubusercontent.com/26427366/116510730-398dc180-a87a-11eb-871e-f236056175dd.png">

Maintainers should then add the final release notes to the pre-release and promote it to a full release to conclude this process.