### PR TITLE
Use the libraries included with the clang distribution for bindgen

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -29,7 +29,7 @@ tasks:
       - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
       - "..."
       - "@examples//..."
-      # This test fails under bazel test but not when run directly due to -rpath issues.
+      # This test requires --incompatible_macos_set_install_name and Bazel 4.2.0+
       - "-@examples//ffi/rust_calling_c:matrix_dylib_test"
     build_targets: *osx_targets
     test_targets: *osx_targets

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -29,10 +29,8 @@ tasks:
       - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
       - "..."
       - "@examples//..."
-      # Skip tests for dylib support on osx, since we don't support it yet.
+      # This test fails under bazel test but not when run directly due to -rpath issues.
       - "-@examples//ffi/rust_calling_c:matrix_dylib_test"
-      - "-@examples//ffi/rust_calling_c:matrix_dynamically_linked"
-      - "-@examples//ffi/rust_calling_c/simple/..."
     build_targets: *osx_targets
     test_targets: *osx_targets
     build_flags:

--- a/bindgen/BUILD.bazel
+++ b/bindgen/BUILD.bazel
@@ -19,10 +19,13 @@ rust_bindgen_toolchain(
         "//conditions:default": "@bindgen_clang_linux//:clang",
     }),
     libclang = select({
-        "//rust/platform:osx": "@bindgen_clang_osx//:libclang.so",
+        "//rust/platform:osx": "@bindgen_clang_osx//:libclang.dylib",
         "//conditions:default": "@bindgen_clang_linux//:libclang.so",
     }),
-    libstdcxx = "@local_libstdcpp//:libstdc++",
+    libstdcxx = select({
+        "//rust/platform:osx": "@bindgen_clang_osx//:lib/libc++.dylib",
+        "//conditions:default": "@bindgen_clang_linux//:lib/libc++.so",
+    }),
 )
 
 toolchain(

--- a/bindgen/BUILD.bazel
+++ b/bindgen/BUILD.bazel
@@ -24,7 +24,7 @@ rust_bindgen_toolchain(
     }),
     libstdcxx = select({
         "//rust/platform:osx": "@bindgen_clang_osx//:lib/libc++.dylib",
-        "//conditions:default": "@bindgen_clang_linux//:lib/libc++.so",
+        "//conditions:default": None,
     }),
 )
 

--- a/bindgen/BUILD.bazel
+++ b/bindgen/BUILD.bazel
@@ -19,11 +19,11 @@ rust_bindgen_toolchain(
         "//conditions:default": "@bindgen_clang_linux//:clang",
     }),
     libclang = select({
-        "//rust/platform:osx": "@bindgen_clang_osx//:libclang.dylib",
-        "//conditions:default": "@bindgen_clang_linux//:libclang.so",
+        "//rust/platform:osx": "@bindgen_clang_osx//:libclang",
+        "//conditions:default": "@bindgen_clang_linux//:libclang",
     }),
     libstdcxx = select({
-        "//rust/platform:osx": "@bindgen_clang_osx//:lib/libc++.dylib",
+        "//rust/platform:osx": "@bindgen_clang_osx//:libc++",
         "//conditions:default": None,
     }),
 )

--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -125,6 +125,7 @@ def _rust_bindgen_impl(ctx):
 
     if libstdcxx:
         env["LD_LIBRARY_PATH"] = ":".join([f.dirname for f in _get_libs_for_static_executable(libstdcxx).to_list()])
+        # DYLD_LIBRARY_PATH is LD_LIBRARY_PATH on macOS.
         env["DYLD_LIBRARY_PATH"] = env["LD_LIBRARY_PATH"]
 
     ctx.actions.run(

--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -123,9 +123,10 @@ def _rust_bindgen_impl(ctx):
         "RUST_BACKTRACE": "1",
     }
 
+    # Set the dynamic linker search path so that clang uses the libstdcxx from the toolchain.
+    # DYLD_LIBRARY_PATH is LD_LIBRARY_PATH on macOS.
     if libstdcxx:
         env["LD_LIBRARY_PATH"] = ":".join([f.dirname for f in _get_libs_for_static_executable(libstdcxx).to_list()])
