### PR TITLE
Add missing android extensions

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -42,6 +42,7 @@ _SYSTEM_TO_BUILTIN_SYS_SUFFIX = {
 }
 
 _SYSTEM_TO_BINARY_EXT = {
+    "android": "",
     "darwin": "",
     "emscripten": ".js",
     "freebsd": "",
@@ -56,6 +57,7 @@ _SYSTEM_TO_BINARY_EXT = {
 }
 
 _SYSTEM_TO_STATICLIB_EXT = {
+    "android": ".a",
     "darwin": ".a",
     "emscripten": ".js",
     "freebsd": ".a",
@@ -67,6 +69,7 @@ _SYSTEM_TO_STATICLIB_EXT = {
 }
 
 _SYSTEM_TO_DYLIB_EXT = {
+    "android": ".so",
     "darwin": ".dylib",
     "emscripten": ".js",
     "freebsd": ".so",


### PR DESCRIPTION
Specify extensions for android system.

This is a drive-by fix. We don't currently have any android tests here and I didn't test it manually, but I think it's correct.

(original conversation: https://github.com/bazelbuild/rules_rust/pull/797#discussion_r660884773)