### PR TITLE
Removed redundant check for srcs in clippy

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -91,7 +91,7 @@ tasks:
     platform: ubuntu1804
     working_directory: examples
     build_flags:
-      - "--aspects=@rules_rust//rust:rust.bzl%rust_clippy_aspect"
+      - "--aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect"
       - "--output_groups=clippy_checks"
     build_targets:
       - //...

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -75,6 +75,7 @@ PAGES = dict([
     ),
     page(
         name = "rust_clippy",
+        header_template = ":rust_clippy.vm",
         symbols = [
             "rust_clippy",
             "rust_clippy_aspect",

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -381,9 +381,7 @@ Similar to `rust_clippy_aspect`, but allows specifying a list of dependencies wi
 For example, given the following example targets:
 
 ```python
-package(default_visibility = ["//visibility:public"])
-
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
     name = "hello_lib",
@@ -400,6 +398,8 @@ rust_test(
 Rust clippy can be set as a build target with the following:
 
 ```python
+load("@rules_rust//rust:defs.bzl", "rust_clippy")
+
 rust_clippy(
     name = "hello_library_clippy",
     testonly = True,
@@ -417,7 +417,7 @@ rust_clippy(
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_clippy-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="rust_clippy-deps"></a>deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_clippy-deps"></a>deps |  Rust targets to run clippy on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#rust_doc"></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ supported in certain environments.
 
 - [defs](defs.md): standard rust rules for building and testing libraries and binaries.
 - [rust_doc](rust_doc.md): rules for generating and testing rust documentation.
+- [rust_clippy](rust_clippy.md): rules for running [clippy](https://github.com/rust-lang/rust-clippy#readme).
 - [rust_proto](rust_proto.md): rules for generating [protobuf](https://developers.google.com/protocol-buffers).
   and [gRPC](https://grpc.io) stubs.
 - [rust_bindgen](rust_bindgen.md): rules for generating C++ bindings.

--- a/docs/rust_clippy.md
+++ b/docs/rust_clippy.md
@@ -3,6 +3,30 @@
 * [rust_clippy](#rust_clippy)
 * [rust_clippy_aspect](#rust_clippy_aspect)
 
+
+## Overview
+
+
+[Clippy][clippy] is a tool for catching common mistakes in [Rust][rust] code and improving it. An
+expansive list of lints and their justification can be found in their [documentation][docs].
+
+[clippy]: https://github.com/rust-lang/rust-clippy#readme
+[docs]: https://rust-lang.github.io/rust-clippy/
+[rust]: https://github.com/rust-lang/rust
+
+
+### Setup
+
+
+Simply add the following to the `.bazelrc` file in the root of your workspace:
+
+```text
+build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
+build --output_groups=+clippy_checks
+```
+
+This will enable clippy on all [Rust targets](./defs.md).
+
 <a id="#rust_clippy"></a>
 
 ## rust_clippy
@@ -18,9 +42,7 @@ Similar to `rust_clippy_aspect`, but allows specifying a list of dependencies wi
 For example, given the following example targets:
 
 ```python
-package(default_visibility = ["//visibility:public"])
-
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
     name = "hello_lib",
@@ -37,6 +59,8 @@ rust_test(
 Rust clippy can be set as a build target with the following:
 
 ```python
+load("@rules_rust//rust:defs.bzl", "rust_clippy")
+
 rust_clippy(
     name = "hello_library_clippy",
     testonly = True,
@@ -54,6 +78,6 @@ rust_clippy(
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_clippy-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="rust_clippy-deps"></a>deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="rust_clippy-deps"></a>deps |  Rust targets to run clippy on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 

--- a/docs/rust_clippy.md
+++ b/docs/rust_clippy.md
@@ -7,12 +7,11 @@
 ## Overview
 
 
-[Clippy][clippy] is a tool for catching common mistakes in [Rust][rust] code and improving it. An
-expansive list of lints and their justification can be found in their [documentation][docs].
+[Clippy][clippy] is a tool for catching common mistakes in Rust code and improving it. An
+expansive list of lints and the justification can be found in their [documentation][docs].
 
 [clippy]: https://github.com/rust-lang/rust-clippy#readme
 [docs]: https://rust-lang.github.io/rust-clippy/
-[rust]: https://github.com/rust-lang/rust
 
 
 ### Setup

--- a/docs/rust_clippy.vm
+++ b/docs/rust_clippy.vm
@@ -1,0 +1,23 @@
+#[[
+## Overview
+]]#
+
+[Clippy][clippy] is a tool for catching common mistakes in [Rust][rust] code and improving it. An
+expansive list of lints and their justification can be found in their [documentation][docs].
+
+[clippy]: https://github.com/rust-lang/rust-clippy#readme
+[docs]: https://rust-lang.github.io/rust-clippy/
+[rust]: https://github.com/rust-lang/rust
+
+#[[
+### Setup
+]]#
+
+Simply add the following to the `.bazelrc` file in the root of your workspace:
+
+```text
+build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
+build --output_groups=+clippy_checks
+```
+
+This will enable clippy on all [Rust targets](./defs.md).

--- a/docs/rust_clippy.vm
+++ b/docs/rust_clippy.vm
@@ -2,12 +2,11 @@
 ## Overview
 ]]#
 
-[Clippy][clippy] is a tool for catching common mistakes in [Rust][rust] code and improving it. An
-expansive list of lints and their justification can be found in their [documentation][docs].
+[Clippy][clippy] is a tool for catching common mistakes in Rust code and improving it. An
+expansive list of lints and the justification can be found in their [documentation][docs].
 
 [clippy]: https://github.com/rust-lang/rust-clippy#readme
 [docs]: https://rust-lang.github.io/rust-clippy/
-[rust]: https://github.com/rust-lang/rust
 
 #[[
 ### Setup

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# buildifier: disable=module-docstring
+"""A module defining clippy rules"""
+
 load("//rust/private:common.bzl", "rust_common")
-load(
-    "//rust/private:rust.bzl",
-    "crate_root_src",
-)
+load("//rust/private:rust.bzl", "crate_root_src")
 load(
     "//rust/private:rustc.bzl",
     "collect_deps",
@@ -26,35 +24,20 @@ load(
 )
 load("//rust/private:utils.bzl", "determine_output_hash", "find_cc_toolchain", "find_toolchain")
 
-_rust_extensions = [
-    "rs",
-]
-
-def _is_rust_target(srcs):
-    return any([src.extension in _rust_extensions for src in srcs])
-
-def _rust_sources(target, rule):
-    srcs = []
-    if "srcs" in dir(rule.attr):
-        srcs += [f for src in rule.attr.srcs for f in src.files.to_list()]
-    if "hdrs" in dir(rule.attr):
-        srcs += [f for hdr in rule.attr.hdrs for f in hdr.files.to_list()]
-    return [src for src in srcs if src.extension in _rust_extensions]
-
 def _clippy_aspect_impl(target, ctx):
     if rust_common.crate_info not in target:
         return []
-    rust_srcs = _rust_sources(target, ctx.rule)
 
     toolchain = find_toolchain(ctx)
     cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
     crate_info = target[rust_common.crate_info]
+    rust_srcs = crate_info.srcs.to_list()
     crate_type = crate_info.type
 
     if crate_info.is_test:
         root = crate_info.root
     else:
-        if rust_srcs == []:
+        if not rust_srcs:
             # nothing to do
             return []
         root = crate_root_src(ctx.rule.attr, rust_srcs, crate_info.type)
@@ -134,7 +117,7 @@ def _clippy_aspect_impl(target, ctx):
     ]
 
 # Example: Run the clippy checker on all targets in the codebase.
-#   bazel build --aspects=@rules_rust//rust:rust.bzl%rust_clippy_aspect \
+#   bazel build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect \
 #               --output_groups=clippy_checks \
 #               //...
 rust_clippy_aspect = aspect(
@@ -142,13 +125,20 @@ rust_clippy_aspect = aspect(
     host_fragments = ["cpp"],
     attrs = {
         "_cc_toolchain": attr.label(
+            doc = (
+                "Required attribute to access the cc_toolchain. See [Accessing the C++ toolchain]" +
+                "(https://docs.bazel.build/versions/master/integrating-with-rules-cc.html#accessing-the-c-toolchain)"
+            ),
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
-        "_error_format": attr.label(default = "//:error_format"),
+        "_error_format": attr.label(
+            doc = "The desired `--error-format` flags for clippy",
+            default = "//:error_format",
+        ),
         "_process_wrapper": attr.label(
+            doc = "A process wrapper for running clippy on all platforms",
             default = Label("//util/process_wrapper"),
             executable = True,
-            allow_single_file = True,
             cfg = "exec",
         ),
     },
@@ -163,12 +153,10 @@ Executes the clippy checker on specified targets.
 
 This aspect applies to existing rust_library, rust_test, and rust_binary rules.
 
-As an example, if the following is defined in `hello_lib/BUILD`:
+As an example, if the following is defined in `examples/hello_lib/BUILD.bazel`:
 
 ```python
-package(default_visibility = ["//visibility:public"])
-
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
     name = "hello_lib",
@@ -185,7 +173,7 @@ rust_test(
 Then the targets can be analyzed with clippy using the following command:
 
 ```output
-$ bazel build --aspects=@rules_rust//rust:rust.bzl%rust_clippy_aspect \
+$ bazel build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect \
               --output_groups=clippy_checks //hello_lib:all
 ```
 """,
@@ -198,7 +186,11 @@ def _rust_clippy_rule_impl(ctx):
 rust_clippy = rule(
     implementation = _rust_clippy_rule_impl,
     attrs = {
-        "deps": attr.label_list(aspects = [rust_clippy_aspect]),
+        "deps": attr.label_list(
+            doc = "Rust targets to run clippy on.",
+            providers = [rust_common.crate_info],
+            aspects = [rust_clippy_aspect],
+        ),
     },
     doc = """\
 Executes the clippy checker on a specific target.
@@ -209,9 +201,7 @@ within the build system.
 For example, given the following example targets:
 
 ```python
-package(default_visibility = ["//visibility:public"])
-
-load("@rules_rust//rust:rust.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(
     name = "hello_lib",
@@ -228,6 +218,8 @@ rust_test(
 Rust clippy can be set as a build target with the following:
 
 ```python
+load("@rules_rust//rust:defs.bzl", "rust_clippy")
+
 rust_clippy(
     name = "hello_library_clippy",
     testonly = True,

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -30,9 +30,7 @@ def _clippy_aspect_impl(target, ctx):
     toolchain = find_toolchain(ctx)
     cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
     crate_info = target[rust_common.crate_info]
-    rust_srcs = crate_info.srcs.to_list()
     crate_type = crate_info.type
-    root = crate_info.root
 
     dep_info, build_info = collect_deps(
         ctx.label,
@@ -68,7 +66,7 @@ def _clippy_aspect_impl(target, ctx):
         crate_type,
         crate_info,
         dep_info,
-        output_hash = determine_output_hash(root),
+        output_hash = determine_output_hash(crate_info.root),
         rust_flags = [],
         out_dir = out_dir,
         build_env_files = build_env_files,

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -15,7 +15,6 @@
 """A module defining clippy rules"""
 
 load("//rust/private:common.bzl", "rust_common")
-load("//rust/private:rust.bzl", "crate_root_src")
 load(
     "//rust/private:rustc.bzl",
     "collect_deps",
@@ -33,14 +32,7 @@ def _clippy_aspect_impl(target, ctx):
     crate_info = target[rust_common.crate_info]
     rust_srcs = crate_info.srcs.to_list()
     crate_type = crate_info.type
-
-    if crate_info.is_test:
-        root = crate_info.root
-    else:
-        if not rust_srcs:
-            # nothing to do
-            return []
-        root = crate_root_src(ctx.rule.attr, rust_srcs, crate_info.type)
+    root = crate_info.root
 
     dep_info, build_info = collect_deps(
         ctx.label,


### PR DESCRIPTION
The `_rust_sources` check seems redundant here. [CrateInfo](https://github.com/bazelbuild/rules_rust/blob/feaeb7ab712da45c1c94f7950e799d79e367ddeb/rust/private/providers.bzl#L17-L32) has a `srcs` field which should contain the exact same data and because the implementation filters for targets which only contain the `CrateInfo` provider, this should be limited to targets which have a `srcs` attribute that only accept `.rs` files:
https://github.com/bazelbuild/rules_rust/blob/feaeb7ab712da45c1c94f7950e799d79e367ddeb/rust/private/rust.bzl#L660-L669

Happy to hear a good reason why we shouldn't use `CrateInfo.srcs` though.

Additionally, this adds a top level section for `rust_clippy` to the docs.