### PR TITLE
Updated `rules_nodejs` for wasm_bindgen rules

### DIFF
--- a/wasm_bindgen/repositories.bzl
+++ b/wasm_bindgen/repositories.bzl
@@ -30,8 +30,8 @@ def rust_wasm_bindgen_repositories(register_default_toolchain = True):
     maybe(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        sha256 = "55a25a762fcf9c9b88ab54436581e671bc9f4f523cb5a1bd32459ebec7be68a8",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.2.2/rules_nodejs-3.2.2.tar.gz"],
+        sha256 = "8a7c981217239085f78acc9898a1f7ba99af887c1996ceb3b4504655383a2c3c",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.0.0/rules_nodejs-4.0.0.tar.gz"],
     )
 
     # Load dependencies of the default toolchain and register it.

--- a/wasm_bindgen/wasm_bindgen.bzl
+++ b/wasm_bindgen/wasm_bindgen.bzl
@@ -117,7 +117,7 @@ def _rust_wasm_bindgen_impl(ctx):
         DeclarationInfo(
             declarations = declarations,
             transitive_declarations = declarations,
-            type_blacklisted_declarations = depset([]),
+            type_blocklisted_declarations = depset([]),
         ),
         JSModuleInfo(
             direct_sources = es5_sources,


### PR DESCRIPTION
[rules_nodejs](https://github.com/bazelbuild/rules_nodejs) made some updates to the names of some symbols. This PR picks those up so `rules_rust` may also benefit.