### PR TITLE
Allow tags to be applied to bindgen libraries.

### DIFF
--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -51,17 +51,23 @@ def rust_bindgen_library(
         **kwargs: Arguments to forward to the underlying `rust_library` rule.
     """
 
+    tags = kwargs.get("tags") or []
+    if "tags" in kwargs:
+        kwargs.pop("tags")
+
     rust_bindgen(
         name = name + "__bindgen",
         header = header,
         cc_lib = cc_lib,
         bindgen_flags = bindgen_flags or [],
         clang_flags = clang_flags or [],
+        tags = tags,
     )
+
     rust_library(
         name = name,
         srcs = [name + "__bindgen.rs"],
-        tags = ["__bindgen"],
+        tags = tags + ["__bindgen"],
         deps = [cc_lib],
         **kwargs
     )


### PR DESCRIPTION
I tried setting the examples to manual while testing another change and found this. `rust_bindgen_library` targets should support tags