### PR TITLE
Updated `rustdoc` rules to use `//util/launcher`

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -45,10 +45,6 @@ tasks:
       - "//test/..."
       - "@examples//..."
       - "-//test/conflicting_deps:conflicting_deps_test"
-      # rust_doc_test is likely not fully sandboxed
-      - "-//test/chained_direct_deps:mod3_doc_test"
-      - "-@examples//fibonacci:fibonacci_doc_test"
-      - "-@examples//hello_lib:hello_lib_doc_test"
       - "-@examples//ffi/rust_calling_c/simple/..."
       # See https://github.com/bazelbuild/bazel/issues/9987
       - "-@examples//ffi/rust_calling_c:matrix_dylib_test"

--- a/rust/private/BUILD.bazel
+++ b/rust/private/BUILD.bazel
@@ -8,5 +8,6 @@ bzl_library(
     visibility = ["//rust:__subpackages__"],
     deps = [
         "//rust/platform:rules",
+        "//util/launcher:bzl_lib",
     ],
 )

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -141,6 +141,7 @@ def _build_rustdoc_flags(ctx, dep_info, crate_info, toolchain):
     sysroot = find_sysroot(toolchain, short_path = True)
     if sysroot:
         link_search_flags.extend(["--sysroot", "${{pwd}}/{}".format(sysroot)])
+    link_search_flags.extend(["--target", toolchain.target_flag_value])
 
     # TODO(hlopko): use the more robust logic from rustc.bzl also here, through a reasonable API.
     for lib_to_link in dep_info.transitive_noncrates.to_list():

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -139,15 +139,6 @@ def _build_rustdoc_flags(ctx, dep_info, crate_info, toolchain):
     link_flags += ["--extern=" + c.name + "=" + c.dep.output.short_path for c in d.direct_crates.to_list()]
     link_search_flags += ["-Ldependency={}".format(_dirname(c.output.short_path)) for c in d.transitive_crates.to_list()]
 
-    # Gets the paths to the folders containing the standard library (or libcore)
-    rust_lib_files = depset(transitive = [toolchain.rust_lib.files, toolchain.rustc_lib.files])
-    rust_lib_paths = depset([file.short_path for file in rust_lib_files.to_list()]).to_list()
-    rust_lib_dirs = depset([file.rsplit("/", 1)[0] for file in rust_lib_paths]).to_list()
-    rust_lib_dirs = ["${{pwd}}/{}".format(lib) for lib in rust_lib_dirs]
-
-    # Tell Rustc where to find the standard library
-    link_search_flags.extend(["-L {}".format(lib) for lib in rust_lib_dirs])
-
     sysroot = find_sysroot(toolchain, short_path = True)
     if sysroot:
         link_search_flags.append("--sysroot=${{pwd}}/{}".format(sysroot))
@@ -201,6 +192,11 @@ def _build_rustdoc_flags(ctx, dep_info, crate_info, toolchain):
         if cc_toolchain.sysroot:
             env["SYSROOT"] = cc_toolchain.sysroot
 
+    # Gets the paths to the folders containing the standard library (or libcore)
+    rust_lib_files = depset(transitive = [toolchain.rust_lib.files, toolchain.rustc_lib.files])
+    rust_lib_paths = depset([file.short_path for file in rust_lib_files.to_list()]).to_list()
+    rust_lib_dirs = depset([file.rsplit("/", 1)[0] for file in rust_lib_paths]).to_list()
+    rust_lib_dirs = ["${{pwd}}/{}".format(lib) for lib in rust_lib_dirs]
     # env["SYSROOT"] = "${{pwd}}/{}".format(sysroot)
     env["LD_LIBRARY_PATH"] = env.get("LD_LIBRARY_PATH", "") + ":".join(rust_lib_dirs)
     env["DYLD_LIBRARY_PATH"] = env.get("DYLD_LIBRARY_PATH", "") + ":".join(rust_lib_dirs)

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -97,6 +97,7 @@ def _rust_doc_test_impl(ctx):
         env = env,
         toolchain = toolchain,
         providers = [DefaultInfo(
+            files = toolchain.rustc_lib.files,
             runfiles = ctx.runfiles(transitive_files = compile_inputs),
         )],
         executable = rustdoc,

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -183,12 +183,13 @@ def _build_rustdoc_flags(ctx, dep_info, crate_info, toolchain):
         if cc_executable:
             env["CC"] = cc_executable
         ar_executable = cc_toolchain.ar_executable
