### PR TITLE
Flip default incompatible flag value for #591

### DIFF
--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -5,7 +5,7 @@ package(default_visibility = ["//visibility:public"])
 
 incompatible_flag(
     name = "split_rust_library",
-    build_setting_default = False,
+    build_setting_default = True,
     issue = "https://github.com/bazelbuild/rules_rust/issues/591",
 )
 


### PR DESCRIPTION
See details in https://github.com/bazelbuild/rules_rust/issues/591 (and let's have any potential discussions there).