### PR TITLE
rust-analyzer: Set a library's `display_name` when consolidating crate specs

### DIFF
--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -145,6 +145,7 @@ def _create_single_crate(ctx, info):
     crate["display_name"] = crate_name
     crate["edition"] = info.crate.edition
     crate["env"] = {}
+    crate["crate_type"] = info.crate.type
 
     # Switch on external/ to determine if crates are in the workspace or remote.
     # TODO: Some folks may want to override this for vendored dependencies.

--- a/tools/rust_analyzer/BUILD.bazel
+++ b/tools/rust_analyzer/BUILD.bazel
@@ -41,6 +41,9 @@ rust_library(
 rust_test(
     name = "gen_rust_project_lib_test",
     crate = ":gen_rust_project_lib",
+    deps = [
+        "//tools/rust_analyzer/raze:itertools",
+    ],
 )
 
 rust_clippy(

--- a/tools/rust_analyzer/raze/BUILD.bazel
+++ b/tools/rust_analyzer/raze/BUILD.bazel
@@ -31,6 +31,15 @@ alias(
 )
 
 alias(
+    name = "itertools",
+    actual = "@rules_rust_tools_rust_analyzer__itertools__0_10_1//:itertools",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "log",
     actual = "@rules_rust_tools_rust_analyzer__log__0_4_14//:log",
     tags = [

--- a/tools/rust_analyzer/raze/Cargo.raze.lock
+++ b/tools/rust_analyzer/raze/Cargo.raze.lock
@@ -68,11 +68,18 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "env_logger",
+ "itertools",
  "log",
  "serde",
  "serde_json",
  "structopt",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
@@ -110,6 +117,15 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"

--- a/tools/rust_analyzer/raze/Cargo.toml
+++ b/tools/rust_analyzer/raze/Cargo.toml
@@ -14,6 +14,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
 
+[dev-dependencies]
+itertools = "0.10"
+
 [package.metadata.raze]
 genmode = "Remote"
 workspace_path = "//tools/rust_analyzer/raze"

--- a/tools/rust_analyzer/raze/crates.bzl
+++ b/tools/rust_analyzer/raze/crates.bzl
@@ -83,6 +83,16 @@ def rules_rust_tools_rust_analyzer_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "rules_rust_tools_rust_analyzer__either__1_6_1",
+        url = "https://crates.io/api/v1/crates/either/1.6.1/download",
+        type = "tar.gz",
+        sha256 = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457",
+        strip_prefix = "either-1.6.1",
+        build_file = Label("//tools/rust_analyzer/raze/remote:BUILD.either-1.6.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "rules_rust_tools_rust_analyzer__env_logger__0_9_0",
         url = "https://crates.io/api/v1/crates/env_logger/0.9.0/download",
         type = "tar.gz",
@@ -119,6 +129,16 @@ def rules_rust_tools_rust_analyzer_fetch_remote_crates():
         sha256 = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
         strip_prefix = "humantime-2.1.0",
         build_file = Label("//tools/rust_analyzer/raze/remote:BUILD.humantime-2.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_rust_tools_rust_analyzer__itertools__0_10_1",
+        url = "https://crates.io/api/v1/crates/itertools/0.10.1/download",
+        type = "tar.gz",
+        sha256 = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf",
+        strip_prefix = "itertools-0.10.1",
+        build_file = Label("//tools/rust_analyzer/raze/remote:BUILD.itertools-0.10.1.bazel"),
     )
 
     maybe(

--- a/tools/rust_analyzer/raze/remote/BUILD.either-1.6.1.bazel
+++ b/tools/rust_analyzer/raze/remote/BUILD.either-1.6.1.bazel
@@ -1,0 +1,53 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//tools/rust_analyzer/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "either",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.6.1",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)

--- a/tools/rust_analyzer/raze/remote/BUILD.itertools-0.10.1.bazel
+++ b/tools/rust_analyzer/raze/remote/BUILD.itertools-0.10.1.bazel
@@ -1,0 +1,99 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//tools/rust_analyzer/raze", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "bench1" with type "bench" omitted
+
+# Unsupported target "combinations" with type "bench" omitted
+
+# Unsupported target "combinations_with_replacement" with type "bench" omitted
+
+# Unsupported target "fold_specialization" with type "bench" omitted
+
+# Unsupported target "powerset" with type "bench" omitted
+
+# Unsupported target "tree_fold1" with type "bench" omitted
+
+# Unsupported target "tuple_combinations" with type "bench" omitted
+
+# Unsupported target "tuples" with type "bench" omitted
+
+# Unsupported target "iris" with type "example" omitted
+
+rust_library(
+    name = "itertools",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "use_alloc",
+        "use_std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.10.1",
+    # buildifier: leave-alone
+    deps = [
+        "@rules_rust_tools_rust_analyzer__either__1_6_1//:either",
+    ],
+)
+
+# Unsupported target "adaptors_no_collect" with type "test" omitted
+
+# Unsupported target "flatten_ok" with type "test" omitted
+
+# Unsupported target "fold_specialization" with type "test" omitted
+
+# Unsupported target "macros_hygiene" with type "test" omitted
+
+# Unsupported target "merge_join" with type "test" omitted
+
+# Unsupported target "peeking_take_while" with type "test" omitted
+
+# Unsupported target "quick" with type "test" omitted
+
+# Unsupported target "specializations" with type "test" omitted
+
+# Unsupported target "test_core" with type "test" omitted
+
+# Unsupported target "test_std" with type "test" omitted
+
+# Unsupported target "tuples" with type "test" omitted
+
+# Unsupported target "zip" with type "test" omitted

--- a/tools/rust_analyzer/rust_project.rs
+++ b/tools/rust_analyzer/rust_project.rs
@@ -231,6 +231,7 @@ mod tests {
                 cfg: vec!["test".into(), "debug_assertions".into()],
                 env: BTreeMap::new(),
                 target: "x86_64-unknown-linux-gnu".into(),
+                crate_type: "rlib".into(),
             }]),
         )
         .expect("expect success");
@@ -260,6 +261,7 @@ mod tests {
                     cfg: vec!["test".into(), "debug_assertions".into()],
                     env: BTreeMap::new(),
                     target: "x86_64-unknown-linux-gnu".into(),
+                    crate_type: "rlib".into(),
                 },
                 CrateSpec {
                     crate_id: "ID-dep_a".into(),
@@ -273,6 +275,7 @@ mod tests {
                     cfg: vec!["test".into(), "debug_assertions".into()],
                     env: BTreeMap::new(),
                     target: "x86_64-unknown-linux-gnu".into(),
+                    crate_type: "rlib".into(),
                 },
                 CrateSpec {
                     crate_id: "ID-dep_b".into(),
@@ -286,6 +289,7 @@ mod tests {
                     cfg: vec!["test".into(), "debug_assertions".into()],
                     env: BTreeMap::new(),
                     target: "x86_64-unknown-linux-gnu".into(),
+                    crate_type: "rlib".into(),
                 },
             ]),
         )


### PR DESCRIPTION
This PR addresses the issue https://github.com/bazelbuild/rules_rust/issues/1032.

When there were multiple build targets sharing the same source, their crate specs were consolidated into one, and their `display_name` depended on the result of aquery. Since the `display_name` is actually a target name, it caused a mismatch between the `display_name` and the actual crate name referenced by the Rust source, leading to unresolved import errors.

To eliminate the possibility of the name mismatch, this PR changes to set a library's `display_name` when consolidating crate specs. This change resolved the unresolved import errors of Rust Analyzer in [my reproduction repository of the issue](https://github.com/reiyw/rules_rust_1032_repro).