### PR TITLE
Use a param file when invoking rustc since the argument list can become too large

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -562,6 +562,8 @@ def construct_arguments(
 
     # Rustc arguments
     rustc_flags = ctx.actions.args()
+    rustc_flags.set_param_file_format("multiline")
+    rustc_flags.use_param_file("@%s", use_always = False)
     rustc_flags.add(crate_info.root)
     rustc_flags.add("--crate-name=" + crate_info.name)
     rustc_flags.add("--crate-type=" + crate_info.type)


### PR DESCRIPTION
Even with #1030 I still seem to experience build errors due to the argument list being too long. This change ensures that arguments are written to a param file should they exceed the maximum length on the current platform.