-        # if ar_executable:
+        if ar_executable:
             # The default MacOS toolchain uses libtool as ar_executable not ar.
             # This doesn't work when used as $AR, so simply don't set it - tools will probably fall back to
             # /usr/bin/ar which is probably good enough.
-            # if not ar_executable.endswith("libtool"):
-            #     env["AR"] = ar_executable
+            if not ar_executable.endswith("libtool"):
+                env["AR"] = ar_executable
+                flags.extend(["-C", "linker={}".format(ar_executable)])
         if cc_toolchain.sysroot:
             env["SYSROOT"] = cc_toolchain.sysroot
 

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -140,8 +140,8 @@ def _build_rustdoc_flags(ctx, dep_info, crate_info, toolchain):
 
     sysroot = find_sysroot(toolchain, short_path = True)
     if sysroot:
-        link_search_flags.extend(["--sysroot", "${{pwd}}/{}".format(sysroot)])
-    link_search_flags.extend(["--target", toolchain.target_flag_value])
+        link_search_flags.append("--sysroot=${{pwd}}/{}".format(sysroot))
+    link_search_flags.append("--target={}".format(toolchain.target_flag_value))
 
     # TODO(hlopko): use the more robust logic from rustc.bzl also here, through a reasonable API.
     for lib_to_link in dep_info.transitive_noncrates.to_list():

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -14,6 +14,7 @@
 
 # buildifier: disable=module-docstring
 load("//rust/private:common.bzl", "rust_common")
+load("//rust/private:toolchain_utils.bzl", "find_sysroot")
 load("//rust/private:utils.bzl", "find_toolchain", "get_lib_name", "get_preferred_artifact")
 load("//util/launcher:launcher.bzl", "create_launcher")
 
@@ -113,6 +114,10 @@ def _build_rustdoc_flags(dep_info, crate_info, toolchain):
     link_flags.append("--extern=" + crate_info.name + "=" + crate_info.output.short_path)
     link_flags += ["--extern=" + c.name + "=" + c.dep.output.short_path for c in d.direct_crates.to_list()]
     link_search_flags += ["-Ldependency={}".format(_dirname(c.output.short_path)) for c in d.transitive_crates.to_list()]
+
+    sysroot = find_sysroot(toolchain, short_path = True)
+    if sysroot:
+        link_search_flags.extend(["--sysroot", "${{pwd}}/{}".format(sysroot)])
 
     # TODO(hlopko): use the more robust logic from rustc.bzl also here, through a reasonable API.
     for lib_to_link in dep_info.transitive_noncrates.to_list():

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -188,6 +188,7 @@ def _build_rustdoc_flags(ctx, dep_info, crate_info, toolchain):
         if cc_toolchain.sysroot:
             env["SYSROOT"] = cc_toolchain.sysroot
 
