### PR TITLE
Added `rules_rust` prefix to transitive workspace names.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,17 +2,17 @@
 default_linux_targets: &default_linux_targets
   - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
   - "..."
-  - "@examples//..."
+  - "@rules_rust_examples//..."
   # TODO: Switch manual tag to platform constraint after bazel 4.0.
   - "//test/versioned_dylib:versioned_dylib_test"
   # Bindgen currently only has a working toolchain for 18.04
-  - "-@examples//ffi/rust_calling_c/simple/..."
+  - "-@rules_rust_examples//ffi/rust_calling_c/simple/..."
 tasks:
   ubuntu1804:
     build_targets: *default_linux_targets
     test_targets:
       - "..."
-      - "@examples//..."
+      - "@rules_rust_examples//..."
       # TODO: Switch manual tag to platform constraint after bazel 4.0.
       - "//test/versioned_dylib:versioned_dylib_test"
     build_flags:
@@ -28,9 +28,9 @@ tasks:
     osx_targets: &osx_targets
       - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
       - "..."
-      - "@examples//..."
+      - "@rules_rust_examples//..."
       # This test requires --incompatible_macos_set_install_name and Bazel 4.2.0+
-      - "-@examples//ffi/rust_calling_c:matrix_dylib_test"
+      - "-@rules_rust_examples//ffi/rust_calling_c:matrix_dylib_test"
     build_targets: *osx_targets
     test_targets: *osx_targets
     build_flags:
@@ -40,15 +40,16 @@ tasks:
       - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
       - "..."
       - "//test/..."
-      - "@examples//..."
+      - "@rules_rust_examples//..."
       - "-//test/conflicting_deps:conflicting_deps_test"
       # rust_doc_test is likely not fully sandboxed
+      # https://github.com/bazelbuild/rules_rust/issues/804
       - "-//test/chained_direct_deps:mod3_doc_test"
-      - "-@examples//fibonacci:fibonacci_doc_test"
-      - "-@examples//hello_lib:hello_lib_doc_test"
-      - "-@examples//ffi/rust_calling_c/simple/..."
+      - "-@rules_rust_examples//fibonacci:doc_test"
+      - "-@rules_rust_examples//hello_lib:doc_test"
+      - "-@rules_rust_examples//ffi/rust_calling_c/simple/..."
       # See https://github.com/bazelbuild/bazel/issues/9987
-      - "-@examples//ffi/rust_calling_c:matrix_dylib_test"
+      - "-@rules_rust_examples//ffi/rust_calling_c:matrix_dylib_test"
     build_flags:
       - "--config=rustfmt"
   windows:
@@ -64,13 +65,13 @@ tasks:
       - "-//test/proto/..."
       - "-//tools/rust_analyzer/..."
       - "-//test/rustfmt/..."
-      - "@examples//..."
-      - "-@examples//ffi/rust_calling_c:matrix_dylib_test"
-      - "-@examples//ffi/rust_calling_c:matrix_dynamically_linked"
-      - "-@examples//ffi/rust_calling_c/simple/..."
-      - "-@examples//sys/..."
-      - "-@examples//proto/..."
-      - "-@examples//wasm/..."
+      - "@rules_rust_examples//..."
+      - "-@rules_rust_examples//ffi/rust_calling_c:matrix_dylib_test"
+      - "-@rules_rust_examples//ffi/rust_calling_c:matrix_dynamically_linked"
+      - "-@rules_rust_examples//ffi/rust_calling_c/simple/..."
+      - "-@rules_rust_examples//sys/..."
+      - "-@rules_rust_examples//proto/..."
+      - "-@rules_rust_examples//wasm/..."
     build_targets: *windows_targets
     test_targets: *windows_targets
   examples:

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,22 +1,22 @@
 workspace(name = "rules_rust")
 
