### PR TITLE
Make it easier to use rust_test_suite in macros.

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1210,8 +1210,9 @@ def rust_test_suite(name, srcs, **kwargs):
         if not src.endswith(".rs"):
             fail("srcs should have `.rs` extensions")
 
+        # Prefixed with `name` to allow parameterization with macros
         # The test name should not end with `.rs`
-        test_name = src[:-3]
+        test_name = name + src[:-3]
         rust_test(
             name = test_name,
             crate_name = test_name.replace("/", "_"),

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1212,7 +1212,7 @@ def rust_test_suite(name, srcs, **kwargs):
 
         # Prefixed with `name` to allow parameterization with macros
         # The test name should not end with `.rs`
-        test_name = name + src[:-3]
+        test_name = name + "_" + src[:-3]
         rust_test(
             name = test_name,
             crate_name = test_name.replace("/", "_"),


### PR DESCRIPTION
As written, this function produces duplicate test rules if used in macros. This patch aims to make it easy to run integration tests with different `crate_features`, via a macro.