### PR TITLE
Only consider iso_date arg in preparing URL if specific version provided

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1653,7 +1653,7 @@ See `load_arbitrary_tool` in `@rules_rust//rust:repositories.bzl` for more detai
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="rust_repositories-version"></a>version |  The version of Rust. Either "nightly", "beta", or an exact version. Defaults to a modern version.   |  <code>"1.54.0"</code> |
-| <a id="rust_repositories-iso_date"></a>iso_date |  The date of the nightly or beta release (or None, if the version is a specific version).   |  <code>None</code> |
+| <a id="rust_repositories-iso_date"></a>iso_date |  The date of the nightly or beta release (ignored if the version is a specific version).   |  <code>None</code> |
 | <a id="rust_repositories-rustfmt_version"></a>rustfmt_version |  The version of rustfmt. Either "nightly", "beta", or an exact version. Defaults to <code>version</code> if not specified.   |  <code>None</code> |
 | <a id="rust_repositories-edition"></a>edition |  The rust edition to be used by default (2015 (default) or 2018)   |  <code>None</code> |
 | <a id="rust_repositories-dev_components"></a>dev_components |  Whether to download the rustc-dev components (defaults to False). Requires version to be "nightly".   |  <code>False</code> |

--- a/docs/rust_repositories.md
+++ b/docs/rust_repositories.md
@@ -197,7 +197,7 @@ See `load_arbitrary_tool` in `@rules_rust//rust:repositories.bzl` for more detai
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="rust_repositories-version"></a>version |  The version of Rust. Either "nightly", "beta", or an exact version. Defaults to a modern version.   |  <code>"1.54.0"</code> |
-| <a id="rust_repositories-iso_date"></a>iso_date |  The date of the nightly or beta release (or None, if the version is a specific version).   |  <code>None</code> |
+| <a id="rust_repositories-iso_date"></a>iso_date |  The date of the nightly or beta release (ignored if the version is a specific version).   |  <code>None</code> |
 | <a id="rust_repositories-rustfmt_version"></a>rustfmt_version |  The version of rustfmt. Either "nightly", "beta", or an exact version. Defaults to <code>version</code> if not specified.   |  <code>None</code> |
 | <a id="rust_repositories-edition"></a>edition |  The rust edition to be used by default (2015 (default) or 2018)   |  <code>None</code> |
 | <a id="rust_repositories-dev_components"></a>dev_components |  Whether to download the rustc-dev components (defaults to False). Requires version to be "nightly".   |  <code>False</code> |

--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -460,10 +460,7 @@ def produce_tool_suburl(tool_name, target_triple, version, iso_date = None):
         str: The fully qualified url path for the specified tool.
     """
     path = produce_tool_path(tool_name, target_triple, version)
-    if version in ("beta", "nightly"):
-        return iso_date + "/" + path if iso_date else path
-    else:
-        return path
+    return iso_date + "/" + path if (iso_date and version in ("beta", "nightly")) else path
 
 def produce_tool_path(tool_name, target_triple, version):
     """Produces a qualified Rust tool name

--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -271,14 +271,9 @@ def load_rustfmt(ctx):
     """
     target_triple = ctx.attr.exec_triple
 
-    if ctx.attr.rustfmt_version in ("beta", "nightly"):
-        iso_date = ctx.attr.iso_date
-    else:
-        iso_date = None
-
     load_arbitrary_tool(
         ctx,
-        iso_date = iso_date,
+        iso_date = ctx.attr.iso_date,
         target_triple = target_triple,
         tool_name = "rustfmt",
         tool_subdirectories = ["rustfmt-preview"],
@@ -437,10 +432,6 @@ def check_version_valid(version, iso_date, param_prefix = ""):
     if version in ("beta", "nightly") and not iso_date:
         fail("{param_prefix}iso_date must be specified if version is 'beta' or 'nightly'".format(param_prefix = param_prefix))
 
-    if version not in ("beta", "nightly") and iso_date:
-        # buildifier: disable=print
-        print("{param_prefix}iso_date is ineffective if an exact version is specified".format(param_prefix = param_prefix))
-
 def serialized_constraint_set_from_triple(target_triple):
     """Returns a string representing a set of constraints
 
@@ -469,7 +460,10 @@ def produce_tool_suburl(tool_name, target_triple, version, iso_date = None):
         str: The fully qualified url path for the specified tool.
     """
     path = produce_tool_path(tool_name, target_triple, version)
-    return iso_date + "/" + path if iso_date else path
+    if version in ("beta", "nightly"):
+        return iso_date + "/" + path if iso_date else path
+    else:
+        return path
 
 def produce_tool_path(tool_name, target_triple, version):
     """Produces a qualified Rust tool name
@@ -516,11 +510,10 @@ def load_arbitrary_tool(ctx, tool_name, tool_subdirectories, version, iso_date, 
                                              .../etc
             tool_subdirectories = ["clippy-preview", "rustc"]
         version (str): The version of the tool among "nightly", "beta', or an exact version.
-        iso_date (str): The date of the tool (or None, if the version is a specific version).
+        iso_date (str): The date of the tool (ignored if the version is a specific version).
         target_triple (str): The rust-style target triple of the tool
         sha256 (str, optional): The expected hash of hash of the Rust tool. Defaults to "".
     """
-
     check_version_valid(version, iso_date, param_prefix = tool_name + "_")
 
     # View the indices mentioned in the docstring to find the tool_suburl for a given

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -60,7 +60,7 @@ def rust_repositories(
 
     Args:
         version (str, optional): The version of Rust. Either "nightly", "beta", or an exact version. Defaults to a modern version.
-        iso_date (str, optional): The date of the nightly or beta release (or None, if the version is a specific version).
+        iso_date (str, optional): The date of the nightly or beta release (ignored if the version is a specific version).
         rustfmt_version (str, optional): The version of rustfmt. Either "nightly", "beta", or an exact version. Defaults to `version` if not specified.
         edition (str, optional): The rust edition to be used by default (2015 (default) or 2018)
         dev_components (bool, optional): Whether to download the rustc-dev components (defaults to False). Requires version to be "nightly".

--- a/test/unit/repository_utils/repository_utils_test.bzl
+++ b/test/unit/repository_utils/repository_utils_test.bzl
@@ -45,6 +45,16 @@ def _produce_tool_suburl_test_impl(ctx):
             target_triple = None,
         ),
     )
+    asserts.equals(
+        env,
+        "rust-src-1.54.0",
+        produce_tool_suburl(
+            iso_date = "2021-08-15",
+            tool_name = "rust-src",
+            version = "1.54.0",
+            target_triple = None,
+        ),
+    )
     return unittest.end(env)
 
 def _produce_tool_path_test_impl(ctx):


### PR DESCRIPTION
This allows e.g.

```
rust_repositories(
    edition = "2018",
    include_rustc_srcs = True,
    version = "1.54.0",
    rustfmt_version = "nightly",
    iso_date = "2021-08-16",
)
```