### PR TITLE
Fix C++ compilation warning

### DIFF
--- a/util/process_wrapper/utils.cc
+++ b/util/process_wrapper/utils.cc
@@ -110,7 +110,7 @@ bool ReadStampStatusToArray(
     return false;
   }
 
-  for (int i = 0; i < stamp_block.size(); ++i) {
+  for (System::StrVecType::size_type i = 0; i < stamp_block.size(); ++i) {
     size_t space_pos = stamp_block[i].find(' ');
     if (space_pos == std::string::npos) {
       std::cerr << "process wrapper error: wrong workspace status file "


### PR DESCRIPTION
This fixes the following warning which I found when building on Linux
```
INFO: From Compiling util/process_wrapper/utils.cc:
external/rules_rust/util/process_wrapper/utils.cc: In function 'bool process_wrapper::ReadStampStatusToArray(const StrType&, std::vector<std::pair<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >&)':
external/rules_rust/util/process_wrapper/utils.cc:113:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  113 |   for (int i = 0; i < stamp_block.size(); ++i) {
      |                   ~~^~~~~~~~~~~~~~~~~~~~
```