+    env["SYSROOT"] = "${{pwd}}/{}".format(sysroot)
     return flags, env, toolchain_tools
 
 rust_doc_test = rule(

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -170,6 +170,7 @@ def _build_rustdoc_flags(ctx, dep_info, crate_info, toolchain):
     toolchain_tools = []
     cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
     cc_env = get_cc_compile_env(cc_toolchain, feature_configuration)
+    print(cc_env)
 
     # MSVC requires INCLUDE to be set
     include = cc_env.get("INCLUDE")

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -183,12 +183,12 @@ def _build_rustdoc_flags(ctx, dep_info, crate_info, toolchain):
         if cc_executable:
             env["CC"] = cc_executable
         ar_executable = cc_toolchain.ar_executable
-        if ar_executable:
+        # if ar_executable:
             # The default MacOS toolchain uses libtool as ar_executable not ar.
             # This doesn't work when used as $AR, so simply don't set it - tools will probably fall back to
             # /usr/bin/ar which is probably good enough.
-            if not ar_executable.endswith("libtool"):
-                env["AR"] = ar_executable
+            # if not ar_executable.endswith("libtool"):
+            #     env["AR"] = ar_executable
         if cc_toolchain.sysroot:
             env["SYSROOT"] = cc_toolchain.sysroot
 

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -139,6 +139,14 @@ def _build_rustdoc_flags(ctx, dep_info, crate_info, toolchain):
     link_flags += ["--extern=" + c.name + "=" + c.dep.output.short_path for c in d.direct_crates.to_list()]
     link_search_flags += ["-Ldependency={}".format(_dirname(c.output.short_path)) for c in d.transitive_crates.to_list()]
 
+    # Gets the paths to the folders containing the standard library (or libcore)
+    rust_lib_files = depset(transitive = [toolchain.rust_lib.files, toolchain.rustc_lib.files])
+    rust_lib_paths = depset([file.short_path for file in rust_lib_files.to_list()]).to_list()
+    rust_lib_dirs = depset([file.rsplit("/", 1)[0] for file in rust_lib_paths]).to_list()
+
+    # Tell Rustc where to find the standard library
+    link_search_flags.extend(["-L ${{pwd}}/{}".format(lib) for lib in rust_lib_dirs])
+
     sysroot = find_sysroot(toolchain, short_path = True)
     if sysroot:
         link_search_flags.append("--sysroot=${{pwd}}/{}".format(sysroot))

--- a/rust/private/toolchain_utils.bzl
+++ b/rust/private/toolchain_utils.bzl
@@ -1,5 +1,31 @@
 """A module defining toolchain utilities"""
 
+def find_sysroot(rust_toolchain, short_path = False):
+    """Locate the sysroot for a given toolchain
+
+    Args:
+        rust_toolchain (rust_toolchain): A rust toolchain
+        short_path (bool): Whether or not to use a short path to the sysroot
+
+    Returns:
+        str, optional: The path of the toolchain's sysroot
+    """
+
+    # Sysroot is determined by using a rust stdlib file, expected to be at
+    # `${SYSROOT}/lib/rustlib/${target_triple}/lib`, and strip the known
+    # directories from the sysroot path.
+    rust_stdlib_files = rust_toolchain.rust_lib.files.to_list()
+    if rust_stdlib_files:
+        # Determine the sysroot by taking a rust stdlib file, expected to be `${sysroot}/lib`
+        if short_path:
+            split = rust_stdlib_files[0].short_path.rsplit("/", 5)
+        else:
+            split = rust_stdlib_files[0].path.rsplit("/", 5)
+        sysroot = split[0]
+        return sysroot
+
+    return None
+
 def _toolchain_files_impl(ctx):
     toolchain = ctx.toolchains[str(Label("//rust:toolchain"))]
 

--- a/util/launcher/BUILD.bazel
+++ b/util/launcher/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//rust:rust.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
@@ -6,4 +7,11 @@ rust_binary(
     name = "launcher",
     srcs = ["launcher_main.rs"],
     edition = "2018",
+)
+
+bzl_library(
+    name = "bzl_lib",
+    srcs = glob(
+        ["**/*.bzl"],
+    ),
 )

--- a/util/launcher/launcher.bzl
+++ b/util/launcher/launcher.bzl
@@ -1,0 +1,150 @@
+"""Rust executable launcher module"""
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:utils.bzl", "expand_dict_value_locations")
+
+def _write_environ(ctx, launcher_filename, env, data):
+    file = ctx.actions.declare_file(launcher_filename + ".launchfiles/env")
+    environ = expand_dict_value_locations(
+        ctx,
+        env,
+        data,
+    )
+
+    # Convert the environment variables into a list to be written into a file.
+    environ_list = []
+    for key, value in sorted(environ.items()):
+        environ_list.extend([key, value])
+
+    ctx.actions.write(
+        output = file,
+        content = "\n".join(environ_list),
+    )
+
+    return file
+
+def _write_args(ctx, launcher_filename, args, data):
+    # Convert the arguments list into a dictionary so args can benefit from
+    # the existing expand_dict_value_locations functionality
+    args_dict = {"{}".format(i): args[i] for i in range(0, len(args))}
+
+    file = ctx.actions.declare_file(launcher_filename + ".launchfiles/args")
+    expanded_args = expand_dict_value_locations(
+        ctx,
+        args_dict,
+        data,
+    )
+
+    ctx.actions.write(
+        output = file,
+        content = "\n".join(expanded_args.values()),
+    )
+
+    return file
+
+def _write_executable(ctx, launcher_filename, executable = None):
+    file = ctx.actions.declare_file(launcher_filename + ".launchfiles/exec")
+
+    ctx.actions.write(
+        output = file,
+        content = executable.path if executable else "",
+    )
+
+    return file
+
+def _merge_providers(ctx, providers, launcher, launcher_files, executable = None):
+    # Replace the `DefaultInfo` provider in the returned list
+    default_info = None
+    for i in range(len(providers)):
+        if type(providers[i]) == "DefaultInfo":
+            default_info = providers[i]
+            providers.pop(i)
+            break
+
+    if not default_info:
+        fail("list must contain a `DefaultInfo` provider")
+
+    # Additionally update the `OutputGroupInfo` provider
+    output_group_info = None
+    for i in range(len(providers)):
+        if type(providers[i]) == "OutputGroupInfo":
+            output_group_info = providers[i]
+            providers.pop(i)
+            break
+
+    if output_group_info:
+        output_group_info = OutputGroupInfo(
+            launcher_files = depset(launcher_files),
+            output = depset([executable or default_info.files_to_run.executable]),
+            **output_group_info
+        )
+    else:
+        output_group_info = OutputGroupInfo(
+            launcher_files = depset(launcher_files),
+            output = depset([executable or default_info.files_to_run.executable]),
+        )
+
+    providers.extend([
+        DefaultInfo(
+            files = default_info.files,
+            runfiles = default_info.default_runfiles.merge(
+                # The original executable is now also considered a runfile
+                ctx.runfiles(files = launcher_files + [
+                    executable or default_info.files_to_run.executable,
+                ]),
+            ),
+            executable = launcher,
+        ),
+        output_group_info,
+    ])
+
+    return providers
+
+def create_launcher(ctx, toolchain, args = [], env = {}, data = [], providers = [], executable = None):
+    """Create a process wrapper to ensure runtime environment variables are defined for the test binary
+
+    Args:
+        ctx (ctx): The rule's context object
+        toolchain (rust_toolchain): The current rust toolchain
+        args (list, optional): Optional arguments to include in the lancher
+        env (dict, optional): Optional environment variables to include in the lancher
+        data (list, optional): Targets to use when performing location expansion on `args` and `env`.
+        providers (list, optional): Providers from a rust compile action. See `rustc_compile_action`
+        executable (File, optional): An optional executable for the launcher to wrap
+
+    Returns:
+        list: A list of providers similar to `rustc_compile_action` but with modified default info
+    """
+
+    # TODO: It's unclear if the toolchain is in the same configuration as the `_launcher` attribute
+    # This should be investigated but for now, we generally assume if the target environment is windows,
+    # the execution environment is windows.
+    if toolchain.os == "windows":
+        launcher_filename = ctx.label.name + ".launcher.exe"
+    else:
+        launcher_filename = ctx.label.name + ".launcher"
+
+    launcher = ctx.actions.declare_file(launcher_filename)
+
+    # Because returned executables must be created from the same rule, the
+    # launcher target is simply symlinked and exposed.
+    ctx.actions.symlink(
+        output = launcher,
+        target_file = ctx.executable._launcher,
+        is_executable = True,
+    )
+
+    # Expand the environment variables and write them to a file
+    launcher_files = [
+        _write_environ(ctx, launcher_filename, env, data),
+        _write_args(ctx, launcher_filename, args, data),
+        _write_executable(ctx, launcher_filename, executable),
+    ]
+
+    return _merge_providers(
+        ctx = ctx,
+        providers = providers,
+        launcher = launcher,
+        launcher_files = launcher_files,
+        executable = executable,
+    )

--- a/util/launcher/launcher.bzl
+++ b/util/launcher/launcher.bzl
@@ -84,6 +84,13 @@ def _merge_providers(ctx, providers, launcher, launcher_files, executable = None
             output = depset([executable or default_info.files_to_run.executable]),
         )
 
+    print(ctx.label, default_info.default_runfiles.merge(
+        # The original executable is now also considered a runfile
+        ctx.runfiles(files = launcher_files + [
+            executable or default_info.files_to_run.executable,
+        ]),
+    ).files)
+
     providers.extend([
         DefaultInfo(
             files = default_info.files,

--- a/util/launcher/launcher.bzl
+++ b/util/launcher/launcher.bzl
@@ -85,12 +85,12 @@ def _merge_providers(ctx, providers, launcher, launcher_files, executable = None
         )
 
     # buildifier: disable=print
-    print(ctx.label, default_info.default_runfiles.merge(
-        # The original executable is now also considered a runfile
-        ctx.runfiles(files = launcher_files + [
-            executable or default_info.files_to_run.executable,
-        ]),
-    ).files)
+    # print(ctx.label, default_info.default_runfiles.merge(
+    #     # The original executable is now also considered a runfile
+    #     ctx.runfiles(files = launcher_files + [
+    #         executable or default_info.files_to_run.executable,
+    #     ]),
+    # ).files)
 
     providers.extend([
         DefaultInfo(

--- a/util/launcher/launcher.bzl
+++ b/util/launcher/launcher.bzl
@@ -84,6 +84,7 @@ def _merge_providers(ctx, providers, launcher, launcher_files, executable = None
             output = depset([executable or default_info.files_to_run.executable]),
         )
 
+    # buildifier: disable=print
     print(ctx.label, default_info.default_runfiles.merge(
         # The original executable is now also considered a runfile
         ctx.runfiles(files = launcher_files + [

--- a/util/launcher/launcher_main.rs
+++ b/util/launcher/launcher_main.rs
@@ -110,6 +110,10 @@ fn exec(environ: BTreeMap<String, String>, executable: PathBuf, args: Vec<String
 /// so instead we allow the command to run in a subprocess.
 #[cfg(target_family = "windows")]
 fn exec(environ: BTreeMap<String, String>, executable: PathBuf, args: Vec<String>) {
+    println!("{:?}", std::env::current_dir());
+    println!("{:#?}", args);
+    println!("{:#?}", environ);
+    println!("{:?}", executable);
     let result = Command::new(executable)
         .envs(environ.iter())
         .args(args)

--- a/util/launcher/launcher_main.rs
+++ b/util/launcher/launcher_main.rs
@@ -94,6 +94,10 @@ fn args() -> Vec<String> {
 /// Simply replace the current process with our test
 #[cfg(target_family = "unix")]
 fn exec(environ: BTreeMap<String, String>, executable: PathBuf, args: Vec<String>) {
+    println!("{:?}", std::env::current_dir());
+    println!("{:#?}", args);
+    println!("{:#?}", environ);
+    println!("{:?}", executable);
     let error = Command::new(&executable)
         .envs(environ.iter())
         .args(args)

--- a/util/launcher/launcher_main.rs
+++ b/util/launcher/launcher_main.rs
@@ -83,7 +83,10 @@ fn args() -> Vec<String> {
     // Note that arguments from the args file always go first
     BufReader::new(file)
         .lines()
-        .map(|line| line.expect("Failed to read file").replace("${pwd}", &pwd_str))
+        .map(|line| {
+            line.expect("Failed to read file")
+                .replace("${pwd}", &pwd_str)
+        })
         .chain(std::env::args().skip(1))
         .collect()
 }

--- a/util/launcher/launcher_main.rs
+++ b/util/launcher/launcher_main.rs
@@ -98,6 +98,14 @@ fn exec(environ: BTreeMap<String, String>, executable: PathBuf, args: Vec<String
     println!("{:#?}", args);
     println!("{:#?}", environ);
     println!("{:?}", executable);
+
+    if environ.contains_key("SYSROOT") {
+        let paths = std::fs::read_dir(&environ["SYSROOT"]).unwrap();
+        for path in paths {
+            println!("Name: {}", path.unwrap().path().display())
+        }
+    }
+
     let error = Command::new(&executable)
         .envs(environ.iter())
         .args(args)
@@ -120,6 +128,7 @@ fn exec(environ: BTreeMap<String, String>, executable: PathBuf, args: Vec<String
         .status()
         .expect("Failed to run process");
 
+    println!("{:?}", result.code().unwrap_or(1234));
     std::process::exit(result.code().unwrap_or(1));
 }
 

--- a/util/launcher/launcher_main.rs
+++ b/util/launcher/launcher_main.rs
@@ -75,10 +75,15 @@ fn args() -> Vec<String> {
     let args_path = std::env::args().next().expect("arg 0 was not set") + LAUNCHFILES_ARGS_PATH;
     let file = File::open(args_path).expect("Failed to load the environment file");
 
+    // Variables will have the `${pwd}` variable replaced which is rendered by
+    // `@rules_rust//rust/private:util.bzl::expand_dict_value_locations`
+    let pwd = std::env::current_dir().expect("Failed to get current working directory");
+    let pwd_str = pwd.to_string_lossy();
+
     // Note that arguments from the args file always go first
     BufReader::new(file)
         .lines()
-        .map(|line| line.expect("Failed to read file"))
+        .map(|line| line.expect("Failed to read file").replace("${pwd}", &pwd_str))
         .chain(std::env::args().skip(1))
         .collect()
 }


### PR DESCRIPTION
The `//util/launcher` target has also been updated to be more commonly usable outside of it's current use case (`rust_test`).