### PR TITLE
Document visibility requirements

### DIFF
--- a/docs/rust_analyzer.md
+++ b/docs/rust_analyzer.md
@@ -51,7 +51,7 @@ A list of `rust_analyzer` compatible targets can be found by usign the following
 bazel query 'kind("rust_*library|rust_binary", //...:all)'
 ```
 
-Note that visibility rules apply.
+Note: __All `rust_*` targets provided to the root rust_analyzer must have `//visibility:public`.__
 
 Run `bazel run @rules_rust//tools/rust_analyzer:gen_rust_project` whenever
 dependencies change to regenerate the `rust-project.json` file. It should be

--- a/docs/rust_analyzer.vm
+++ b/docs/rust_analyzer.vm
@@ -45,7 +45,7 @@ A list of `rust_analyzer` compatible targets can be found by usign the following
 bazel query 'kind("rust_*library|rust_binary", //...:all)'
 ```
 
-WARNING: All rust_* targets provided to the root rust_analyzer must have `//visibility:public`.
+Note: __All `rust_*` targets provided to the root rust_analyzer must have `//visibility:public`.__
 
 Run `bazel run @rules_rust//tools/rust_analyzer:gen_rust_project` whenever
 dependencies change to regenerate the `rust-project.json` file. It should be

--- a/docs/rust_analyzer.vm
+++ b/docs/rust_analyzer.vm
@@ -45,7 +45,7 @@ A list of `rust_analyzer` compatible targets can be found by usign the following
 bazel query 'kind("rust_*library|rust_binary", //...:all)'
 ```
 
-Note that visibility rules apply.
+WARNING: All rust_* targets provided to the root rust_analyzer must have `//visibility:public`.
 
 Run `bazel run @rules_rust//tools/rust_analyzer:gen_rust_project` whenever
 dependencies change to regenerate the `rust-project.json` file. It should be


### PR DESCRIPTION
The targets to rust_analyzer need to be visible to the root rust_analyzer. Unfortunately, because rust_analyzer is a singular rule at the source of the repo, any package_gorup based visibility will lead to cycles in the build graph. Thus, the rules must have //visibility:public.

See conversation in #905 