### PR TITLE
declare CARGO_CFG_(WINDOWS|UNIX) in build scripts

### DIFF
--- a/cargo/cargo_build_script_runner/BUILD.bazel
+++ b/cargo/cargo_build_script_runner/BUILD.bazel
@@ -16,3 +16,9 @@ rust_binary(
     visibility = ["//visibility:public"],
     deps = [":cargo_build_script_output_parser"],
 )
+
+rust_test(
+    name = "bin_test",
+    crate = ":cargo_build_script_runner",
+    deps = [":cargo_build_script_runner"],
+)

--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -236,6 +236,10 @@ fn get_target_env_vars<P: AsRef<Path>>(rustc: &P) -> Result<BTreeMap<String, Str
     let stdout = std::str::from_utf8(&output.stdout)
         .map_err(|err| format!("Non-UTF8 stdout from rustc: {:?}", err))?;
 
+    Ok(parse_rustc_cfg_output(stdout))
+}
+
+fn parse_rustc_cfg_output(stdout: &str) -> BTreeMap<String, String> {
     let mut values = BTreeMap::new();
 
     for line in stdout.lines() {
@@ -251,14 +255,16 @@ fn get_target_env_vars<P: AsRef<Path>>(rustc: &P) -> Result<BTreeMap<String, Str
                     .push(value[1..(value.len() - 1)].to_owned());
             }
         } else if ["windows", "unix"].contains(&line) {
+            // the 'windows' or 'unix' line received from rustc will be turned
+            // into eg. CARGO_CFG_WINDOWS='' below
             values.insert(line, vec![]);
         }
     }
 
-    Ok(values
+    values
         .into_iter()
         .map(|(key, value)| (format!("CARGO_CFG_{}", key.to_uppercase()), value.join(",")))
-        .collect())
+        .collect()
 }
 
 fn main() {
@@ -270,4 +276,50 @@ fn main() {
             1
         }
     });
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn rustc_cfg_parsing() {
+        let macos_output = r#"\
+debug_assertions
+target_arch="x86_64"
+target_endian="little"
+target_env=""
+target_family="unix"
+target_feature="fxsr"
+target_feature="sse"
+target_feature="sse2"
+target_feature="sse3"
+target_feature="ssse3"
+target_os="macos"
+target_pointer_width="64"
+target_vendor="apple"
+unix
+"#;
+        let tree = parse_rustc_cfg_output(macos_output);
+        assert_eq!(tree["CARGO_CFG_UNIX"], "");
+        assert_eq!(tree["CARGO_CFG_TARGET_FAMILY"], "unix");
+
+        let windows_output = r#"\
+debug_assertions
+target_arch="x86_64"
+target_endian="little"
+target_env="msvc"
+target_family="windows"
+target_feature="fxsr"
+target_feature="sse"
+target_feature="sse2"
+target_os="windows"
+target_pointer_width="64"
+target_vendor="pc"
+windows
+"#;
+        let tree = parse_rustc_cfg_output(windows_output);
+        assert_eq!(tree["CARGO_CFG_WINDOWS"], "");
+        assert_eq!(tree["CARGO_CFG_TARGET_FAMILY"], "windows");
+    }
 }

--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -250,6 +250,8 @@ fn get_target_env_vars<P: AsRef<Path>>(rustc: &P) -> Result<BTreeMap<String, Str
                     .or_insert_with(Vec::new)
                     .push(value[1..(value.len() - 1)].to_owned());
             }
+        } else if ["windows", "unix"].contains(&line) {
+            values.insert(line, vec![]);
         }
     }
 


### PR DESCRIPTION
These variables are documented as being available:
https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts

The latest rusqlite depends on CARGO_CFG_WINDOWS to be defined
in order to link correctly: https://github.com/rusqlite/rusqlite/pull/961