### PR TITLE
Fix docs to use up-to-date rule name

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -803,7 +803,7 @@ proto_library(
     srcs = ["my.proto"]
 )
 
-proto_rust_library(
+rust_proto_library(
     name = "rust",
     deps = [":my_proto"],
 )

--- a/docs/rust_proto.md
+++ b/docs/rust_proto.md
@@ -180,7 +180,7 @@ proto_library(
     srcs = ["my.proto"]
 )
 
-proto_rust_library(
+rust_proto_library(
     name = "rust",
     deps = [":my_proto"],
 )

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -331,7 +331,7 @@ proto_library(
     srcs = ["my.proto"]
 )
 
-proto_rust_library(
+rust_proto_library(
     name = "rust",
     deps = [":my_proto"],
 )


### PR DESCRIPTION
As the rule now seems to be loaded with name `rust_proto_library`, docs should use the up-to-date name when giving usage examples.