-load("@rules_rust//rust:repositories.bzl", "rust_repositories")
+load("//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories(include_rustc_srcs = True)
 
-load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
+load("//proto:repositories.bzl", "rust_proto_repositories")
 
 rust_proto_repositories()
 
-load("@rules_rust//bindgen:repositories.bzl", "rust_bindgen_repositories")
+load("//bindgen:repositories.bzl", "rust_bindgen_repositories")
 
 rust_bindgen_repositories()
 
-load("@rules_rust//tools/rust_analyzer/raze:crates.bzl", "rules_rust_tools_rust_analyzer_fetch_remote_crates")
+load("//tools/rust_analyzer/raze:crates.bzl", "rules_rust_tools_rust_analyzer_fetch_remote_crates")
 
 rules_rust_tools_rust_analyzer_fetch_remote_crates()
 
-load("@rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_repositories")
+load("//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_repositories")
 
 rust_wasm_bindgen_repositories()
 
@@ -52,37 +52,37 @@ rbe_autoconfig(name = "buildkite_config")
 # Load all dependencies for examples
 
 local_repository(
-    name = "examples",
+    name = "rules_rust_examples",
     path = "examples",
 )
 
-load("@examples//:examples_repositories.bzl", examples_repositories = "repositories")
+load("@rules_rust_examples//:examples_repositories.bzl", examples_repositories = "repositories")
 
 examples_repositories()
 
-load("@examples//:examples_deps.bzl", examples_deps = "deps")
+load("@rules_rust_examples//:examples_deps.bzl", examples_deps = "deps")
 
 examples_deps()
 
-load("@examples//:examples_transitive_deps.bzl", examples_transitive_deps = "transitive_deps")
+load("@rules_rust_examples//:examples_transitive_deps.bzl", examples_transitive_deps = "transitive_deps")
 
 examples_transitive_deps(is_top_level = True)
 
 # Load all dependencies for docs
 
 local_repository(
-    name = "docs",
+    name = "rules_rust_docs",
     path = "docs",
 )
 
-load("@docs//:docs_repositories.bzl", docs_repositories = "repositories")
+load("@rules_rust_docs//:docs_repositories.bzl", docs_repositories = "repositories")
 
 docs_repositories()
 
-load("@docs//:docs_deps.bzl", docs_deps = "deps")
+load("@rules_rust_docs//:docs_deps.bzl", docs_deps = "deps")
 
 docs_deps()
 
-load("@docs//:docs_transitive_deps.bzl", docs_transitive_deps = "transitive_deps")
+load("@rules_rust_docs//:docs_transitive_deps.bzl", docs_transitive_deps = "transitive_deps")
 
 docs_transitive_deps(is_top_level = True)

--- a/docs/WORKSPACE.bazel
+++ b/docs/WORKSPACE.bazel
@@ -1,4 +1,4 @@
-workspace(name = "io_bazel_rules_rust_docs")
+workspace(name = "rules_rust_docs")
 
 load(":docs_repositories.bzl", "repositories")
 

--- a/docs/rust_wasm_bindgen.md
+++ b/docs/rust_wasm_bindgen.md
@@ -11,13 +11,13 @@
 To build a `rust_binary` for `wasm32-unknown-unknown` target add the `--platforms=@rules_rust//rust/platform:wasm` flag.
 
 ```command
-bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasm
+bazel build @rules_rust_examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasm
 ```
 
 To build a `rust_binary` for `wasm32-wasi` target add the `--platforms=@rules_rust//rust/platform:wasi` flag.
 
 ```command
-bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasi
+bazel build @rules_rust_examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasi
 ```
 
 `rust_wasm_bindgen` will automatically transition to the `wasm` platform and can be used when

--- a/docs/rust_wasm_bindgen.vm
+++ b/docs/rust_wasm_bindgen.vm
@@ -4,13 +4,13 @@
 To build a `rust_binary` for `wasm32-unknown-unknown` target add the `--platforms=@rules_rust//rust/platform:wasm` flag.
 
 ```command
-bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasm
+bazel build @rules_rust_examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasm
 ```
 
 To build a `rust_binary` for `wasm32-wasi` target add the `--platforms=@rules_rust//rust/platform:wasi` flag.
 
 ```command
-bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasi
+bazel build @rules_rust_examples//hello_world_wasm --platforms=@rules_rust//rust/platform:wasi
 ```
 
 `rust_wasm_bindgen` will automatically transition to the `wasm` platform and can be used when

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -1,4 +1,4 @@
-workspace(name = "examples")
+workspace(name = "rules_rust_examples")
 
 load(":examples_repositories.bzl", "repositories")
 

--- a/examples/examples_deps.bzl
+++ b/examples/examples_deps.bzl
@@ -2,13 +2,13 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@examples//sys/basic/raze:crates.bzl", "rules_rust_examples_basic_sys_fetch_remote_crates")
-load("@examples//sys/complex:repositories.bzl", "rules_rust_examples_complex_sys_repositories")
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 load("@rules_rust//bindgen:repositories.bzl", "rust_bindgen_repositories")
 load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories", "rust_repository_set")
 load("@rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_repositories")
+load("@rules_rust_examples//sys/basic/raze:crates.bzl", "rules_rust_examples_basic_sys_fetch_remote_crates")
+load("@rules_rust_examples//sys/complex:repositories.bzl", "rules_rust_examples_complex_sys_repositories")
 
 def deps():
     """Define dependencies for `rules_rust` examples"""
@@ -43,7 +43,7 @@ def deps():
     maybe(
         http_archive,
         name = "libc",
-        build_file = "@examples//ffi:libc.BUILD",
+        build_file = "@rules_rust_examples//ffi:libc.BUILD",
         sha256 = "1ac4c2ac6ed5a8fb9020c166bc63316205f1dc78d4b964ad31f4f21eb73f0c6d",
         strip_prefix = "libc-0.2.20",
         urls = [

--- a/examples/fibonacci/BUILD.bazel
+++ b/examples/fibonacci/BUILD.bazel
@@ -33,6 +33,6 @@ rust_doc(
 )
 
 rust_doc_test(
-    name = "fibonacci_doc_test",
+    name = "doc_test",
     crate = ":fibonacci",
 )

--- a/examples/hello_lib/BUILD.bazel
+++ b/examples/hello_lib/BUILD.bazel
@@ -83,7 +83,7 @@ rust_doc(
 )
 
 rust_doc_test(
-    name = "hello_lib_doc_test",
+    name = "doc_test",
     crate = ":hello_lib",
 )
 

--- a/examples/hello_runfiles/hello_runfiles.rs
+++ b/examples/hello_runfiles/hello_runfiles.rs
@@ -6,7 +6,7 @@ use runfiles::Runfiles;
 fn main() {
     let r = Runfiles::create().unwrap();
 
-    let mut f = File::open(r.rlocation("examples/hello_runfiles/hello_runfiles.rs")).unwrap();
+    let mut f = File::open(r.rlocation("rules_rust_examples/hello_runfiles/hello_runfiles.rs")).unwrap();
 
     let mut buffer = String::new();
     f.read_to_string(&mut buffer).unwrap();

--- a/examples/hello_world/BUILD.bazel
+++ b/examples/hello_world/BUILD.bazel
@@ -9,7 +9,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "hello_world",
     srcs = ["src/main.rs"],
-    deps = ["@examples//hello_lib"],
+    deps = ["@rules_rust_examples//hello_lib"],
 )
 
 rust_doc(

--- a/examples/proto/helloworld/helloworld_test.rs
+++ b/examples/proto/helloworld/helloworld_test.rs
@@ -37,7 +37,7 @@ impl ServerInfo {
     fn new() -> ServerInfo {
         let r = Runfiles::create().unwrap();
         let mut c =
-            Command::new(r.rlocation("examples/proto/helloworld/greeter_server/greeter_server"))
+            Command::new(r.rlocation("rules_rust_examples/proto/helloworld/greeter_server/greeter_server"))
                 .arg("0")
                 .stdout(Stdio::piped())
                 .spawn()
@@ -66,7 +66,7 @@ impl ServerInfo {
         let r = Runfiles::create().unwrap();
 
         let mut cmd0 =
-            Command::new(r.rlocation("examples/proto/helloworld/greeter_client/greeter_client"));
+            Command::new(r.rlocation("rules_rust_examples/proto/helloworld/greeter_client/greeter_client"));
         let cmd = cmd0.arg(format!("-p={}", self.port));
 
         let output = if let Some(s) = arg { cmd.arg(s) } else { cmd }

--- a/examples/sys/complex/repositories.bzl
+++ b/examples/sys/complex/repositories.bzl
@@ -14,5 +14,5 @@ def rules_rust_examples_complex_sys_repositories():
         strip_prefix = "openssl-OpenSSL_1_1_1d",
         urls = ["https://github.com/openssl/openssl/archive/OpenSSL_1_1_1d.tar.gz"],
         sha256 = "23011a5cc78e53d0dc98dfa608c51e72bcd350aa57df74c5d5574ba4ffb62e74",
-        build_file = "@examples//third_party/openssl:BUILD.openssl.bazel",
+        build_file = "@rules_rust_examples//third_party/openssl:BUILD.openssl.bazel",
     )


### PR DESCRIPTION
I prefer all repositories/transitive workspaces generated by any repository to use the repository name as a prefix (or be user defined). This helps me quickly identify where things came from when crawling `output_base`.

For me this is minor improvement when debugging things.

Requires:
- https://github.com/bazelbuild/rules_rust/pull/803