### PR TITLE
Fix clippy warnings for //tools/rust_analyzer:gen_rust_project

### DIFF
--- a/tools/rust_analyzer/BUILD.bazel
+++ b/tools/rust_analyzer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//rust:defs.bzl", "rust_binary")
+load("//rust:defs.bzl", "rust_binary", "rust_clippy")
 
 rust_binary(
     name = "gen_rust_project",
@@ -9,5 +9,14 @@ rust_binary(
         "//tools/rust_analyzer/raze:anyhow",
         "//tools/rust_analyzer/raze:structopt",
         "//util/label",
+    ],
+)
+
+rust_clippy(
+    name = "gen_rust_project_clippy",
+    testonly = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":gen_rust_project",
     ],
 )

--- a/tools/rust_analyzer/main.rs
+++ b/tools/rust_analyzer/main.rs
@@ -108,8 +108,8 @@ fn parse_config() -> anyhow::Result<Config> {
     let output = String::from_utf8_lossy(&output.stdout.as_slice());
     let bazel_info = output
         .trim()
-        .split("\n")
-        .map(|line| line.split_at(line.find(":").expect("missing `:` in bazel info output")))
+        .split('\n')
+        .map(|line| line.split_at(line.find(':').expect("missing `:` in bazel info output")))
         .map(|(k, v)| (k, (&v[1..]).trim()))
         .collect::<HashMap<_, _>>();
 

--- a/tools/rustfmt/BUILD.bazel
+++ b/tools/rustfmt/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_clippy")
+load("//rust:defs.bzl", "rust_binary", "rust_clippy", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/rustfmt/BUILD.bazel
+++ b/tools/rustfmt/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//rust:defs.bzl", "rust_binary", "rust_library")
+load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_clippy")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -56,5 +56,14 @@ rust_binary(
     deps = [
         ":rustfmt_lib",
         "//tools/runfiles",
+    ],
+)
+
+rust_clippy(
+    name = "rustfmt_clippy",
+    testonly = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":rustfmt",
     ],
 )


### PR DESCRIPTION
The command `bazel run @rules_rust//tools/rust_analyzer:gen_rust_project` fails when run configuring `.bazelrc` like bellow.

```
build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
build --output_groups=+clippy_checks
```