### PR TITLE
wasm_bindgen: Add support for non-bundler target configs

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1200,7 +1200,7 @@ Generates a toolchain-bearing repository that declares the toolchains from some 
 ## rust_wasm_bindgen
 
 <pre>
-rust_wasm_bindgen(<a href="#rust_wasm_bindgen-name">name</a>, <a href="#rust_wasm_bindgen-bindgen_flags">bindgen_flags</a>, <a href="#rust_wasm_bindgen-wasm_file">wasm_file</a>)
+rust_wasm_bindgen(<a href="#rust_wasm_bindgen-name">name</a>, <a href="#rust_wasm_bindgen-bindgen_flags">bindgen_flags</a>, <a href="#rust_wasm_bindgen-target">target</a>, <a href="#rust_wasm_bindgen-wasm_file">wasm_file</a>)
 </pre>
 
 Generates javascript and typescript bindings for a webassembly module using [wasm-bindgen][ws].
@@ -1228,6 +1228,7 @@ An example of this rule in use can be seen at [@rules_rust//examples/wasm](../ex
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_wasm_bindgen-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_wasm_bindgen-bindgen_flags"></a>bindgen_flags |  Flags to pass directly to the bindgen executable. See https://github.com/rustwasm/wasm-bindgen/ for details.   | List of strings | optional | [] |
+| <a id="rust_wasm_bindgen-target"></a>target |  The type of output to generate. See https://rustwasm.github.io/wasm-bindgen/reference/deployment.html for details.   | String | optional | "bundler" |
 | <a id="rust_wasm_bindgen-wasm_file"></a>wasm_file |  The .wasm file to generate bindings for.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/docs/rust_wasm_bindgen.md
+++ b/docs/rust_wasm_bindgen.md
@@ -28,7 +28,7 @@ building WebAssembly code for the host target.
 ## rust_wasm_bindgen
 
 <pre>
-rust_wasm_bindgen(<a href="#rust_wasm_bindgen-name">name</a>, <a href="#rust_wasm_bindgen-bindgen_flags">bindgen_flags</a>, <a href="#rust_wasm_bindgen-wasm_file">wasm_file</a>)
+rust_wasm_bindgen(<a href="#rust_wasm_bindgen-name">name</a>, <a href="#rust_wasm_bindgen-bindgen_flags">bindgen_flags</a>, <a href="#rust_wasm_bindgen-target">target</a>, <a href="#rust_wasm_bindgen-wasm_file">wasm_file</a>)
 </pre>
 
 Generates javascript and typescript bindings for a webassembly module using [wasm-bindgen][ws].
@@ -56,6 +56,7 @@ An example of this rule in use can be seen at [@rules_rust//examples/wasm](../ex
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_wasm_bindgen-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_wasm_bindgen-bindgen_flags"></a>bindgen_flags |  Flags to pass directly to the bindgen executable. See https://github.com/rustwasm/wasm-bindgen/ for details.   | List of strings | optional | [] |
+| <a id="rust_wasm_bindgen-target"></a>target |  The type of output to generate. See https://rustwasm.github.io/wasm-bindgen/reference/deployment.html for details.   | String | optional | "bundler" |
 | <a id="rust_wasm_bindgen-wasm_file"></a>wasm_file |  The .wasm file to generate bindings for.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/examples/wasm/BUILD.bazel
+++ b/examples/wasm/BUILD.bazel
@@ -14,13 +14,22 @@
 
 # buildifier: disable=module-docstring
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_shared_library")
 load("@rules_rust//wasm_bindgen:wasm_bindgen.bzl", "rust_wasm_bindgen")
 
 package(default_visibility = ["//visibility:public"])
 
 rust_binary(
-    name = "hello_world_wasm",
+    name = "hello_world_bin_wasm",
+    srcs = ["main.rs"],
+    edition = "2018",
+    deps = [
+        "@rules_rust//wasm_bindgen/raze:wasm_bindgen",
+    ],
+)
+
+rust_shared_library(
+    name = "hello_world_lib_wasm",
     srcs = ["main.rs"],
     edition = "2018",
     deps = [
@@ -29,12 +38,42 @@ rust_binary(
 )
 
 rust_wasm_bindgen(
-    name = "hello_world_wasm_bindgen",
-    wasm_file = ":hello_world_wasm",
+    name = "hello_world_bundler_wasm_bindgen",
+    wasm_file = ":hello_world_bin_wasm",
+)
+
+rust_wasm_bindgen(
+    name = "hello_world_web_wasm_bindgen",
+    target = "web",
+    wasm_file = ":hello_world_lib_wasm",
+)
+
+rust_wasm_bindgen(
+    name = "hello_world_deno_wasm_bindgen",
+    target = "deno",
+    wasm_file = ":hello_world_lib_wasm",
+)
+
+rust_wasm_bindgen(
+    name = "hello_world_nomodules_wasm_bindgen",
+    target = "no-modules",
+    wasm_file = ":hello_world_lib_wasm",
+)
+
+rust_wasm_bindgen(
+    name = "hello_world_nodejs_wasm_bindgen",
+    target = "nodejs",
+    wasm_file = ":hello_world_lib_wasm",
 )
 
 nodejs_test(
     name = "hello_world_wasm_test",
-    data = [":hello_world_wasm_bindgen"],
+    data = [
+        ":hello_world_bundler_wasm_bindgen",
+        ":hello_world_deno_wasm_bindgen",
+        ":hello_world_nodejs_wasm_bindgen",
+        ":hello_world_nomodules_wasm_bindgen",
+        ":hello_world_web_wasm_bindgen",
+    ],
     entry_point = "hello_world_wasm_test.js",
 )

--- a/examples/wasm/hello_world_wasm_test.js
+++ b/examples/wasm/hello_world_wasm_test.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-const main = async function () {
-  const wasm_file = path.join(__dirname, 'hello_world_wasm_bindgen_bg.wasm');
+const main = async function (typ) {
+  const wasm_file = path.join(__dirname, 'hello_world_'+typ+'_wasm_bindgen_bg.wasm');
   assert.ok(fs.existsSync(wasm_file));
 
   const buf = fs.readFileSync(wasm_file);
@@ -15,7 +15,9 @@ const main = async function () {
   assert.strictEqual(res.instance.exports.double(2), 4);
 };
 
-main().catch(function (err) {
-  console.error(err);
-  process.exit(1);
-});
+["bundler", "web", "deno", "nomodules", "nodejs"].forEach((typ) => {
+  main(typ).catch(function (err) {
+    console.error(err);
+    process.exit(1);
+  });
+})

--- a/examples/wasm/main.rs
+++ b/examples/wasm/main.rs
@@ -5,6 +5,7 @@ pub fn double(i: i32) -> i32 {
     i * 2
 }
 
+#[allow(dead_code)]
 fn main() {
     println!("Hello {}", double(2));
 }

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -90,6 +90,8 @@ def _determine_lib_name(name, crate_type, toolchain, lib_hash = ""):
     prefix = "lib"
     if (toolchain.target_triple.find("windows") != -1) and crate_type not in ("lib", "rlib"):
         prefix = ""
+    if toolchain.target_arch == "wasm32" and crate_type == "cdylib":
+        prefix = ""
 
     return "{prefix}{name}-{lib_hash}{extension}".format(
         prefix = prefix,

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -580,7 +580,7 @@ def rustc_compile_action(
     if hasattr(ctx.attr, "out_binary"):
         out_binary = getattr(ctx.attr, "out_binary")
 
-    return establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configuration) + [
+    info = [
         crate_info,
         dep_info,
         DefaultInfo(
@@ -590,6 +590,10 @@ def rustc_compile_action(
             executable = crate_info.output if crate_info.type == "bin" or crate_info.is_test or out_binary else None,
         ),
     ]
+    if toolchain.target_arch != "wasm32":
+        info += establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configuration)
+
+    return info
 
 def _is_dylib(dep):
     return not bool(dep.static_library or dep.pic_static_library)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -580,7 +580,7 @@ def rustc_compile_action(
     if hasattr(ctx.attr, "out_binary"):
         out_binary = getattr(ctx.attr, "out_binary")
 
-    info = [
+    providers = [
         crate_info,
         dep_info,
         DefaultInfo(
@@ -591,9 +591,9 @@ def rustc_compile_action(
         ),
     ]
     if toolchain.target_arch != "wasm32":
-        info += establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configuration)
+        providers += establish_cc_info(ctx, crate_info, toolchain, cc_toolchain, feature_configuration)
 
-    return info
+    return providers
 
 def _is_dylib(dep):
     return not bool(dep.static_library or dep.pic_static_library)


### PR DESCRIPTION
This allows specifying a `target` like `web` or `nodejs` in `wasm_bindgen` and ensures that you can build a wasm `rust_shared_library`.

Closes #627 