### PR TITLE
Add incompatible flag for splitting rust_library

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -46,6 +46,13 @@ PAGES = dict([
         ],
     ),
     page(
+        name = "settings",
+        symbols = [
+            "incompatible_flag",
+            "fail_when_enabled",
+        ],
+    ),
+    page(
         name = "defs",
         symbols = [
             "rust_binary",

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -3,6 +3,8 @@
 * [cargo_build_script](#cargo_build_script)
 * [crate](#crate)
 * [crate_universe](#crate_universe)
+* [fail_when_enabled](#fail_when_enabled)
+* [incompatible_flag](#incompatible_flag)
 * [rust_analyzer](#rust_analyzer)
 * [rust_analyzer_aspect](#rust_analyzer_aspect)
 * [rust_benchmark](#rust_benchmark)

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -83,6 +83,44 @@ Environment Variables:
 | <a id="crate_universe-version"></a>version |  The version of cargo the resolver should use   | String | optional | "1.53.0" |
 
 
+<a id="#fail_when_enabled"></a>
+
+## fail_when_enabled
+
+<pre>
+fail_when_enabled(<a href="#fail_when_enabled-name">name</a>, <a href="#fail_when_enabled-flag">flag</a>)
+</pre>
+
+A rule that will fail analysis when a flag is enabled.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="fail_when_enabled-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="fail_when_enabled-flag"></a>flag |  The incompatible flag to check   | String | required |  |
+
+
+<a id="#incompatible_flag"></a>
+
+## incompatible_flag
+
+<pre>
+incompatible_flag(<a href="#incompatible_flag-name">name</a>, <a href="#incompatible_flag-issue">issue</a>)
+</pre>
+
+A rule defining an incompatible flag.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="incompatible_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="incompatible_flag-issue"></a>issue |  The link to the github issue associated with this flag   | String | required |  |
+
+
 <a id="#rust_analyzer"></a>
 
 ## rust_analyzer

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -4,3 +4,41 @@
 * [incompatible_flag](#incompatible_flag)
 * [fail_when_enabled](#fail_when_enabled)
 
+<a id="#fail_when_enabled"></a>
+
+## fail_when_enabled
+
+<pre>
+fail_when_enabled(<a href="#fail_when_enabled-name">name</a>, <a href="#fail_when_enabled-flag">flag</a>)
+</pre>
+
+A rule that will fail analysis when a flag is enabled.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="fail_when_enabled-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="fail_when_enabled-flag"></a>flag |  The incompatible flag to check   | String | required |  |
+
+
+<a id="#incompatible_flag"></a>
+
+## incompatible_flag
+
+<pre>
+incompatible_flag(<a href="#incompatible_flag-name">name</a>, <a href="#incompatible_flag-issue">issue</a>)
+</pre>
+
+A rule defining an incompatible flag.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="incompatible_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="incompatible_flag-issue"></a>issue |  The link to the github issue associated with this flag   | String | required |  |
+
+

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,6 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+# Settings
+
+* [incompatible_flag](#incompatible_flag)
+* [fail_when_enabled](#fail_when_enabled)
+

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -61,14 +61,14 @@ load(
     _rust_toolchain_repository_proxy = "rust_toolchain_repository_proxy",
 )
 load(
-    "@rules_rust//rust/settings:incompatible.bzl",
-    _fail_when_enabled = "fail_when_enabled",
-    _incompatible_flag = "incompatible_flag",
-)
-load(
     "@rules_rust//rust:toolchain.bzl",
     _rust_stdlib_filegroup = "rust_stdlib_filegroup",
     _rust_toolchain = "rust_toolchain",
+)
+load(
+    "@rules_rust//rust/settings:incompatible.bzl",
+    _fail_when_enabled = "fail_when_enabled",
+    _incompatible_flag = "incompatible_flag",
 )
 load(
     "@rules_rust//wasm_bindgen:repositories.bzl",

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -61,6 +61,11 @@ load(
     _rust_toolchain_repository_proxy = "rust_toolchain_repository_proxy",
 )
 load(
+    "@rules_rust//rust/settings:incompatible.bzl",
+    _fail_when_enabled = "fail_when_enabled",
+    _incompatible_flag = "incompatible_flag",
+)
+load(
     "@rules_rust//rust:toolchain.bzl",
     _rust_stdlib_filegroup = "rust_stdlib_filegroup",
     _rust_toolchain = "rust_toolchain",
@@ -73,11 +78,6 @@ load(
     "@rules_rust//wasm_bindgen:wasm_bindgen.bzl",
     _rust_wasm_bindgen = "rust_wasm_bindgen",
     _rust_wasm_bindgen_toolchain = "rust_wasm_bindgen_toolchain",
-)
-load(
-    "@rules_rust//rust/settings:incompatible.bzl",
-    _fail_when_enabled = "fail_when_enabled",
-    _incompatible_flag = "incompatible_flag",
 )
 
 rust_binary = _rust_binary

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -74,6 +74,11 @@ load(
     _rust_wasm_bindgen = "rust_wasm_bindgen",
     _rust_wasm_bindgen_toolchain = "rust_wasm_bindgen_toolchain",
 )
+load(
+    "@rules_rust//rust/settings:incompatible.bzl",
+    _fail_when_enabled = "fail_when_enabled",
+    _incompatible_flag = "incompatible_flag",
+)
 
 rust_binary = _rust_binary
 rust_library = _rust_library
@@ -120,3 +125,6 @@ crate = _crate
 
 rustfmt_aspect = _rustfmt_aspect
 rustfmt_test = _rustfmt_test
+
+incompatible_flag = _incompatible_flag
+fail_when_enabled = _fail_when_enabled

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -20,5 +20,6 @@ bzl_library(
     deps = [
         "//rust/platform:rules",
         "//rust/private:rules",
+        "//rust/settings:rules",
     ],
 )

--- a/rust/rust.bzl
+++ b/rust/rust.bzl
@@ -33,6 +33,7 @@ load(
     _rust_test = "rust_test",
     _rust_test_binary = "rust_test_binary",
 )
+load("//rust/settings:incompatible.bzl", "fail_when_enabled")
 
 def rust_library(**args):
     """Deprecated. Use the version from "@rules_rust//rust:defs.bzl" instead.
@@ -43,6 +44,11 @@ def rust_library(**args):
     Returns:
         a target.
     """
+    fail_when_enabled(
+        name = "fail_" + args["name"],
+        flag = "split_rust_library",
+    )
+
     if "crate_type" in args:
         crate_type = args.pop("crate_type")
         if crate_type in ["lib", "rlib", "dylib"]:

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -7,3 +7,8 @@ incompatible_flag(
     build_setting_default = False,
     issue = "https://github.com/bazelbuild/rules_rust/issues/591",
 )
+
+bzl_library(
+    name = "rules",
+    srcs = glob(["**/*.bzl"]),
+)

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -1,5 +1,5 @@
-load(":incompatible.bzl", "incompatible_flag")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":incompatible.bzl", "incompatible_flag")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -1,0 +1,9 @@
+load(":incompatible.bzl", "incompatible_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+incompatible_flag(
+    name = "split_rust_library",
+    build_setting_default = False,
+    issue = "https://github.com/bazelbuild/rules_rust/issues/591",
+)

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -1,4 +1,5 @@
 load(":incompatible.bzl", "incompatible_flag")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/rust/settings/incompatible.bzl
+++ b/rust/settings/incompatible.bzl
@@ -1,0 +1,39 @@
+"""This file contains definitions of all current incompatible flags.
+
+See COMPATIBILITY.md for the backwards compatibility policy.
+"""
+
+IncompatibleFlagInfo = provider(
+    doc = "Set the --error-format flag for all rustc invocations",
+    fields = {
+        "enabled": "(bool) whether the flag is enabled",
+        "issue": "(string) link to the github issue associated with this flag",
+    },
+)
+
+def _incompatible_flag_impl(ctx):
+    return [IncompatibleFlagInfo(enabled = ctx.build_setting_value, issue = ctx.attr.issue)]
+
+incompatible_flag = rule(
+    doc = "A rule defining an incompatible flag.",
+    implementation = _incompatible_flag_impl,
+    build_setting = config.bool(flag = True),
+    attrs = {
+        "issue": attr.string(),
+    },
+)
+
+def _fail_when_enabled_impl(ctx):
+    flag = ctx.attr.flag
+    flag_info = getattr(ctx.attr, "_" + flag)[IncompatibleFlagInfo]
+    if flag_info.enabled:
+        fail("Incompatible flag {} has been flipped, see {} for details.".format(flag, flag_info.issue))
+
+fail_when_enabled = rule(
+    doc = "A rule that will fail analysis when a flag is enabled.",
+    implementation = _fail_when_enabled_impl,
+    attrs = {
+        "flag": attr.string(),
+        "_split_rust_library": attr.label(default = "//rust/settings:split_rust_library"),
+    },
+)

--- a/rust/settings/incompatible.bzl
+++ b/rust/settings/incompatible.bzl
@@ -4,7 +4,7 @@ See COMPATIBILITY.md for the backwards compatibility policy.
 """
 
 IncompatibleFlagInfo = provider(
-    doc = "Set the --error-format flag for all rustc invocations",
+    doc = "Provider for the current value of an incompatible flag.",
     fields = {
         "enabled": "(bool) whether the flag is enabled",
         "issue": "(string) link to the github issue associated with this flag",
@@ -19,7 +19,10 @@ incompatible_flag = rule(
     implementation = _incompatible_flag_impl,
     build_setting = config.bool(flag = True),
     attrs = {
-        "issue": attr.string(),
+        "issue": attr.string(
+            doc = "The link to the github issue associated with this flag",
+            mandatory = True,
+        ),
     },
 )
 
@@ -33,7 +36,10 @@ fail_when_enabled = rule(
     doc = "A rule that will fail analysis when a flag is enabled.",
     implementation = _fail_when_enabled_impl,
     attrs = {
-        "flag": attr.string(),
+        "flag": attr.string(
+            doc = "The incompatible flag to check",
+            mandatory = True,
+        ),
         "_split_rust_library": attr.label(default = "//rust/settings:split_rust_library"),
     },
 )


### PR DESCRIPTION
This PR adds some elementary infrastructure for incompatible flags.