### PR TITLE
Expose crate versions in CrateInfo

### DIFF
--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -229,6 +229,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
         toolchain = find_toolchain(ctx),
         crate_info = rust_common.create_crate_info(
             name = crate_name,
+            version = ctx.attr.version,
             type = "rlib",
             root = lib_rs,
             srcs = depset(srcs),

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -23,6 +23,7 @@ CrateInfo = provider(
         "edition": "str: The edition of this crate.",
         "is_test": "bool: If the crate is being compiled in a test context",
         "name": "str: The name of this crate.",
+        "version": "str: The version of this crate.",
         "output": "File: The output File that will be produced, depends on crate type.",
         "owner": "Label: The label of the target that produced this CrateInfo",
         "proc_macro_deps": "depset[DepVariantInfo|Target]: This crate's rust proc_macro dependencies' providers.",

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -261,6 +261,7 @@ def _rust_library_common(ctx, crate_type):
         toolchain = toolchain,
         crate_info = rust_common.create_crate_info(
             name = crate_name,
+            version = ctx.attr.version,
             type = crate_type,
             root = crate_root,
             srcs = depset(ctx.files.srcs),
@@ -302,6 +303,7 @@ def _rust_binary_impl(ctx):
         toolchain = toolchain,
         crate_info = rust_common.create_crate_info(
             name = crate_name,
+            version = ctx.attr.version,
             type = ctx.attr.crate_type,
             root = crate_root_src(ctx.attr, ctx.files.srcs, ctx.attr.crate_type),
             srcs = depset(ctx.files.srcs),
@@ -426,6 +428,7 @@ def _rust_test_common(ctx, toolchain, output):
         # Build the test binary using the dependency's srcs.
         crate_info = rust_common.create_crate_info(
             name = crate_name,
+            version = ctx.attr.version,
             type = crate_type,
             root = crate.root,
             srcs = depset(ctx.files.srcs, transitive = [crate.srcs]),
@@ -444,6 +447,7 @@ def _rust_test_common(ctx, toolchain, output):
         # Target is a standalone crate. Build the test binary as its own crate.
         crate_info = rust_common.create_crate_info(
             name = crate_name,
+            version = ctx.attr.version,
             type = crate_type,
             root = crate_root_src(ctx.attr, ctx.files.srcs, "lib"),
             srcs = depset(ctx.files.srcs),


### PR DESCRIPTION
We're trying to automatically collect crates.io dependencies (exposed with the help of `cargo raze`) of a `rust_library` target (see vaticle/bazel-distribution#323 for exact context)

While names of those crates are available by reading `target[CrateInfo].name`, versions were not. In order to help address this, we're extending `CrateInfo` provider to also contain `version` field