### PR TITLE
Added missing aspects to documentation

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1678,3 +1678,78 @@ Declare dependencies needed for [rust_wasm_bindgen](#rust_wasm_bindgen).
 | <a id="rust_wasm_bindgen_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain) (<code>@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
 
 
+<a id="#rust_analyzer_aspect"></a>
+
+## rust_analyzer_aspect
+
+<pre>
+rust_analyzer_aspect(<a href="#rust_analyzer_aspect-name">name</a>)
+</pre>
+
+Annotates rust rules with RustAnalyzerInfo later used to build a rust-project.json
+
+**ASPECT ATTRIBUTES**
+
+
+| Name | Type |
+| :------------- | :------------- |
+| deps| String |
+| proc_macro_deps| String |
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_analyzer_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
+
+
+<a id="#rust_clippy_aspect"></a>
+
+## rust_clippy_aspect
+
+<pre>
+rust_clippy_aspect(<a href="#rust_clippy_aspect-name">name</a>)
+</pre>
+
+Executes the clippy checker on specified targets.
+
+This aspect applies to existing rust_library, rust_test, and rust_binary rules.
+
+As an example, if the following is defined in `examples/hello_lib/BUILD.bazel`:
+
+```python
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "hello_lib",
+    srcs = ["src/lib.rs"],
+)
+
+rust_test(
+    name = "greeting_test",
+    srcs = ["tests/greeting.rs"],
+    deps = [":hello_lib"],
+)
+```
+
+Then the targets can be analyzed with clippy using the following command:
+
+```output
+$ bazel build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect               --output_groups=clippy_checks //hello_lib:all
+```
+
+
+**ASPECT ATTRIBUTES**
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_clippy_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
+
+

--- a/docs/rust_analyzer.md
+++ b/docs/rust_analyzer.md
@@ -101,3 +101,30 @@ Produces a rust-project.json for the given targets. Configure rust-analyzer to l
 | <a id="rust_analyzer-targets"></a>targets |  List of all targets to be included in the index   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
+<a id="#rust_analyzer_aspect"></a>
+
+## rust_analyzer_aspect
+
+<pre>
+rust_analyzer_aspect(<a href="#rust_analyzer_aspect-name">name</a>)
+</pre>
+
+Annotates rust rules with RustAnalyzerInfo later used to build a rust-project.json
+
+**ASPECT ATTRIBUTES**
+
+
+| Name | Type |
+| :------------- | :------------- |
+| deps| String |
+| proc_macro_deps| String |
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_analyzer_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
+
+

--- a/docs/rust_clippy.md
+++ b/docs/rust_clippy.md
@@ -80,3 +80,51 @@ rust_clippy(
 | <a id="rust_clippy-deps"></a>deps |  Rust targets to run clippy on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
+<a id="#rust_clippy_aspect"></a>
+
+## rust_clippy_aspect
+
+<pre>
+rust_clippy_aspect(<a href="#rust_clippy_aspect-name">name</a>)
+</pre>
+
+Executes the clippy checker on specified targets.
+
+This aspect applies to existing rust_library, rust_test, and rust_binary rules.
+
+As an example, if the following is defined in `examples/hello_lib/BUILD.bazel`:
+
+```python
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "hello_lib",
+    srcs = ["src/lib.rs"],
+)
+
+rust_test(
+    name = "greeting_test",
+    srcs = ["tests/greeting.rs"],
+    deps = [":hello_lib"],
+)
+```
+
+Then the targets can be analyzed with clippy using the following command:
+
+```output
+$ bazel build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect               --output_groups=clippy_checks //hello_lib:all
+```
+
+
+**ASPECT ATTRIBUTES**
+
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_clippy_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
+
+

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -37,9 +37,11 @@ load(
 load(
     "@rules_rust//rust:defs.bzl",
     _rust_analyzer = "rust_analyzer",
+    _rust_analyzer_aspect = "rust_analyzer_aspect",
     _rust_benchmark = "rust_benchmark",
     _rust_binary = "rust_binary",
     _rust_clippy = "rust_clippy",
+    _rust_clippy_aspect = "rust_clippy_aspect",
     _rust_doc = "rust_doc",
     _rust_doc_test = "rust_doc_test",
     _rust_library = "rust_library",
@@ -105,7 +107,9 @@ rust_toolchain_repository = _rust_toolchain_repository
 rust_toolchain_repository_proxy = _rust_toolchain_repository_proxy
 
 rust_clippy = _rust_clippy
+rust_clippy_aspect = _rust_clippy_aspect
 rust_analyzer = _rust_analyzer
+rust_analyzer_aspect = _rust_analyzer_aspect
 
 crate_universe = _crate_universe
 crate = _crate


### PR DESCRIPTION
The links for `rust_analyzer_aspect` and `rust_clippy_aspect` lead to nothing. This fixes that by actually rendering those docs