-        # DYLD_LIBRARY_PATH is LD_LIBRARY_PATH on macOS.
         env["DYLD_LIBRARY_PATH"] = env["LD_LIBRARY_PATH"]
 
     ctx.actions.run(

--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -132,6 +132,7 @@ def _rust_bindgen_impl(ctx):
 
     if libstdcxx:
         env["LD_LIBRARY_PATH"] = ":".join([f.dirname for f in _get_libs_for_static_executable(libstdcxx).to_list()])
+        env["DYLD_LIBRARY_PATH"] = env["LD_LIBRARY_PATH"]
 
     ctx.actions.run(
         executable = bindgen_bin,

--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -87,13 +87,6 @@ def _rust_bindgen_impl(ctx):
     rustfmt_bin = toolchain.rustfmt or rust_toolchain.rustfmt
     clang_bin = toolchain.clang
     libclang = toolchain.libclang
-
-    # TODO: This rule shouldn't need to depend on libstdc++
-    #  This rule requires an explicit dependency on a libstdc++ because
-    #    1. It is a runtime dependency of libclang.so
-    #    2. We cannot locate it in the cc_toolchain yet
-    #  Depending on how libclang.so was compiled, it may try to locate its libstdc++ dependency
-    #  in a way that makes our handling here unnecessary (eg. system /usr/lib/x86_64-linux-gnu/libstdc++.so.6)
     libstdcxx = toolchain.libstdcxx
 
     # rustfmt is not where bindgen expects to find it, so we format manually
@@ -233,9 +226,10 @@ rust_bindgen_toolchain = rule(
             providers = [CcInfo],
         ),
         "libstdcxx": attr.label(
-            doc = "A cc_library that satisfies libclang's libstdc++ dependency.",
+            doc = "A cc_library that satisfies libclang's libstdc++ dependency. This is used to make the execution of clang hermetic. If not specified, clang will attempt to use the system libraries.",
             cfg = "exec",
             providers = [CcInfo],
+            mandatory = False,
         ),
         "rustfmt": attr.label(
             doc = "The label of a `rustfmt` executable. If this is provided, generated sources will be formatted.",

--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -134,9 +134,9 @@ def _rust_bindgen_impl(ctx):
             transitive = [
                 cc_lib[CcInfo].compilation_context.headers,
                 _get_libs_for_static_executable(libclang),
-            ] + [
+            ] + ([
                 _get_libs_for_static_executable(libstdcxx),
-            ] if libstdcxx else [],
+            ] if libstdcxx else []),
         ),
         outputs = [unformatted_output],
         mnemonic = "RustBindgen",
@@ -226,7 +226,7 @@ rust_bindgen_toolchain = rule(
             providers = [CcInfo],
         ),
         "libstdcxx": attr.label(
-            doc = "A cc_library that satisfies libclang's libstdc++ dependency. This is used to make the execution of clang hermetic. If not specified, clang will attempt to use the system libraries.",
+            doc = "A cc_library that satisfies libclang's libstdc++ dependency. This is used to make the execution of clang hermetic. If None, system libraries will be used instead.",
             cfg = "exec",
             providers = [CcInfo],
             mandatory = False,

--- a/bindgen/repositories.bzl
+++ b/bindgen/repositories.bzl
@@ -43,19 +43,29 @@ http_archive(
 """
 
 _CLANG_BUILD_FILE = """\
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_import")
 
 package(default_visibility = ["//visibility:public"])
 
 sh_binary(
     name = "clang",
     srcs = ["bin/clang"],
-    data = glob(["lib/**"]),
 )
 
-cc_library(
+cc_import(
+    name = "libclang",
+    shared_library = "lib/libclang.{suffix}",
+)
+
+alias(
     name = "libclang.so",
-    srcs = ["{}"],
+    actual = ":libclang",
+    deprecation = "Use :libclang instead",
+)
+
+cc_import(
+    name = "libc++",
+    shared_library = "lib/libc++.{suffix}"
 )
 """
 
@@ -67,7 +77,7 @@ def _bindgen_clang_repositories():
         urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"],
         strip_prefix = "clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04",
         sha256 = "b25f592a0c00686f03e3b7db68ca6dc87418f681f4ead4df4745a01d9be63843",
-        build_file_content = _CLANG_BUILD_FILE.format("lib/libclang.so"),
+        build_file_content = _CLANG_BUILD_FILE.format(suffix="so"),
         workspace_file_content = _COMMON_WORKSPACE.format("bindgen_clang_linux"),
     )
 
@@ -77,6 +87,6 @@ def _bindgen_clang_repositories():
         urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz"],
         strip_prefix = "clang+llvm-10.0.0-x86_64-apple-darwin",
         sha256 = "633a833396bf2276094c126b072d52b59aca6249e7ce8eae14c728016edb5e61",
-        build_file_content = _CLANG_BUILD_FILE.format("lib/libclang.dylib"),
+        build_file_content = _CLANG_BUILD_FILE.format(suffix="dylib"),
         workspace_file_content = _COMMON_WORKSPACE.format("bindgen_clang_osx"),
     )

--- a/bindgen/repositories.bzl
+++ b/bindgen/repositories.bzl
@@ -77,7 +77,7 @@ def _bindgen_clang_repositories():
         urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"],
         strip_prefix = "clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04",
         sha256 = "b25f592a0c00686f03e3b7db68ca6dc87418f681f4ead4df4745a01d9be63843",
-        build_file_content = _CLANG_BUILD_FILE.format(suffix="so"),
+        build_file_content = _CLANG_BUILD_FILE.format(suffix = "so"),
         workspace_file_content = _COMMON_WORKSPACE.format("bindgen_clang_linux"),
     )
 
@@ -87,6 +87,6 @@ def _bindgen_clang_repositories():
         urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz"],
         strip_prefix = "clang+llvm-10.0.0-x86_64-apple-darwin",
         sha256 = "633a833396bf2276094c126b072d52b59aca6249e7ce8eae14c728016edb5e61",
-        build_file_content = _CLANG_BUILD_FILE.format(suffix="dylib"),
+        build_file_content = _CLANG_BUILD_FILE.format(suffix = "dylib"),
         workspace_file_content = _COMMON_WORKSPACE.format("bindgen_clang_osx"),
     )

--- a/bindgen/repositories.bzl
+++ b/bindgen/repositories.bzl
@@ -24,11 +24,6 @@ def rust_bindgen_repositories():
     # nb. The bindgen rule itself should work on any platform.
     _bindgen_clang_repositories()
 
-    maybe(
-        _local_libstdcpp,
-        name = "local_libstdcpp",
-    )
-
     rules_rust_bindgen_fetch_remote_crates()
 
     native.register_toolchains(str(Label("//bindgen:default_bindgen_toolchain")))
@@ -85,29 +80,3 @@ def _bindgen_clang_repositories():
         build_file_content = _CLANG_BUILD_FILE.format("lib/libclang.dylib"),
         workspace_file_content = _COMMON_WORKSPACE.format("bindgen_clang_osx"),
     )
-
-_LIBSTDCPP_BUILD_FILE = """\
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
-cc_library(
-  name = "libstdc++",
-  srcs = ["{}"],
-  visibility = ["//visibility:public"]
-)
-"""
-
-def _local_libstdcpp_impl(repository_ctx):
-    os = repository_ctx.os.name.lower()
-    if os == "linux":
-        repository_ctx.symlink("/usr/lib/x86_64-linux-gnu/libstdc++.so.6", "libstdc++.so.6")
-        repository_ctx.file("BUILD.bazel", _LIBSTDCPP_BUILD_FILE.format("libstdc++.so.6"))
-    elif os.startswith("mac"):
-        repository_ctx.symlink("/usr/lib/libstdc++.6.dylib", "libstdc++.6.dylib")
-        repository_ctx.file("BUILD.bazel", _LIBSTDCPP_BUILD_FILE.format("libstdc++.6.dylib"))
-    else:
-        fail(os + " is not supported.")
-    repository_ctx.file("WORKSPACE.bazel", _COMMON_WORKSPACE.format(repository_ctx.name))
-
-_local_libstdcpp = repository_rule(
-    implementation = _local_libstdcpp_impl,
-)

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -367,7 +367,7 @@ The tools required for the `rust_bindgen` rule.
 | <a id="rust_bindgen_toolchain-bindgen"></a>bindgen |  The label of a <code>bindgen</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-clang"></a>clang |  The label of a <code>clang</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-libclang"></a>libclang |  A cc_library that provides bindgen's runtime dependency on libclang.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_bindgen_toolchain-libstdcxx"></a>libstdcxx |  A cc_library that satisfies libclang's libstdc++ dependency. This is used to make the execution of clang hermetic. If not specified, clang will attempt to use the system libraries.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_bindgen_toolchain-libstdcxx"></a>libstdcxx |  A cc_library that satisfies libclang's libstdc++ dependency. This is used to make the execution of clang hermetic. If None, system libraries will be used instead.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-rustfmt"></a>rustfmt |  The label of a <code>rustfmt</code> executable. If this is provided, generated sources will be formatted.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -367,7 +367,7 @@ The tools required for the `rust_bindgen` rule.
 | <a id="rust_bindgen_toolchain-bindgen"></a>bindgen |  The label of a <code>bindgen</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-clang"></a>clang |  The label of a <code>clang</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-libclang"></a>libclang |  A cc_library that provides bindgen's runtime dependency on libclang.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_bindgen_toolchain-libstdcxx"></a>libstdcxx |  A cc_library that satisfies libclang's libstdc++ dependency.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_bindgen_toolchain-libstdcxx"></a>libstdcxx |  A cc_library that satisfies libclang's libstdc++ dependency. This is used to make the execution of clang hermetic. If not specified, clang will attempt to use the system libraries.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-rustfmt"></a>rustfmt |  The label of a <code>rustfmt</code> executable. If this is provided, generated sources will be formatted.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/docs/rust_bindgen.md
+++ b/docs/rust_bindgen.md
@@ -47,7 +47,7 @@ The tools required for the `rust_bindgen` rule.
 | <a id="rust_bindgen_toolchain-bindgen"></a>bindgen |  The label of a <code>bindgen</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-clang"></a>clang |  The label of a <code>clang</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-libclang"></a>libclang |  A cc_library that provides bindgen's runtime dependency on libclang.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_bindgen_toolchain-libstdcxx"></a>libstdcxx |  A cc_library that satisfies libclang's libstdc++ dependency.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_bindgen_toolchain-libstdcxx"></a>libstdcxx |  A cc_library that satisfies libclang's libstdc++ dependency. This is used to make the execution of clang hermetic. If not specified, clang will attempt to use the system libraries.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-rustfmt"></a>rustfmt |  The label of a <code>rustfmt</code> executable. If this is provided, generated sources will be formatted.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/docs/rust_bindgen.md
+++ b/docs/rust_bindgen.md
@@ -47,7 +47,7 @@ The tools required for the `rust_bindgen` rule.
 | <a id="rust_bindgen_toolchain-bindgen"></a>bindgen |  The label of a <code>bindgen</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-clang"></a>clang |  The label of a <code>clang</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-libclang"></a>libclang |  A cc_library that provides bindgen's runtime dependency on libclang.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="rust_bindgen_toolchain-libstdcxx"></a>libstdcxx |  A cc_library that satisfies libclang's libstdc++ dependency. This is used to make the execution of clang hermetic. If not specified, clang will attempt to use the system libraries.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="rust_bindgen_toolchain-libstdcxx"></a>libstdcxx |  A cc_library that satisfies libclang's libstdc++ dependency. This is used to make the execution of clang hermetic. If None, system libraries will be used instead.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_bindgen_toolchain-rustfmt"></a>rustfmt |  The label of a <code>rustfmt</code> executable. If this is provided, generated sources will be formatted.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -752,12 +752,12 @@ def _compute_rpaths(toolchain, output_dir, dep_info):
     Returns:
         depset: A set of relative paths from the output directory to each dependency
     """
-    preferreds = [get_preferred_artifact(lib) for linker_input in dep_info.transitive_noncrates.to_list() for lib in linker_input.libraries]
-
-    # TODO(augie): I don't understand why this can't just be filtering on
-    # _is_dylib(lib), but doing that causes failures on darwin and windows
-    # examples that otherwise work.
-    dylibs = [lib for lib in preferreds if _has_dylib_ext(lib, toolchain.dylib_ext)]
+    dylibs = [
+        get_preferred_artifact(lib)
+        for linker_input in dep_info.transitive_noncrates.to_list()
+        for lib in linker_input.libraries
+        if _is_dylib(lib)
+    ]
     if not dylibs:
         return depset([])
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -752,6 +752,11 @@ def _compute_rpaths(toolchain, output_dir, dep_info):
     Returns:
         depset: A set of relative paths from the output directory to each dependency
     """
+
+    # Windows has no rpath equivalent, so always return an empty depset.
+    if toolchain.os == "windows":
+        return depset([])
+
     dylibs = [
         get_preferred_artifact(lib)
         for linker_input in dep_info.transitive_noncrates.to_list()


### PR DESCRIPTION
Prior to this PR, bindgen is broken on macOS 11.4 because it cannot find the file `/usr/lib/libstdc++.6.dylib` (it's a broken symlink).

As far as I can tell, what this code is trying to do is invoke `clang` with `LD_LIBRARY_PATH` so that it reads the libraries specified in the toolchain. On macOS, this variable name is actually `DYLD_LIBRARY_PATH` so this wasn't really working at all before on macOS -- probably the system libraries were being used instead. I'm not sure if you can detect the OS from inside a rule, so I'm setting both LD_LIBRARY_PATH and DYLD_LIBRARY_PATH because I don't think it hurts anything, but if there's a better way to write it I'm happy to change.

The bindgen toolchain is also kind of weird because it asks for a label to a library like `libstdc++.dylib` but there's really no guarantee that 1) clang was compiled with libstdc++ (on macOS, it isn't -- libc++ is used instead), and 2) there's several other dynamic libraries that are typically required, such as `libc++abi.dylib` and `libunwind.dylib`. Still, this all just happens to work because all of these typically reside in the same directory, and the starlark rule just gets the directory from whatever you pass to the libstdcxx attribute, but I suppose if you were hooking this up to a fully hermetic bazel build of LLVM that might not be true.