### PR TITLE
Provide CcInfo with stdlib_linkopts from rust_toolchain

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1172,7 +1172,7 @@ See @rules_rust//rust:repositories.bzl for examples of defining the @rust_cpuX r
 | <a id="rust_toolchain-rustc_srcs"></a>rustc_srcs |  The source code of rustc.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-rustfmt"></a>rustfmt |  The location of the <code>rustfmt</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-staticlib_ext"></a>staticlib_ext |  The extension for static libraries created from rustc.   | String | required |  |
-| <a id="rust_toolchain-stdlib_linkflags"></a>stdlib_linkflags |  Additional linker libs used when std lib is linked, see https://github.com/rust-lang/rust/blob/master/src/libstd/build.rs   | List of strings | required |  |
+| <a id="rust_toolchain-stdlib_linkflags"></a>stdlib_linkflags |  Additional linker flags to use when Rust std lib is linked by a C++ linker (rustc will deal with these automatically), see https://github.com/rust-lang/rust/blob/master/src/libstd/build.rs   | List of strings | required |  |
 | <a id="rust_toolchain-target_json"></a>target_json |  Override the target_triple with a custom target specification. For more details see: https://doc.rust-lang.org/rustc/targets/custom.html   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-target_triple"></a>target_triple |  The platform triple for the toolchains target environment. For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations   | String | optional | "" |
 

--- a/docs/rust_repositories.md
+++ b/docs/rust_repositories.md
@@ -102,7 +102,7 @@ See @rules_rust//rust:repositories.bzl for examples of defining the @rust_cpuX r
 | <a id="rust_toolchain-rustc_srcs"></a>rustc_srcs |  The source code of rustc.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-rustfmt"></a>rustfmt |  The location of the <code>rustfmt</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-staticlib_ext"></a>staticlib_ext |  The extension for static libraries created from rustc.   | String | required |  |
