### PR TITLE
Added link to github repo in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Rules rust
+# [Rules rust](https://github.com/bazelbuild/rules_rust)
 
 ## Overview
 
@@ -20,11 +20,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "224ebaf1156b6f2d3680e5b8c25191e71483214957dfecd25d0f29b2f283283b",
-    strip_prefix = "rules_rust-a814d859845c420fd105c629134c4a4cb47ba3f8",
+    sha256 = "531bdd470728b61ce41cf7604dc4f9a115983e455d46ac1d0c1632f613ab9fc3",
+    strip_prefix = "rules_rust-d8238877c0e552639d3e057aadd6bfcf37592408",
     urls = [
-        # `main` branch as of 2021-06-15
-        "https://github.com/bazelbuild/rules_rust/archive/a814d859845c420fd105c629134c4a4cb47ba3f8.tar.gz",
+        # `main` branch as of 2021-08-23
+        "https://github.com/bazelbuild/rules_rust/archive/d8238877c0e552639d3e057aadd6bfcf37592408.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Most times when I search for `rules_rust` trying to get to the github page, I get to the docs instead. This link would reduce the amount of scrolling or re-querying I have to do.