### PR TITLE
Fix @examples//ffi/rust_calling_c/c/native_matrix_test on RBE.

### DIFF
--- a/examples/ffi/rust_calling_c/c/BUILD.bazel
+++ b/examples/ffi/rust_calling_c/c/BUILD.bazel
@@ -13,6 +13,7 @@ cc_test(
     name = "native_matrix_test",
     srcs = ["matrix_test.c"],
     copts = ["-std=c99"],
+    linkstatic = 1,
     deps = [
         ":native_matrix",
     ],


### PR DESCRIPTION
Seems the RBE toolchain is not working well with C++ dynamic mode tests.
Rather than struggling through the complicated fixing of the toolchain
we tell Bazel to not use dynamic mode.

Fixes https://github.com/bazelbuild/rules_rust/issues/589.