-| <a id="rust_toolchain-stdlib_linkflags"></a>stdlib_linkflags |  Additional linker libs used when std lib is linked, see https://github.com/rust-lang/rust/blob/master/src/libstd/build.rs   | List of strings | required |  |
+| <a id="rust_toolchain-stdlib_linkflags"></a>stdlib_linkflags |  Additional linker flags to use when Rust std lib is linked by a C++ linker (rustc will deal with these automatically), see https://github.com/rust-lang/rust/blob/master/src/libstd/build.rs   | List of strings | required |  |
 | <a id="rust_toolchain-target_json"></a>target_json |  Override the target_triple with a custom target specification. For more details see: https://doc.rust-lang.org/rustc/targets/custom.html   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-target_triple"></a>target_triple |  The platform triple for the toolchains target environment. For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations   | String | optional | "" |
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -877,7 +877,7 @@ def establish_cc_info(ctx, attr, crate_info, toolchain, cc_toolchain, feature_co
 
     cc_infos = [
         CcInfo(linking_context = linking_context),
-        toolchain.stdlib_linkflags_cc_info,
+        toolchain.stdlib_linkflags,
     ]
     for dep in getattr(attr, "deps", []):
         if CcInfo in dep:

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -868,7 +868,6 @@ def establish_cc_info(ctx, attr, crate_info, toolchain, cc_toolchain, feature_co
     link_input = cc_common.create_linker_input(
         owner = ctx.label,
         libraries = depset([library_to_link]),
-        user_link_flags = depset(toolchain.stdlib_linkflags),
     )
 
     linking_context = cc_common.create_linking_context(
@@ -876,7 +875,10 @@ def establish_cc_info(ctx, attr, crate_info, toolchain, cc_toolchain, feature_co
         linker_inputs = depset([link_input]),
     )
 
-    cc_infos = [CcInfo(linking_context = linking_context)]
+    cc_infos = [
+        CcInfo(linking_context = linking_context),
+        toolchain.stdlib_linkflags_cc_info,
+    ]
     for dep in getattr(attr, "deps", []):
         if CcInfo in dep:
             cc_infos.append(dep[CcInfo])

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -231,6 +231,18 @@ def _rust_toolchain_impl(ctx):
         fail("Do not specify both target_triple and target_json, either use a builtin triple or provide a custom specification file.")
 
     make_rust_providers_target_independent = ctx.attr._incompatible_make_rust_providers_target_independent[IncompatibleFlagInfo]
+    linking_context = cc_common.create_linking_context(
+        linker_inputs = depset([
+            cc_common.create_linker_input(
+                owner = ctx.label,
+                user_link_flags = depset(ctx.attr.stdlib_linkflags),
+            ),
+        ]),
+    )
+    stdlib_linkflags_cc_info = CcInfo(
+        compilation_context = cc_common.create_compilation_context(),
+        linking_context = linking_context,
+    )
 
     toolchain = platform_common.ToolchainInfo(
         rustc = ctx.file.rustc,
@@ -246,7 +258,15 @@ def _rust_toolchain_impl(ctx):
         binary_ext = ctx.attr.binary_ext,
         staticlib_ext = ctx.attr.staticlib_ext,
         dylib_ext = ctx.attr.dylib_ext,
+        # Contains linker flags needed to link Rust standard library.
+        # These need to be added to linker command lines when the linker is not rustc
+        # (rustc does this automatically). Only use these flags for direct actions and
+        # Use `stdlib_linkflags_cc_info for propagation (otherwise `stdlib_linkflags`
+        # may end up being unnecessailry duplicated).
         stdlib_linkflags = ctx.attr.stdlib_linkflags,
+        # Empty `CcInfo` whose only purpose is to provide `stdlib_linkflags` in a way
+        # that doesn't duplicate them per target providing a `CcInfo`.
+        stdlib_linkflags_cc_info = stdlib_linkflags_cc_info,
         target_triple = ctx.attr.target_triple,
         exec_triple = ctx.attr.exec_triple,
         os = ctx.attr.os,
@@ -345,7 +365,8 @@ rust_toolchain = rule(
         ),
         "stdlib_linkflags": attr.string_list(
             doc = (
-                "Additional linker libs used when std lib is linked, " +
+                "Additional linker flags to use when Rust std lib is linked by a C++ linker " +
+                "(rustc will deal with these automatically), " +
                 "see https://github.com/rust-lang/rust/blob/master/src/libstd/build.rs"
             ),
             mandatory = True,

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -260,13 +260,10 @@ def _rust_toolchain_impl(ctx):
         dylib_ext = ctx.attr.dylib_ext,
         # Contains linker flags needed to link Rust standard library.
         # These need to be added to linker command lines when the linker is not rustc
-        # (rustc does this automatically). Only use these flags for direct actions and
-        # Use `stdlib_linkflags_cc_info for propagation (otherwise `stdlib_linkflags`
-        # may end up being unnecessailry duplicated).
-        stdlib_linkflags = ctx.attr.stdlib_linkflags,
-        # Empty `CcInfo` whose only purpose is to provide `stdlib_linkflags` in a way
-        # that doesn't duplicate them per target providing a `CcInfo`.
-        stdlib_linkflags_cc_info = stdlib_linkflags_cc_info,
+        # (rustc does this automatically). Linker flags wrapped in an otherwise empty
+        # `CcInfo` to provide the flags in a way that doesn't duplicate them per target
+        # providing a `CcInfo`.
+        stdlib_linkflags = stdlib_linkflags_cc_info,
         target_triple = ctx.attr.target_triple,
         exec_triple = ctx.attr.exec_triple,
         os = ctx.attr.os,


### PR DESCRIPTION
I believe this is the most principled solution to the problem discussed in #870, #951, #955, and #1030.

The problem was that `rust_library`-like rules need to provide `CcInfo`, they need to pass `stdlib_linkflags` to the linker, and they didn't know if there was another `rust_library`-like rule that did it already, so they had to add those flags themselves.

This PR solves the problem by providing a `CcInfo` from the `rust_toolchain`. All `rust_library`-like rules can depend on this provider, and luckily, `user_link_flags` will then be expanded only once.

Closes #951, #955, #1030

If you were using the `rust_toolchain.stdlib_linkflags` field before, please replace it with `rust_toolchain.cc_info.linking_context.linker_inputs.to_list()[0].user_link_flags`.