### PR TITLE
Add `exec` configuration to `rust_toolchain::rustc_lib`

### DIFF
--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -295,6 +295,7 @@ rust_toolchain = rule(
         ),
         "rustc_lib": attr.label(
             doc = "The libraries used by rustc during compilation.",
+            cfg = "exec",
         ),
         "rustc_srcs": attr.label(
             doc = "The source code of rustc.",


### PR DESCRIPTION
Creating this PR in response to https://github.com/bazelbuild/rules_rust/pull/855#issuecomment-886484229