### PR TITLE
Forward CXX env and arguments from cargo_build_script

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@
 
 Google Inc.
 Spotify AB
+VMware Inc.
 Damien Martin-Guillerez <dmarting@google.com>
 David Chen <dzc@google.com>
 Florian Weikert <fwe@google.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,3 +20,4 @@ Philipp Wollermann <philwo@google.com>
 Ulf Adams <ulfjack@google.com>
 Justine Alexandra Roberts Tunney <jart@google.com>
 John Edmonds <jedmonds@spotify.com>
+Ivan Kalchev <kivan@vmware.com>

--- a/test/cargo_build_script/BUILD.bazel
+++ b/test/cargo_build_script/BUILD.bazel
@@ -7,7 +7,10 @@ load("//rust:defs.bzl", "rust_test")
 cargo_build_script(
     name = "tools_exec_build_rs",
     srcs = ["build.rs"],
-    build_script_env = {"TOOL": "$(execpath :tool)"},
+    build_script_env = {
+        "TOOL": "$(execpath :tool)",
+        "CXXFLAGS": "-DMY_DEFINE"
+    },
     tools = [":tool"],
 )
 

--- a/test/cargo_build_script/build.rs
+++ b/test/cargo_build_script/build.rs
@@ -4,6 +4,10 @@ fn main() {
         "cargo:rustc-env=TOOL_PATH={}",
         std::env::var("TOOL").unwrap()
     );
+    println!(
+        "cargo:rustc-env=CXXFLAGS={}",
+        std::env::var("CXXFLAGS").unwrap()
+    );
 
     // Assert that the CC and CXX env vars existed and were executable.
     // We don't assert what happens when they're executed (in particular, we don't check for a

--- a/test/cargo_build_script/tools_exec.rs
+++ b/test/cargo_build_script/tools_exec.rs
@@ -7,3 +7,13 @@ pub fn test_tool_exec() {
         tool_path
     );
 }
+
+#[test]
+pub fn test_cxxflags() {
+    let cxxflags = env!("CXXFLAGS");
+    assert!(
+        cxxflags.contains("-DMY_DEFINE"),
+        "CXXFLAGS did not contain '-DMY_DEFINE', {}",
+        cxxflags
+    );
+}


### PR DESCRIPTION
We need to forward the C++ command line arguments and env to ``bin.rs``
to make sure cargo_build libraries are compiled with the same options
as `cc_*` targets.

Fixes https://github.com/bazelbuild/rules_rust/issues/1003