### PR TITLE
Update `//proto` rules to provide all required dependencies.

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -8,6 +8,10 @@ load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 
 rust_proto_repositories()
 
+load("@rules_rust//proto:transitive_repositories.bzl", "rust_proto_transitive_repositories")
+
+rust_proto_transitive_repositories()
+
 load("@rules_rust//bindgen:repositories.bzl", "rust_bindgen_repositories")
 
 rust_bindgen_repositories()
@@ -85,4 +89,4 @@ docs_deps()
 
 load("@docs//:docs_transitive_deps.bzl", docs_transitive_deps = "transitive_deps")
 
-docs_transitive_deps(is_top_level = True)
+docs_transitive_deps()

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -9,10 +9,12 @@ bzl_library(
     srcs = [
         "@bazel_tools//tools:bzl_srcs",
         "@build_bazel_rules_nodejs//internal/providers:bzl",
+        "@com_google_protobuf//:bzl_srcs",
     ],
     deps = [
         "@bazel_skylib//lib:paths",
-        "@rules_proto//proto:rules",
+        "@rules_proto//proto:defs",
+        "@rules_proto//proto:repositories",
     ],
 )
 
@@ -112,6 +114,7 @@ PAGES = dict([
             "rust_grpc_library",
             "rust_proto_library",
             "rust_proto_repositories",
+            "rust_proto_transitive_repositories",
             "rust_proto_toolchain",
         ],
     ),

--- a/docs/docs_deps.bzl
+++ b/docs/docs_deps.bzl
@@ -1,6 +1,7 @@
 """Define dependencies for `rules_rust` docs"""
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 load("@rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_repositories")
 
@@ -9,5 +10,7 @@ def deps():
     rust_repositories()
 
     rust_wasm_bindgen_repositories()
+
+    rust_proto_repositories()
 
     stardoc_repositories()

--- a/docs/docs_transitive_deps.bzl
+++ b/docs/docs_transitive_deps.bzl
@@ -1,31 +1,11 @@
 """Define transitive dependencies for `rules_rust` docs"""
 
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
-load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
+load("@rules_rust//proto:transitive_repositories.bzl", "rust_proto_transitive_repositories")
 
-def transitive_deps(is_top_level = False):
+def transitive_deps():
     """Define transitive dependencies for `rules_rust` docs
-
-    Args:
-        is_top_level (bool, optional): Indicates wheather or not this is being called
-            from the root WORKSPACE file of `rules_rust`. Defaults to False.
     """
-    rust_proto_repositories()
+    rust_proto_transitive_repositories()
 
     node_repositories()
