### PR TITLE
Deduplicate the CrateInfo provider

### DIFF
--- a/rust/rust_common.bzl
+++ b/rust/rust_common.bzl
@@ -14,19 +14,6 @@
 
 """Module with Rust definitions required to write custom Rust rules."""
 
-CrateInfo = provider(
-    doc = "A provider containing general Crate information.",
-    fields = {
-        "aliases": "Dict[Label, String]: Renamed and aliased crates",
-        "deps": "List[Provider]: This crate's (rust or cc) dependencies' providers.",
-        "edition": "str: The edition of this crate.",
-        "is_test": "bool: If the crate is being compiled in a test context",
-        "name": "str: The name of this crate.",
-        "output": "File: The output File that will be produced, depends on crate type.",
-        "proc_macro_deps": "List[CrateInfo]: This crate's rust proc_macro dependencies' providers.",
-        "root": "File: The source File entrypoint to this crate, eg. lib.rs",
-        "rustc_env": "Dict[String, String]: Additional `\"key\": \"value\"` environment variables to set for rustc.",
-        "srcs": "List[File]: All source Files that are part of the crate.",
-        "type": "str: The type of this crate. eg. lib or bin",
-    },
-)
+load("//rust/private:providers.bzl", _CrateInfo = "CrateInfo")
+
+CrateInfo = _CrateInfo


### PR DESCRIPTION
It seems there should be a single source of truth here? The only difference seems to be in the docs for the parameters:
```diff
diff --git a/rust/private/providers.bzl b/rust/private/providers.bzl
index 53bfbc8..549e371 100644
--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -18,15 +18,15 @@ CrateInfo = provider(
     doc = "A provider containing general Crate information.",
     fields = {
         "aliases": "Dict[Label, String]: Renamed and aliased crates",
-        "deps": "depset[Provider]: This crate's (rust or cc) dependencies' providers.",
+        "deps": "List[Provider]: This crate's (rust or cc) dependencies' providers.",
         "edition": "str: The edition of this crate.",
         "is_test": "bool: If the crate is being compiled in a test context",
         "name": "str: The name of this crate.",
         "output": "File: The output File that will be produced, depends on crate type.",
-        "proc_macro_deps": "depset[CrateInfo]: This crate's rust proc_macro dependencies' providers.",
+        "proc_macro_deps": "List[CrateInfo]: This crate's rust proc_macro dependencies' providers.",
         "root": "File: The source File entrypoint to this crate, eg. lib.rs",
         "rustc_env": "Dict[String, String]: Additional `\"key\": \"value\"` environment variables to set for rustc.",
-        "srcs": "depset[File]: All source Files that are part of the crate.",
+        "srcs": "List[File]: All source Files that are part of the crate.",
         "type": "str: The type of this crate. eg. lib or bin",
     },
 )
```

Any reason to not unify these? Note that users will still be able to load the provider from the same path.