### PR TITLE
Use rbe_preconfig for RBE toolchain config

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -23,6 +23,8 @@ tasks:
     build_targets: *default_linux_targets
     test_targets: *default_linux_targets
   rbe_ubuntu1604:
+    shell_commands:
+      - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets:
       - "//..."
     test_targets:
@@ -52,6 +54,8 @@ tasks:
   rbe_ubuntu1604_with_aspects:
     name: With Aspects
     platform: rbe_ubuntu1604
+    shell_commands:
+      - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets: *default_linux_targets
     test_targets:
       - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
@@ -64,6 +68,8 @@ tasks:
   rbe_ubuntu1604_with_aspects:
     name: RBE Rolling Bazel Version With Aspects
     platform: rbe_ubuntu1604
+    shell_commands:
+      - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets: *default_linux_targets
     test_targets:
       - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
@@ -208,6 +214,8 @@ tasks:
       # The bindgen rules currently do not work on RBE
       # see: https://github.com/bazelbuild/rules_rust/issues/919
       - "-//bindgen/..."
+    shell_commands:
+      - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets: *rbe_examples_targets
     test_targets: *rbe_examples_targets
     build_flags: *aspects_flags
@@ -266,6 +274,8 @@ tasks:
     environment:
       RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP: true
     working_directory: examples/crate_universe
+    shell_commands:
+      - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets:
       - "//..."
     test_targets:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,6 +24,7 @@ tasks:
     test_targets: *default_linux_targets
   rbe_ubuntu1604:
     shell_commands:
+      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets:
       - "//..."
@@ -55,6 +56,7 @@ tasks:
     name: With Aspects
     platform: rbe_ubuntu1604
     shell_commands:
+      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets: *default_linux_targets
     test_targets:
@@ -69,6 +71,7 @@ tasks:
     name: RBE Rolling Bazel Version With Aspects
     platform: rbe_ubuntu1604
     shell_commands:
+      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets: *default_linux_targets
     test_targets:
@@ -215,6 +218,7 @@ tasks:
       # see: https://github.com/bazelbuild/rules_rust/issues/919
       - "-//bindgen/..."
     shell_commands:
+      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets: *rbe_examples_targets
     test_targets: *rbe_examples_targets
@@ -275,6 +279,7 @@ tasks:
       RULES_RUST_CRATE_UNIVERSE_BOOTSTRAP: true
     working_directory: examples/crate_universe
     shell_commands:
+      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets:
       - "//..."

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -37,18 +37,18 @@ rules_rust_test_deps()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "bazel_toolchains",
-    sha256 = "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
-    strip_prefix = "bazel-toolchains-4.1.0",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-    ],
+    name = "bazelci_rules",
+    url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
+    sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
+    strip_prefix= "bazelci_rules-1.0.0",
 )
 
-load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
 # Creates a default toolchain config for RBE.
 # Use this as is if you are using the rbe_ubuntu16_04 container,
 # otherwise refer to RBE docs.
-rbe_autoconfig(name = "buildkite_config")
+rbe_preconfig(
+    name = "buildkite_config",
+    toolchain = "ubuntu1604-bazel-java8",
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -38,17 +38,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazelci_rules",
-    url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
     sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
-    strip_prefix= "bazelci_rules-1.0.0",
+    strip_prefix = "bazelci_rules-1.0.0",
+    url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
 )
 
 load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
-# Creates a default toolchain config for RBE.
-# Use this as is if you are using the rbe_ubuntu16_04 container,
-# otherwise refer to RBE docs.
-rbe_preconfig(
-    name = "buildkite_config",
-    toolchain = "ubuntu1604-bazel-java8",
-)
+# To run with RBE on Bazel CI, uncomment the following line.
+#
+# rbe_preconfig(name = "buildkite_config", toolchain = "ubuntu1604-bazel-java8")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -43,8 +43,7 @@ http_archive(
     url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
 )
 
-load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
-
 # To run with RBE on Bazel CI, uncomment the following line.
 #
+# load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 # rbe_preconfig(name = "buildkite_config", toolchain = "ubuntu1604-bazel-java8")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -43,7 +43,7 @@ http_archive(
     url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
 )
 
-# To run with RBE on Bazel CI, uncomment the following line.
+# To run with RBE on Bazel CI, uncomment the following lines.
 #
 # load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 # rbe_preconfig(name = "buildkite_config", toolchain = "ubuntu1604-bazel-java8")


### PR DESCRIPTION
`rbe_autoconfig` doesn't support Bazel 5.0.0+. Use `rbe_preconfig` instead.