### PR TITLE
Also propagate linkstamps through rust_libraries

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -147,6 +147,9 @@ def collect_deps(label, deps, proc_macro_deps, aliases, are_linkstamps_supported
         cc_info = _get_cc_info(dep)
         dep_build_info = _get_build_info(dep)
 
+        if cc_info and are_linkstamps_supported:
+            linkstamps.append(cc_info.linking_context.linkstamps())
+
         if crate_info:
             # This dependency is a rust_library
 
@@ -174,8 +177,6 @@ def collect_deps(label, deps, proc_macro_deps, aliases, are_linkstamps_supported
             libs = [get_preferred_artifact(lib) for li in linker_inputs for lib in li.libraries]
             transitive_noncrate_libs.append(depset(libs))
             transitive_noncrates.append(cc_info.linking_context.linker_inputs)
-            if are_linkstamps_supported:
-                linkstamps.append(cc_info.linking_context.linkstamps())
         elif dep_build_info:
             if build_info:
                 fail("Several deps are providing build information, " +


### PR DESCRIPTION
Before this PR we were only propagating linkstamps from C++
dependency to Rust target, but we did not propagate from Rust to Rust.
This PR fixes it by moving the logic to collect linkstamps from
dependencies from the if branch that only covers C++ deps to a place
that affects all deps.