### PR TITLE
Exposed supported platform triples lists

### DIFF
--- a/rust/platform/platform.bzl
+++ b/rust/platform/platform.bzl
@@ -3,73 +3,24 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load(
     ":triple_mappings.bzl",
+    "SUPPORTED_CPU_ARCH",
+    "SUPPORTED_PLATFORM_TRIPLES",
+    "SUPPORTED_SYSTEMS",
     "cpu_arch_to_constraints",
     "system_to_constraints",
     "triple_to_constraint_set",
 )
 
-# All T1 Platforms should be supported, but aren't, see inline notes.
-_SUPPORTED_T1_PLATFORM_TRIPLES = [
-    "i686-apple-darwin",
-    "i686-pc-windows-msvc",
-    "i686-unknown-linux-gnu",
-    "x86_64-apple-darwin",
-    "x86_64-pc-windows-msvc",
-    "x86_64-unknown-linux-gnu",
-    # N.B. These "alternative" envs are not supported, as bazel cannot distinguish between them
-    # and others using existing @platforms// config_values
-    #
-    #"i686-pc-windows-gnu",
-    #"x86_64-pc-windows-gnu",
-]
-
-# Some T2 Platforms are supported, provided we have mappings to @platforms// entries.
-# See @rules_rust//rust/platform:triple_mappings.bzl for the complete list.
-_SUPPORTED_T2_PLATFORM_TRIPLES = [
-    "aarch64-apple-darwin",
-    "aarch64-apple-ios",
-    "aarch64-linux-android",
-    "aarch64-unknown-linux-gnu",
-    "arm-unknown-linux-gnueabi",
-    "i686-linux-android",
-    "i686-unknown-freebsd",
-    "powerpc-unknown-linux-gnu",
-    "s390x-unknown-linux-gnu",
-    "wasm32-unknown-unknown",
-    "wasm32-wasi",
-    "x86_64-apple-ios",
-    "x86_64-linux-android",
-    "x86_64-unknown-freebsd",
-]
-
-_SUPPORTED_CPU_ARCH = [
-    "aarch64",
-    "arm",
-    "i686",
-    "powerpc",
-    "s390x",
-    "x86_64",
-]
-
-_SUPPORTED_SYSTEMS = [
-    "android",
-    "darwin",
-    "freebsd",
-    "ios",
-    "linux",
-    "windows",
-]
-
 # buildifier: disable=unnamed-macro
 def declare_config_settings():
     """Helper function for declaring `config_setting`s"""
-    for cpu_arch in _SUPPORTED_CPU_ARCH:
+    for cpu_arch in SUPPORTED_CPU_ARCH:
         native.config_setting(
             name = cpu_arch,
             constraint_values = cpu_arch_to_constraints(cpu_arch),
         )
 
-    for system in _SUPPORTED_SYSTEMS:
+    for system in SUPPORTED_SYSTEMS:
         native.config_setting(
             name = system,
             constraint_values = system_to_constraints(system),
@@ -88,7 +39,7 @@ def declare_config_settings():
         actual = ":darwin",
     )
 
