### PR TITLE
Added `rust_stdlib_filegroup` rule, a helper for creating toolchains

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -113,6 +113,7 @@ PAGES = dict([
             "rust_toolchain",
             "rust_toolchain_repository",
             "rust_toolchain_repository_proxy",
+            "rust_stdlib_filegroup",
         ],
     ),
     page(

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -25,6 +25,7 @@
 * [rust_repository_set](#rust_repository_set)
 * [rust_shared_library](#rust_shared_library)
 * [rust_static_library](#rust_static_library)
+* [rust_stdlib_filegroup](#rust_stdlib_filegroup)
 * [rust_test](#rust_test)
 * [rust_test_suite](#rust_test_suite)
 * [rust_toolchain](#rust_toolchain)
@@ -891,6 +892,25 @@ When building the whole binary in Bazel, use `rust_library` instead.
 | <a id="rust_static_library-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   | List of strings | optional | [] |
 | <a id="rust_static_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="rust_static_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+
+
+<a id="#rust_stdlib_filegroup"></a>
+
+## rust_stdlib_filegroup
+
+<pre>
+rust_stdlib_filegroup(<a href="#rust_stdlib_filegroup-name">name</a>, <a href="#rust_stdlib_filegroup-srcs">srcs</a>)
+</pre>
+
+A dedicated filegroup-like rule for Rust stdlib artifacts.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_stdlib_filegroup-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_stdlib_filegroup-srcs"></a>srcs |  The list of targets/files that are components of the rust-stdlib file group   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 
 <a id="#rust_test"></a>

--- a/docs/rust_repositories.md
+++ b/docs/rust_repositories.md
@@ -6,6 +6,26 @@
 * [rust_toolchain](#rust_toolchain)
 * [rust_toolchain_repository](#rust_toolchain_repository)
 * [rust_toolchain_repository_proxy](#rust_toolchain_repository_proxy)
+* [rust_stdlib_filegroup](#rust_stdlib_filegroup)
+
+<a id="#rust_stdlib_filegroup"></a>
+
+## rust_stdlib_filegroup
+
+<pre>
+rust_stdlib_filegroup(<a href="#rust_stdlib_filegroup-name">name</a>, <a href="#rust_stdlib_filegroup-srcs">srcs</a>)
+</pre>
+
+A dedicated filegroup-like rule for Rust stdlib artifacts.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_stdlib_filegroup-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_stdlib_filegroup-srcs"></a>srcs |  The list of targets/files that are components of the rust-stdlib file group   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+
 
 <a id="#rust_toolchain"></a>
 

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -62,6 +62,7 @@ load(
 )
 load(
     "@rules_rust//rust:toolchain.bzl",
+    _rust_stdlib_filegroup = "rust_stdlib_filegroup",
     _rust_toolchain = "rust_toolchain",
 )
 load(
@@ -96,6 +97,7 @@ rust_bindgen_repositories = _rust_bindgen_repositories
 rust_toolchain = _rust_toolchain
 rust_proto_toolchain = _rust_proto_toolchain
 rust_proto_repositories = _rust_proto_repositories
+rust_stdlib_filegroup = _rust_stdlib_filegroup
 
 cargo_build_script = _cargo_build_script
 

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -15,6 +15,10 @@
 """Public entry point to all Rust rules and supported APIs."""
 
 load(
+    "//rust:toolchain.bzl",
+    _rust_stdlib_filegroup = "rust_stdlib_filegroup",
+)
+load(
     "//rust/private:clippy.bzl",
     _rust_clippy = "rust_clippy",
     _rust_clippy_aspect = "rust_clippy_aspect",
@@ -111,3 +115,6 @@ rustfmt_aspect = _rustfmt_aspect
 
 rustfmt_test = _rustfmt_test
 # See @rules_rust//rust/private:rustfmt.bzl for a complete description.
+
+rust_stdlib_filegroup = _rust_stdlib_filegroup
+# See @rules_rust//rust:toolchain.bzl for a complete description.

--- a/rust/private/common.bzl
+++ b/rust/private/common.bzl
@@ -23,9 +23,10 @@ which exports the `rust_common` struct.
 In the Bazel lingo, `rust_common` gives the access to the Rust Sandwich API.
 """
 
-load(":providers.bzl", "CrateInfo", "DepInfo")
+load(":providers.bzl", "CrateInfo", "DepInfo", "StdLibInfo")
 
 rust_common = struct(
     crate_info = CrateInfo,
     dep_info = DepInfo,
+    stdlib_info = StdLibInfo,
 )

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -42,3 +42,20 @@ DepInfo = provider(
         "transitive_noncrates": "depset[LinkerInput]: All transitive dependencies that aren't crates.",
     },
 )
+
+StdLibInfo = provider(
+    doc = (
+        "A collection of files either found within the `rust-stdlib` artifact or " +
+        "generated based on existing files."
+    ),
+    fields = {
+        "alloc_files": "List[File]: `.a` files related to the `alloc` module.",
+        "between_alloc_and_core_files": "List[File]: `.a` files related to the `compiler_builtins` module.",
+        "between_core_and_std_files": "List[File]: `.a` files related to all modules except `adler`, `alloc`, `compiler_builtins`, `core`, and `std`.",
+        "core_files": "List[File]: `.a` files related to the `core` and `adler` modules",
+        "dot_a_files": "Depset[File]: Generated `.a` files",
+        "srcs": "List[Target]: The original `src` attribute.",
+        "std_files": "Depset[File]: `.a` files associated with the `std` module.",
+        "std_rlibs": "List[File]: All `.rlib` files",
+    },
+)

--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -138,7 +138,9 @@ def BUILD_for_clippy(target_triple):
     return _build_file_for_clippy_template.format(binary_ext = system_to_binary_ext(system))
 
 _build_file_for_stdlib_template = """\
-filegroup(
+load("@rules_rust//rust:toolchain.bzl", "rust_stdlib_filegroup")
+
+rust_stdlib_filegroup(
     name = "rust_lib-{target_triple}",
     srcs = glob(
         [

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -1,48 +1,48 @@
 """The rust_toolchain rule definition and implementation."""
 
-load(
-    "//rust/private:utils.bzl",
-    "find_cc_toolchain",
+load("//rust/private:utils.bzl", "find_cc_toolchain")
+
+RustStdLibInfo = provider(
+    doc = (
+        "A collection of files either found within the `rust-stdlib` artifact or " +
+        "generated based on existing files."
+    ),
+    fields = {
+        "alloc_files": "List[File]: `.a` files related to the `alloc` module.",
+        "between_alloc_and_core_files": "List[File]: `.a` files related to the `compiler_builtins` module.",
+        "between_core_and_std_files": "List[File]: `.a` files related to all modules except `adler`, `alloc`, `compiler_builtins`, `core`, and `std`.",
+        "core_files": "List[File]: `.a` files related to the `core` and `adler` modules",
+        "dot_a_files": "Depset[File]: Generated `.a` files",
+        "srcs": "List[Target]: The original `src` attribute.",
+        "std_files": "Depset[File]: `.a` files associated with the `std` module.",
+        "std_rlibs": "List[File]: All `.rlib` files",
+    },
 )
 
-def _make_dota(ctx, f):
+def _make_dota(ctx, file):
     """Add a symlink for a file that ends in .a, so it can be used as a staticlib.
 
     Args:
         ctx (ctx): The rule's context object.
-        f (File): The file to symlink.
+        file (File): The file to symlink.
 
     Returns:
         The symlink's File.
     """
-    dot_a = ctx.actions.declare_file(f.basename + ".a", sibling = f)
-    ctx.actions.symlink(output = dot_a, target_file = f)
+    dot_a = ctx.actions.declare_file(file.basename + ".a", sibling = file)
+    ctx.actions.symlink(output = dot_a, target_file = file)
     return dot_a
 
-def _ltl(library, ctx, cc_toolchain, feature_configuration):
-    return cc_common.create_library_to_link(
-        actions = ctx.actions,
-        feature_configuration = feature_configuration,
-        cc_toolchain = cc_toolchain,
-        static_library = library,
-        pic_static_library = library,
-    )
+def _rust_stdlib_filegroup_impl(ctx):
+    rust_lib = ctx.files.srcs
+    dot_a_files = []
+    between_alloc_and_core_files = []
+    core_files = []
+    between_core_and_std_files = []
+    std_files = []
+    alloc_files = []
 
-def _make_libstd_and_allocator_ccinfo(ctx, rust_lib, allocator_library):
-    """Make the CcInfo (if possible) for libstd and allocator libraries.
-
-    Args:
-        ctx (ctx): The rule's context object.
-        rust_lib: The rust standard library.
-        allocator_library: The target to use for providing allocator functions.
-
-
-    Returns:
-        A CcInfo object for the required libraries, or None if no such libraries are available.
-    """
-    cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
-    link_inputs = []
-    std_rlibs = [f for f in rust_lib.files.to_list() if f.basename.endswith(".rlib")]
+    std_rlibs = [f for f in rust_lib if f.basename.endswith(".rlib")]
     if std_rlibs:
         # std depends on everything
         #
@@ -71,26 +71,78 @@ def _make_libstd_and_allocator_ccinfo(ctx, rust_lib, allocator_library):
                 print("File partitioned: {}".format(f.basename))
             fail("rust_toolchain couldn't properly partition rlibs in rust_lib. Partitioned {} out of {} files. This is probably a bug in the rule implementation.".format(partitioned_files_len, len(dot_a_files)))
 
+    return [
+        DefaultInfo(
+            files = depset(ctx.files.srcs),
+        ),
+        RustStdLibInfo(
+            std_rlibs = std_rlibs,
+            dot_a_files = dot_a_files,
+            between_alloc_and_core_files = between_alloc_and_core_files,
+            core_files = core_files,
+            between_core_and_std_files = between_core_and_std_files,
+            std_files = std_files,
+            alloc_files = alloc_files,
+        ),
+    ]
+
+rust_stdlib_filegroup = rule(
+    doc = "A dedicated filegroup-like rule for Rust stdlib artifacts.",
+    implementation = _rust_stdlib_filegroup_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+            doc = "The list of targets/files that are components of the rust-stdlib file group",
+            mandatory = True,
+        ),
+    },
+)
+
+def _ltl(library, ctx, cc_toolchain, feature_configuration):
+    return cc_common.create_library_to_link(
+        actions = ctx.actions,
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        static_library = library,
+        pic_static_library = library,
+    )
+
+def _make_libstd_and_allocator_ccinfo(ctx, rust_lib, allocator_library):
+    """Make the CcInfo (if possible) for libstd and allocator libraries.
+
+    Args:
+        ctx (ctx): The rule's context object.
+        rust_lib: The rust standard library.
+        allocator_library: The target to use for providing allocator functions.
+
+
+    Returns:
+        A CcInfo object for the required libraries, or None if no such libraries are available.
+    """
+    cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
+    link_inputs = []
+    rust_stdlib_info = ctx.attr.rust_lib[RustStdLibInfo]
+    if rust_stdlib_info.std_rlibs:
         alloc_inputs = depset(
-            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in alloc_files],
+            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in rust_stdlib_info.alloc_files],
         )
         between_alloc_and_core_inputs = depset(
-            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in between_alloc_and_core_files],
+            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in rust_stdlib_info.between_alloc_and_core_files],
             transitive = [alloc_inputs],
             order = "topological",
         )
         core_inputs = depset(
-            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in core_files],
+            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in rust_stdlib_info.core_files],
             transitive = [between_alloc_and_core_inputs],
             order = "topological",
         )
         between_core_and_std_inputs = depset(
-            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in between_core_and_std_files],
+            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in rust_stdlib_info.between_core_and_std_files],
             transitive = [core_inputs],
             order = "topological",
         )
         std_inputs = depset(
-            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in std_files],
+            [_ltl(f, ctx, cc_toolchain, feature_configuration) for f in rust_stdlib_info.std_files],
             transitive = [between_core_and_std_inputs],
             order = "topological",
         )

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -125,13 +125,10 @@ def _make_libstd_and_allocator_ccinfo(ctx, rust_lib, allocator_library):
     if not RustStdLibInfo in ctx.attr.rust_lib:
         fail(dedent("""\
             {} --
-            The `rust_lib` must be a `rust_stdlib_filegroup` target. This rule should be a simple
-            drop-in replacement for the previous `filegroup` that was expected. If for some reason the 
-            `rust_lib` target is provied from a custom rule, then this rule should return a `RustStdLibInfo`
-            provider. Both `rust_stdlib_filegroup` and `RustStdLibInfo` can be loaded from
-            `@rules_rust//rust:toolchain.bzl`. For any additional assistence pleas file an issue on the
-            GitHub project (https://github.com/bazelbuild/rules_rust) or reach out in the slack channel
-            (https://bazelbuild.slack.com/archives/CSV56UT0F).
+            The `rust_lib` must be a target providing `rust_common.stdlib_info` 
+            (typically `rust_stdlib_filegroup` rule from @rules_rust//rust:defs.bzl).
+            See https://github.com/bazelbuild/rules_rust/pull/802 for more information.
+            
         """).format(ctx.label))
     rust_stdlib_info = ctx.attr.rust_lib[RustStdLibInfo]
 


### PR DESCRIPTION
This reduces the complexity of the toolchain itself making it lighter weight and allows the rest of the code to otherwise treat the rust stdlib artifact as a general filegroup but benefit from from having additional required files used for compilation/linking.