### PR TITLE
Escape trailing backslashes in build script env vars

### DIFF
--- a/test/build_env/src/build.rs
+++ b/test/build_env/src/build.rs
@@ -1,4 +1,5 @@
 fn main() {
     println!("cargo:rustc-env=CARGO_PKG_NAME_FROM_BUILD_SCRIPT={}", env!("CARGO_PKG_NAME"));
     println!("cargo:rustc-env=CARGO_CRATE_NAME_FROM_BUILD_SCRIPT={}", env!("CARGO_CRATE_NAME"));
+    println!("cargo:rustc-env=HAS_TRAILING_SLASH=foo\\");
 }

--- a/test/build_env/tests/cargo.rs
+++ b/test/build_env/tests/cargo.rs
@@ -4,4 +4,5 @@ fn cargo_env_vars() {
     assert_eq!(env!("CARGO_CRATE_NAME"), "cargo_env_vars_test");
     assert_eq!(env!("CARGO_PKG_NAME_FROM_BUILD_SCRIPT"), "cargo_build_script_env-vars");
     assert_eq!(env!("CARGO_CRATE_NAME_FROM_BUILD_SCRIPT"), "cargo_build_script_env_vars");
+    assert_eq!(env!("HAS_TRAILING_SLASH"), "foo\\");
 }


### PR DESCRIPTION
Fixes #710.