### PR TITLE
Replaced uses of `@bazel_tools` with `@rules_cc`

### DIFF
--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -195,7 +195,7 @@ rust_bindgen = rule(
             allow_single_file = True,
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
         "_process_wrapper": attr.label(
             default = Label("//util/process_wrapper"),
@@ -209,7 +209,7 @@ rust_bindgen = rule(
     toolchains = [
         str(Label("//bindgen:bindgen_toolchain")),
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
 )

--- a/cargo/cargo_bootstrap.bzl
+++ b/cargo/cargo_bootstrap.bzl
@@ -264,7 +264,7 @@ cargo_bootstrap_repository = repository_rule(
             default = rust_common.default_version,
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
     },
 )

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -1,6 +1,6 @@
 # buildifier: disable=module-docstring
-load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
+load("@rules_cc//cc:find_cc_toolchain.bzl", find_cpp_toolchain = "find_cc_toolchain")
 load("//rust:defs.bzl", "rust_binary", "rust_common")
 
 # buildifier: disable=bzl-visibility
@@ -232,13 +232,13 @@ _build_script_run = rule(
             cfg = "exec",
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
     },
     fragments = ["cpp"],
     toolchains = [
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
 )

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -10,6 +10,7 @@ bzl_library(
         "@bazel_tools//tools:bzl_srcs",
         "@build_bazel_rules_nodejs//:bzl",
         "@com_google_protobuf//:bzl_srcs",
+        "@rules_cc//cc:bzl_srcs",
     ],
     deps = [
         "@bazel_skylib//lib:paths",

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -300,7 +300,7 @@ rust_proto_library = rule(
             doc = "The crates the generated library depends on.",
         ),
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
         "_optional_output_wrapper": attr.label(
             executable = True,
@@ -319,7 +319,7 @@ rust_proto_library = rule(
     toolchains = [
         str(Label("//proto:toolchain")),
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     # TODO: Remove once (bazelbuild/bazel#11584) is closed and the rules use
     # the version of Bazel that issue was closed on as the min supported version
@@ -378,7 +378,7 @@ rust_grpc_library = rule(
             doc = "The crates the generated library depends on.",
         ),
         "_cc_toolchain": attr.label(
-            default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+            default = "@rules_cc//cc:current_cc_toolchain",
         ),
         "_optional_output_wrapper": attr.label(
             executable = True,
@@ -397,7 +397,7 @@ rust_grpc_library = rule(
     toolchains = [
         str(Label("//proto:toolchain")),
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     # TODO: Remove once (bazelbuild/bazel#11584) is closed and the rules use
     # the version of Bazel that issue was closed on as the min supported version

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -177,7 +177,7 @@ rust_clippy_aspect = aspect(
                 "Required attribute to access the cc_toolchain. See [Accessing the C++ toolchain]" +
                 "(https://docs.bazel.build/versions/master/integrating-with-rules-cc.html#accessing-the-c-toolchain)"
             ),
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
         "_config": attr.label(
             doc = "The `clippy.toml` file used for configuration",
@@ -199,7 +199,7 @@ rust_clippy_aspect = aspect(
     provides = [ClippyInfo],
     toolchains = [
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
     implementation = _clippy_aspect_impl,

--- a/rust/private/dummy_cc_toolchain/BUILD.bazel
+++ b/rust/private/dummy_cc_toolchain/BUILD.bazel
@@ -9,5 +9,5 @@ toolchain(
     name = "dummy_cc_wasm32_toolchain",
     target_compatible_with = ["//rust/platform/cpu:wasm32"],
     toolchain = ":dummy_cc_wasm32",
-    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    toolchain_type = "@rules_cc//cc:toolchain_type",
 )

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -658,7 +658,7 @@ _common_attrs = {
         default = "0.0.0",
     ),
     "_cc_toolchain": attr.label(
-        default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+        default = "@rules_cc//cc:current_cc_toolchain",
     ),
     "_error_format": attr.label(default = "//:error_format"),
     "_extra_rustc_flags": attr.label(default = "//:extra_rustc_flags"),
@@ -734,7 +734,7 @@ rust_library = rule(
     host_fragments = ["cpp"],
     toolchains = [
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
     doc = dedent("""\
@@ -811,7 +811,7 @@ rust_static_library = rule(
     host_fragments = ["cpp"],
     toolchains = [
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
     doc = dedent("""\
@@ -835,7 +835,7 @@ rust_shared_library = rule(
     host_fragments = ["cpp"],
     toolchains = [
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
     doc = dedent("""\
@@ -859,7 +859,7 @@ rust_proc_macro = rule(
     host_fragments = ["cpp"],
     toolchains = [
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
     doc = dedent("""\
@@ -909,7 +909,7 @@ rust_binary = rule(
     host_fragments = ["cpp"],
     toolchains = [
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
     doc = dedent("""\
@@ -1009,7 +1009,7 @@ rust_test = rule(
     test = True,
     toolchains = [
         str(Label("//rust:toolchain")),
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
     doc = dedent("""\

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -14,10 +14,7 @@
 
 # buildifier: disable=module-docstring
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(
-    "@bazel_tools//tools/build_defs/cc:action_names.bzl",
-    "CPP_LINK_EXECUTABLE_ACTION_NAME",
-)
+load("@rules_cc//cc:action_names.bzl", "CPP_LINK_EXECUTABLE_ACTION_NAME")
 load("//rust/private:common.bzl", "rust_common")
 load("//rust/private:providers.bzl", _BuildInfo = "BuildInfo")
 load("//rust/private:stamp.bzl", "is_stamping_enabled")

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -14,7 +14,7 @@
 
 """Utility functions not specific to the rust toolchain."""
 
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", find_rules_cc_toolchain = "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", find_rules_cc_toolchain = "find_cc_toolchain")
 load(":providers.bzl", "BuildInfo", "CrateInfo", "DepInfo", "DepVariantInfo")
 
 def find_toolchain(ctx):

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -362,17 +362,17 @@ rust_toolchain = rule(
             ),
         ),
         "_cc_toolchain": attr.label(
-            default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+            default = "@rules_cc//cc:current_cc_toolchain",
         ),
         "_crosstool": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
         ),
         "_incompatible_make_rust_providers_target_independent": attr.label(
             default = "@rules_rust//rust/settings:incompatible_make_rust_providers_target_independent",
         ),
     },
     toolchains = [
-        "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_cc//cc:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
     doc = """Declares a Rust toolchain for use.

--- a/test/unit/consistent_crate_name/with_modified_crate_name.bzl
+++ b/test/unit/consistent_crate_name/with_modified_crate_name.bzl
@@ -59,7 +59,7 @@ with_modified_crate_name = rule(
         "deps": attr.label_list(),
         "src": attr.label(allow_single_file = [".rs"]),
         "_cc_toolchain": attr.label(
-            default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+            default = "@rules_cc//cc:current_cc_toolchain",
         ),
         "_error_format": attr.label(default = "@rules_rust//:error_format"),
         "_process_wrapper": attr.label(
@@ -69,7 +69,7 @@ with_modified_crate_name = rule(
             cfg = "exec",
         ),
     },
-    toolchains = ["@rules_rust//rust:toolchain", "@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = ["@rules_rust//rust:toolchain", "@rules_cc//cc:toolchain_type"],
     incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )

--- a/test/unit/force_all_deps_direct/generator.bzl
+++ b/test/unit/force_all_deps_direct/generator.bzl
@@ -76,7 +76,7 @@ generator = rule(
     attrs = {
         "deps": attr.label_list(),
         "_cc_toolchain": attr.label(
-            default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+            default = "@rules_cc//cc:current_cc_toolchain",
         ),
         "_error_format": attr.label(default = "@rules_rust//:error_format"),
         "_process_wrapper": attr.label(
@@ -86,7 +86,7 @@ generator = rule(
             cfg = "exec",
         ),
     },
-    toolchains = ["@rules_rust//rust:toolchain", "@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = ["@rules_rust//rust:toolchain", "@rules_cc//cc:toolchain_type"],
     incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )


### PR DESCRIPTION
This is kinda a minor cleanup but really just wondering if it makes sense to use `rules_cc` for more things vs `bazel_tools`.