### PR TITLE
Temporarily disable `rust_doc_test` targets on windows

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -75,6 +75,11 @@ tasks:
       - "-@examples//sys/..."
       - "-@examples//proto/..."
       - "-@examples//wasm/..."
+      # rust_doc_test targets are currently broken on windows
+      # see: https://github.com/bazelbuild/rules_rust/issues/887
+      - "-@examples//hello_lib:hello_lib_doc_test"
+      - "-@examples//fibonacci:fibonacci_doc_test"
+      - "-//test/chained_direct_deps:mod3_doc_test"
     build_targets: *windows_targets
     test_targets: *windows_targets
   examples:


### PR DESCRIPTION
It's by no means ideal to disable these tests but there's currently no known solution and this is blocking all other PRs to the project. As far as I'm aware, `rust_doc_test` continues to work on some (the previous) windows environments but additional work will need to be done to update this rule to consistently work everywhere.

related to:
- https://github.com/bazelbuild/rules_rust/issues/887