### PR TITLE
Allow explicitly setting Cargo package name in `cargo_build_script`

### DIFF
--- a/docs/cargo.md
+++ b/docs/cargo.md
@@ -40,8 +40,8 @@ A rule for bootstrapping a Rust binary using [Cargo](https://doc.rust-lang.org/c
 ## cargo_build_script
 
 <pre>
-cargo_build_script(<a href="#cargo_build_script-name">name</a>, <a href="#cargo_build_script-crate_features">crate_features</a>, <a href="#cargo_build_script-version">version</a>, <a href="#cargo_build_script-deps">deps</a>, <a href="#cargo_build_script-build_script_env">build_script_env</a>, <a href="#cargo_build_script-data">data</a>, <a href="#cargo_build_script-tools">tools</a>, <a href="#cargo_build_script-links">links</a>,
-                   <a href="#cargo_build_script-rustc_env">rustc_env</a>, <a href="#cargo_build_script-visibility">visibility</a>, <a href="#cargo_build_script-tags">tags</a>, <a href="#cargo_build_script-kwargs">kwargs</a>)
+cargo_build_script(<a href="#cargo_build_script-name">name</a>, <a href="#cargo_build_script-crate_features">crate_features</a>, <a href="#cargo_build_script-version">version</a>, <a href="#cargo_build_script-deps">deps</a>, <a href="#cargo_build_script-build_script_env">build_script_env</a>, <a href="#cargo_build_script-pkg_name">pkg_name</a>, <a href="#cargo_build_script-data">data</a>, <a href="#cargo_build_script-tools">tools</a>,
+                   <a href="#cargo_build_script-links">links</a>, <a href="#cargo_build_script-rustc_env">rustc_env</a>, <a href="#cargo_build_script-visibility">visibility</a>, <a href="#cargo_build_script-tags">tags</a>, <a href="#cargo_build_script-kwargs">kwargs</a>)
 </pre>
 
 Compile and execute a rust build script to generate build attributes
@@ -112,6 +112,7 @@ The `hello_lib` target will be build with the flags and the environment variable
 | <a id="cargo_build_script-version"></a>version |  The semantic version (semver) of the crate.   |  <code>None</code> |
 | <a id="cargo_build_script-deps"></a>deps |  The dependencies of the crate.   |  <code>[]</code> |
 | <a id="cargo_build_script-build_script_env"></a>build_script_env |  Environment variables for build scripts.   |  <code>{}</code> |
+| <a id="cargo_build_script-pkg_name"></a>pkg_name |  The name to use as the build script's Cargo package name.   |  <code>None</code> |
 | <a id="cargo_build_script-data"></a>data |  Files needed by the build script.   |  <code>[]</code> |
 | <a id="cargo_build_script-tools"></a>tools |  Tools (executables) needed by the build script.   |  <code>[]</code> |
 | <a id="cargo_build_script-links"></a>links |  Name of the native library this crate links against.   |  <code>None</code> |

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1438,8 +1438,8 @@ A collection of files either found within the `rust-stdlib` artifact or generate
 ## cargo_build_script
 
 <pre>
-cargo_build_script(<a href="#cargo_build_script-name">name</a>, <a href="#cargo_build_script-crate_features">crate_features</a>, <a href="#cargo_build_script-version">version</a>, <a href="#cargo_build_script-deps">deps</a>, <a href="#cargo_build_script-build_script_env">build_script_env</a>, <a href="#cargo_build_script-data">data</a>, <a href="#cargo_build_script-tools">tools</a>, <a href="#cargo_build_script-links">links</a>,
-                   <a href="#cargo_build_script-rustc_env">rustc_env</a>, <a href="#cargo_build_script-visibility">visibility</a>, <a href="#cargo_build_script-tags">tags</a>, <a href="#cargo_build_script-kwargs">kwargs</a>)
+cargo_build_script(<a href="#cargo_build_script-name">name</a>, <a href="#cargo_build_script-crate_features">crate_features</a>, <a href="#cargo_build_script-version">version</a>, <a href="#cargo_build_script-deps">deps</a>, <a href="#cargo_build_script-build_script_env">build_script_env</a>, <a href="#cargo_build_script-pkg_name">pkg_name</a>, <a href="#cargo_build_script-data">data</a>, <a href="#cargo_build_script-tools">tools</a>,
+                   <a href="#cargo_build_script-links">links</a>, <a href="#cargo_build_script-rustc_env">rustc_env</a>, <a href="#cargo_build_script-visibility">visibility</a>, <a href="#cargo_build_script-tags">tags</a>, <a href="#cargo_build_script-kwargs">kwargs</a>)
 </pre>
 
 Compile and execute a rust build script to generate build attributes
@@ -1510,6 +1510,7 @@ The `hello_lib` target will be build with the flags and the environment variable
 | <a id="cargo_build_script-version"></a>version |  The semantic version (semver) of the crate.   |  <code>None</code> |
 | <a id="cargo_build_script-deps"></a>deps |  The dependencies of the crate.   |  <code>[]</code> |
 | <a id="cargo_build_script-build_script_env"></a>build_script_env |  Environment variables for build scripts.   |  <code>{}</code> |
+| <a id="cargo_build_script-pkg_name"></a>pkg_name |  The name to use as the build script's Cargo package name.   |  <code>None</code> |
 | <a id="cargo_build_script-data"></a>data |  Files needed by the build script.   |  <code>[]</code> |
 | <a id="cargo_build_script-tools"></a>tools |  Tools (executables) needed by the build script.   |  <code>[]</code> |
 | <a id="cargo_build_script-links"></a>links |  Name of the native library this crate links against.   |  <code>None</code> |

--- a/test/build_env/BUILD.bazel
+++ b/test/build_env/BUILD.bazel
@@ -27,17 +27,18 @@ rust_test(
     # Intentionally uses a mix of -s and _s because those normalisations are part of what is being tested.
     name = "cargo_env-vars_test",
     srcs = ["tests/cargo.rs"],
-    deps = [":cargo_build_script_env-vars_build_script"],
+    deps = [":build_script_build"],
 )
 
 rust_test(
     name = "cargo-env-vars-custom-crate-name-test",
     srcs = ["tests/custom_crate_name.rs"],
     crate_name = "custom_crate_name",
-    deps = [":cargo_build_script_env-vars_build_script"],
+    deps = [":build_script_build"],
 )
 
 cargo_build_script(
-    name = "cargo_build_script_env-vars_build_script",
+    name = "build_script_build",
     srcs = ["src/build.rs"],
+    pkg_name = "cargo_build_script_env-vars",
 )


### PR DESCRIPTION
Cargo build scripts are (to my knowledge) all represented as targets named `build_script_build` but it seems `cargo_build_script` has some components that are closely related to specific naming conventions of [cargo-raze](https://github.com/google/cargo-raze/blob/v0.12.0/impl/src/rendering/templates/partials/build_script.template#L9). I think it's slightly more correct to allow for setting an explicit package name when defining build scripts to get closer 1-1 translations of Cargo targets to Rust targets.