### PR TITLE
Enhance label.rs to support implicit targets and expose absolute-ness.

### DIFF
--- a/util/label/label.rs
+++ b/util/label/label.rs
@@ -17,7 +17,7 @@ pub fn analyze(input: &'_ str) -> Result<Label<'_>> {
         (None, None) => {
             return Err(LabelError(err(
                 label,
-                "labels must have a package and/or a target.",
+                "labels must have a package and/or a name.",
             )))
         }
         (Some(package_name), None) => name_from_package(package_name),


### PR DESCRIPTION
This PR enhances the label parsing library (label.rs) to allow it to support implicit targets (e.g. `//foo/bar` has an implicit target of `bar`, and is equivalent to `//foo/bar:bar`), and to expose whether the label that was parsed was absolute (e.g. to distinguish `//foo` and `foo`).

I also reworked some of the implementation of `consume_package_name`, to make it a little more idiomatic and easier to follow (IMO).