### PR TITLE
Absolutify CXX as well as CC 

### DIFF
--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -88,13 +88,15 @@ fn run_buildrs() -> Result<(), String> {
         }
     }
 
-    if let Some(cc_path) = env::var_os("CC") {
-        let mut cc_path = exec_root.join(cc_path).into_os_string();
-        if let Some(sysroot_path) = env::var_os("SYSROOT") {
-            cc_path.push(" --sysroot=");
-            cc_path.push(&exec_root.join(sysroot_path));
+    for compiler_env_var in &["CC", "CXX"] {
+        if let Some(compiler_path) = env::var_os(compiler_env_var) {
+            let mut compiler_path = exec_root.join(compiler_path).into_os_string();
+            if let Some(sysroot_path) = env::var_os("SYSROOT") {
+                compiler_path.push(" --sysroot=");
+                compiler_path.push(&exec_root.join(sysroot_path));
+            }
+            command.env(compiler_env_var, compiler_path);
         }
-        command.env("CC", cc_path);
     }
 
     if let Some(ar_path) = env::var_os("AR") {

--- a/test/cargo_build_script/build.rs
+++ b/test/cargo_build_script/build.rs
@@ -4,4 +4,24 @@ fn main() {
         "cargo:rustc-env=TOOL_PATH={}",
         std::env::var("TOOL").unwrap()
     );
+
+    // Assert that the CC and CXX env vars existed and were executable.
+    // We don't assert what happens when they're executed (in particular, we don't check for a
+    // non-zero exit code), but this asserts that it's an existing file which is executable.
+    //
+    // Unfortunately we need to shlex the path, because we add a `--sysroot=...` arg to the env var.
+    for env_var in &["CC", "CXX"] {
+        let v = std::env::var(env_var)
+            .unwrap_or_else(|err| panic!("Error getting {}: {}", env_var, err));
+        let (path, args) = if let Some(index) = v.find("--sysroot") {
+            let (path, args) = v.split_at(index);
+            (path, Some(args))
+        } else {
+            (v.as_str(), None)
+        };
+        std::process::Command::new(path)
+            .args(args.into_iter())
+            .status()
+            .unwrap();
+    }
 }


### PR DESCRIPTION
Also add the `--sysroot` flag if needed

This is needed for in-tree CXX values because we chdir before execing the build script binary.

Fixes #950