### PR TITLE
Fix rustc panic on Windows due to how stdout/stderr are set up in the process wrapper

### DIFF
--- a/util/process_wrapper/system_windows.cc
+++ b/util/process_wrapper/system_windows.cc
@@ -206,9 +206,8 @@ int System::Exec(const System::StrType& executable,
   OutputPipe stderr_pipe;
 
   if (!stdout_file.empty() || !stderr_file.empty()) {
-    // We will be setting our own stdout/stderr handles.
-    // Note that when setting `STARTF_USESTDHANDLES` it is critical to set *all* handles or the
-    // child process might get a null handle (or garbage).
+    // We will be setting our own stdout/stderr handles. Note that when setting `STARTF_USESTDHANDLES`
+    // it is critical to set *all* handles or the child process might get a null handle (or garbage).
     startup_info.dwFlags |= STARTF_USESTDHANDLES;
     startup_info.hStdInput = INVALID_HANDLE_VALUE;
 

--- a/util/process_wrapper/system_windows.cc
+++ b/util/process_wrapper/system_windows.cc
@@ -103,9 +103,9 @@ class OutputPipe {
     CloseWriteEnd();
   }
 
-  bool CreateEnds(SECURITY_ATTRIBUTES *saAttr) {
+  bool CreateEnds(SECURITY_ATTRIBUTES& saAttr) {
     if (!::CreatePipe(&output_pipe_handles_[kReadEndHandle],
-                      &output_pipe_handles_[kWriteEndHandle], saAttr, 0)) {
+                      &output_pipe_handles_[kWriteEndHandle], &saAttr, 0)) {
       return false;
     }
 
@@ -219,7 +219,7 @@ int System::Exec(const System::StrType& executable,
     saAttr.lpSecurityDescriptor = NULL;
 
     if (!stdout_file.empty()) {
-      if (!stdout_pipe.CreateEnds(&saAttr)) {
+      if (!stdout_pipe.CreateEnds(saAttr)) {
         std::cerr << "process wrapper error: failed to create stdout pipe: "
                   << GetLastErrorAsStr();
         return -1;
@@ -230,7 +230,7 @@ int System::Exec(const System::StrType& executable,
     }
 
     if (!stderr_file.empty()) {
-      if (!stderr_pipe.CreateEnds(&saAttr)) {
+      if (!stderr_pipe.CreateEnds(saAttr)) {
         std::cerr << "process wrapper error: failed to create stderr pipe: "
                   << GetLastErrorAsStr();
         return -1;


### PR DESCRIPTION
I noticed that rustc was panicking with an unexpected null handle when running a `rust_clippy` target on Windows (see below for panic).

I remember that we were specifically setting a `--stderr-file` or `--stdout-file` and I looked at how the process wrapper was actually setting these when invoking rustc/clippy-driver. We are altering the `STARTUPINFO` struct to pass specific file handles for whatever stream we are interested in (see https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfoa for docs).

Setting `hStdInput`, `hStdOutput` or `hStdError` requires setting `STARTF_USESTDHANDLES` on the `dwFlag`. However, the docs say that while setting this flag, *all* three streams should be set on the `STARTUPINFO` to a handle or `INVALID_HANDLE_VALUE`.
Since we were failing to do so, rustc was trying to retrieve `stdout`/`stderr` and tripping on this [assert](https://github.com/rust-lang/rust/blob/18bc4bee9710b181b440a472635150f0d6257713/library/std/src/os/windows/io/handle.rs#L183) since they weren't actually set to anything.

Note that I ran into this with Clippy because it's the first thing I tried that was setting an output file but I suspect it could happen with other configs as well.

```
thread 'main' panicked at 'assertion failed: !handle.is_null()', /rustc/18bc4bee9710b181b440a472635150f0d6257713\library\std\src\os\windows\io\handle.rs:183:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'main' panicked at 'assertion failed: !handle.is_null()', /rustc/18bc4bee9710b181b440a472635150f0d6257713\library\std\src\os\windows\io\handle.rs:183:9
stack backtrace:
   0:     0x7ff824178c6f - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h4287336b592e4e30
   1:     0x7ff8241a2eba - core::fmt::write::h8a2c40ddb66ccc71
   2:     0x7ff82416b5b8 - <std::io::IoSlice as core::fmt::Debug>::fmt::h37489b9473b33977
   3:     0x7ff82417c1b6 - std::panicking::take_hook::hf14c76592f73c762
   4:     0x7ff82417bc9c - std::panicking::take_hook::hf14c76592f73c762
   5:     0x7ff60d73c2de - <unknown>
   6:     0x7ff82417cac9 - std::panicking::rust_panic_with_hook::hbc0e9c80ca88eac0
   7:     0x7ff82417c53f - rust_begin_unwind
   8:     0x7ff8241795a7 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h4287336b592e4e30
   9:     0x7ff82417c4c9 - rust_begin_unwind
  10:     0x7ff8241d7460 - core::panicking::panic_fmt::hc1b1ca620e7a2c9f
  11:     0x7ff8241d73ac - core::panicking::panic::hfef5cee9afdef02a
  12:     0x7ff8199f250c - <winapi_util[f773672ce88e7109]::console::ScreenBufferInfo>::window_rect
  13:     0x7ff8199f25ef - <winapi_util[f773672ce88e7109]::console::Console>::stdout
  14:     0x7ff8199ee322 - <termcolor[bad27d1885d957ed]::StandardStream>::stderr
  15:     0x7ff8199b5f27 - <rustc_errors[a61263f7b91ac297]::emitter::EmitterWriter>::stderr
  16:     0x7ff60d73c339 - <unknown>
  17:     0x7ff82417cac9 - std::panicking::rust_panic_with_hook::hbc0e9c80ca88eac0
  18:     0x7ff82417c53f - rust_begin_unwind
  19:     0x7ff8241795a7 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h4287336b592e4e30
  20:     0x7ff82417c4c9 - rust_begin_unwind
  21:     0x7ff8241d7460 - core::panicking::panic_fmt::hc1b1ca620e7a2c9f
  22:     0x7ff8241d73ac - core::panicking::panic::hfef5cee9afdef02a
  23:     0x7ff8199f250c - <winapi_util[f773672ce88e7109]::console::ScreenBufferInfo>::window_rect
  24:     0x7ff8199f25ef - <winapi_util[f773672ce88e7109]::console::Console>::stdout
  25:     0x7ff8199ee322 - <termcolor[bad27d1885d957ed]::StandardStream>::stderr
  26:     0x7ff8199d93ca - <rustc_errors[a61263f7b91ac297]::Handler>::with_tty_emitter_and_flags
  27:     0x7ff8199d9361 - <rustc_errors[a61263f7b91ac297]::Handler>::with_tty_emitter
  28:     0x7ff8199161f1 - <rustc_session[ee853a0d40990e94]::parse::ParseSess>::with_silent_emitter
  29:     0x7ff81534443c - <rustc_hir[19483fb96cca7fbf]::definitions::Definitions>::get_root_def
  30:     0x7ff815400efe - <rustc_interface[4e115dbf7cfc9743]::passes::boxed_resolver::BoxedResolver>::to_resolver_outputs
  31:     0x7ff81540d774 - rustc_interface[4e115dbf7cfc9743]::interface::parse_cfgspecs
  32:     0x7ff8151eb83b - <rustc_driver[29a5c9a0ba568b]::RunCompiler>::run
  33:     0x7ff60d733f2c - <unknown>
  34:     0x7ff60d731387 - <unknown>
  35:     0x7ff60d73cdaa - <unknown>
  36:     0x7ff60d7315a6 - <unknown>
  37:     0x7ff60d73299c - <unknown>
  38:     0x7ff8241784d7 - std::rt::lang_start_internal::h1ae7afc8cb06dd46
  39:     0x7ff60d73cde7 - <unknown>
  40:     0x7ff60db2f8c8 - <unknown>
  41:     0x7ff8627d7034 - BaseThreadInitThunk
  42:     0x7ff864362651 - RtlUserThreadStart

thread panicked while processing panic. aborting.
```