### PR TITLE
Correct test example code.

### DIFF
--- a/docs/defs.md
+++ b/docs/defs.md
@@ -484,8 +484,8 @@ impl Greeter {
         Greeter { greeting: greeting.to_string(), }
     }
 
-    pub fn greet(&self, thing: &str) {
-        println!("{} {}", &self.greeting, thing);
+    pub fn greet(&self, thing: &str) -> String {
+        format!("{} {}", &self.greeting, thing)
     }
 }
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -924,8 +924,8 @@ impl Greeter {
         Greeter { greeting: greeting.to_string(), }
     }
 
-    pub fn greet(&self, thing: &str) {
-        println!("{} {}", &self.greeting, thing);
+    pub fn greet(&self, thing: &str) -> String {
+        format!("{} {}", &self.greeting, thing)
     }
 }
 

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1017,8 +1017,8 @@ rust_test = rule(
                 Greeter { greeting: greeting.to_string(), }
             }
 
-            pub fn greet(&self, thing: &str) {
-                println!("{} {}", &self.greeting, thing);
+            pub fn greet(&self, thing: &str) -> String {
+                format!("{} {}", &self.greeting, thing)
             }
         }
 


### PR DESCRIPTION
`assert_eq!` can't be called on the result of `fn greet()` as written. Fixes #777.