### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is…

### DIFF
--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -211,7 +211,6 @@ rust_bindgen = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
 )
 
 def _rust_bindgen_toolchain_impl(ctx):

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -240,7 +240,6 @@ _build_script_run = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
 )
 
 def cargo_build_script(

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -322,7 +322,6 @@ rust_proto_library = rule(
     ],
     # TODO: Remove once (bazelbuild/bazel#11584) is closed and the rules use
     # the version of Bazel that issue was closed on as the min supported version
-    incompatible_use_toolchain_transition = True,
     doc = """\
 Builds a Rust library crate from a set of `proto_library`s.
 
@@ -400,7 +399,6 @@ rust_grpc_library = rule(
     ],
     # TODO: Remove once (bazelbuild/bazel#11584) is closed and the rules use
     # the version of Bazel that issue was closed on as the min supported version
-    incompatible_use_toolchain_transition = True,
     doc = """\
 Builds a Rust library crate from a set of `proto_library`s suitable for gRPC.
 

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -201,7 +201,6 @@ rust_clippy_aspect = aspect(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
     implementation = _clippy_aspect_impl,
     doc = """\
 Executes the clippy checker on specified targets.

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -702,7 +702,6 @@ rust_library = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
     doc = dedent("""\
         Builds a Rust library crate.
 
@@ -779,7 +778,6 @@ rust_static_library = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
     doc = dedent("""\
         Builds a Rust static library.
 
@@ -803,7 +801,6 @@ rust_shared_library = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
     doc = dedent("""\
         Builds a Rust shared library.
 
@@ -827,7 +824,6 @@ rust_proc_macro = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
     doc = dedent("""\
         Builds a Rust proc-macro crate.
         """),
@@ -887,7 +883,6 @@ rust_binary = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
     doc = dedent("""\
         Builds a Rust binary crate.
 
@@ -987,7 +982,6 @@ rust_test = rule(
         str(Label("//rust:toolchain")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
     doc = dedent("""\
         Builds a Rust test crate.
 

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -103,7 +103,6 @@ rust_analyzer_aspect = aspect(
     attr_aspects = ["deps", "proc_macro_deps", "crate"],
     implementation = _rust_analyzer_aspect_impl,
     toolchains = [str(Label("//rust:toolchain"))],
-    incompatible_use_toolchain_transition = True,
     doc = "Annotates rust rules with RustAnalyzerInfo later used to build a rust-project.json",
 )
 
@@ -250,7 +249,6 @@ rust_analyzer = rule(
     },
     implementation = _rust_analyzer_impl,
     toolchains = [str(Label("//rust:toolchain"))],
-    incompatible_use_toolchain_transition = True,
     doc = """\
 Produces a rust-project.json for the given targets. Configure rust-analyzer to load the generated file via the linked projects mechanism.
 """,

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -194,5 +194,4 @@ rust_doc = rule(
         "rust_doc_zip": "%{name}.zip",
     },
     toolchains = [str(Label("//rust:toolchain"))],
-    incompatible_use_toolchain_transition = True,
 )

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -216,7 +216,6 @@ rust_doc_test = rule(
     executable = True,
     test = True,
     toolchains = [str(Label("//rust:toolchain"))],
-    incompatible_use_toolchain_transition = True,
     doc = """Runs Rust documentation tests.
 
 Example:

--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -126,7 +126,6 @@ source files are also ignored by this aspect.
             default = Label("//util/process_wrapper"),
         ),
     },
-    incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [

--- a/rust/private/toolchain_utils.bzl
+++ b/rust/private/toolchain_utils.bzl
@@ -77,5 +77,4 @@ toolchain_files = rule(
     toolchains = [
         str(Label("//rust:toolchain")),
     ],
-    incompatible_use_toolchain_transition = True,
 )

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -374,7 +374,6 @@ rust_toolchain = rule(
     toolchains = [
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
     doc = """Declares a Rust toolchain for use.
 
 This is for declaring a custom toolchain, eg. for configuring a particular version of rust or supporting a new platform.

--- a/test/unit/force_all_deps_direct/generator.bzl
+++ b/test/unit/force_all_deps_direct/generator.bzl
@@ -87,6 +87,5 @@ generator = rule(
         ),
     },
     toolchains = ["@rules_rust//rust:toolchain", "@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )

--- a/wasm_bindgen/wasm_bindgen.bzl
+++ b/wasm_bindgen/wasm_bindgen.bzl
@@ -181,7 +181,6 @@ rust_wasm_bindgen = rule(
     toolchains = [
         str(Label("//wasm_bindgen:wasm_bindgen_toolchain")),
     ],
-    incompatible_use_toolchain_transition = True,
 )
 
 def _rust_wasm_bindgen_toolchain_impl(ctx):


### PR DESCRIPTION
… enabled by

default in Bazel 5.0.

This is a step towards removing it entirely.

Part of https://github.com/bazelbuild/bazel/issues/14127.