### PR TITLE
cleanup: use `tut.actions` consistently across unit tests

### DIFF
--- a/test/unit/crate_name/crate_name_test.bzl
+++ b/test/unit/crate_name/crate_name_test.bzl
@@ -7,49 +7,43 @@ load("//test/unit:common.bzl", "assert_argv_contains")
 def _default_crate_name_library_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
 
     # Note: Hyphens in crate name converted to underscores.
-    assert_argv_contains(env, actions[0], "--crate-name=default_crate_name_library")
+    assert_argv_contains(env, tut.actions[0], "--crate-name=default_crate_name_library")
     return analysistest.end(env)
 
 def _custom_crate_name_library_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    assert_argv_contains(env, actions[0], "--crate-name=custom_name")
+    assert_argv_contains(env, tut.actions[0], "--crate-name=custom_name")
     return analysistest.end(env)
 
 def _default_crate_name_binary_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
 
     # Note: Hyphens in crate name converted to underscores.
-    assert_argv_contains(env, actions[0], "--crate-name=default_crate_name_binary")
+    assert_argv_contains(env, tut.actions[0], "--crate-name=default_crate_name_binary")
     return analysistest.end(env)
 
 def _custom_crate_name_binary_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    assert_argv_contains(env, actions[0], "--crate-name=custom_name")
+    assert_argv_contains(env, tut.actions[0], "--crate-name=custom_name")
     return analysistest.end(env)
 
 def _default_crate_name_test_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
 
     # Note: Hyphens in crate name converted to underscores.
-    assert_argv_contains(env, actions[0], "--crate-name=default_crate_name_test")
+    assert_argv_contains(env, tut.actions[0], "--crate-name=default_crate_name_test")
     return analysistest.end(env)
 
 def _custom_crate_name_test_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    assert_argv_contains(env, actions[0], "--crate-name=custom_name")
+    assert_argv_contains(env, tut.actions[0], "--crate-name=custom_name")
     return analysistest.end(env)
 
 def _invalid_default_crate_name_test_impl(ctx):

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -14,8 +14,7 @@ def _native_dep_lib_name(ctx):
 def _lib_has_no_native_libs_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    action = actions[0]
+    action = tut.actions[0]
     assert_argv_contains(env, action, "--crate-type=lib")
     assert_argv_contains_prefix_suffix(env, action, "-Lnative=", "/native_deps")
     assert_argv_contains_not(env, action, "-lstatic=native_dep")
@@ -25,8 +24,7 @@ def _lib_has_no_native_libs_test_impl(ctx):
 def _rlib_has_no_native_libs_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    action = actions[0]
+    action = tut.actions[0]
     assert_argv_contains(env, action, "--crate-type=rlib")
     assert_argv_contains_not(env, action, "-lstatic=native_dep")
     assert_argv_contains_not(env, action, "-ldylib=native_dep")
@@ -35,8 +33,7 @@ def _rlib_has_no_native_libs_test_impl(ctx):
 def _dylib_has_native_libs_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    action = actions[0]
+    action = tut.actions[0]
     assert_argv_contains(env, action, "--crate-type=dylib")
     assert_argv_contains(env, action, "-lstatic=native_dep")
     return analysistest.end(env)
@@ -44,8 +41,7 @@ def _dylib_has_native_libs_test_impl(ctx):
 def _cdylib_has_native_libs_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    action = actions[0]
+    action = tut.actions[0]
     assert_argv_contains(env, action, "--crate-type=cdylib")
     assert_argv_contains_prefix_suffix(env, action, "link-arg=", "/native_deps/" + _native_dep_lib_name(ctx))
     return analysistest.end(env)
@@ -53,8 +49,7 @@ def _cdylib_has_native_libs_test_impl(ctx):
 def _staticlib_has_native_libs_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    action = actions[0]
+    action = tut.actions[0]
     assert_argv_contains(env, action, "--crate-type=staticlib")
     assert_argv_contains_prefix_suffix(env, action, "link-arg=", "/native_deps/" + _native_dep_lib_name(ctx))
     return analysistest.end(env)
@@ -62,9 +57,8 @@ def _staticlib_has_native_libs_test_impl(ctx):
 def _proc_macro_has_native_libs_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    asserts.equals(env, 1, len(actions))
-    action = actions[0]
+    asserts.equals(env, 1, len(tut.actions))
+    action = tut.actions[0]
     assert_argv_contains(env, action, "--crate-type=proc-macro")
     assert_argv_contains_prefix_suffix(env, action, "link-arg=", "/native_deps/" + _native_dep_lib_name(ctx))
     return analysistest.end(env)
@@ -72,8 +66,7 @@ def _proc_macro_has_native_libs_test_impl(ctx):
 def _bin_has_native_libs_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    action = actions[0]
+    action = tut.actions[0]
     assert_argv_contains_prefix_suffix(env, action, "link-arg=", "/native_deps/" + _native_dep_lib_name(ctx))
     return analysistest.end(env)
 
@@ -89,8 +82,7 @@ def _extract_linker_args(argv):
 def _bin_has_native_dep_and_alwayslink_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    action = actions[0]
+    action = tut.actions[0]
 
     if ctx.target_platform_has_constraint(ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]):
         want = [
@@ -120,8 +112,7 @@ def _bin_has_native_dep_and_alwayslink_test_impl(ctx):
 def _cdylib_has_native_dep_and_alwayslink_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    actions = analysistest.target_actions(env)
-    action = actions[0]
+    action = tut.actions[0]
 
     if ctx.target_platform_has_constraint(ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]):
         want = [


### PR DESCRIPTION
This updates unit test code to use `tut.actions` consistently as a follow-up to https://github.com/bazelbuild/rules_rust/pull/849#discussion_r675486935.

No functional changes intended.