### PR TITLE
fix: load providers from //:providers.bzl

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -8,7 +8,7 @@ bzl_library(
     name = "docs_deps",
     srcs = [
         "@bazel_tools//tools:bzl_srcs",
-        "@build_bazel_rules_nodejs//internal/providers:bzl",
+        "@build_bazel_rules_nodejs//:providers:bzl",
         "@com_google_protobuf//:bzl_srcs",
     ],
     deps = [

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -8,7 +8,7 @@ bzl_library(
     name = "docs_deps",
     srcs = [
         "@bazel_tools//tools:bzl_srcs",
-        "@build_bazel_rules_nodejs//:providers:bzl",
+        "@build_bazel_rules_nodejs//:providers.bzl",
         "@com_google_protobuf//:bzl_srcs",
     ],
     deps = [

--- a/wasm_bindgen/providers.bzl
+++ b/wasm_bindgen/providers.bzl
@@ -1,11 +1,8 @@
 """A module for re-exporting the providers used by the rust_wasm_bindgen rule"""
 
 load(
-    "@build_bazel_rules_nodejs//internal/providers:declaration_info.bzl",
+    "@build_bazel_rules_nodejs//:providers.bzl",
     _DeclarationInfo = "DeclarationInfo",
-)
-load(
-    "@build_bazel_rules_nodejs//internal/providers:js_providers.bzl",
     _JSEcmaScriptModuleInfo = "JSEcmaScriptModuleInfo",
     _JSModuleInfo = "JSModuleInfo",
     _JSNamedModuleInfo = "JSNamedModuleInfo",


### PR DESCRIPTION
**BREAKING CHANGE**: `@build_bazel_rules_nodejs//:declaration_provider.bzl` has been deleted; load from `@build_bazel_rules_nodejs//:providers.bzl` instead. See https://github.com/bazelbuild/rules_nodejs/commit/cc648183160832b1540c3893963e8ef4a45e4220