### PR TITLE
Regenerated cargo-raze outputs for sys examples

### DIFF
--- a/examples/sys/basic/Cargo.toml
+++ b/examples/sys/basic/Cargo.toml
@@ -12,7 +12,7 @@ bzip2 = "=0.3.3"
 [package.metadata.raze]
 workspace_path = "//sys/basic/raze"
 genmode = "Remote"
-gen_workspace_prefix = "rules_rust_examples_basic_sys"
+gen_workspace_prefix = "basic_sys"
 rust_rules_workspace_name = "rules_rust"
 package_aliases_dir = "raze"
 default_gen_buildrs = false

--- a/examples/sys/basic/raze/BUILD.bazel
+++ b/examples/sys/basic/raze/BUILD.bazel
@@ -14,7 +14,7 @@ licenses([
 # Aliased targets
 alias(
     name = "bzip2",
-    actual = "@rules_rust_examples_basic_sys__bzip2__0_3_3//:bzip2",
+    actual = "@basic_sys__bzip2__0_3_3//:bzip2",
     tags = [
         "cargo-raze",
         "manual",

--- a/examples/sys/basic/raze/crates.bzl
+++ b/examples/sys/basic/raze/crates.bzl
@@ -9,11 +9,11 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")  # bui
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")  # buildifier: disable=load
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")  # buildifier: disable=load
 
-def rules_rust_examples_basic_sys_fetch_remote_crates():
+def basic_sys_fetch_remote_crates():
     """This function defines a collection of repos and should be called in a WORKSPACE file"""
     maybe(
         http_archive,
-        name = "rules_rust_examples_basic_sys__bzip2__0_3_3",
+        name = "basic_sys__bzip2__0_3_3",
         url = "https://crates.io/api/v1/crates/bzip2/0.3.3/download",
         type = "tar.gz",
         sha256 = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b",
@@ -23,7 +23,7 @@ def rules_rust_examples_basic_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_basic_sys__bzip2_sys__0_1_9_1_0_8",
+        name = "basic_sys__bzip2_sys__0_1_9_1_0_8",
         url = "https://crates.io/api/v1/crates/bzip2-sys/0.1.9+1.0.8/download",
         type = "tar.gz",
         sha256 = "ad3b39a260062fca31f7b0b12f207e8f2590a67d32ec7d59c20484b07ea7285e",
@@ -33,7 +33,7 @@ def rules_rust_examples_basic_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_basic_sys__cc__1_0_60",
+        name = "basic_sys__cc__1_0_60",
         url = "https://crates.io/api/v1/crates/cc/1.0.60/download",
         type = "tar.gz",
         sha256 = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c",
@@ -43,7 +43,7 @@ def rules_rust_examples_basic_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_basic_sys__libc__0_2_77",
+        name = "basic_sys__libc__0_2_77",
         url = "https://crates.io/api/v1/crates/libc/0.2.77/download",
         type = "tar.gz",
         sha256 = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235",
@@ -53,7 +53,7 @@ def rules_rust_examples_basic_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_basic_sys__pkg_config__0_3_18",
+        name = "basic_sys__pkg_config__0_3_18",
         url = "https://crates.io/api/v1/crates/pkg-config/0.3.18/download",
         type = "tar.gz",
         sha256 = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33",

--- a/examples/sys/basic/raze/remote/BUILD.bzip2-0.3.3.bazel
+++ b/examples/sys/basic/raze/remote/BUILD.bzip2-0.3.3.bazel
@@ -49,8 +49,8 @@ rust_library(
     version = "0.3.3",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_basic_sys__bzip2_sys__0_1_9_1_0_8//:bzip2_sys",
-        "@rules_rust_examples_basic_sys__libc__0_2_77//:libc",
+        "@basic_sys__bzip2_sys__0_1_9_1_0_8//:bzip2_sys",
+        "@basic_sys__libc__0_2_77//:libc",
     ],
 )
 

--- a/examples/sys/basic/raze/remote/BUILD.bzip2-sys-0.1.9+1.0.8.bazel
+++ b/examples/sys/basic/raze/remote/BUILD.bzip2-sys-0.1.9+1.0.8.bazel
@@ -57,8 +57,8 @@ cargo_build_script(
     version = "0.1.9+1.0.8",
     visibility = ["//visibility:private"],
     deps = [
-        "@rules_rust_examples_basic_sys__cc__1_0_60//:cc",
-        "@rules_rust_examples_basic_sys__pkg_config__0_3_18//:pkg_config",
+        "@basic_sys__cc__1_0_60//:cc",
+        "@basic_sys__pkg_config__0_3_18//:pkg_config",
     ],
 )
 
@@ -82,6 +82,6 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":bzip2_sys_build_script",
-        "@rules_rust_examples_basic_sys__libc__0_2_77//:libc",
+        "@basic_sys__libc__0_2_77//:libc",
     ],
 )

--- a/examples/sys/complex/Cargo.toml
+++ b/examples/sys/complex/Cargo.toml
@@ -14,7 +14,7 @@ openssl-sys = "=0.9.60"
 [package.metadata.raze]
 workspace_path = "//sys/complex/raze"
 genmode = "Remote"
-gen_workspace_prefix = "rules_rust_examples_complex_sys"
+gen_workspace_prefix = "complex_sys"
 rust_rules_workspace_name = "rules_rust"
 package_aliases_dir = "raze"
 default_gen_buildrs = true

--- a/examples/sys/complex/raze/BUILD.bazel
+++ b/examples/sys/complex/raze/BUILD.bazel
@@ -14,7 +14,7 @@ licenses([
 # Aliased targets
 alias(
     name = "git2",
-    actual = "@rules_rust_examples_complex_sys__git2__0_13_12//:git2",
+    actual = "@complex_sys__git2__0_13_12//:git2",
     tags = [
         "cargo-raze",
         "manual",
@@ -23,7 +23,7 @@ alias(
 
 alias(
     name = "openssl",
-    actual = "@rules_rust_examples_complex_sys__openssl__0_10_32//:openssl",
+    actual = "@complex_sys__openssl__0_10_32//:openssl",
     tags = [
         "cargo-raze",
         "manual",
@@ -32,7 +32,7 @@ alias(
 
 alias(
     name = "openssl_sys",
-    actual = "@rules_rust_examples_complex_sys__openssl_sys__0_9_60//:openssl_sys",
+    actual = "@complex_sys__openssl_sys__0_9_60//:openssl_sys",
     tags = [
         "cargo-raze",
         "manual",

--- a/examples/sys/complex/raze/crates.bzl
+++ b/examples/sys/complex/raze/crates.bzl
@@ -9,11 +9,11 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")  # bui
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")  # buildifier: disable=load
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")  # buildifier: disable=load
 
-def rules_rust_examples_complex_sys_fetch_remote_crates():
+def complex_sys_fetch_remote_crates():
     """This function defines a collection of repos and should be called in a WORKSPACE file"""
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__autocfg__1_0_1",
+        name = "complex_sys__autocfg__1_0_1",
         url = "https://crates.io/api/v1/crates/autocfg/1.0.1/download",
         type = "tar.gz",
         sha256 = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a",
@@ -23,7 +23,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__bitflags__1_2_1",
+        name = "complex_sys__bitflags__1_2_1",
         url = "https://crates.io/api/v1/crates/bitflags/1.2.1/download",
         type = "tar.gz",
         sha256 = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693",
@@ -33,7 +33,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__cc__1_0_69",
+        name = "complex_sys__cc__1_0_69",
         url = "https://crates.io/api/v1/crates/cc/1.0.69/download",
         type = "tar.gz",
         sha256 = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2",
@@ -43,7 +43,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__cfg_if__1_0_0",
+        name = "complex_sys__cfg_if__1_0_0",
         url = "https://crates.io/api/v1/crates/cfg-if/1.0.0/download",
         type = "tar.gz",
         sha256 = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
@@ -53,7 +53,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__foreign_types__0_3_2",
+        name = "complex_sys__foreign_types__0_3_2",
         url = "https://crates.io/api/v1/crates/foreign-types/0.3.2/download",
         type = "tar.gz",
         sha256 = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1",
@@ -63,7 +63,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__foreign_types_shared__0_1_1",
+        name = "complex_sys__foreign_types_shared__0_1_1",
         url = "https://crates.io/api/v1/crates/foreign-types-shared/0.1.1/download",
         type = "tar.gz",
         sha256 = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b",
@@ -73,7 +73,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__form_urlencoded__1_0_1",
+        name = "complex_sys__form_urlencoded__1_0_1",
         url = "https://crates.io/api/v1/crates/form_urlencoded/1.0.1/download",
         type = "tar.gz",
         sha256 = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191",
@@ -83,7 +83,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__git2__0_13_12",
+        name = "complex_sys__git2__0_13_12",
         url = "https://crates.io/api/v1/crates/git2/0.13.12/download",
         type = "tar.gz",
         sha256 = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224",
@@ -93,7 +93,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__idna__0_2_3",
+        name = "complex_sys__idna__0_2_3",
         url = "https://crates.io/api/v1/crates/idna/0.2.3/download",
         type = "tar.gz",
         sha256 = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8",
@@ -103,7 +103,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__jobserver__0_1_23",
+        name = "complex_sys__jobserver__0_1_23",
         url = "https://crates.io/api/v1/crates/jobserver/0.1.23/download",
         type = "tar.gz",
         sha256 = "f5ca711fd837261e14ec9e674f092cbb931d3fa1482b017ae59328ddc6f3212b",
@@ -113,7 +113,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__lazy_static__1_4_0",
+        name = "complex_sys__lazy_static__1_4_0",
         url = "https://crates.io/api/v1/crates/lazy_static/1.4.0/download",
         type = "tar.gz",
         sha256 = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
@@ -123,7 +123,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__libc__0_2_98",
+        name = "complex_sys__libc__0_2_98",
         url = "https://crates.io/api/v1/crates/libc/0.2.98/download",
         type = "tar.gz",
         sha256 = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790",
@@ -133,7 +133,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__libgit2_sys__0_12_21_1_1_0",
+        name = "complex_sys__libgit2_sys__0_12_21_1_1_0",
         url = "https://crates.io/api/v1/crates/libgit2-sys/0.12.21+1.1.0/download",
         type = "tar.gz",
         sha256 = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825",
@@ -143,7 +143,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__libssh2_sys__0_2_21",
+        name = "complex_sys__libssh2_sys__0_2_21",
         url = "https://crates.io/api/v1/crates/libssh2-sys/0.2.21/download",
         type = "tar.gz",
         sha256 = "e0186af0d8f171ae6b9c4c90ec51898bad5d08a2d5e470903a50d9ad8959cbee",
@@ -153,7 +153,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__libz_sys__1_1_3",
+        name = "complex_sys__libz_sys__1_1_3",
         url = "https://crates.io/api/v1/crates/libz-sys/1.1.3/download",
         type = "tar.gz",
         sha256 = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66",
@@ -163,7 +163,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__log__0_4_14",
+        name = "complex_sys__log__0_4_14",
         url = "https://crates.io/api/v1/crates/log/0.4.14/download",
         type = "tar.gz",
         sha256 = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710",
@@ -173,7 +173,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__matches__0_1_8",
+        name = "complex_sys__matches__0_1_8",
         url = "https://crates.io/api/v1/crates/matches/0.1.8/download",
         type = "tar.gz",
         sha256 = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08",
@@ -183,7 +183,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__openssl__0_10_32",
+        name = "complex_sys__openssl__0_10_32",
         url = "https://crates.io/api/v1/crates/openssl/0.10.32/download",
         type = "tar.gz",
         sha256 = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70",
@@ -193,7 +193,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__openssl_probe__0_1_4",
+        name = "complex_sys__openssl_probe__0_1_4",
         url = "https://crates.io/api/v1/crates/openssl-probe/0.1.4/download",
         type = "tar.gz",
         sha256 = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a",
@@ -203,7 +203,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__openssl_sys__0_9_60",
+        name = "complex_sys__openssl_sys__0_9_60",
         url = "https://crates.io/api/v1/crates/openssl-sys/0.9.60/download",
         type = "tar.gz",
         sha256 = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6",
@@ -213,7 +213,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__percent_encoding__2_1_0",
+        name = "complex_sys__percent_encoding__2_1_0",
         url = "https://crates.io/api/v1/crates/percent-encoding/2.1.0/download",
         type = "tar.gz",
         sha256 = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e",
@@ -223,7 +223,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__pkg_config__0_3_19",
+        name = "complex_sys__pkg_config__0_3_19",
         url = "https://crates.io/api/v1/crates/pkg-config/0.3.19/download",
         type = "tar.gz",
         sha256 = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c",
@@ -233,7 +233,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__tinyvec__1_3_1",
+        name = "complex_sys__tinyvec__1_3_1",
         url = "https://crates.io/api/v1/crates/tinyvec/1.3.1/download",
         type = "tar.gz",
         sha256 = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338",
@@ -243,7 +243,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__tinyvec_macros__0_1_0",
+        name = "complex_sys__tinyvec_macros__0_1_0",
         url = "https://crates.io/api/v1/crates/tinyvec_macros/0.1.0/download",
         type = "tar.gz",
         sha256 = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c",
@@ -253,7 +253,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__unicode_bidi__0_3_5",
+        name = "complex_sys__unicode_bidi__0_3_5",
         url = "https://crates.io/api/v1/crates/unicode-bidi/0.3.5/download",
         type = "tar.gz",
         sha256 = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0",
@@ -263,7 +263,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__unicode_normalization__0_1_19",
+        name = "complex_sys__unicode_normalization__0_1_19",
         url = "https://crates.io/api/v1/crates/unicode-normalization/0.1.19/download",
         type = "tar.gz",
         sha256 = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9",
@@ -273,7 +273,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__url__2_2_2",
+        name = "complex_sys__url__2_2_2",
         url = "https://crates.io/api/v1/crates/url/2.2.2/download",
         type = "tar.gz",
         sha256 = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c",
@@ -283,7 +283,7 @@ def rules_rust_examples_complex_sys_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "rules_rust_examples_complex_sys__vcpkg__0_2_15",
+        name = "complex_sys__vcpkg__0_2_15",
         url = "https://crates.io/api/v1/crates/vcpkg/0.2.15/download",
         type = "tar.gz",
         sha256 = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426",

--- a/examples/sys/complex/raze/remote/BUILD.cc-1.0.69.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.cc-1.0.69.bazel
@@ -53,7 +53,7 @@ rust_binary(
     # buildifier: leave-alone
     deps = [
         ":cc",
-        "@rules_rust_examples_complex_sys__jobserver__0_1_23//:jobserver",
+        "@complex_sys__jobserver__0_1_23//:jobserver",
     ],
 )
 
@@ -78,7 +78,7 @@ rust_library(
     version = "1.0.69",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_complex_sys__jobserver__0_1_23//:jobserver",
+        "@complex_sys__jobserver__0_1_23//:jobserver",
     ],
 )
 

--- a/examples/sys/complex/raze/remote/BUILD.foreign-types-0.3.2.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.foreign-types-0.3.2.bazel
@@ -49,6 +49,6 @@ rust_library(
     version = "0.3.2",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_complex_sys__foreign_types_shared__0_1_1//:foreign_types_shared",
+        "@complex_sys__foreign_types_shared__0_1_1//:foreign_types_shared",
     ],
 )

--- a/examples/sys/complex/raze/remote/BUILD.form_urlencoded-1.0.1.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.form_urlencoded-1.0.1.bazel
@@ -49,7 +49,7 @@ rust_library(
     version = "1.0.1",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_complex_sys__matches__0_1_8//:matches",
-        "@rules_rust_examples_complex_sys__percent_encoding__2_1_0//:percent_encoding",
+        "@complex_sys__matches__0_1_8//:matches",
+        "@complex_sys__percent_encoding__2_1_0//:percent_encoding",
     ],
 )

--- a/examples/sys/complex/raze/remote/BUILD.git2-0.13.12.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.git2-0.13.12.bazel
@@ -85,11 +85,11 @@ rust_library(
     version = "0.13.12",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_complex_sys__bitflags__1_2_1//:bitflags",
-        "@rules_rust_examples_complex_sys__libc__0_2_98//:libc",
-        "@rules_rust_examples_complex_sys__libgit2_sys__0_12_21_1_1_0//:libgit2_sys",
-        "@rules_rust_examples_complex_sys__log__0_4_14//:log",
-        "@rules_rust_examples_complex_sys__url__2_2_2//:url",
+        "@complex_sys__bitflags__1_2_1//:bitflags",
+        "@complex_sys__libc__0_2_98//:libc",
+        "@complex_sys__libgit2_sys__0_12_21_1_1_0//:libgit2_sys",
+        "@complex_sys__log__0_4_14//:log",
+        "@complex_sys__url__2_2_2//:url",
     ] + selects.with_or({
         # cfg(all(unix, not(target_os = "macos")))
         (
@@ -107,8 +107,8 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@rules_rust_examples_complex_sys__openssl_probe__0_1_4//:openssl_probe",
-            "@rules_rust_examples_complex_sys__openssl_sys__0_9_60//:openssl_sys",
+            "@complex_sys__openssl_probe__0_1_4//:openssl_probe",
+            "@complex_sys__openssl_sys__0_9_60//:openssl_sys",
         ],
         "//conditions:default": [],
     }),

--- a/examples/sys/complex/raze/remote/BUILD.idna-0.2.3.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.idna-0.2.3.bazel
@@ -51,9 +51,9 @@ rust_library(
     version = "0.2.3",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_complex_sys__matches__0_1_8//:matches",
-        "@rules_rust_examples_complex_sys__unicode_bidi__0_3_5//:unicode_bidi",
-        "@rules_rust_examples_complex_sys__unicode_normalization__0_1_19//:unicode_normalization",
+        "@complex_sys__matches__0_1_8//:matches",
+        "@complex_sys__unicode_bidi__0_3_5//:unicode_bidi",
+        "@complex_sys__unicode_normalization__0_1_19//:unicode_normalization",
     ],
 )
 

--- a/examples/sys/complex/raze/remote/BUILD.jobserver-0.1.23.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.jobserver-0.1.23.bazel
@@ -71,7 +71,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@rules_rust_examples_complex_sys__libc__0_2_98//:libc",
+            "@complex_sys__libc__0_2_98//:libc",
         ],
         "//conditions:default": [],
     }),

--- a/examples/sys/complex/raze/remote/BUILD.libgit2-sys-0.12.21+1.1.0.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.libgit2-sys-0.12.21+1.1.0.bazel
@@ -62,10 +62,10 @@ cargo_build_script(
     version = "0.12.21+1.1.0",
     visibility = ["//visibility:private"],
     deps = [
-        "@rules_rust_examples_complex_sys__cc__1_0_69//:cc",
-        "@rules_rust_examples_complex_sys__libssh2_sys__0_2_21//:libssh2_sys",
-        "@rules_rust_examples_complex_sys__libz_sys__1_1_3//:libz_sys",
-        "@rules_rust_examples_complex_sys__pkg_config__0_3_19//:pkg_config",
+        "@complex_sys__cc__1_0_69//:cc",
+        "@complex_sys__libssh2_sys__0_2_21//:libssh2_sys",
+        "@complex_sys__libz_sys__1_1_3//:libz_sys",
+        "@complex_sys__pkg_config__0_3_19//:pkg_config",
     ] + selects.with_or({
         # cfg(unix)
         (
@@ -86,7 +86,7 @@ cargo_build_script(
             "@rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@rules_rust_examples_complex_sys__openssl_sys__0_9_60//:openssl_sys",
+            "@complex_sys__openssl_sys__0_9_60//:openssl_sys",
         ],
         "//conditions:default": [],
     }),
@@ -119,9 +119,9 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":libgit2_sys_build_script",
-        "@rules_rust_examples_complex_sys__libc__0_2_98//:libc",
-        "@rules_rust_examples_complex_sys__libssh2_sys__0_2_21//:libssh2_sys",
-        "@rules_rust_examples_complex_sys__libz_sys__1_1_3//:libz_sys",
+        "@complex_sys__libc__0_2_98//:libc",
+        "@complex_sys__libssh2_sys__0_2_21//:libssh2_sys",
+        "@complex_sys__libz_sys__1_1_3//:libz_sys",
     ] + selects.with_or({
         # cfg(unix)
         (
@@ -142,7 +142,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@rules_rust_examples_complex_sys__openssl_sys__0_9_60//:openssl_sys",
+            "@complex_sys__openssl_sys__0_9_60//:openssl_sys",
         ],
         "//conditions:default": [],
     }),

--- a/examples/sys/complex/raze/remote/BUILD.libssh2-sys-0.2.21.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.libssh2-sys-0.2.21.bazel
@@ -59,16 +59,16 @@ cargo_build_script(
     version = "0.2.21",
     visibility = ["//visibility:private"],
     deps = [
-        "@rules_rust_examples_complex_sys__cc__1_0_69//:cc",
-        "@rules_rust_examples_complex_sys__libz_sys__1_1_3//:libz_sys",
-        "@rules_rust_examples_complex_sys__pkg_config__0_3_19//:pkg_config",
+        "@complex_sys__cc__1_0_69//:cc",
+        "@complex_sys__libz_sys__1_1_3//:libz_sys",
+        "@complex_sys__pkg_config__0_3_19//:pkg_config",
     ] + selects.with_or({
         # cfg(target_env = "msvc")
         (
             "@rules_rust//rust/platform:i686-pc-windows-msvc",
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
-            "@rules_rust_examples_complex_sys__vcpkg__0_2_15//:vcpkg",
+            "@complex_sys__vcpkg__0_2_15//:vcpkg",
         ],
         "//conditions:default": [],
     }) + selects.with_or({
@@ -91,7 +91,7 @@ cargo_build_script(
             "@rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@rules_rust_examples_complex_sys__openssl_sys__0_9_60//:openssl_sys",
+            "@complex_sys__openssl_sys__0_9_60//:openssl_sys",
         ],
         "//conditions:default": [],
     }),
@@ -119,8 +119,8 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":libssh2_sys_build_script",
-        "@rules_rust_examples_complex_sys__libc__0_2_98//:libc",
-        "@rules_rust_examples_complex_sys__libz_sys__1_1_3//:libz_sys",
+        "@complex_sys__libc__0_2_98//:libc",
+        "@complex_sys__libz_sys__1_1_3//:libz_sys",
     ] + selects.with_or({
         # cfg(target_env = "msvc")
         (
@@ -149,7 +149,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-freebsd",
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
-            "@rules_rust_examples_complex_sys__openssl_sys__0_9_60//:openssl_sys",
+            "@complex_sys__openssl_sys__0_9_60//:openssl_sys",
         ],
         "//conditions:default": [],
     }),

--- a/examples/sys/complex/raze/remote/BUILD.libz-sys-1.1.3.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.libz-sys-1.1.3.bazel
@@ -58,15 +58,15 @@ cargo_build_script(
     version = "1.1.3",
     visibility = ["//visibility:private"],
     deps = [
-        "@rules_rust_examples_complex_sys__cc__1_0_69//:cc",
-        "@rules_rust_examples_complex_sys__pkg_config__0_3_19//:pkg_config",
+        "@complex_sys__cc__1_0_69//:cc",
+        "@complex_sys__pkg_config__0_3_19//:pkg_config",
     ] + selects.with_or({
         # cfg(target_env = "msvc")
         (
             "@rules_rust//rust/platform:i686-pc-windows-msvc",
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
-            "@rules_rust_examples_complex_sys__vcpkg__0_2_15//:vcpkg",
+            "@complex_sys__vcpkg__0_2_15//:vcpkg",
         ],
         "//conditions:default": [],
     }),
@@ -95,7 +95,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":libz_sys_build_script",
-        "@rules_rust_examples_complex_sys__libc__0_2_98//:libc",
+        "@complex_sys__libc__0_2_98//:libc",
     ] + selects.with_or({
         # cfg(target_env = "msvc")
         (

--- a/examples/sys/complex/raze/remote/BUILD.log-0.4.14.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.log-0.4.14.bazel
@@ -81,7 +81,7 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":log_build_script",
-        "@rules_rust_examples_complex_sys__cfg_if__1_0_0//:cfg_if",
+        "@complex_sys__cfg_if__1_0_0//:cfg_if",
     ],
 )
 

--- a/examples/sys/complex/raze/remote/BUILD.openssl-0.10.32.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.openssl-0.10.32.bazel
@@ -56,7 +56,7 @@ cargo_build_script(
     version = "0.10.32",
     visibility = ["//visibility:private"],
     deps = [
-        "@rules_rust_examples_complex_sys__openssl_sys__0_9_60//:openssl_sys",
+        "@complex_sys__openssl_sys__0_9_60//:openssl_sys",
     ],
 )
 
@@ -82,11 +82,11 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":openssl_build_script",
-        "@rules_rust_examples_complex_sys__bitflags__1_2_1//:bitflags",
-        "@rules_rust_examples_complex_sys__cfg_if__1_0_0//:cfg_if",
-        "@rules_rust_examples_complex_sys__foreign_types__0_3_2//:foreign_types",
-        "@rules_rust_examples_complex_sys__lazy_static__1_4_0//:lazy_static",
-        "@rules_rust_examples_complex_sys__libc__0_2_98//:libc",
-        "@rules_rust_examples_complex_sys__openssl_sys__0_9_60//:openssl_sys",
+        "@complex_sys__bitflags__1_2_1//:bitflags",
+        "@complex_sys__cfg_if__1_0_0//:cfg_if",
+        "@complex_sys__foreign_types__0_3_2//:foreign_types",
+        "@complex_sys__lazy_static__1_4_0//:lazy_static",
+        "@complex_sys__libc__0_2_98//:libc",
+        "@complex_sys__openssl_sys__0_9_60//:openssl_sys",
     ],
 )

--- a/examples/sys/complex/raze/remote/BUILD.openssl-sys-0.9.60.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.openssl-sys-0.9.60.bazel
@@ -62,16 +62,16 @@ cargo_build_script(
     version = "0.9.60",
     visibility = ["//visibility:private"],
     deps = [
-        "@rules_rust_examples_complex_sys__autocfg__1_0_1//:autocfg",
-        "@rules_rust_examples_complex_sys__cc__1_0_69//:cc",
-        "@rules_rust_examples_complex_sys__pkg_config__0_3_19//:pkg_config",
+        "@complex_sys__autocfg__1_0_1//:autocfg",
+        "@complex_sys__cc__1_0_69//:cc",
+        "@complex_sys__pkg_config__0_3_19//:pkg_config",
     ] + selects.with_or({
         # cfg(target_env = "msvc")
         (
             "@rules_rust//rust/platform:i686-pc-windows-msvc",
             "@rules_rust//rust/platform:x86_64-pc-windows-msvc",
         ): [
-            "@rules_rust_examples_complex_sys__vcpkg__0_2_15//:vcpkg",
+            "@complex_sys__vcpkg__0_2_15//:vcpkg",
         ],
         "//conditions:default": [],
     }),
@@ -99,8 +99,8 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":openssl_sys_build_script",
+        "@complex_sys__libc__0_2_98//:libc",
         "@openssl//:openssl",
-        "@rules_rust_examples_complex_sys__libc__0_2_98//:libc",
     ] + selects.with_or({
         # cfg(target_env = "msvc")
         (

--- a/examples/sys/complex/raze/remote/BUILD.tinyvec-1.3.1.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.tinyvec-1.3.1.bazel
@@ -54,7 +54,7 @@ rust_library(
     version = "1.3.1",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_complex_sys__tinyvec_macros__0_1_0//:tinyvec_macros",
+        "@complex_sys__tinyvec_macros__0_1_0//:tinyvec_macros",
     ],
 )
 

--- a/examples/sys/complex/raze/remote/BUILD.unicode-bidi-0.3.5.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.unicode-bidi-0.3.5.bazel
@@ -50,6 +50,6 @@ rust_library(
     version = "0.3.5",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_complex_sys__matches__0_1_8//:matches",
+        "@complex_sys__matches__0_1_8//:matches",
     ],
 )

--- a/examples/sys/complex/raze/remote/BUILD.unicode-normalization-0.1.19.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.unicode-normalization-0.1.19.bazel
@@ -53,6 +53,6 @@ rust_library(
     version = "0.1.19",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_complex_sys__tinyvec__1_3_1//:tinyvec",
+        "@complex_sys__tinyvec__1_3_1//:tinyvec",
     ],
 )

--- a/examples/sys/complex/raze/remote/BUILD.url-2.2.2.bazel
+++ b/examples/sys/complex/raze/remote/BUILD.url-2.2.2.bazel
@@ -51,10 +51,10 @@ rust_library(
     version = "2.2.2",
     # buildifier: leave-alone
     deps = [
-        "@rules_rust_examples_complex_sys__form_urlencoded__1_0_1//:form_urlencoded",
-        "@rules_rust_examples_complex_sys__idna__0_2_3//:idna",
-        "@rules_rust_examples_complex_sys__matches__0_1_8//:matches",
-        "@rules_rust_examples_complex_sys__percent_encoding__2_1_0//:percent_encoding",
+        "@complex_sys__form_urlencoded__1_0_1//:form_urlencoded",
+        "@complex_sys__idna__0_2_3//:idna",
+        "@complex_sys__matches__0_1_8//:matches",
+        "@complex_sys__percent_encoding__2_1_0//:percent_encoding",
     ],
 )
 

--- a/examples/sys/complex/repositories.bzl
+++ b/examples/sys/complex/repositories.bzl
@@ -1,12 +1,12 @@
 # buildifier: disable=module-docstring
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//sys/complex/raze:crates.bzl", "rules_rust_examples_complex_sys_fetch_remote_crates")
+load("//sys/complex/raze:crates.bzl", "complex_sys_fetch_remote_crates")
 
-def rules_rust_examples_complex_sys_repositories():
+def complex_sys_repositories():
     """Define repository dependencies for the `complex_sys` example"""
 
-    rules_rust_examples_complex_sys_fetch_remote_crates()
+    complex_sys_fetch_remote_crates()
 
     maybe(
         http_archive,

--- a/examples/sys/sys_deps.bzl
+++ b/examples/sys/sys_deps.bzl
@@ -1,6 +1,6 @@
 # buildifier: disable=module-docstring
-load("//sys/basic/raze:crates.bzl", "rules_rust_examples_basic_sys_fetch_remote_crates")
-load("//sys/complex:repositories.bzl", "rules_rust_examples_complex_sys_repositories")
+load("//sys/basic/raze:crates.bzl", "basic_sys_fetch_remote_crates")
+load("//sys/complex:repositories.bzl", "complex_sys_repositories")
 
 def sys_deps():
     """This macro loads dependencies for the `sys` crate examples
@@ -10,5 +10,5 @@ def sys_deps():
     [cargo-raze](https://github.com/google/cargo-raze) to gather these
     dependencies and make them avaialble in the workspace.
     """
-    rules_rust_examples_basic_sys_fetch_remote_crates()
-    rules_rust_examples_complex_sys_repositories()
+    basic_sys_fetch_remote_crates()
+    complex_sys_repositories()


### PR DESCRIPTION
In order to get the `sys` package buildable on windows, there needs to be a shorter prefix for the repositories being generated here. Windows has that dumb MAX_PATH character limit which results in tools (`cl.exe`) claiming a file does not exist.