### PR TITLE
Added `rust_common.create_crate_info`

### DIFF
--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -222,7 +222,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
         ctx = ctx,
         toolchain = find_toolchain(ctx),
         crate_type = "rlib",
-        crate_info = rust_common.crate_info(
+        crate_info = rust_common.create_crate_info(
             name = crate_name,
             type = "rlib",
             root = lib_rs,

--- a/rust/private/common.bzl
+++ b/rust/private/common.bzl
@@ -25,7 +25,11 @@ In the Bazel lingo, `rust_common` gives the access to the Rust Sandwich API.
 
 load(":providers.bzl", "CrateInfo", "DepInfo")
 
+def _create_crate_info(**kwargs):
+    return CrateInfo(**kwargs)
+
 rust_common = struct(
+    create_crate_info = _create_crate_info,
     crate_info = CrateInfo,
     dep_info = DepInfo,
 )

--- a/rust/private/common.bzl
+++ b/rust/private/common.bzl
@@ -26,6 +26,17 @@ In the Bazel lingo, `rust_common` gives the access to the Rust Sandwich API.
 load(":providers.bzl", "CrateInfo", "DepInfo")
 
 def _create_crate_info(**kwargs):
+    """A constructor for a `CrateInfo` provider
+
+    This macro should be used in place of directly creating a `CrateInfo`
+    provider to improve API stability.
+
+    Args:
+        **kwargs: An inital set of keyword arguments.
+
+    Returns:
+        CrateInfo: A provider
+    """
     return CrateInfo(**kwargs)
 
 rust_common = struct(

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -254,7 +254,7 @@ def _rust_library_common(ctx, crate_type):
         ctx = ctx,
         toolchain = toolchain,
         crate_type = crate_type,
-        crate_info = rust_common.crate_info(
+        crate_info = rust_common.create_crate_info(
             name = crate_name,
             type = crate_type,
             root = crate_root,
@@ -289,7 +289,7 @@ def _rust_binary_impl(ctx):
         ctx = ctx,
         toolchain = toolchain,
         crate_type = ctx.attr.crate_type,
-        crate_info = rust_common.crate_info(
+        crate_info = rust_common.create_crate_info(
             name = crate_name,
             type = ctx.attr.crate_type,
             root = crate_root_src(ctx.attr, ctx.files.srcs, ctx.attr.crate_type),
@@ -406,7 +406,7 @@ def _rust_test_common(ctx, toolchain, output):
         # Target is building the crate in `test` config
         # Build the test binary using the dependency's srcs.
         crate = ctx.attr.crate[rust_common.crate_info]
-        crate_info = rust_common.crate_info(
+        crate_info = rust_common.create_crate_info(
             name = crate_name,
             type = crate_type,
             root = crate.root,
@@ -421,7 +421,7 @@ def _rust_test_common(ctx, toolchain, output):
         )
     else:
         # Target is a standalone crate. Build the test binary as its own crate.
-        crate_info = rust_common.crate_info(
+        crate_info = rust_common.create_crate_info(
             name = crate_name,
             type = crate_type,
             root = crate_root_src(ctx.attr, ctx.files.srcs, "lib"),


### PR DESCRIPTION
The `rust_common.create_crate_info` macro creates a `CrateInfo` provider through a macro which allows for the rules to maintain better backwards compatibility when making changes to `CrateInfo`.