### PR TITLE
Added `default_edition` and `default_version` to `rust_common`

### DIFF
--- a/.github/workflows/release_begin.yaml
+++ b/.github/workflows/release_begin.yaml
@@ -57,7 +57,7 @@ jobs:
           # Install rust toolchains for host
 
           # Detect the current version of rust
-          version="$(grep 'DEFAULT_RUST_VERSION =' ./rust/repositories.bzl | sed 's/DEFAULT_RUST_VERSION = "//' | sed 's/"//')"
+          version="$(grep 'DEFAULT_RUST_VERSION =' ./rust/private/common.bzl | sed 's/DEFAULT_RUST_VERSION = "//' | sed 's/"//')"
 
           rustup override set "${version}"
           rustup update stable && rustup default stable

--- a/cargo/cargo_bootstrap.bzl
+++ b/cargo/cargo_bootstrap.bzl
@@ -1,7 +1,7 @@
 """The `cargo_bootstrap` rule is used for bootstrapping cargo binaries in a repository rule."""
 
 load("//cargo/private:cargo_utils.bzl", "get_cargo_and_rustc", "get_host_triple")
-load("//rust:repositories.bzl", "DEFAULT_RUST_VERSION")
+load("//rust:defs.bzl", "rust_common")
 
 _CARGO_BUILD_MODES = [
     "release",
@@ -184,7 +184,7 @@ cargo_bootstrap_repository = repository_rule(
         ),
         "version": attr.string(
             doc = "The version of cargo the resolver should use",
-            default = DEFAULT_RUST_VERSION,
+            default = rust_common.default_version,
         ),
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),

--- a/crate_universe/bootstrap.bzl
+++ b/crate_universe/bootstrap.bzl
@@ -1,7 +1,7 @@
 """A module for declaraing a repository for bootstrapping crate_universe"""
 
 load("//cargo:defs.bzl", "cargo_bootstrap_repository")
-load("//rust:repositories.bzl", "DEFAULT_RUST_VERSION")
+load("//rust:defs.bzl", "rust_common")
 
 def crate_universe_bootstrap():
     cargo_bootstrap_repository(
@@ -9,6 +9,6 @@ def crate_universe_bootstrap():
         cargo_lockfile = Label("//crate_universe:Cargo.lock"),
         cargo_toml = Label("//crate_universe:Cargo.toml"),
         srcs = [Label("//crate_universe:resolver_srcs")],
-        version = DEFAULT_RUST_VERSION,
+        version = rust_common.default_version,
         binary = "crate_universe_resolver",
     )

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -2,7 +2,8 @@
 
 load("//crate_universe/private:defaults.bzl", "DEFAULT_SHA256_CHECKSUMS", "DEFAULT_URL_TEMPLATE")
 load("//crate_universe/private:util.bzl", "get_cargo_and_rustc", "get_host_triple")
-load("//rust:repositories.bzl", "DEFAULT_RUST_VERSION", "DEFAULT_TOOLCHAIN_TRIPLES")
+load("//rust:defs.bzl", "rust_common")
+load("//rust:repositories.bzl", "DEFAULT_TOOLCHAIN_TRIPLES")
 load("//rust/platform:triple_mappings.bzl", "system_to_binary_ext", "triple_to_system")
 
 DEFAULT_CRATE_REGISTRY_TEMPLATE = "https://crates.io/api/v1/crates/{crate}/{version}/download"