-    all_supported_triples = _SUPPORTED_T1_PLATFORM_TRIPLES + _SUPPORTED_T2_PLATFORM_TRIPLES
+    all_supported_triples = SUPPORTED_PLATFORM_TRIPLES
     for triple in all_supported_triples:
         native.config_setting(
             name = triple,

--- a/rust/platform/platform.bzl
+++ b/rust/platform/platform.bzl
@@ -3,24 +3,40 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load(
     ":triple_mappings.bzl",
-    "SUPPORTED_CPU_ARCH",
     "SUPPORTED_PLATFORM_TRIPLES",
-    "SUPPORTED_SYSTEMS",
     "cpu_arch_to_constraints",
     "system_to_constraints",
     "triple_to_constraint_set",
 )
 
+_SUPPORTED_CPU_ARCH = [
+    "aarch64",
+    "arm",
+    "i686",
+    "powerpc",
+    "s390x",
+    "x86_64",
+]
+
+_SUPPORTED_SYSTEMS = [
+    "android",
+    "darwin",
+    "freebsd",
+    "ios",
+    "linux",
+    "windows",
+]
+
 # buildifier: disable=unnamed-macro
 def declare_config_settings():
     """Helper function for declaring `config_setting`s"""
-    for cpu_arch in SUPPORTED_CPU_ARCH:
+    for cpu_arch in _SUPPORTED_CPU_ARCH:
         native.config_setting(
             name = cpu_arch,
             constraint_values = cpu_arch_to_constraints(cpu_arch),
         )
 
-    for system in SUPPORTED_SYSTEMS:
+    for system in _SUPPORTED_SYSTEMS:
         native.config_setting(
             name = system,
             constraint_values = system_to_constraints(system),

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -36,24 +36,6 @@ SUPPORTED_T2_PLATFORM_TRIPLES = [
 
 SUPPORTED_PLATFORM_TRIPLES = SUPPORTED_T1_PLATFORM_TRIPLES + SUPPORTED_T2_PLATFORM_TRIPLES
 
-SUPPORTED_CPU_ARCH = [
-    "aarch64",
-    "arm",
-    "i686",
-    "powerpc",
-    "s390x",
-    "x86_64",
-]
-
-SUPPORTED_SYSTEMS = [
-    "android",
-    "darwin",
-    "freebsd",
-    "ios",
-    "linux",
-    "windows",
-]
-
 # CPUs that map to a "@platforms//cpu entry
 _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX = {
     "aarch64": "aarch64",

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -1,5 +1,59 @@
 """Helpers for constructing supported Rust platform triples"""
 
+# All T1 Platforms should be supported, but aren't, see inline notes.
+SUPPORTED_T1_PLATFORM_TRIPLES = [
+    "i686-apple-darwin",
+    "i686-pc-windows-msvc",
+    "i686-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    # N.B. These "alternative" envs are not supported, as bazel cannot distinguish between them
+    # and others using existing @platforms// config_values
+    #
+    #"i686-pc-windows-gnu",
+    #"x86_64-pc-windows-gnu",
+]
+
+# Some T2 Platforms are supported, provided we have mappings to @platforms// entries.
+# See @rules_rust//rust/platform:triple_mappings.bzl for the complete list.
+SUPPORTED_T2_PLATFORM_TRIPLES = [
+    "aarch64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+    "aarch64-unknown-linux-gnu",
+    "arm-unknown-linux-gnueabi",
+    "i686-linux-android",
+    "i686-unknown-freebsd",
+    "powerpc-unknown-linux-gnu",
+    "s390x-unknown-linux-gnu",
+    "wasm32-unknown-unknown",
+    "wasm32-wasi",
+    "x86_64-apple-ios",
+    "x86_64-linux-android",
+    "x86_64-unknown-freebsd",
+]
+
+SUPPORTED_PLATFORM_TRIPLES = SUPPORTED_T1_PLATFORM_TRIPLES + SUPPORTED_T2_PLATFORM_TRIPLES
+
+SUPPORTED_CPU_ARCH = [
+    "aarch64",
+    "arm",
+    "i686",
+    "powerpc",
+    "s390x",
+    "x86_64",
+]
+
+SUPPORTED_SYSTEMS = [
+    "android",
+    "darwin",
+    "freebsd",
+    "ios",
+    "linux",
+    "windows",
+]
+
 # CPUs that map to a "@platforms//cpu entry
 _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX = {
     "aarch64": "aarch64",
@@ -42,6 +96,7 @@ _SYSTEM_TO_BUILTIN_SYS_SUFFIX = {
 }
 
 _SYSTEM_TO_BINARY_EXT = {
+    "android": "",
     "darwin": "",
     "emscripten": ".js",
     "freebsd": "",
@@ -56,6 +111,7 @@ _SYSTEM_TO_BINARY_EXT = {
 }
 
 _SYSTEM_TO_STATICLIB_EXT = {
+    "android": ".a",
     "darwin": ".a",
     "emscripten": ".js",
     "freebsd": ".a",
@@ -67,6 +123,7 @@ _SYSTEM_TO_STATICLIB_EXT = {
 }
 
 _SYSTEM_TO_DYLIB_EXT = {
+    "android": ".so",
     "darwin": ".dylib",
     "emscripten": ".js",
     "freebsd": ".so",

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -78,7 +78,6 @@ _SYSTEM_TO_BUILTIN_SYS_SUFFIX = {
 }
 
 _SYSTEM_TO_BINARY_EXT = {
-    "android": "",
     "darwin": "",
     "emscripten": ".js",
     "freebsd": "",
@@ -93,7 +92,6 @@ _SYSTEM_TO_BINARY_EXT = {
 }
 
 _SYSTEM_TO_STATICLIB_EXT = {
-    "android": ".a",
     "darwin": ".a",
     "emscripten": ".js",
     "freebsd": ".a",
@@ -105,7 +103,6 @@ _SYSTEM_TO_STATICLIB_EXT = {
 }
 
 _SYSTEM_TO_DYLIB_EXT = {
-    "android": ".so",
     "darwin": ".dylib",
     "emscripten": ".js",
     "freebsd": ".so",


### PR DESCRIPTION
This information really ought to be public or at least consumable by other modules in `//rust`. But I think it's fine to expose publicly. There's a similar list in [cargo-raze](https://github.com/google/cargo-raze/blob/ee2effee5b6c95cfcfd5e496677ce61dcd35c472/impl/src/util.rs#L27-L50) which needs to be in sync with this so having it be part of the public API would be a good improvement.