### PR TITLE
Don't duplicate stdlib link flags in rustc compile action arguments 

### DIFF
--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -133,7 +133,7 @@ def _rust_bindgen_impl(ctx):
         "RUST_BACKTRACE": "1",
     }
     cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
-    _, _, linker_env = get_linker_and_args(ctx, ctx.attr, cc_toolchain, feature_configuration, None)
+    _, _, linker_env = get_linker_and_args(ctx, ctx.attr, cc_toolchain, feature_configuration, None, rust_toolchain.stdlib_linkflags)
     env.update(**linker_env)
 
     # Set the dynamic linker search path so that clang uses the libstdcxx from the toolchain.

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -92,7 +92,7 @@ def _build_script_impl(ctx):
     # Pull in env vars which may be required for the cc_toolchain to work (e.g. on OSX, the SDK version).
     # We hope that the linker env is sufficient for the whole cc_toolchain.
     cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
-    _, _, linker_env = get_linker_and_args(ctx, ctx.attr, cc_toolchain, feature_configuration, None)
+    _, _, linker_env = get_linker_and_args(ctx, ctx.attr, cc_toolchain, feature_configuration, None, toolchain.stdlib_linkflags)
     env.update(**linker_env)
 
     # MSVC requires INCLUDE to be set

--- a/test/unit/stdlib_link_args/BUILD.bazel
+++ b/test/unit/stdlib_link_args/BUILD.bazel
@@ -1,0 +1,4 @@
+load(":stdlib_link_args.bzl", "stdlib_link_args_test_suite")
+
+############################ UNIT TESTS #############################
+stdlib_link_args_test_suite(name = "stdlib_link_args_test_suite")

--- a/test/unit/stdlib_link_args/a.rs
+++ b/test/unit/stdlib_link_args/a.rs
@@ -1,0 +1,1 @@
+pub fn hello_a() {}

--- a/test/unit/stdlib_link_args/ba.rs
+++ b/test/unit/stdlib_link_args/ba.rs
@@ -1,0 +1,1 @@
+pub fn hello_ba() {}

--- a/test/unit/stdlib_link_args/bb.rs
+++ b/test/unit/stdlib_link_args/bb.rs
@@ -1,0 +1,1 @@
+pub fn hello_bb() {}

--- a/test/unit/stdlib_link_args/ca.rs
+++ b/test/unit/stdlib_link_args/ca.rs
@@ -1,0 +1,1 @@
+pub fn hello_ca() {}

--- a/test/unit/stdlib_link_args/cb.rs
+++ b/test/unit/stdlib_link_args/cb.rs
@@ -1,0 +1,1 @@
+pub fn hello_cb() {}

--- a/test/unit/stdlib_link_args/stdlib_link_args.bzl
+++ b/test/unit/stdlib_link_args/stdlib_link_args.bzl
@@ -1,0 +1,68 @@
+"""Unittests to check that we don't create stdlib link args duplicates."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//rust:defs.bzl", "rust_library")
+
+def _stdlib_link_args_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+    argv = tut.actions[0].argv
+
+    link_args = None
+    for arg in argv:
+        if arg.startswith("link-args="):
+            link_args = arg
+            break
+    asserts.true(env, link_args != None)
+
+    # Make sure that each stdlib linkflag is only present once
+    linkflags = []
+    for flag in link_args.split(" "):
+        # Ideally we would only do this check for args that are in `stdlib_linkflags`
+        # but that would require access to the rust toolchain.
+        asserts.false(env, flag in linkflags)
+        linkflags.append(flag)
+
+    return analysistest.end(env)
+
+stdlib_link_args_test = analysistest.make(_stdlib_link_args_test_impl)
+
+def _stdlib_link_args_test():
+    rust_library(
+        name = "a",
+        srcs = ["a.rs"],
+        deps = [":ba", ":bb"],
+    )
+    rust_library(
+        name = "ba",
+        srcs = ["ba.rs"],
+        deps = [":ca"],
+    )
+    rust_library(
+        name = "bb",
+        srcs = ["bb.rs"],
+        deps = [":cb"],
+    )
+    rust_library(
+        name = "ca",
+        srcs = ["ca.rs"],
+    )
+    rust_library(
+        name = "cb",
+        srcs = ["cb.rs"],
+    )
+
+    stdlib_link_args_test(
+        name = "stdlib_link_args_test",
+        target_under_test = ":a",
+    )
+
+def stdlib_link_args_test_suite(name):
+    _stdlib_link_args_test()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":stdlib_link_args_test",
+        ],
+    )


### PR DESCRIPTION
I've been migration a semi large Rust codebase from our own rules to `rules_rust` and frequently run into errors when spawning clang due to the argument list being too large.

It looks like the argument list is mostly filled with hundreds or even thousands duplicated entries for `stdlib_linkflags` (since they appear in each transitive Rust dependency).

This patch attempts to prevent the duplication of `stdlib_linkflags` in the linker args for a given compile action.