### PR TITLE
Expose `DepInfo` provider

### DIFF
--- a/rust/rust_common.bzl
+++ b/rust/rust_common.bzl
@@ -14,6 +14,7 @@
 
 """Module with Rust definitions required to write custom Rust rules."""
 
-load("//rust/private:providers.bzl", _CrateInfo = "CrateInfo")
+load("//rust/private:providers.bzl", _CrateInfo = "CrateInfo", _DepInfo = "DepInfo")
 
 CrateInfo = _CrateInfo
+DepInfo = _DepInfo


### PR DESCRIPTION
This is useful when developing rules that need to collect Rust dependencies from existing targets.