### PR TITLE
Better handling of versioned library filenames

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -929,24 +929,6 @@ def _create_extra_input_args(ctx, file, build_info, dep_info):
 
     return input_files, out_dir, build_env_file, build_flags_files
 
-def _has_dylib_ext(file, dylib_ext):
-    """Determines whether or not the file in question the platform dynamic library extension
-
-    Args:
-        file (File): The file to check
-        dylib_ext (str): The extension (eg `.so`).
-
-    Returns:
-        bool: Whether or not file ends with the requested extension
-    """
-    if file.basename.endswith(dylib_ext):
-        return True
-    split = file.basename.split(".", 2)
-    if len(split) == 2:
-        if split[1] == dylib_ext[1:]:
-            return True
-    return False
-
 def _compute_rpaths(toolchain, output_dir, dep_info):
     """Determine the artifact's rpaths relative to the bazel root for runtime linking of shared libraries.
 

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -99,9 +99,24 @@ def get_lib_name(lib):
     Returns:
         str: The name of the library
     """
+    # On macos and windows, dynamic/static libraries always end with the
+    # extension and potential versions will be before the extension, and should
+    # be part of the library name.
+    # On linux, the version usually comes after the extension.
+    # So regardless of the platform we want to find the extension and make
+    # everything left to it the library name.
 
-    # NB: The suffix may contain a version number like 'so.1.2.3'
-    libname = lib.basename.split(".", 1)[0]
+    # Search for the extension - starting from the right - by removing any
+    # trailing digit.
+    comps = lib.basename.split(".")
+    for comp in reversed(comps):
+        if comp.isdigit():
+            comps.pop()
+        else:
+            break
+
+    # The library name is now everything minus the extension.
+    libname = ".".join(comps[:-1])
 
     if libname.startswith("lib"):
         return libname[3:]

--- a/test/unit/versioned_libs/BUILD.bazel
+++ b/test/unit/versioned_libs/BUILD.bazel
@@ -1,0 +1,7 @@
+load(":versioned_libs_analysis_test.bzl", "versioned_libs_analysis_test_suite")
+load(":versioned_libs_unit_test.bzl", "versioned_libs_unit_test_suite")
+
+############################ UNIT TESTS #############################
+versioned_libs_unit_test_suite(name = "versioned_libs_unit_test_suite")
+
+versioned_libs_analysis_test_suite(name = "versioned_libs_analysis_test_suite")

--- a/test/unit/versioned_libs/a.rs
+++ b/test/unit/versioned_libs/a.rs
@@ -1,0 +1,1 @@
+pub fn hello() {}

--- a/test/unit/versioned_libs/b.c
+++ b/test/unit/versioned_libs/b.c
@@ -1,0 +1,1 @@
+void hello(void) {}

