### PR TITLE
Allow rust toolchain repositories from custom repo rules

### DIFF
--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -157,7 +157,7 @@ __WARNING__: This rule experimental and subject to change without warning.
 Environment Variables:
 - `REPIN`: Re-pin the lockfile if set (useful for repinning deps from multiple rulesets).
 - `RULES_RUST_REPIN`: Re-pin the lockfile if set (useful for only repinning Rust deps).
-- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE`: Override URL to use to download resolver binary 
+- `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE`: Override URL to use to download resolver binary
     - for local paths use a `file://` URL.
 - `RULES_RUST_CRATE_UNIVERSE_RESOLVER_URL_OVERRIDE_SHA256`: An optional sha256 value for the binary at the override url location.
 """,
@@ -225,6 +225,13 @@ Dict of registry_name: index_url.
                 "will be replaced in the string if present."
             ),
             default = "rust_{system}_{arch}",
+        ),
+        "rust_toolchain_repository_tool_path": attr.string_dict(
+            doc = "The relative path of the tools in the repository",
+            default = {
+                "cargo": ":bin/cargo",
+                "rustc": ":bin/rustc",
+            },
         ),
         "sha256s": attr.string_dict(
             doc = "The sha256 checksum of the desired rust artifacts",

--- a/crate_universe/private/util.bzl
+++ b/crate_universe/private/util.bzl
@@ -134,8 +134,17 @@ def get_cargo_and_rustc(repository_ctx, host_triple):
     rust_toolchain_repository = rust_toolchain_repository.replace("{triple}", host_triple)
     rust_toolchain_repository = rust_toolchain_repository.replace("{arch}", arch)
 
-    cargo_path = repository_ctx.path(Label("@{}{}".format(rust_toolchain_repository, "//:bin/cargo" + extension)))
-    rustc_path = repository_ctx.path(Label("@{}{}".format(rust_toolchain_repository, "//:bin/rustc" + extension)))
+    tool_path = repository_ctx.attr.rust_toolchain_repository_tool_path
+    cargo_path = repository_ctx.path(Label("@{}//{}{}".format(
+        rust_toolchain_repository,
+        tool_path["cargo"],
+        extension,
+    )))
+    rustc_path = repository_ctx.path(Label("@{}//{}{}".format(
+        rust_toolchain_repository,
+        tool_path["rustc"],
+        extension,
+    )))
 
     return struct(
         cargo = cargo_path,


### PR DESCRIPTION
This change allows `crate_universe` to use a custom repo for the rust toolchain. I.e. suppose that `cargo` and `rustc` come from a custom repo rule and have different paths inside the repo rule (compared to the standard "upstream")

Fixes #1019