### PR TITLE
Made clippy's output file more look less like a target.

### DIFF
--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -53,7 +53,7 @@ def _clippy_aspect_impl(target, ctx):
 
     # A marker file indicating clippy has executed successfully.
     # This file is necessary because "ctx.actions.run" mandates an output.
-    clippy_marker = ctx.actions.declare_file(ctx.label.name + "_clippy.ok")
+    clippy_marker = ctx.actions.declare_file(ctx.label.name + ".clippy.ok")
 
     args, env = construct_arguments(
         ctx,


### PR DESCRIPTION
I find it easier to identify this file at a glance using `.clippy.ok` since I generally assume something with `_clippy` is a real target.