### PR TITLE
Add test case for OUT_DIR in tests.

### DIFF
--- a/test/out_dir_in_tests/BUILD.bazel
+++ b/test/out_dir_in_tests/BUILD.bazel
@@ -1,0 +1,26 @@
+load(
+    "//rust:rust.bzl",
+    "rust_library",
+    "rust_test",
+)
+load("//cargo:cargo_build_script.bzl", "cargo_build_script")
+
+cargo_build_script(
+    name = "build_script",
+    srcs = ["build.rs"],
+)
+
+rust_library(
+    name = "demo_lib",
+    srcs = [
+        "src/lib.rs",
+    ],
+    deps = [":build_script"],
+)
+
+rust_test(
+    name = "demo_lib_test",
+    crate = ":demo_lib",
+)
+
+# Add a test suite once the unit test works.

--- a/test/out_dir_in_tests/Cargo.toml
+++ b/test/out_dir_in_tests/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "out_dir_integration_tests"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test/out_dir_in_tests/build.rs
+++ b/test/out_dir_in_tests/build.rs
@@ -1,0 +1,11 @@
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::PathBuf;
+
+fn main() -> std::io::Result<()> {
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let mut file = File::create(out_path.join("test_content.txt"))?;
+    file.write_all(b"Test content")?;
+    Ok(())
+}

--- a/test/out_dir_in_tests/src/lib.rs
+++ b/test/out_dir_in_tests/src/lib.rs
@@ -1,0 +1,13 @@
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn can_find_the_out_dir_file() {
+        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let contents = fs::read_to_string(out_path.join("test_content.txt")).unwrap();
+        assert_eq!("Test content", contents);
+    }
+}

--- a/test/out_dir_in_tests/tests/out_dir_reader.rs
+++ b/test/out_dir_in_tests/tests/out_dir_reader.rs
@@ -1,0 +1,10 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn can_find_the_out_dir_file() {
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let contents = fs::read_to_string(out_path.join("test_content.txt")).unwrap();
+    assert_eq!("Test content", contents);
+}


### PR DESCRIPTION
This doesn't pass right now, but it does pass under `cargo test`. I see the `rustc` rule has a way to pass `OUT_DIR`, but it looks like tests aren't getting this right now. Posting this now, before I dig further, in case someone knows of a quick fix here.