### PR TITLE
add CXX var to configure cpp compiler

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -107,6 +107,7 @@ def _build_script_impl(ctx):
         cc_executable = cc_toolchain.compiler_executable
         if cc_executable:
             env["CC"] = cc_executable
+            env["CXX"] = cc_executable
         ar_executable = cc_toolchain.ar_executable
         if ar_executable:
             env["AR"] = ar_executable


### PR DESCRIPTION
I use [cpp crate](https://docs.rs/cpp/0.5.6/cpp/) to integrate Rust and C++ code in my project which depends on `cc` crate.

`cc` relies on [CXX env variable](https://github.com/alexcrichton/cc-rs#c-support) to find `cpp` compiler.

This PR sets this env variable along with `CC`.