### PR TITLE
[crate_universe] Add README to `examples/crate_universe` directory

### DIFF
--- a/crate_universe/CONTRIBUTING.md
+++ b/crate_universe/CONTRIBUTING.md
@@ -18,16 +18,11 @@ Some areas have unit testing, there are a few (very brittle) integration tests, 
 
 ## How to test local changes
 
-To use a local version, first bootstrap it:
-
-```console
-rules_rust $ ./bootstrap.sh
-```
+To use a local version, first bootstrap it. See [crate_universe/private/bootstrap/README.md](./private/bootstrap/README.md) for instructions on how to do this.
 
 This will build `crate_universe_resolver` and generate a `crate_universe.bazelrc` file which contains
 [override_repository](https://docs.bazel.build/versions/master/command-line-reference.html#flag--override_repository)
-definitions fo the newly built binary. For more details on the build process, see
-[crate_universe/private/bootstrap/README.md](./private/bootstrap/README.md).
+definitions of the newly built binary.
 
 To get verbose logging, edit `defs.bzl` to set `RUST_LOG` to `debug` or `trace` instead of `info`. In particular, that will print out the generated `Cargo.toml`, and the path to the generated workspace file.
 

--- a/crate_universe/CONTRIBUTING.md
+++ b/crate_universe/CONTRIBUTING.md
@@ -20,8 +20,7 @@ Some areas have unit testing, there are a few (very brittle) integration tests, 
 
 To use a local version, first bootstrap it. See [crate_universe/private/bootstrap/README.md](./private/bootstrap/README.md) for instructions on how to do this.
 
-This will build `crate_universe_resolver` and generate a `crate_universe.bazelrc` file which contains
-[override_repository](https://docs.bazel.build/versions/master/command-line-reference.html#flag--override_repository)
+This will build `crate_universe_resolver` and configure bazel to use the binary you just built.
 definitions of the newly built binary.
 
 To get verbose logging, edit `defs.bzl` to set `RUST_LOG` to `debug` or `trace` instead of `info`. In particular, that will print out the generated `Cargo.toml`, and the path to the generated workspace file.

--- a/crate_universe/CONTRIBUTING.md
+++ b/crate_universe/CONTRIBUTING.md
@@ -21,7 +21,6 @@ Some areas have unit testing, there are a few (very brittle) integration tests, 
 To use a local version, first bootstrap it. See [crate_universe/private/bootstrap/README.md](./private/bootstrap/README.md) for instructions on how to do this.
 
 This will build `crate_universe_resolver` and configure bazel to use the binary you just built.
-definitions of the newly built binary.
 
 To get verbose logging, edit `defs.bzl` to set `RUST_LOG` to `debug` or `trace` instead of `info`. In particular, that will print out the generated `Cargo.toml`, and the path to the generated workspace file.
 

--- a/examples/crate_universe/README.md
+++ b/examples/crate_universe/README.md
@@ -1,0 +1,22 @@
+# `crate_universe` examples
+
+### Instructions
+
+Set the `RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP` environment variable to `true`
+
+```bash
+$ export RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP=true
+```
+
+Build the examples
+
+```bash
+$ bazel build //...
+```
+
+Run the examples' tests
+
+```bash
+$ bazel test //...
+```
+


### PR DESCRIPTION
This adds a README.md to the `examples/crate_universe` directory in order to explain that the `RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP` environment variable
must be set to `true` in order for the examples to "just work."

It also removes reference to `bootstrap.sh` from the
`crate_universe/CONTRIBUTING.md` file since `bootstrap.sh` no longer exists.