### PR TITLE
Update formatting of `--extern` flags passed to `rustc`

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -866,7 +866,7 @@ def _crate_to_link_flag(crate_info):
     Returns:
         list: Link flags for the current crate info
     """
-    return ["--extern", "{}={}".format(crate_info.name, crate_info.dep.output.path)]
+    return ["--extern={}={}".format(crate_info.name, crate_info.dep.output.path)]
 
 def _get_crate_dirname(crate):
     """A helper macro used by `add_crate_link_flags` for getting the directory name of the current crate's output path

--- a/test/unit/common.bzl
+++ b/test/unit/common.bzl
@@ -29,6 +29,18 @@ def assert_argv_contains_prefix_suffix(env, action, prefix, suffix):
         ),
     )
 
+def assert_argv_contains_prefix(env, action, prefix):
+    for found_flag in action.argv:
+        if found_flag.startswith(prefix):
+            return
+    unittest.fail(
+        env,
+        "Expected an arg with prefix '{prefix}' in {args}".format(
+            prefix = prefix,
+            args = action.argv,
+        ),
+    )
+
 def assert_action_mnemonic(env, action, mnemonic):
     if not action.mnemonic == mnemonic:
         unittest.fail(

--- a/test/unit/exports/BUILD.bazel
+++ b/test/unit/exports/BUILD.bazel
@@ -1,0 +1,5 @@
+load(":exports_test.bzl", "exports_test_suite")
+
+exports_test_suite(
+    name = "exports_test_suite",
+)

--- a/test/unit/exports/exports_test.bzl
+++ b/test/unit/exports/exports_test.bzl
@@ -1,9 +1,9 @@
 """Unittest to verify re-exported symbols propagate to downstream crates"""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("//test/unit:common.bzl", "assert_argv_contains_prefix_suffix")
+load("//test/unit:common.bzl", "assert_argv_contains_prefix", "assert_argv_contains_prefix_suffix")
 
-def _exports_test_impl(ctx, deps):
+def _exports_test_impl(ctx, dependencies, externs):
     env = analysistest.begin(ctx)
     target = analysistest.target_under_test(env)
 
@@ -13,7 +13,7 @@ def _exports_test_impl(ctx, deps):
     # Transitive symbols that get re-exported are expected to be located by a `-Ldependency` flag.
     # The assert below ensures that each dependnecy flag is passed to the Rustc action. For details see
     # https://doc.rust-lang.org/rustc/command-line-arguments.html#-l-add-a-directory-to-the-library-search-path
-    for dep in deps:
+    for dep in dependencies:
         assert_argv_contains_prefix_suffix(
             env = env,
             action = action,
@@ -21,17 +21,32 @@ def _exports_test_impl(ctx, deps):
             suffix = dep,
         )
 
+    for dep in externs:
+        assert_argv_contains_prefix(
+            env = env,
+            action = action,
+            prefix = "--extern={}=".format(dep),
+        )
+
     return analysistest.end(env)
 
 def _lib_exports_test_impl(ctx):
     # This test is only expected to be used with
     # `//test/unit/exports/lib_c`
-    return _exports_test_impl(ctx, ["lib_a", "lib_b"])
+    return _exports_test_impl(
+        ctx = ctx,
+        dependencies = ["lib_a", "lib_b"],
+        externs = ["lib_b"],
+    )
 
 def _test_exports_test_impl(ctx):
     # This test is only expected to be used with
     # `//test/unit/exports/lib_c:lib_c_test`
-    return _exports_test_impl(ctx, ["lib_a", "lib_b"])
+    return _exports_test_impl(
+        ctx = ctx,
+        dependencies = ["lib_a", "lib_b"],
+        externs = ["lib_b"],
+    )
 
 lib_exports_test = analysistest.make(_lib_exports_test_impl)
 test_exports_test = analysistest.make(_test_exports_test_impl)

--- a/test/unit/exports/exports_test.bzl
+++ b/test/unit/exports/exports_test.bzl
@@ -1,0 +1,62 @@
+"""Unittest to verify re-exported symbols propagate to downstream crates"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//test/unit:common.bzl", "assert_argv_contains_prefix_suffix")
+
+def _exports_test_impl(ctx, deps):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    action = target.actions[0]
+    asserts.equals(env, action.mnemonic, "Rustc")
+
+    # Transitive symbols that get re-exported are expected to be located by a `-Ldependency` flag.
+    # The assert below ensures that each dependnecy flag is passed to the Rustc action. For details see
+    # https://doc.rust-lang.org/rustc/command-line-arguments.html#-l-add-a-directory-to-the-library-search-path
+    for dep in deps:
+        assert_argv_contains_prefix_suffix(
+            env = env,
+            action = action,
+            prefix = "-Ldependency",
+            suffix = dep,
+        )
+
+    return analysistest.end(env)
+
+def _lib_exports_test_impl(ctx):
+    # This test is only expected to be used with
+    # `//test/unit/exports/lib_c`
+    return _exports_test_impl(ctx, ["lib_a", "lib_b"])
+
+def _test_exports_test_impl(ctx):
+    # This test is only expected to be used with
+    # `//test/unit/exports/lib_c:lib_c_test`
+    return _exports_test_impl(ctx, ["lib_a", "lib_b"])
+
+lib_exports_test = analysistest.make(_lib_exports_test_impl)
+test_exports_test = analysistest.make(_test_exports_test_impl)
+
+def exports_test_suite(name):
+    """Entry-point macro called from the BUILD file.
+
+    Args:
+        name (str): Name of the macro.
+    """
+
+    lib_exports_test(
+        name = "lib_exports_test",
+        target_under_test = "//test/unit/exports/lib_c",
+    )
+
+    test_exports_test(
+        name = "test_exports_test",
+        target_under_test = "//test/unit/exports/lib_c:lib_c_test",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":lib_exports_test",
+            ":test_exports_test",
+        ],
+    )

--- a/test/unit/exports/lib_a/BUILD.bazel
+++ b/test/unit/exports/lib_a/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//rust:defs.bzl", "rust_library")
+
+package(default_visibility = ["//test:__subpackages__"])
+
+rust_library(
+    name = "lib_a",
+    srcs = ["src/lib.rs"],
+    edition = "2018",
+)

--- a/test/unit/exports/lib_a/src/lib.rs
+++ b/test/unit/exports/lib_a/src/lib.rs
@@ -1,0 +1,7 @@
+pub fn greeting_from(from: &str) -> String {
+    format!("Hello from {}!", from)
+}
+
+pub fn greeting_a() -> String {
+    greeting_from("lib_a")
+}

--- a/test/unit/exports/lib_b/BUILD.bazel
+++ b/test/unit/exports/lib_b/BUILD.bazel
@@ -1,0 +1,10 @@
+load("//rust:defs.bzl", "rust_library")
+
+package(default_visibility = ["//test:__subpackages__"])
+
+rust_library(
+    name = "lib_b",
+    srcs = ["src/lib.rs"],
+    edition = "2018",
+    deps = ["//test/unit/exports/lib_a"],
+)

--- a/test/unit/exports/lib_b/src/lib.rs
+++ b/test/unit/exports/lib_b/src/lib.rs
@@ -1,0 +1,6 @@
+// The functionality from `lib_a` should be usable within this crate
+pub use lib_a::{greeting_a, greeting_from};
+
+pub fn greeting_b() -> String {
+    greeting_from("lib_b")
+}

--- a/test/unit/exports/lib_c/BUILD.bazel
+++ b/test/unit/exports/lib_c/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//test:__subpackages__"])
+
+rust_library(
+    name = "lib_c",
+    srcs = ["src/lib.rs"],
+    edition = "2018",
+    deps = ["//test/unit/exports/lib_b"],
+)
+
+rust_test(
+    name = "lib_c_test",
+    crate = ":lib_c",
+)

--- a/test/unit/exports/lib_c/src/lib.rs
+++ b/test/unit/exports/lib_c/src/lib.rs
@@ -1,0 +1,20 @@
+// Symbols that `lib_b` exports are re-exports from `lib_a`.
+use lib_b::greeting_from;
+
+pub fn greeting_c() -> String {
+    greeting_from("lib_c")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use lib_b::{greeting_a, greeting_b};
+
+    #[test]
+    fn test_all_greetings() {
+        assert_eq!(greeting_a(), "Hello from lib_a!".to_owned());
+        assert_eq!(greeting_b(), "Hello from lib_b!".to_owned());
+        assert_eq!(greeting_c(), "Hello from lib_c!".to_owned());
+    }
+}

--- a/test/unit/exports/lib_c/src/lib.rs
+++ b/test/unit/exports/lib_c/src/lib.rs
@@ -1,4 +1,4 @@
-// Symbols that `lib_b` exports are re-exports from `lib_a`.
+// This symbol is an export that `lib_b` exports are re-exports from `lib_a`.
 use lib_b::greeting_from;
 
 pub fn greeting_c() -> String {


### PR DESCRIPTION
In an effort to make the the rules more testable, the `--extern` flags, which were previously:
```
['--extern', 'crate=some/path/to/libcrate.rlib']
```
have been updated to: 
```
['--extern=crate=some/path/to/libcrate.rlib']
```

Additionally, a test has been added to test regressions in accessibility to symbols in dependencies and transitive dependencies of a target. [re-exports](https://doc.rust-lang.org/reference/items/use-declarations.html#use-visibility) (ie `pub use ...`) for example.