### PR TITLE
Added unit tests for `rust_clippy_aspect`

### DIFF
--- a/test/clippy/BUILD.bazel
+++ b/test/clippy/BUILD.bazel
@@ -6,6 +6,8 @@ load(
     "rust_test",
 )
 
+package(default_visibility = ["//test:__subpackages__"])
+
 # Declaration of passing targets.
 
 rust_binary(

--- a/test/unit/clippy/BUILD.bazel
+++ b/test/unit/clippy/BUILD.bazel
@@ -1,0 +1,5 @@
+load(":clippy_test.bzl", "clippy_test_suite")
+
+clippy_test_suite(
+    name = "clippy_test_suite",
+)

--- a/test/unit/clippy/clippy_test.bzl
+++ b/test/unit/clippy/clippy_test.bzl
@@ -1,0 +1,112 @@
+"""Unittest to verify properties of clippy rules"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest")
+load("//rust:defs.bzl", "rust_clippy_aspect")
+load("//test/unit:common.bzl", "assert_argv_contains", "assert_list_contains_adjacent_elements")
+
+def _find_clippy_action(actions):
+    for action in actions:
+        if action.mnemonic == "Clippy":
+            return action
+    fail("Failed to find Clippy action")
+
+def _clippy_aspect_action_has_flag_impl(ctx, flags):
+    env = analysistest.begin(ctx)
+
+    # TODO: Replace with `analysistest.target_under_test(env)` upstream fix
+    # https://github.com/bazelbuild/bazel-skylib/pull/299
+    target = env.ctx.attr.target_under_test_with_aspect
+
+    clippy_action = _find_clippy_action(target.actions)
+
+    # Ensure each flag is present in the clippy action
+    for flag in flags:
+        assert_argv_contains(
+            env,
+            clippy_action,
+            flag,
+        )
+
+    clippy_checks = target[OutputGroupInfo].clippy_checks.to_list()
+    if len(clippy_checks) > 1:
+        fail("clippy_checks is only expected to contain 1 file")
+
+    # Ensure the arguments to generate the marker file are present in
+    # the clippy action
+    assert_list_contains_adjacent_elements(
+        env,
+        clippy_action.argv,
+        [
+            "--touch-file",
+            clippy_checks[0].path,
+        ],
+    )
+
+    return analysistest.end(env)
+
+def _binary_clippy_aspect_action_has_warnings_flag_test_impl(ctx):
+    return _clippy_aspect_action_has_flag_impl(
+        ctx,
+        ["-Dwarnings"],
+    )
+
+def _library_clippy_aspect_action_has_warnings_flag_test_impl(ctx):
+    return _clippy_aspect_action_has_flag_impl(
+        ctx,
+        ["-Dwarnings"],
+    )
+
+def _test_clippy_aspect_action_has_warnings_flag_test_impl(ctx):
+    return _clippy_aspect_action_has_flag_impl(
+        ctx,
+        [
+            "-Dwarnings",
+            "--test",
+        ],
+    )
+
+def make_clippy_aspect_unittest(impl):
+    return analysistest.make(
+        impl,
+        attrs = {
+            # We can't just use target_under_test because we need to add our own aspect to the attribute.
+            # See https://github.com/bazelbuild/bazel-skylib/pull/299
+            "target_under_test_with_aspect": attr.label(aspects = [rust_clippy_aspect], mandatory = True),
+        },
+    )
+
+binary_clippy_aspect_action_has_warnings_flag_test = make_clippy_aspect_unittest(_binary_clippy_aspect_action_has_warnings_flag_test_impl)
+library_clippy_aspect_action_has_warnings_flag_test = make_clippy_aspect_unittest(_library_clippy_aspect_action_has_warnings_flag_test_impl)
+test_clippy_aspect_action_has_warnings_flag_test = make_clippy_aspect_unittest(_test_clippy_aspect_action_has_warnings_flag_test_impl)
+
+def clippy_test_suite(name):
+    """Entry-point macro called from the BUILD file.
+
+    Args:
+        name (str): Name of the macro.
+    """
+
+    binary_clippy_aspect_action_has_warnings_flag_test(
+        name = "binary_clippy_aspect_action_has_warnings_flag_test",
+        target_under_test = Label("//test/clippy:ok_binary"),
+        target_under_test_with_aspect = Label("//test/clippy:ok_binary"),
+    )
+    library_clippy_aspect_action_has_warnings_flag_test(
+        name = "library_clippy_aspect_action_has_warnings_flag_test",
+        target_under_test = Label("//test/clippy:ok_library"),
+        target_under_test_with_aspect = Label("//test/clippy:ok_library"),
+    )
+    test_clippy_aspect_action_has_warnings_flag_test(
+        name = "test_clippy_aspect_action_has_warnings_flag_test",
+        target_under_test = Label("//test/clippy:ok_test"),
+        target_under_test_with_aspect = Label("//test/clippy:ok_test"),
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":binary_clippy_aspect_action_has_warnings_flag_test",
+            ":library_clippy_aspect_action_has_warnings_flag_test",
+            ":test_clippy_aspect_action_has_warnings_flag_test",
+        ],
+    )

--- a/test/unit/clippy/clippy_test.bzl
+++ b/test/unit/clippy/clippy_test.bzl
@@ -28,7 +28,7 @@ def _clippy_aspect_action_has_flag_impl(ctx, flags):
         )
 
     clippy_checks = target[OutputGroupInfo].clippy_checks.to_list()
-    if len(clippy_checks) > 1:
+    if len(clippy_checks) != 1:
         fail("clippy_checks is only expected to contain 1 file")
 
     # Ensure the arguments to generate the marker file are present in


### PR DESCRIPTION
This should ensure the extra flags to the clippy action are always set and the marker is always created.