### PR TITLE
Define backwards compatibility policy for `rules_rust`

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -55,8 +55,8 @@ are only available in Bazel rolling releases). `rules_rust` will aim that new
 features available to the current Bazel rolling release will be available to the
 next Bazel LTS release at latest.
 
-Whenever there is a new Bazel LTS release, all releases of `rules_rust` in the
-first 3 months will support both Bazel LTS versions unless Bazel doesn't allow this.
+Whenever there is a new Bazel LTS release, all releases of `rules_rust` will maintain
+support for the older LTS version for at least 3 months unless Bazel doesn't allow this.
 
 ## What host platforms are supported?
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -54,9 +54,9 @@ first 3 months will support both Bazel LTS versions.
 
 ## What host platforms are supported?
 
-The only platform subject to backwards compatibility policy is `x86_64-unknown-linux-gnu` on
-`x86_64`, as the only fully supported platform. Process for moving a best effort
-platform to a supported platform is consensus-based.
+The only platform subject to backwards compatibility policy is
+`x86_64-unknown-linux-gnu`, as the only fully supported platform. Process for
+moving a best effort platform to a supported platform is consensus-based.
 
 ## What are the stable APIs of `rules_rust`?
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -50,7 +50,7 @@ features available to the current Bazel rolling release will be available to the
 next Bazel LTS release at latest.
 
 Whenever there is a new Bazel LTS release, all releases of `rules_rust` in the
-first 3 months will support both Bazel LTS versions.
+first 3 months will support both Bazel LTS versions unless Bazel doesn't allow this.
 
 ## What host platforms are supported?
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -54,7 +54,7 @@ first 3 months will support both Bazel LTS versions.
 
 ## What host platforms are supported?
 
-The only platform subject to backwards compatibility policy is `Linux` on
+The only platform subject to backwards compatibility policy is `x86_64-unknown-linux-gnu` on
 `x86_64`, as the only fully supported platform. Process for moving a best effort
 platform to a supported platform is consensus-based.
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -45,7 +45,7 @@ same. We hope red CI with the current rolling release will be rare.
 current Bazel rolling release to be be available to the current Bazel LTS
 release (because Bazel compatibility policy doesn't allow us to make that
 promise, and some new features of `rules_rust` require new Bazel features that
-are only available in Bazel rolling releases). `rules_rust` do promise that new
+are only available in Bazel rolling releases). `rules_rust` will aim that new
 features available to the current Bazel rolling release will be available to the
 next Bazel LTS release at latest.
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -60,9 +60,9 @@ first 3 months will support both Bazel LTS versions unless Bazel doesn't allow t
 
 ## What host platforms are supported?
 
-The only platform subject to backwards compatibility policy is
-`x86_64-unknown-linux-gnu`, as the only fully supported platform. Process for
-moving a best effort platform to a supported platform is consensus-based.
+Platforms subject to backwards compatibility policy are
+`x86_64-unknown-linux-gnu` and `x86_64-apple-darwin` (platforms supported by `rules_rust`).
+Process for moving a best effort platform to a supported platform is consensus-based.
 
 ## What are the stable APIs of `rules_rust`?
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -72,9 +72,11 @@ that anything directly accessible from this file is considered stable.
 `//rust/private/…` is not subject to the backwards compatibility policy. Content
 of this package is an implementation detail.
 
-`//cargo`, `//util`, `//tools`, `//test`, `//examples`, `//bindgen`, `//proto`, `//wasm_bindgen`
-and any packages not mentioned by this document are by default not subject to
-the backwards compatibility policy.
+`//cargo:cargo_build_script.bzl` is subject to the backwards compatibility policy.
+
+`//cargo`, `//util`, `//tools`, `//test`, `//examples`, `//bindgen`, `//proto`,
+`//wasm_bindgen` and any packages not mentioned by this document are by default
+not subject to the backwards compatibility policy.
 
 Experimental build settings are not subject to the backward compatibility
 policy. They should be added to `//rust:experimental.bzl`.
@@ -85,7 +87,9 @@ They should be added to `//rust:incompatible.bzl`.
 
 Bug fixes are not a breaking change by default. We'll use Common Sense (and we
 will pull in more maintainers and the community to discuss) if we see a certain
