### PR TITLE
Use bazelrc over hard coded env vars for crate_universe examples

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -112,8 +112,6 @@ tasks:
   crate_universe_examples_ubuntu2004:
     name: Crate Universe Examples
     platform: ubuntu2004
-    environment:
-      RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP: true
     working_directory: examples/crate_universe
     build_targets:
       - "//..."
@@ -122,8 +120,6 @@ tasks:
   crate_universe_rbe_ubuntu1604:
     name: Crate Universe Examples
     platform: rbe_ubuntu1604
-    environment:
-      RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP: true
     working_directory: examples/crate_universe
     build_targets:
       - "//..."
@@ -132,8 +128,6 @@ tasks:
   crate_universe_examples_macos:
     name: Crate Universe Examples
     platform: macos
-    environment:
-      RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP: true
     working_directory: examples/crate_universe
     build_targets:
       - "//..."
@@ -142,8 +136,6 @@ tasks:
   crate_universe_examples_windows:
     name: Crate Universe Examples
     platform: windows
-    environment:
-      RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP: true
     working_directory: examples/crate_universe
     build_flags:
       - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts

--- a/examples/crate_universe/.bazelrc
+++ b/examples/crate_universe/.bazelrc
@@ -1,0 +1,1 @@
+build --repo_env=RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP=true


### PR DESCRIPTION
I find this much easier to work with since I don't have to constantly set this environment variable. Thought others might find this beneficial too.