--- a/test/unit/versioned_libs/versioned_libs_analysis_test.bzl
+++ b/test/unit/versioned_libs/versioned_libs_analysis_test.bzl
@@ -1,0 +1,233 @@
+"""Analysis tests for getting the link name of a versioned library."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import")
+load("//rust:defs.bzl", "rust_shared_library")
+
+LIBNAMES = ["sterling", "cheryl", "lana", "pam", "malory", "cyril"]
+
+def _is_in_argv(argv, version = None):
+    return any(["-ldylib={}{}".format(name, version or "") in argv for name in LIBNAMES])
+
+def _no_version_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+    argv = tut.actions[0].argv
+
+    asserts.true(env, _is_in_argv(argv))
+
+    return analysistest.end(env)
+
+def _prefix_version_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+    argv = tut.actions[0].argv
+
+    asserts.true(env, _is_in_argv(argv, "3.8"))
+
+    return analysistest.end(env)
+
+def _suffix_version_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+    argv = tut.actions[0].argv
+
+    asserts.true(env, _is_in_argv(argv))
+
+    return analysistest.end(env)
+
+no_version_test = analysistest.make(_no_version_test_impl)
+prefix_version_test = analysistest.make(_prefix_version_test_impl)
+suffix_version_test = analysistest.make(_suffix_version_test_impl)
+
+def _test_linux():
+    rust_shared_library(
+        name = "linux_no_version",
+        srcs = ["a.rs"],
+        deps = [":import_libsterling.so"],
+        target_compatible_with = ["@platforms//os:linux"],
+    )
+    cc_import(
+        name = "import_libsterling.so",
+        shared_library = "libsterling.so",
+    )
+    cc_binary(
+        name = "libsterling.so",
+        srcs = ["b.c"],
+        linkshared = True,
+    )
+    no_version_test(
+        name = "linux_no_version_test",
+        target_under_test = ":linux_no_version",
+        target_compatible_with = ["@platforms//os:linux"],
+    )
+
+    rust_shared_library(
+        name = "linux_suffix_version",
+        srcs = ["a.rs"],
+        deps = [":import_libcheryl.so.3.8", ":import_libcheryl.so"],
+        target_compatible_with = ["@platforms//os:linux"],
+    )
+    cc_import(
+        name = "import_libcheryl.so.3.8",
+        shared_library = "libcheryl.so.3.8",
+    )
+    cc_binary(
+        name = "libcheryl.so.3.8",
+        srcs = ["b.c"],
+        linkshared = True,
+    )
+    cc_import(
+        name = "import_libcheryl.so",
+        shared_library = "libcheryl.so",
+    )
+    copy_file(
+        name = "copy_unversioned",
+        src = ":libcheryl.so.3.8",
+        out = "libcheryl.so",
+    )
+    suffix_version_test(
+        name = "linux_suffix_version_test",
+        target_under_test = ":linux_suffix_version",
+        target_compatible_with = ["@platforms//os:linux"],
+    )
+
+    return [
+        ":linux_no_version_test",
+        ":linux_suffix_version_test",
+    ]
+
+def _test_macos():
+    rust_shared_library(
+        name = "no_version",
+        srcs = ["a.rs"],
+        deps = [":import_liblana.dylib"],
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+    cc_import(
+        name = "import_liblana.dylib",
+        shared_library = "liblana.dylib",
+    )
+    cc_binary(
+        name = "liblana.dylib",
+        srcs = ["b.c"],
+        linkshared = True,
+    )
+    no_version_test(
+        name = "macos_no_version_test",
+        target_under_test = ":no_version",
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+
+    rust_shared_library(
+        name = "prefix_version",
+        srcs = ["a.rs"],
+        deps = [":import_libpam3.8.dylib"],
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+    cc_import(
+        name = "import_libpam3.8.dylib",
+        shared_library = "libpam3.8.dylib",
+    )
+    cc_binary(
+        name = "libpam3.8.dylib",
+        srcs = ["b.c"],
+        linkshared = True,
+    )
+    prefix_version_test(
+        name = "macos_prefix_version_test",
+        target_under_test = ":prefix_version",
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+
+    return [
+        ":macos_no_version_test",
+        ":macos_prefix_version_test",
+    ]
+
+def _test_windows():
+    rust_shared_library(
+        name = "windows_no_version",
+        srcs = ["a.rs"],
+        deps = [":import_malory.dll"],
+        target_compatible_with = ["@platforms//os:windows"],
+    )
+    cc_import(
+        name = "import_malory.dll",
+        interface_library = ":malory.lib",
+        shared_library = "malory.dll",
+    )
+    cc_binary(
+        name = "malory.dll",
+        srcs = ["b.c"],
+        linkshared = True,
+    )
+    native.filegroup(
+        name = "malory_interface_lib",
+        srcs = [":malory.dll"],
+        output_group = "interface_library",
+    )
+    copy_file(
+        name = "copy_malory_interface_lib",
+        src = ":malory_interface_lib",
+        out = "malory.lib",
+    )
+    no_version_test(
+        name = "windows_no_version_test",
+        target_under_test = ":windows_no_version",
+        target_compatible_with = ["@platforms//os:windows"],
+    )
+
+    rust_shared_library(
+        name = "windows_prefix_version",
+        srcs = ["a.rs"],
+        deps = [":import_cyril3.8.dll"],
+        target_compatible_with = ["@platforms//os:windows"],
+    )
+    cc_import(
+        name = "import_cyril3.8.dll",
+        interface_library = ":cyril3.8.lib",
+        shared_library = "cyril3.8.dll",
+    )
+    cc_binary(
+        name = "cyril3.8.dll",
+        srcs = ["b.c"],
+        linkshared = True,
+    )
+    native.filegroup(
+        name = "cyril_interface_lib",
+        srcs = [":cyril3.8.dll"],
+        output_group = "interface_library",
+    )
+    copy_file(
+        name = "copy_cyril_interface_lib",
+        src = ":cyril_interface_lib",
+        out = "cyril3.8.lib",
+    )
+    prefix_version_test(
+        name = "windows_prefix_version_test",
+        target_under_test = ":windows_prefix_version",
+        target_compatible_with = ["@platforms//os:windows"],
+    )
+
+    return [
+        ":windows_no_version_test",
+        ":windows_prefix_version_test",
+    ]
+
+def versioned_libs_analysis_test_suite(name):
+    """Analysis tests for getting the link name of a versioned library.
+
+    Args:
+        name: the test suite name
+    """
+    tests = []
+    tests += _test_linux()
+    tests += _test_macos()
+    tests += _test_windows()
+
+    native.test_suite(
+        name = name,
+        tests = tests,
+    )

--- a/test/unit/versioned_libs/versioned_libs_unit_test.bzl
+++ b/test/unit/versioned_libs/versioned_libs_unit_test.bzl
@@ -1,0 +1,46 @@
+"""Unit tests for getting the link name of a versioned library."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:utils.bzl", "get_lib_name")
+
+def _produced_expected_lib_name_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, "python", get_lib_name(struct(basename = "libpython.dylib")))
+    asserts.equals(env, "python", get_lib_name(struct(basename = "libpython.so")))
+    asserts.equals(env, "python", get_lib_name(struct(basename = "libpython.a")))
+    asserts.equals(env, "python", get_lib_name(struct(basename = "python.dll")))
+    asserts.equals(env, "python", get_lib_name(struct(basename = "python.lib")))
+
+    asserts.equals(env, "python3", get_lib_name(struct(basename = "libpython3.dylib")))
+    asserts.equals(env, "python3.8", get_lib_name(struct(basename = "libpython3.8.dylib")))
+    asserts.equals(env, "python3", get_lib_name(struct(basename = "libpython3.a")))
+    asserts.equals(env, "python3.8", get_lib_name(struct(basename = "libpython3.8.a")))
+
+    asserts.equals(env, "python38", get_lib_name(struct(basename = "python38.dll")))
+    asserts.equals(env, "python38m", get_lib_name(struct(basename = "python38m.dll")))
+
+    asserts.equals(env, "python", get_lib_name(struct(basename = "libpython.so.3")))
+    asserts.equals(env, "python", get_lib_name(struct(basename = "libpython.so.3.8")))
+    asserts.equals(env, "python", get_lib_name(struct(basename = "libpython.so.3.8.0")))
+    asserts.equals(env, "python", get_lib_name(struct(basename = "libpython.a.3")))
+    asserts.equals(env, "python", get_lib_name(struct(basename = "libpython.a.3.8")))
+    asserts.equals(env, "python", get_lib_name(struct(basename = "libpython.a.3.8.0")))
+    asserts.equals(env, "python-3.8.0", get_lib_name(struct(basename = "libpython-3.8.0.so.3.8.0")))
+
+    return unittest.end(env)
+
+produced_expected_lib_name_test = unittest.make(_produced_expected_lib_name_test_impl)
+
+def versioned_libs_unit_test_suite(name):
+    """Unit tests for getting the link name of a versioned library.
+
+    Args:
+        name: the test suite name
+    """
+    unittest.suite(
+        name,
+        produced_expected_lib_name_test,
+    )


### PR DESCRIPTION
#513 fixed an issue that prevented linking against a versioned library (using a version suffix on linux) but didn’t address a problem with `get_lib_name` that prevents from linking against certain libraries that happen to include the version number **before** the extension, such as `libpython3.8.dylib` on macos.

Before this patch, we would attempt to link `-lpython3` (since it would cut the filename up to the first `.` in the library name) and thus failing whereas after the diff it correctly links against `-lpython3.8`.

Also removed the `_has_dylib_ext` function that seems to be a leftover that was added in #808 but left unused after #820.