### PR TITLE
Make sure each linkstamp is compiled just once.

### DIFF
--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -63,11 +63,13 @@ def _clippy_aspect_impl(target, ctx):
     cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
     crate_type = crate_info.type
 
-    dep_info, build_info = collect_deps(
+    dep_info, build_info, linkstamps = collect_deps(
         label = ctx.label,
         deps = crate_info.deps,
         proc_macro_deps = crate_info.proc_macro_deps,
         aliases = crate_info.aliases,
+        # Clippy doesn't need to invoke transitive linking, therefore doesn't need linkstamps.
+        are_linkstamps_supported = False,
         make_rust_providers_target_independent = toolchain._incompatible_make_rust_providers_target_independent,
     )
 
@@ -75,6 +77,7 @@ def _clippy_aspect_impl(target, ctx):
         ctx,
         ctx.rule.file,
         ctx.rule.files,
+        linkstamps,
         toolchain,
         cc_toolchain,
         feature_configuration,

--- a/test/unit/linkstamps/linkstamps_test.bzl
+++ b/test/unit/linkstamps/linkstamps_test.bzl
@@ -64,10 +64,21 @@ def _linkstamps_test():
         }),
     )
 
+    cc_library(
+        name = "cc_lib_with_linkstamp_transitively",
+        deps = [":cc_lib_with_linkstamp"],
+    )
+
     rust_binary(
         name = "some_rust_binary",
         srcs = ["foo.rs"],
         deps = [":cc_lib_with_linkstamp"],
+    )
+
+    rust_binary(
+        name = "some_rust_binary_with_multiple_paths_to_a_linkstamp",
+        srcs = ["foo.rs"],
+        deps = [":cc_lib_with_linkstamp", ":cc_lib_with_linkstamp_transitively"],
     )
 
     rust_test(
@@ -85,6 +96,11 @@ def _linkstamps_test():
     supports_linkstamps_test(
         name = "rust_binary_supports_linkstamps_test",
         target_under_test = ":some_rust_binary",
+    )
+
+    supports_linkstamps_test(
+        name = "rust_binary_supports_duplicated_linkstamps",
+        target_under_test = ":some_rust_binary_with_multiple_paths_to_a_linkstamp",
     )
 
     supports_linkstamps_test(
@@ -116,6 +132,7 @@ def linkstamps_test_suite(name):
         name = name,
         tests = [
             ":rust_binary_supports_linkstamps_test",
+            ":rust_binary_supports_duplicated_linkstamps",
             ":rust_test_supports_linkstamps_test1",
             ":rust_test_supports_linkstamps_test2",
         ],


### PR DESCRIPTION
Previously, if there were multiple different paths to a linkstamp, we
added these linkstamps into a list multiple times, registered multiple
compilation actions, and linked linkstamp objects multiple times.

The last point causes linking to fail with duplicated symbols error.

In this PR we fix the problem by deduplicating linkstamps before
creating compilation actions for them.