-bug fix is controversial.
+bug fix is controversial. Incompatible changes to
+`//cargo:cargo_build_script.bzl` that make `cargo_build_script` more accurately
+follow cargo's behaviour are considered bug fixes.
 
 ## How to make a backwards incompatible change?
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,102 @@
+# `rules_rust` backwards compatibility policy
+
+This document defines the backwards compatibility policy for rules\_rust and
+defines the process for making compatibility breaking changes. Any exception to
+this process will have to be thoroughly discussed and there will have to be a
+consensus between maintainers that the exception should be granted.
+
+## What is a compatibility breaking change?
+
+A backwards compatible change has the property that a build that is green,
+correct, is using stable APIs of `rules_rust,` and is using a supported version
+of Bazel before the change is still green and correct after the change. In
+practice it means that users should not have to modify their project source
+files, their `BUILD` files, their `bzl` files, their `rust_toolchain`
+definitions, their platform definitions, or their build settings.
+
+A backwards compatible release has the property that it only contains backward
+compatible changes.
+
+`rules_rust` follow [SemVer 2.0.0](https://semver.org/). `rules_rust` promise
+that all minor version number and patch version number releases only contain
+backwards compatible changes.
+
+`rules_rust` don't make any guarantees about compatibility between a released
+version and the state of the `rules_rust` at HEAD.
+
+Backwards incompatible changes will have to follow a process in order to be
+released. Users will be given at least one release where the old behavior is
+still present but deprecated to allow smooth migration of their project to the
+new behavior.
+
+## What Bazel versions are supported?
+
+`rules_rust` support the current Bazel LTS at the time of a `rules_rust`
+release.
+
+Support for the current Bazel rolling release is on the best effort basis. If
+the CI build of `rules_rust` against the current Bazel rolling release is green,
+it has to stay green. If the build is already red (because the new Bazel rolling
+release had incompatible changes that broke `rules_rust`), it is acceptable to
+merge PRs leaving the build red as long as the reason for failure remains the
+same. We hope red CI with the current rolling release will be rare.
+
+`rules_rust` don't promise all new `rules_rust` features available to the
+current Bazel rolling release to be be available to the current Bazel LTS
+release (because Bazel compatibility policy doesn't allow us to make that
+promise, and some new features of `rules_rust` require new Bazel features that
+are only available in Bazel rolling releases). `rules_rust` do promise that new
+features available to the current Bazel rolling release will be available to the
+next Bazel LTS release at latest.
+
+Whenever there is a new Bazel LTS release, all releases of `rules_rust` in the
+first 3 months will support both Bazel LTS versions.
+
+## What host platforms are supported?
+
+The only platform subject to backwards compatibility policy is `Linux` on
+`x86_64`, as the only fully supported platform. Process for moving a best effort
+platform to a supported platform is consensus-based.
+
+## What are the stable APIs of `rules_rust`?
+
+`//rust:defs.bzl` is subject to the backwards compatibility policy. That means
+that anything directly accessible from this file is considered stable.
+
+`//rust/private/…` is not subject to the backwards compatibility policy. Content
+of this package is an implementation detail.
+
+`//cargo`, `//util`, `//tools`, `//test`, `//examples`, `//bindgen`, `//proto`
+and any packages not mentioned by this document are by default not subject to
+the backwards compatibility policy.
+
+Experimental build settings are not subject to the backward compatibility
+policy. They should be added to `//rust:experimental.bzl`.
+
+Incompatible build settings are subject to the backward compatibility policy,
+meaning the behavior of the flag cannot change in a backwards incompatible way.
+They should be added to `//rust:incompatible.bzl`.
+
+Bug fixes are not a breaking change by default. We'll use Common Sense (and we
+will pull in more maintainers and the community to discuss) if we see a certain
+bug fix is controversial.
+
+## How to make a backwards incompatible change?
+
+1. Create a GitHub issue (example:
+[Split rust\_library into smaller rules#591](https://github.com/bazelbuild/rules_rust/issues/591)).
+2. Describe the change, motivation for the change, provide migration
+instructions/tooling.
+3. Add a build setting into `//rust:incompatible.bzl` that removes the old
+behavior (whenever possible) or changes the current behavior (when just
+removing old behavior is not possible). Users should not need to manually
+flip incompatible flags. If for a specific flag they do need to manually flip
+it, then in the first backwards incompatible release we make the flag be a
+noop, and only in the second backwards incompatible release we remove the
+flag.
+4. Mention the link to the GitHub issue in error messages. Do not add a
+deprecation warning (warnings make the deprecation visible to every user
+building a project, not only to the maintainers of the project or the rules).
+5. Mention the issue in the `CHANGELOG` file.
+6. Give the community 3 months from the first release mentioning the issue until
+the flag flip to migrate.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -29,6 +29,12 @@ released. Users will be given at least one release where the old behavior is
 still present but deprecated to allow smooth migration of their project to the
 new behavior.
 
+### Compatibility before 1.0
+
+All minor version number releases before version 1.0 can be backwards incompatible.
+Backwards incompatible changes still have to follow the the process, but minimum
+time for migration is reduced to 2 weeks.
+
 ## What Bazel versions are supported?
 
 `rules_rust` support the current Bazel LTS at the time of a `rules_rust`

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # `rules_rust` backwards compatibility policy
 
-This document defines the backwards compatibility policy for rules\_rust and
+This document defines the backwards compatibility policy for rules_rust and
 defines the process for making compatibility breaking changes. Any exception to
 this process will have to be thoroughly discussed and there will have to be a
 consensus between maintainers that the exception should be granted.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -84,7 +84,7 @@ bug fix is controversial.
 ## How to make a backwards incompatible change?
 
 1. Create a GitHub issue (example:
-[Split rust\_library into smaller rules#591](https://github.com/bazelbuild/rules_rust/issues/591)).
+[Split rust_library into smaller rules#591](https://github.com/bazelbuild/rules_rust/issues/591)).
 2. Describe the change, motivation for the change, provide migration
 instructions/tooling.
 3. Add a build setting into `//rust:incompatible.bzl` that removes the old

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -66,7 +66,7 @@ that anything directly accessible from this file is considered stable.
 `//rust/private/…` is not subject to the backwards compatibility policy. Content
 of this package is an implementation detail.
 
-`//cargo`, `//util`, `//tools`, `//test`, `//examples`, `//bindgen`, `//proto`
+`//cargo`, `//util`, `//tools`, `//test`, `//examples`, `//bindgen`, `//proto`, `//wasm_bindgen`
 and any packages not mentioned by this document are by default not subject to
 the backwards compatibility policy.
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -99,11 +99,8 @@ follow cargo's behaviour are considered bug fixes.
 instructions/tooling.
 3. Add a build setting into `//rust:incompatible.bzl` that removes the old
 behavior (whenever possible) or changes the current behavior (when just
-removing old behavior is not possible). Users should not need to manually
-flip incompatible flags. If for a specific flag they do need to manually flip
-it, then in the first backwards incompatible release we make the flag be a
-noop, and only in the second backwards incompatible release we remove the
-flag.
+removing the old behavior is not possible). Ideally, users should not need to
+manually flip incompatible flags.
 4. Mention the link to the GitHub issue in error messages. Do not add a
 deprecation warning (warnings make the deprecation visible to every user
 building a project, not only to the maintainers of the project or the rules).

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,7 +8,7 @@ consensus between maintainers that the exception should be granted.
 ## What is a compatibility breaking change?
 
 A backwards compatible change has the property that a build that is green,
-correct, is using stable APIs of `rules_rust,` and is using a supported version
+correct, is using stable APIs of `rules_rust`, and is using a supported version
 of Bazel before the change is still green and correct after the change. In
 practice it means that users should not have to modify their project source
 files, their `BUILD` files, their `bzl` files, their `rust_toolchain`


### PR DESCRIPTION
# Introduction

This document proposes a backward compatibility policy for `rules_rust` and tries to find a balance between:

*   being able to add new features and improve the rule implementation through backwards incompatible changes
*   giving reliability guarantees to our existing and new users

As of 2021-07-08 the [Bazel backward compatibility](https://docs.bazel.build/versions/main/backward-compatibility.html) policy can be summarized as:

*   Bazel LTS releases are cut approximately every 9 months and are supported for 3 years. Each LTS release increments the major version number.
*   Bazel rolling releases are cut approximately once a week and can contain breaking changes. There are no guarantees of stability between rolling releases, or between a rolling release and the current LTS. In other words, Bazel LTS version 7.0.0 can be incompatible with 8.0.0pre1, and both can be incompatible with 8.0.0pre2.

# Proposed policy

See the added `COMPATIBILITY.md` file.

# Alternatives Considered

## Match Bazel versioning

Instead of using SemVer, `rules_rust` could follow Bazel's versioning scheme. Major version number will match the Bazel LTS version supported. Minor version number will be increased on breaking changes, patch version number will be increased on backwards compatible changes.

I don't feel strongly about this or SemVer. I picked SemVer because that is what is the standard in the Rust ecosystem, but I'm open to doing the standard thing in the Bazel ecosystem as well :)

## Supporting past releases

Current proposal says the `rules_rust` are developed for the latest Bazel LTS (and the latest Bazel rolling release on the best effort basis). It does not promise old releases will be maintained. \
 \
For users wanting to use Bazel LTS for the whole lifetime of it (not only the active phase that is typically 9 months, but also the inactive phase that is up to 3 years, in which the LTS will receive maintenance updates) supporting LTS for 9 months is not enough.

When a new Bazel LTS becomes active, `rules_rust` could create a branch for the old LTS as they create a new `rules_rust` release with the major number incremented. Even better, when `rules\_rust` drop compatibility with an LTS release we could create a branch.

`rules_rust` would then cherry pick and create patch releases for inactive LTS for critical bug fixes, OS compatibility patches, and security patches. No new features will be cherry picked.

If the community and maintainers of `rules_rust` are willing to make this promise, I'm open to that.


## Supporting all Bazel rolling releases of the current epoch

This approach is inspired by the Bazel LTS releases, but promises more stability. This approach maintains SemVer, and each minor version release of the `rules_rust` aims to support all Bazel rolling releases of the given major version number. In other words, a release of `rules_rust` marked as 4.X would be backwards compatible with all 4.Y releases where X > Y, and always compatible with Bazel 4.0 LTS, and all 5.0.0pre Bazel rolling releases for all Z releases released before release 4.X of `rules_rust`. When Bazel releases 5.0 we'd also release 5.0 which does not promise backwards compatibility with 4.x. New features will be made available to all Bazel versions.

This approach was dismissed because of its maintenance overhead. Since Bazel promises no backwards compatibility between rolling releases, `rules_rust` might find themselves in a situation where they would have to release multiple implementations of the rules, and depending on the Bazel version pick one that works. We have to be prepared to do this for Bazel LTS releases (in the past we used a `BAZEL_VERSION` check in a repository rule that conditionally generated a `.bzl` file with implementations of functions for that Bazel version that were used by the rules in analysis). Having to do the same for each Bazel rolling release is too big of a burden - as it also was for the Bazel team, and the result was the current backwards compatibility policy involving LTS and rolling releases that are backwards incompatible.

Second downside of this approach is the lost control over when we can make backward incompatible releases of `rules_rust`. We want to reserve the right to be pragmatic and decide to make a backward incompatible change as a reaction to a substantial Bazel backward incompatible change.

## Supporting the current Bazel rolling release

Currently the proposal doesn't promise strict compatibility with the current Bazel rolling release. The compatibility is only on the best effort basis.

Bazel rolling releases are planned to be released rather often (approximately weekly), and each can potentially break `rules_rust`. Promising strict compatibility with the current Bazel rolling release can create frequent high priority wor. `rules_rust` maintainers would have to be able to potentially every week stop what they were doing and fix Bazel backward incompatible changes (and do so in a way that is backward compatible with Bazel LTS) to be able to continue regular rules development (to have a green CI) and to be able make new releases.

I believe maintainers of `rules_rust` don't have the capacity to make this promise responsibly.

Fixes https://github.com/bazelbuild/rules_rust/issues/600.