### PR TITLE
RFC (not ready to land): A workaround for 2 problems:

### DIFF
--- a/cargo/defs.bzl
+++ b/cargo/defs.bzl
@@ -2,8 +2,11 @@
 
 load(":cargo_bootstrap.bzl", _cargo_bootstrap_repository = "cargo_bootstrap_repository", _cargo_env = "cargo_env")
 load(":cargo_build_script.bzl", _cargo_build_script = "cargo_build_script")
+load(":cargo_environ.bzl", _CARGO_BAZEL_ISOLATED = "CARGO_BAZEL_ISOLATED", _cargo_environ = "cargo_environ")
 
 cargo_bootstrap_repository = _cargo_bootstrap_repository
 cargo_env = _cargo_env
+cargo_environ = _cargo_environ
+CARGO_BAZEL_ISOLATED = _CARGO_BAZEL_ISOLATED
 
 cargo_build_script = _cargo_build_script

--- a/crate_universe/deps_bootstrap.bzl
+++ b/crate_universe/deps_bootstrap.bzl
@@ -6,12 +6,13 @@ load("//crate_universe/private:srcs.bzl", "CARGO_BAZEL_SRCS")
 # buildifier: disable=bzl-visibility
 load("//rust/private:common.bzl", "rust_common")
 
-def cargo_bazel_bootstrap(name = "cargo_bazel_bootstrap", rust_version = rust_common.default_version):
+def cargo_bazel_bootstrap(name = "cargo_bazel_bootstrap", rust_version = rust_common.default_version, cargo_config=None):
     """An optional repository which bootstraps `cargo-bazel` for use with `crates_repository`
 
     Args:
         name (str, optional): The name of the `cargo_bootstrap_repository`.
         rust_version (str, optional): The rust version to use. Defaults to the default of `cargo_bootstrap_repository`.
+        cargo_config (label, optional): A target containing a Cargo config
     """
     cargo_bootstrap_repository(
         name = name,
@@ -19,6 +20,7 @@ def cargo_bazel_bootstrap(name = "cargo_bazel_bootstrap", rust_version = rust_co
         binary = "cargo-bazel",
         cargo_lockfile = "@rules_rust//crate_universe:Cargo.lock",
         cargo_toml = "@rules_rust//crate_universe:Cargo.toml",
+        cargo_config = cargo_config,
         version = rust_version,
         # The increased timeout helps avoid flakes in CI
         timeout = 900,

--- a/crate_universe/private/common_utils.bzl
+++ b/crate_universe/private/common_utils.bzl
@@ -9,8 +9,6 @@ load(
 
 get_host_triple = _get_host_triple
 
-CARGO_BAZEL_ISOLATED = "CARGO_BAZEL_ISOLATED"
-
 _EXECUTE_ERROR_MESSAGE = """\
 Command {args} failed with exit code {exit_code}.
 STDOUT ------------------------------------------------------------------------
@@ -57,53 +55,11 @@ def get_rust_tools(repository_ctx, host_triple):
         struct: A struct containing the expected rust tools
     """
 
-    # This is a bit hidden but to ensure Cargo behaves consistently based
-    # on the user provided config file, the config file is installed into
-    # the `CARGO_HOME` path. This is done so here since fetching tools
-    # is expected to always occur before any subcommands are run.
-    if repository_ctx.attr.isolated and repository_ctx.attr.cargo_config:
-        cargo_home = _cargo_home_path(repository_ctx)
-        cargo_home_config = repository_ctx.path("{}/config.toml".format(cargo_home))
-        cargo_config = repository_ctx.path(repository_ctx.attr.cargo_config)
-        repository_ctx.symlink(cargo_config, cargo_home_config)
-
     return _rust_get_rust_tools(
         cargo_template = repository_ctx.attr.rust_toolchain_cargo_template,
         rustc_template = repository_ctx.attr.rust_toolchain_rustc_template,
         host_triple = host_triple,
         version = repository_ctx.attr.rust_version,
+        repository_ctx = repository_ctx,
     )
 
-def _cargo_home_path(repository_ctx):
-    """Define a path within the repository to use in place of `CARGO_HOME`
-
-    Args:
-        repository_ctx (repository_ctx): The rules context object
-
-    Returns:
-        path: The path to a directory to use as `CARGO_HOME`
-    """
-    return repository_ctx.path(".cargo_home")
-
-def cargo_environ(repository_ctx):
-    """Define Cargo environment varables for use with `cargo-bazel`
-
-    Args:
-        repository_ctx (repository_ctx): The rules context object
-
-    Returns:
-        dict: A set of environment variables for `cargo-bazel` executions
-    """
-    env = dict()
-
-    if CARGO_BAZEL_ISOLATED in repository_ctx.os.environ:
-        if repository_ctx.os.environ[CARGO_BAZEL_ISOLATED].lower() in ["true", "1", "yes", "on"]:
-            env.update({
-                "CARGO_HOME": str(_cargo_home_path(repository_ctx)),
-            })
-    elif repository_ctx.attr.isolated:
-        env.update({
-            "CARGO_HOME": str(_cargo_home_path(repository_ctx)),
-        })
-
-    return env

--- a/crate_universe/private/generate_utils.bzl
+++ b/crate_universe/private/generate_utils.bzl
@@ -1,6 +1,7 @@
 """Utilities directly related to the `generate` step of `cargo-bazel`."""
 
-load(":common_utils.bzl", "CARGO_BAZEL_ISOLATED", "cargo_environ", "execute")
+load("//cargo:defs.bzl", "CARGO_BAZEL_ISOLATED", "cargo_environ")
+load(":common_utils.bzl", "execute")
 
 CARGO_BAZEL_GENERATOR_SHA256 = "CARGO_BAZEL_GENERATOR_SHA256"
 CARGO_BAZEL_GENERATOR_URL = "CARGO_BAZEL_GENERATOR_URL"

--- a/crate_universe/private/splicing_utils.bzl
+++ b/crate_universe/private/splicing_utils.bzl
@@ -1,6 +1,7 @@
 """Utilities directly related to the `splicing` step of `cargo-bazel`."""
 
-load(":common_utils.bzl", "cargo_environ", "execute")
+load("//cargo:defs.bzl", "cargo_environ")
+load(":common_utils.bzl", "execute")
 
 def splicing_config(resolver_version = "1"):
     """arious settings used to configure Cargo manifest splicing behavior.

--- a/crate_universe/repositories.bzl
+++ b/crate_universe/repositories.bzl
@@ -31,16 +31,17 @@ _MANIFESTS = [
     "@rules_rust//crate_universe/tools/urls_generator:Cargo.toml",
 ]
 
-def crate_universe_dependencies(rust_version = rust_common.default_version, bootstrap = False):
+def crate_universe_dependencies(rust_version = rust_common.default_version, bootstrap = False, bootstrap_cargo_config = None):
     """Define dependencies of the `cargo-bazel` Rust target
 
     Args:
         rust_version (str, optional): The version of rust to use when generating dependencies.
         bootstrap (bool, optional): If true, a `cargo_bootstrap_repository` target will be generated.
+        bootstrap_cargo_config (label, optional):  "A target containing a Cargo configuration",
     """
     third_party_deps()
 
-    cargo_bazel_bootstrap(rust_version = rust_version)
+    cargo_bazel_bootstrap(rust_version = rust_version, cargo_config = bootstrap_cargo_config)
 
     if USE_CRATES_REPOSITORY:
         crates_repository(

--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -200,6 +200,7 @@ rust_toolchain(
     exec_triple = "{exec_triple}",
     target_triple = "{target_triple}",
     visibility = ["//visibility:public"],
+    ld_library_path = "{ld_library_path}",
 )
 """
 
@@ -208,6 +209,7 @@ def BUILD_for_rust_toolchain(
         name,
         exec_triple,
         target_triple,
+        ld_library_path,
         include_rustc_srcs,
         default_edition,
         include_rustfmt,
@@ -254,6 +256,7 @@ def BUILD_for_rust_toolchain(
         exec_triple = exec_triple,
         target_triple = target_triple,
         rustfmt_label = rustfmt_label,
+        ld_library_path = ld_library_path,
     )
 
 _build_file_for_toolchain_template = """\
@@ -405,6 +408,7 @@ def load_rust_stdlib(ctx, target_triple):
         exec_triple = ctx.attr.exec_triple,
         include_rustc_srcs = should_include_rustc_srcs(ctx),
         target_triple = target_triple,
+        ld_library_path = ctx.os.environ.get("LD_LIBRARY_PATH", ""),
         stdlib_linkflags = stdlib_linkflags,
         workspace_name = ctx.attr.name,
         default_edition = ctx.attr.edition,

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -91,6 +91,7 @@ def _get_rustc_env(attr, toolchain, crate_name):
         "CARGO_PKG_VERSION_MINOR": minor,
         "CARGO_PKG_VERSION_PATCH": patch,
         "CARGO_PKG_VERSION_PRE": pre,
+        "LD_LIBRARY_PATH": toolchain.ld_library_path,
     }
 
 def get_compilation_mode_opts(ctx, toolchain):

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -14,6 +14,7 @@
 
 """Functionality for constructing actions that invoke the Rust compiler"""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
@@ -307,6 +308,8 @@ def get_linker_and_args(ctx, attr, cc_toolchain, feature_configuration, rpaths):
         action_name = CPP_LINK_EXECUTABLE_ACTION_NAME,
         variables = link_variables,
     )
+    link_args = [i for i in link_args]
+    link_args.append("-B" + paths.dirname(cc_toolchain.ld_executable))
     link_env = cc_common.get_environment_variables(
         feature_configuration = feature_configuration,
         action_name = CPP_LINK_EXECUTABLE_ACTION_NAME,

--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -63,10 +63,13 @@ def _perform_check(edition, srcs, ctx):
     args.add("--check")
     args.add_all(srcs)
 
+    env = {"LD_LIBRARY_PATH": toolchain.ld_libary_path}
+
     ctx.actions.run(
         executable = ctx.executable._process_wrapper,
         inputs = srcs + [config],
         outputs = [marker],
+        env = env,
         tools = [toolchain.rustfmt],
         arguments = [args],
         mnemonic = "Rustfmt",

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -244,7 +244,7 @@ rust_toolchain_repository = repository_rule(
         ),
     },
     implementation = _rust_toolchain_repository_impl,
-    environ = ["RULES_RUST_TOOLCHAIN_INCLUDE_RUSTC_SRCS"],
+    environ = ["RULES_RUST_TOOLCHAIN_INCLUDE_RUSTC_SRCS", "LD_LIBRARY_PATH"],
 )
 
 rust_toolchain_repository_proxy = repository_rule(

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -486,6 +486,9 @@ def _rust_toolchain_impl(ctx):
         # Experimental and incompatible flags
         _rename_first_party_crates = rename_first_party_crates,
         _third_party_dir = third_party_dir,
+
+        # hack workaround for twitter
+        ld_library_path = ctx.attr.ld_library_path,
     )
     return [toolchain]
 
@@ -601,6 +604,9 @@ rust_toolchain = rule(
                 "The platform triple for the toolchains target environment. " +
                 "For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations"
             ),
+        ),
+        "ld_library_path": attr.string(
+            doc = "Value for LD_LIBRARY_PATH environment variable.",
         ),
         "_cc_toolchain": attr.label(
             default = "@bazel_tools//tools/cpp:current_cc_toolchain",


### PR DESCRIPTION
1. My binutils binaries are in a different directory to gcc. I needed to
   work around a bug in bazel iteself reported at
   https://github.com/bazelbuild/bazel/issues/13857.
2. I needed to plumb LD_LIBRARY_PATH throught for the tools to run since
   my libstdc++ is in a different directory from the default lib paths.

My current thoughts are that this should not be landed in this form. The
bazel bug should be fixed in bazel. I'm not exactly sure how to address
the second. One idea raised was statically compiling process_wrapper.
I'm not sure if that's the right plan either. Opinions welcome.