### PR TITLE
cleanup: replace crate_type argument with crate_info.type

### DIFF
--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -221,7 +221,6 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
     return rustc_compile_action(
         ctx = ctx,
         toolchain = find_toolchain(ctx),
-        crate_type = "rlib",
         crate_info = rust_common.create_crate_info(
             name = crate_name,
             type = "rlib",

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -87,7 +87,6 @@ def _clippy_aspect_impl(target, ctx):
         toolchain.clippy_driver.path,
         cc_toolchain,
         feature_configuration,
-        crate_type,
         crate_info,
         dep_info,
         output_hash = determine_output_hash(crate_info.root),

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -253,7 +253,6 @@ def _rust_library_common(ctx, crate_type):
     return rustc_compile_action(
         ctx = ctx,
         toolchain = toolchain,
-        crate_type = crate_type,
         crate_info = rust_common.create_crate_info(
             name = crate_name,
             type = crate_type,
@@ -289,7 +288,6 @@ def _rust_binary_impl(ctx):
     return rustc_compile_action(
         ctx = ctx,
         toolchain = toolchain,
-        crate_type = ctx.attr.crate_type,
         crate_info = rust_common.create_crate_info(
             name = crate_name,
             type = ctx.attr.crate_type,
@@ -450,7 +448,6 @@ def _rust_test_common(ctx, toolchain, output):
     providers = rustc_compile_action(
         ctx = ctx,
         toolchain = toolchain,
-        crate_type = crate_type,
         crate_info = crate_info,
         rust_flags = ["--test"] if ctx.attr.use_libtest_harness else ["--cfg", "test"],
     )

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -334,7 +334,6 @@ def construct_arguments(
         tool_path,
         cc_toolchain,
         feature_configuration,
-        crate_type,
         crate_info,
         dep_info,
         output_hash,
@@ -353,7 +352,6 @@ def construct_arguments(
         tool_path (str): Path to rustc
         cc_toolchain (CcToolchain): The CcToolchain for the current target.
         feature_configuration (FeatureConfiguration): Class used to construct command lines from CROSSTOOL features.
-        crate_type (str): Crate type of the current target.
         crate_info (CrateInfo): The CrateInfo provider of the target crate
         dep_info (DepInfo): The DepInfo provider of the target crate
         output_hash (str): The hashed path of the crate root
@@ -489,7 +487,7 @@ def construct_arguments(
             rustc_flags.add("--codegen=linker=" + ld)
             rustc_flags.add_joined("--codegen", link_args, join_with = " ", format_joined = "link-args=%s")
 
-        _add_native_link_flags(rustc_flags, dep_info, crate_type, toolchain, cc_toolchain, feature_configuration)
+        _add_native_link_flags(rustc_flags, dep_info, crate_info.type, toolchain, cc_toolchain, feature_configuration)
 
     # These always need to be added, even if not linking this crate.
     add_crate_link_flags(rustc_flags, dep_info)
@@ -531,7 +529,6 @@ def construct_arguments(
 def rustc_compile_action(
         ctx,
         toolchain,
-        crate_type,
         crate_info,
         output_hash = None,
         rust_flags = [],
@@ -541,7 +538,6 @@ def rustc_compile_action(
     Args:
         ctx (ctx): The rule's context object
         toolchain (rust_toolchain): The current `rust_toolchain`
-        crate_type (str): Crate type of the current target
         crate_info (CrateInfo): The CrateInfo provider for the current target.
         output_hash (str, optional): The hashed path of the crate root. Defaults to None.
         rust_flags (list, optional): Additional flags to pass to rustc. Defaults to [].
@@ -581,7 +577,6 @@ def rustc_compile_action(
         toolchain.rustc.path,
         cc_toolchain,
         feature_configuration,
-        crate_type,
         crate_info,
         dep_info,
         output_hash,


### PR DESCRIPTION

This removes the `crate_type` argument in internal implementations, replacing uses with `crate_info.type` where appropriate, as a followup to https://github.com/bazelbuild/rules_rust/pull/858#discussion_r679825635.



No functional changes intended.

