### PR TITLE
Fix rustc-dev

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -553,12 +553,16 @@ def _load_rustc_dev_nightly(ctx, target_triple):
         target_triple: The rust-style target triple of the tool
     """
 
+    subdir_name = "rustc-dev"
+    if ctx.attr.iso_date < "2020-12-24":
+        subdir_name = "rustc-dev-{}".format(target_triple)
+
     load_arbitrary_tool(
         ctx,
         iso_date = ctx.attr.iso_date,
         target_triple = target_triple,
         tool_name = "rustc-dev",
-        tool_subdirectories = ["rustc-dev"],
+        tool_subdirectories = [subdir_name],
         version = ctx.attr.version,
     )
 

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -558,7 +558,7 @@ def _load_rustc_dev_nightly(ctx, target_triple):
         iso_date = ctx.attr.iso_date,
         target_triple = target_triple,
         tool_name = "rustc-dev",
-        tool_subdirectories = ["rustc-dev-{}".format(target_triple)],
+        tool_subdirectories = ["rustc-dev"],
         version = ctx.attr.version,
     )
 


### PR DESCRIPTION
Sometime over the past year the layout of rustc-dev's nightly release has changed.