### PR TITLE
Ask rust_toolchain for rustc_src in rust_analyzer.bzl

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,7 +2,7 @@ workspace(name = "rules_rust")
 
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
-rust_repositories()
+rust_repositories(include_rustc_src = True)
 
 load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 

--- a/examples/examples_deps.bzl
+++ b/examples/examples_deps.bzl
@@ -13,7 +13,7 @@ load("@rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_repositori
 def deps():
     """Define dependencies for `rules_rust` examples"""
 
-    rust_repositories()
+    rust_repositories(include_rustc_src = True)
 
     rust_bindgen_repositories()
 

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -173,7 +173,16 @@ def create_crate(ctx, info, crate_mapping):
 # TODO(djmarcin): Run the cargo_build_scripts to gather env vars correctly.
 def _rust_analyzer_impl(ctx):
     rust_toolchain = find_toolchain(ctx)
-    sysroot_src = _exec_root_tmpl + rust_toolchain.rust_lib.label.workspace_root + "/lib/rustlib/src/library"
+
+    if not rust_toolchain.rustc_src:
+        fail(
+            "Current Rust toolchain doesn't contain rustc sources in `rustc_src` attribute.",
+            "These are needed by rust analyzer.",
+            "If you are using the default Rust toolchain, add `rust_repositories(include_rustc_src = True, ...).` to your WORKSPACE file.",
+        )
+    sysroot_src = rust_toolchain.rustc_src.label.package + "/library"
+    if rust_toolchain.rustc_src.label.workspace_root:
+        sysroot_src = _exec_root_tmpl + rust_toolchain.rustc_src.label.workspace_root + "/" + sysroot_src
 
     # Gather all crates and their dependencies into an array.
     # Dependencies are referenced by index, so leaves should come first.


### PR DESCRIPTION
In this PR we remove hardcoded assumption about where rust-analyzer support code looks for rustc sources, and instead read that information from the `rust_toolchain.rustc_src`. We also handle the case when rustc sources are actually in the main repository, so there is no need to use the `__EXEC_ROOT__/` prefix for its path.