### PR TITLE
Fix a unit test for Bazel 5.0

### DIFF
--- a/test/unit/extra_rustc_flags/extra_rustc_flags_test.bzl
+++ b/test/unit/extra_rustc_flags/extra_rustc_flags_test.bzl
@@ -54,7 +54,7 @@ extra_rustc_flags_present_test = analysistest.make(
         ),
     },
     config_settings = {
-        "//:extra_rustc_flags": [EXTRA_FLAG],
+        "@//:extra_rustc_flags": [EXTRA_FLAG],
     },
 )
 


### PR DESCRIPTION
unittest.bzl does a configuration transition, and with Bazel 5.0
repository-relative labels will be interpreted not as in the main
repository, but as in the repository of the transition. For us it means
we have to explicitly specify which repository we mean in our test.