### PR TITLE
Make action_env work for rustc actions

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -729,7 +729,7 @@ def rustc_compile_action(
         stamp = stamp,
     )
 
-    args, env = construct_arguments(
+    args, env_from_args = construct_arguments(
         ctx = ctx,
         attr = attr,
         file = ctx.file,
@@ -748,6 +748,9 @@ def rustc_compile_action(
         force_all_deps_direct = force_all_deps_direct,
         stamp = stamp,
     )
+
+    env = dict(ctx.configuration.default_shell_env)
+    env.update(env_from_args)
 
     if hasattr(attr, "version") and attr.version != "0.0.0":
         formatted_version = " v{}".format(attr.version)


### PR DESCRIPTION
Currently, action_env is not passed through to rustc actions, which means that variables like `DEVELOPER_DIR` needed in some cases on macOS cannot be passed through. This PR passes action_env through to rustc actions.

Similar to existing code at https://github.com/bazelbuild/rules_rust/blob/e2f0fccda912daac686b533ad77c5bc5d2f2ddb7/cargo/cargo_build_script.bzl#L68