@@ -227,7 +228,7 @@ Environment Variables:
         ),
         "version": attr.string(
             doc = "The version of cargo the resolver should use",
-            default = DEFAULT_RUST_VERSION,
+            default = rust_common.default_version,
         ),
     },
     environ = [

--- a/proto/toolchain.bzl
+++ b/proto/toolchain.bzl
@@ -14,6 +14,8 @@
 
 """Toolchain for compiling rust stubs from protobuf and gRPC."""
 
+load("//rust:defs.bzl", "rust_common")
+
 # buildifier: disable=bzl-visibility
 load("//rust/private:utils.bzl", "name_to_crate_name")
 
@@ -144,7 +146,7 @@ rust_proto_toolchain = rule(
     attrs = {
         "edition": attr.string(
             doc = "The edition used by the generated rust source.",
-            default = "2015",
+            default = rust_common.default_edition,
         ),
         "grpc_compile_deps": attr.label_list(
             doc = "The crates the generated grpc libraries depends on.",

--- a/rust/private/common.bzl
+++ b/rust/private/common.bzl
@@ -25,6 +25,15 @@ In the Bazel lingo, `rust_common` gives the access to the Rust Sandwich API.
 
 load(":providers.bzl", "CrateInfo", "DepInfo", "StdLibInfo")
 
+# These constants only represent the default value for attributes and macros
+# defiend in `rules_rust`. Like any attribute public attribute, they can be
+# overwritten by the user on the rules they're defiend on.
+#
+# Note: Code in `.github/workflows/crate_universe.yaml` looks for this line, if
+# you remove it or change its format, you will also need to update that code.
+DEFAULT_RUST_VERSION = "1.54.0"
+DEFAULT_RUST_EDITION = "2015"
+
 def _create_crate_info(**kwargs):
     """A constructor for a `CrateInfo` provider
 
@@ -46,4 +55,6 @@ rust_common = struct(
     crate_info = CrateInfo,
     dep_info = DepInfo,
     stdlib_info = StdLibInfo,
+    default_edition = DEFAULT_RUST_EDITION,
+    default_version = DEFAULT_RUST_VERSION,
 )

--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -202,8 +202,8 @@ def BUILD_for_rust_toolchain(
         exec_triple,
         target_triple,
         include_rustc_srcs,
-        stdlib_linkflags = None,
-        default_edition = "2015"):
+        default_edition,
+        stdlib_linkflags = None):
     """Emits a toolchain declaration to match an existing compiler and stdlib.
 
     Args:
@@ -212,10 +212,11 @@ def BUILD_for_rust_toolchain(
         exec_triple (str): The rust-style target that this compiler runs on
         target_triple (str): The rust-style target triple of the tool
         include_rustc_srcs (bool, optional): Whether to download rustc's src code. This is required in order to use rust-analyzer support. Defaults to False.
+        default_edition (str): Default Rust edition.
         stdlib_linkflags (list, optional): Overriden flags needed for linking to rust
                                            stdlib, akin to BAZEL_LINKLIBS. Defaults to
                                            None.
-        default_edition (str, optional): Default Rust edition. Defaults to "2015".
+
 
     Returns:
         str: A rendered template of a `rust_toolchain` declaration

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -1,6 +1,7 @@
 # buildifier: disable=module-docstring
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//rust/private:common.bzl", "rust_common")
 load(
     "//rust/private:repository_utils.bzl",
     "BUILD_for_toolchain",
@@ -20,7 +21,6 @@ load(
 load_arbitrary_tool = _load_arbitrary_tool
 
 # Note: Code in `.github/workflows/crate_universe.yaml` looks for this line, if you remove it or change its format, you will also need to update that code.
-DEFAULT_RUST_VERSION = "1.54.0"
 DEFAULT_TOOLCHAIN_TRIPLES = {
     "aarch64-apple-darwin": "rust_darwin_aarch64",
     "aarch64-unknown-linux-gnu": "rust_linux_aarch64",
@@ -32,7 +32,7 @@ DEFAULT_TOOLCHAIN_TRIPLES = {
 
 # buildifier: disable=unnamed-macro
 def rust_repositories(
-        version = DEFAULT_RUST_VERSION,
+        version = rust_common.default_version,
         iso_date = None,
         rustfmt_version = None,
         edition = None,
@@ -177,7 +177,7 @@ rust_toolchain_repository = repository_rule(
         ),
         "edition": attr.string(
             doc = "The rust edition to be used by default.",
-            default = "2015",
+            default = rust_common.default_edition,
         ),
         "exec_triple": attr.string(
             doc = "The Rust-style target that this compiler runs on",

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -286,7 +286,7 @@ rust_toolchain = rule(
         ),
         "default_edition": attr.string(
             doc = "The edition to use for rust_* rules that don't specify an edition.",
-            default = "2015",
+            default = rust_common.default_edition,
         ),
         "dylib_ext": attr.string(
             doc = "The extension for dynamic libraries created from rustc.",


### PR DESCRIPTION
This should help keep the use of these variables consistent everywhere.