-
-    # Rules proto does not declare a bzl_library, we stub it there for now.
-    # TODO: Remove this hack if/when rules_proto adds a bzl_library.
-    if is_top_level:
-        maybe(
-            native.local_repository,
-            name = "rules_proto",
-            path = "docs/rules_proto_stub",
-        )
-    else:
-        maybe(
-            native.local_repository,
-            name = "rules_proto",
-            path = "rules_proto_stub",
-        )

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -23,6 +23,7 @@
 * [rust_proto_library](#rust_proto_library)
 * [rust_proto_repositories](#rust_proto_repositories)
 * [rust_proto_toolchain](#rust_proto_toolchain)
+* [rust_proto_transitive_repositories](#rust_proto_transitive_repositories)
 * [rust_repositories](#rust_repositories)
 * [rust_repository_set](#rust_repository_set)
 * [rust_shared_library](#rust_shared_library)
@@ -1604,6 +1605,20 @@ Declare dependencies needed for proto compilation.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain) (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
+
+
+<a id="#rust_proto_transitive_repositories"></a>
+
+## rust_proto_transitive_repositories
+
+<pre>
+rust_proto_transitive_repositories()
+</pre>
+
+Load transitive dependencies of the `@rules_rust//proto` rules.
+
+This macro should be called immediately after the `rust_proto_repositories` macro.
+
 
 
 <a id="#rust_repositories"></a>

--- a/docs/rules_proto_stub/proto/BUILD.bazel
+++ b/docs/rules_proto_stub/proto/BUILD.bazel
@@ -1,7 +1,0 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
-bzl_library(
-    name = "rules",
-    srcs = glob(["**/*.bzl"]),
-    visibility = ["//visibility:public"],
-)

--- a/docs/rules_proto_stub/proto/defs.bzl
+++ b/docs/rules_proto_stub/proto/defs.bzl
@@ -1,6 +1,0 @@
-# buildifier: disable=module-docstring
-# buildifier: disable=provider-params
-ProtoInfo = provider()
-
-def proto_library(**args):
-    pass

--- a/docs/rust_proto.md
+++ b/docs/rust_proto.md
@@ -4,6 +4,7 @@
 * [rust_grpc_library](#rust_grpc_library)
 * [rust_proto_library](#rust_proto_library)
 * [rust_proto_repositories](#rust_proto_repositories)
+* [rust_proto_transitive_repositories](#rust_proto_transitive_repositories)
 * [rust_proto_toolchain](#rust_proto_toolchain)
 
 
@@ -26,6 +27,10 @@ external repositories for the Rust proto toolchain (in addition to the [rust rul
 load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 
 rust_proto_repositories()
+
+load("@rules_rust//proto:transitive_repositories.bzl", "rust_proto_transitive_repositories")
+
+rust_proto_transitive_repositories()
 ```
 
 [raze]: https://github.com/google/cargo-raze
@@ -271,5 +276,19 @@ Declare dependencies needed for proto compilation.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain) (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
+
+
+<a id="#rust_proto_transitive_repositories"></a>
+
+## rust_proto_transitive_repositories
+
+<pre>
+rust_proto_transitive_repositories()
+</pre>
+
+Load transitive dependencies of the `@rules_rust//proto` rules.
+
+This macro should be called immediately after the `rust_proto_repositories` macro.
+
 
 

--- a/docs/rust_proto.vm
+++ b/docs/rust_proto.vm
@@ -18,6 +18,10 @@ external repositories for the Rust proto toolchain (in addition to the [rust rul
 load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 
 rust_proto_repositories()
+
+load("@rules_rust//proto:transitive_repositories.bzl", "rust_proto_transitive_repositories")
+
+rust_proto_transitive_repositories()
 ```
 
 [raze]: https://github.com/google/cargo-raze

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -35,6 +35,10 @@ load(
     _rust_proto_toolchain = "rust_proto_toolchain",
 )
 load(
+    "@rules_rust//proto:transitive_repositories.bzl",
+    _rust_proto_transitive_repositories = "rust_proto_transitive_repositories",
+)
+load(
     "@rules_rust//rust:defs.bzl",
     _rust_analyzer = "rust_analyzer",
     _rust_analyzer_aspect = "rust_analyzer_aspect",
@@ -103,6 +107,7 @@ rust_toolchain = _rust_toolchain
 rust_proto_toolchain = _rust_proto_toolchain
 rust_proto_repositories = _rust_proto_repositories
 rust_stdlib_filegroup = _rust_stdlib_filegroup
+rust_proto_transitive_repositories = _rust_proto_transitive_repositories
 
 cargo_build_script = _cargo_build_script
 

--- a/examples/examples_repositories.bzl
+++ b/examples/examples_repositories.bzl
@@ -13,17 +13,6 @@ def repositories():
 
     maybe(
         http_archive,
-        name = "rules_proto",
-        sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
-        strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-            "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        ],
-    )
-
-    maybe(
-        http_archive,
         name = "rules_foreign_cc",
         strip_prefix = "rules_foreign_cc-d54c78ab86b40770ee19f0949db9d74a831ab9f0",
         url = "https://github.com/bazelbuild/rules_foreign_cc/archive/d54c78ab86b40770ee19f0949db9d74a831ab9f0.zip",

--- a/proto/patches/BUILD.bazel
+++ b/proto/patches/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "com_google_protobuf-v3.10.0-bzl_visibility.patch",
+    "rules_proto-bzl_visibility.patch",
+])

--- a/proto/patches/README.md
+++ b/proto/patches/README.md
@@ -1,0 +1,3 @@
+# @rules_rust//proto patches
+
+The patches here provide the required visibility to `*.bzl` files used by the rules defined in `@rules_rust//proto`.

--- a/proto/patches/com_google_protobuf-v3.10.0-bzl_visibility.patch
+++ b/proto/patches/com_google_protobuf-v3.10.0-bzl_visibility.patch
@@ -1,0 +1,14 @@
+diff --git a/BUILD b/BUILD
+index efc3d8e7f..77e3ea413 100644
+--- a/BUILD
++++ b/BUILD
+@@ -1236,3 +1236,9 @@ sh_test(
+         "update_file_lists.sh",
+     ],
+ )
++
++filegroup(
++    name = "bzl_srcs",
++    srcs = glob(["**/*.bzl"]),
++    visibility = ["//visibility:public"],
++)

--- a/proto/patches/rules_proto-bzl_visibility.patch
+++ b/proto/patches/rules_proto-bzl_visibility.patch
@@ -1,0 +1,19 @@
+diff --git a/proto/BUILD b/proto/BUILD
+index 4856ada..67105f0 100644
+--- a/proto/BUILD
++++ b/proto/BUILD
+@@ -11,3 +11,14 @@ bzl_library(
+         "//proto/private/rules:proto_descriptor_set",
+     ],
+ )
++
++bzl_library(
++    name = "repositories",
++    srcs = [
++        "repositories.bzl",
++    ],
++    visibility = ["//visibility:public"],
++    deps = [
++        "//proto/private:dependencies",
++    ],
++)

--- a/proto/repositories.bzl
+++ b/proto/repositories.bzl
@@ -28,6 +28,21 @@ def rust_proto_repositories(register_default_toolchain = True):
     """
     maybe(
         http_archive,
+        name = "rules_proto",
+        sha256 = "bc12122a5ae4b517fa423ea03a8d82ea6352d5127ea48cb54bc324e8ab78493c",
+        strip_prefix = "rules_proto-af6481970a34554c6942d993e194a9aed7987780",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/af6481970a34554c6942d993e194a9aed7987780.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/af6481970a34554c6942d993e194a9aed7987780.tar.gz",
+        ],
+        patch_args = ["-p1"],
+        patches = [
+            Label("//proto/patches:rules_proto-bzl_visibility.patch"),
+        ],
+    )
+
+    maybe(
+        http_archive,
         name = "com_google_protobuf",
         sha256 = "758249b537abba2f21ebc2d02555bf080917f0f2f88f4cbe2903e0e28c4187ed",
         strip_prefix = "protobuf-3.10.0",
@@ -35,40 +50,9 @@ def rust_proto_repositories(register_default_toolchain = True):
             "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.10.0.tar.gz",
             "https://github.com/protocolbuffers/protobuf/archive/v3.10.0.tar.gz",
         ],
-    )
-
-    maybe(
-        http_archive,
-        name = "rules_python",
-        strip_prefix = "rules_python-0.0.1",
-        type = "zip",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_python/archive/0.0.1.zip",
-            "https://github.com/bazelbuild/rules_python/archive/0.0.1.zip",
-        ],
-        sha256 = "f73c0cf51c32c7aaeaf02669ed03b32d12f2d92e1b05699eb938a75f35a210f4",
-    )
-
-    maybe(
-        http_archive,
-        name = "six",
-        build_file = "@com_google_protobuf//:third_party/six.BUILD",
-        sha256 = "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73",
-        urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz",
-            "https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz",
-        ],
-    )
-
-    maybe(
-        http_archive,
-        name = "zlib",
-        build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-        strip_prefix = "zlib-1.2.11",
-        urls = [
-            "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
-            "https://zlib.net/zlib-1.2.11.tar.gz",
+        patch_args = ["-p1"],
+        patches = [
+            Label("//proto/patches:com_google_protobuf-v3.10.0-bzl_visibility.patch"),
         ],
     )
 

--- a/proto/transitive_repositories.bzl
+++ b/proto/transitive_repositories.bzl
@@ -1,0 +1,15 @@
+"""Definitions for loading transitive `@rules_rust//proto` dependencies"""
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+def rust_proto_transitive_repositories():
+    """Load transitive dependencies of the `@rules_rust//proto` rules.
+
+    This macro should be called immediately after the `rust_proto_repositories` macro.
+    """
+    rules_proto_dependencies()
+
+    rules_proto_toolchains()
+
+    protobuf_deps()


### PR DESCRIPTION
Not all dependencies are currently provided by the `@rules_rust//proto` modules. This PR updates the proto rules to provide these missing dependencies via a new `rules_proto_transitive_repositories` macros.

The setup instructions have been updated accordingly in the generated docs.

This change may contain a breaking change for some users who've only loaded `rules_proto_repositories` and not called `@com_google_protobuf//:protobuf_deps.bzl%protobuf_deps` in their workspace. The fix for this is to simply call `rules_proto_transitive_repositories` as documented in the updated docs.