### PR TITLE
Include generated comment in docs

### DIFF
--- a/docs/cargo_build_script.md
+++ b/docs/cargo_build_script.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Cargo Build Script
 
 * [cargo_build_script](#cargo_build_script)

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Crate Universe
 
 * [crate_universe](#crate_universe)

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Defs
 
 * [rust_binary](#rust_binary)

--- a/docs/page.bzl
+++ b/docs/page.bzl
@@ -32,18 +32,19 @@ def gen_header(page):
     # Set the top level header
     page_names = [w.capitalize() for w in page.name.split("_")]
     cmd = [
-        "echo '# {}' > $@".format(" ".join(page_names)),
-        "echo '' >> $@",
+        "echo '<!-- Generated with Stardoc: http://skydoc.bazel.build -->'",
+        "echo '# {}'".format(" ".join(page_names)),
+        "echo ''",
     ]
 
     # Add table of contents
-    cmd.extend(["echo '* [{rule}](#{rule})' >> $@".format(rule = s) for s in page.symbols])
+    cmd.extend(["echo '* [{rule}](#{rule})'".format(rule = s) for s in page.symbols])
 
     # Render an optional header
     if page.header_template:
         cmd.extend([
-            "echo '' >> $@",
-            "cat $(execpath {}) >> $@".format(page.header_template),
+            "echo ''",
+            "cat $(execpath {})".format(page.header_template),
         ])
         srcs = [page.header_template]
     else:
@@ -52,7 +53,7 @@ def gen_header(page):
     native.genrule(
         name = name,
         outs = outs,
-        cmd = "\n".join(cmd),
+        cmd = "{\n" + "\n".join(cmd) + "\n} > $@",
         srcs = srcs,
         output_to_bindir = True,
     )

--- a/docs/rust_analyzer.md
+++ b/docs/rust_analyzer.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Rust Analyzer
 
 * [rust_analyzer](#rust_analyzer)

--- a/docs/rust_bindgen.md
+++ b/docs/rust_bindgen.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Rust Bindgen
 
 * [rust_bindgen_library](#rust_bindgen_library)

--- a/docs/rust_clippy.md
+++ b/docs/rust_clippy.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Rust Clippy
 
 * [rust_clippy](#rust_clippy)

--- a/docs/rust_doc.md
+++ b/docs/rust_doc.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Rust Doc
 
 * [rust_doc](#rust_doc)

--- a/docs/rust_proto.md
+++ b/docs/rust_proto.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Rust Proto
 
 * [rust_grpc_library](#rust_grpc_library)

--- a/docs/rust_repositories.md
+++ b/docs/rust_repositories.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Rust Repositories
 
 * [rust_repositories](#rust_repositories)

--- a/docs/rust_wasm_bindgen.md
+++ b/docs/rust_wasm_bindgen.md
@@ -1,3 +1,4 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Rust Wasm Bindgen
 
 * [rust_wasm_bindgen_repositories](#rust_wasm_bindgen_repositories)


### PR DESCRIPTION
This helps developers avoid accidentally sending PRs against generated content.
Based on upstream template https://github.com/bazelbuild/stardoc/blob/master/stardoc/templates/markdown_tables/header.vm