### PR TITLE
Reduce rustc flag duplication

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -214,7 +214,7 @@ def get_linker_and_args(ctx, cc_toolchain, feature_configuration, rpaths):
         cc_toolchain = cc_toolchain,
         is_linking_dynamic_library = False,
         runtime_library_search_directories = rpaths,
-        user_link_flags = user_link_flags,
+        user_link_flags = depset(user_link_flags).to_list(),
     )
     link_args = cc_common.get_memory_inefficient_command_line(
         feature_configuration = feature_configuration,


### PR DESCRIPTION
A follow up to https://github.com/bazelbuild/rules_rust/pull/849, I noticed in a build that there were a bunch of duplicate rustc flags
```
(cd /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/87f8cc6ac2ea5ec14312b4b2ac21c9fc/sandbox/linux-sandbox/189/execroot/rules_rust_examples_crate_universe && \
  exec env - \
    CARGO_CFG_TARGET_ARCH=x86_64 \
    CARGO_CFG_TARGET_OS=linux \
    CARGO_CRATE_NAME=h2 \
    CARGO_MANIFEST_DIR='${pwd}/external/has_aliased_deps_deps__h2__0_2_7' \
    CARGO_PKG_AUTHORS='' \
    CARGO_PKG_DESCRIPTION='' \
    CARGO_PKG_HOMEPAGE='' \
    CARGO_PKG_NAME=h2 \
    CARGO_PKG_VERSION=0.2.7 \
    CARGO_PKG_VERSION_MAJOR=0 \
    CARGO_PKG_VERSION_MINOR=2 \
    CARGO_PKG_VERSION_PATCH=7 \
    CARGO_PKG_VERSION_PRE='' \
    SYSROOT=bazel-out/k8-fastbuild/bin/external/rules_rust/rust/toolchain/current \
  bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_rust/util/process_wrapper/process_wrapper --subst 'pwd=${pwd}' -- bazel-out/k8-fastbuild/bin/external/rules_rust/rust/toolchain/current/bin/rustc external/has_aliased_deps_deps__h2__0_2_7/src/lib.rs '--crate-name=h2' '--crate-type=rlib' '--error-format=human' '--codegen=metadata=-680607353' '--out-dir=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__h2__0_2_7' '--codegen=extra-filename=-680607353' '--codegen=opt-level=0' '--codegen=debuginfo=0' '--remap-path-prefix=${pwd}=.' '--emit=dep-info,link' '--color=always' '--target=x86_64-unknown-linux-gnu' -L bazel-out/k8-fastbuild/bin/external/rules_rust/rust/toolchain/current/lib/rustlib/x86_64-unknown-linux-gnu/lib -L bazel-out/k8-fastbuild/bin/external/rules_rust/rust/toolchain/current/lib -L bazel-out/k8-fastbuild/bin/external/rules_rust/rust/toolchain/current/lib/rustlib/x86_64-unknown-linux-gnu/bin '--cap-lints=allow' '--edition=2018' '--codegen=linker=/usr/bin/gcc' --codegen 'link-args=-fuse-ld=gold -Wl,-no-as-needed -Wl,-z,relro,-z,now -B/usr/bin -pass-exit-codes -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -ldl -lpthread -lstdc++ -lm' --extern 'bytes=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__bytes__0_5_6/libbytes--225745396.rlib' --extern 'fnv=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__fnv__1_0_7/libfnv--351998681.rlib' --extern 'futures_core=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__futures_core__0_3_16/libfutures_core-938126416.rlib' --extern 'futures_sink=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__futures_sink__0_3_16/libfutures_sink--280424228.rlib' --extern 'futures_util=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__futures_util__0_3_16/libfutures_util--200256755.rlib' --extern 'http=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__http__0_2_4/libhttp-2068069658.rlib' --extern 'indexmap=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__indexmap__1_7_0/libindexmap-1829724378.rlib' --extern 'slab=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__slab__0_4_3/libslab-703676971.rlib' --extern 'tokio=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__tokio__0_2_25/libtokio-214378357.rlib' --extern 'tokio_util=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__tokio_util__0_3_1/libtokio_util-1949648639.rlib' --extern 'tracing=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__tracing__0_1_26/libtracing-425662279.rlib' --extern 'tracing_futures=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__tracing_futures__0_2_5/libtracing_futures-106518904.rlib' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__bytes__0_5_6' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__fnv__1_0_7' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__futures_core__0_3_16' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__futures_sink__0_3_16' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__futures_io__0_3_16' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__futures_task__0_3_16' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__memchr__2_4_0' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__pin_project_lite__0_2_7' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__pin_utils__0_1_0' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__slab__0_4_3' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__futures_util__0_3_16' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__bytes__1_0_1' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__itoa__0_4_7' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__http__0_2_4' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__hashbrown__0_11_2' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__indexmap__1_7_0' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__libc__0_2_98' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__iovec__0_1_4' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__lazy_static__1_4_0' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__cfg_if__0_1_10' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__cfg_if__1_0_0' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__log__0_4_14' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__net2__0_2_37' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__mio__0_6_23' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__num_cpus__1_13_0' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__pin_project_lite__0_1_12' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__tokio__0_2_25' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__tokio_util__0_3_1' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__tracing_core__0_1_18' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__tracing__0_1_26' '-Ldependency=bazel-out/k8-opt-exec-2B5CBBC6/bin/external/has_aliased_deps_deps__unicode_xid__0_2_2' '-Ldependency=bazel-out/k8-opt-exec-2B5CBBC6/bin/external/has_aliased_deps_deps__proc_macro2__1_0_28' '-Ldependency=bazel-out/k8-opt-exec-2B5CBBC6/bin/external/has_aliased_deps_deps__quote__1_0_9' '-Ldependency=bazel-out/k8-opt-exec-2B5CBBC6/bin/external/has_aliased_deps_deps__syn__1_0_74' '-Ldependency=bazel-out/k8-opt-exec-2B5CBBC6/bin/external/has_aliased_deps_deps__pin_project_internal__1_0_8' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__pin_project__1_0_8' '-Ldependency=bazel-out/k8-fastbuild/bin/external/has_aliased_deps_deps__tracing_futures__0_2_5' --sysroot '${pwd}/bazel-out/k8-fastbuild/bin/external/rules_rust/rust/toolchain/current')
```

(note the repeated `-ldl -lpthread -ldl -lpthread -ldl -lpthread`)

I'm not sure if this is the right solution here but it does feel like something is incorrectly being passed multiple times or not being collapsed.

This solves for the duplication.