### PR TITLE
toolchain: support location expansion for stdlib_linkflags

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1403,8 +1403,8 @@ A provider containing information about a Crate's dependencies.
 ## StdLibInfo
 
 <pre>
-StdLibInfo(<a href="#StdLibInfo-all_targets">all_targets</a>, <a href="#StdLibInfo-alloc_files">alloc_files</a>, <a href="#StdLibInfo-between_alloc_and_core_files">between_alloc_and_core_files</a>, <a href="#StdLibInfo-between_core_and_std_files">between_core_and_std_files</a>,
-           <a href="#StdLibInfo-core_files">core_files</a>, <a href="#StdLibInfo-dot_a_files">dot_a_files</a>, <a href="#StdLibInfo-self_contained_files">self_contained_files</a>, <a href="#StdLibInfo-std_files">std_files</a>, <a href="#StdLibInfo-std_rlibs">std_rlibs</a>)
+StdLibInfo(<a href="#StdLibInfo-alloc_files">alloc_files</a>, <a href="#StdLibInfo-between_alloc_and_core_files">between_alloc_and_core_files</a>, <a href="#StdLibInfo-between_core_and_std_files">between_core_and_std_files</a>, <a href="#StdLibInfo-core_files">core_files</a>,
+           <a href="#StdLibInfo-dot_a_files">dot_a_files</a>, <a href="#StdLibInfo-self_contained_files">self_contained_files</a>, <a href="#StdLibInfo-srcs">srcs</a>, <a href="#StdLibInfo-std_files">std_files</a>, <a href="#StdLibInfo-std_rlibs">std_rlibs</a>)
 </pre>
 
 A collection of files either found within the `rust-stdlib` artifact or generated based on existing files.
@@ -1414,13 +1414,13 @@ A collection of files either found within the `rust-stdlib` artifact or generate
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="StdLibInfo-all_targets"></a>all_targets |  List[Target]: All targets from the original <code>srcs</code> attribute.    |
 | <a id="StdLibInfo-alloc_files"></a>alloc_files |  List[File]: <code>.a</code> files related to the <code>alloc</code> module.    |
 | <a id="StdLibInfo-between_alloc_and_core_files"></a>between_alloc_and_core_files |  List[File]: <code>.a</code> files related to the <code>compiler_builtins</code> module.    |
 | <a id="StdLibInfo-between_core_and_std_files"></a>between_core_and_std_files |  List[File]: <code>.a</code> files related to all modules except <code>adler</code>, <code>alloc</code>, <code>compiler_builtins</code>, <code>core</code>, and <code>std</code>.    |
 | <a id="StdLibInfo-core_files"></a>core_files |  List[File]: <code>.a</code> files related to the <code>core</code> and <code>adler</code> modules    |
 | <a id="StdLibInfo-dot_a_files"></a>dot_a_files |  Depset[File]: Generated <code>.a</code> files    |
 | <a id="StdLibInfo-self_contained_files"></a>self_contained_files |  List[File]: All <code>.o</code> files from the <code>self-contained</code> directory.    |
+| <a id="StdLibInfo-srcs"></a>srcs |  List[Target]: All targets from the original <code>srcs</code> attribute.    |
 | <a id="StdLibInfo-std_files"></a>std_files |  Depset[File]: <code>.a</code> files associated with the <code>std</code> module.    |
 | <a id="StdLibInfo-std_rlibs"></a>std_rlibs |  List[File]: All <code>.rlib</code> files    |
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1174,7 +1174,7 @@ See @rules_rust//rust:repositories.bzl for examples of defining the @rust_cpuX r
 | <a id="rust_toolchain-rustc_srcs"></a>rustc_srcs |  The source code of rustc.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-rustfmt"></a>rustfmt |  The location of the <code>rustfmt</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-staticlib_ext"></a>staticlib_ext |  The extension for static libraries created from rustc.   | String | required |  |
-| <a id="rust_toolchain-stdlib_linkflags"></a>stdlib_linkflags |  Additional linker flags to use when Rust std lib is linked by a C++ linker (rustc will deal with these automatically), see https://github.com/rust-lang/rust/blob/master/src/libstd/build.rs   | List of strings | required |  |
+| <a id="rust_toolchain-stdlib_linkflags"></a>stdlib_linkflags |  Additional linker flags to use when Rust std lib is linked by a C++ linker (rustc will deal with these automatically). Subject to location expansion with respect to the srcs of the rust_lib attribute.   | List of strings | required |  |
 | <a id="rust_toolchain-target_json"></a>target_json |  Override the target_triple with a custom target specification. For more details see: https://doc.rust-lang.org/rustc/targets/custom.html   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-target_triple"></a>target_triple |  The platform triple for the toolchains target environment. For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations   | String | optional | "" |
 
@@ -1403,8 +1403,8 @@ A provider containing information about a Crate's dependencies.
 ## StdLibInfo
 
 <pre>
-StdLibInfo(<a href="#StdLibInfo-alloc_files">alloc_files</a>, <a href="#StdLibInfo-between_alloc_and_core_files">between_alloc_and_core_files</a>, <a href="#StdLibInfo-between_core_and_std_files">between_core_and_std_files</a>, <a href="#StdLibInfo-core_files">core_files</a>,
-           <a href="#StdLibInfo-dot_a_files">dot_a_files</a>, <a href="#StdLibInfo-self_contained_files">self_contained_files</a>, <a href="#StdLibInfo-srcs">srcs</a>, <a href="#StdLibInfo-std_files">std_files</a>, <a href="#StdLibInfo-std_rlibs">std_rlibs</a>)
+StdLibInfo(<a href="#StdLibInfo-all_targets">all_targets</a>, <a href="#StdLibInfo-alloc_files">alloc_files</a>, <a href="#StdLibInfo-between_alloc_and_core_files">between_alloc_and_core_files</a>, <a href="#StdLibInfo-between_core_and_std_files">between_core_and_std_files</a>,
+           <a href="#StdLibInfo-core_files">core_files</a>, <a href="#StdLibInfo-dot_a_files">dot_a_files</a>, <a href="#StdLibInfo-self_contained_files">self_contained_files</a>, <a href="#StdLibInfo-std_files">std_files</a>, <a href="#StdLibInfo-std_rlibs">std_rlibs</a>)
 </pre>
 
 A collection of files either found within the `rust-stdlib` artifact or generated based on existing files.
@@ -1414,13 +1414,13 @@ A collection of files either found within the `rust-stdlib` artifact or generate
 
 | Name  | Description |
 | :------------- | :------------- |
+| <a id="StdLibInfo-all_targets"></a>all_targets |  List[Target]: All targets from the original <code>srcs</code> attribute.    |
 | <a id="StdLibInfo-alloc_files"></a>alloc_files |  List[File]: <code>.a</code> files related to the <code>alloc</code> module.    |
 | <a id="StdLibInfo-between_alloc_and_core_files"></a>between_alloc_and_core_files |  List[File]: <code>.a</code> files related to the <code>compiler_builtins</code> module.    |
 | <a id="StdLibInfo-between_core_and_std_files"></a>between_core_and_std_files |  List[File]: <code>.a</code> files related to all modules except <code>adler</code>, <code>alloc</code>, <code>compiler_builtins</code>, <code>core</code>, and <code>std</code>.    |
 | <a id="StdLibInfo-core_files"></a>core_files |  List[File]: <code>.a</code> files related to the <code>core</code> and <code>adler</code> modules    |
 | <a id="StdLibInfo-dot_a_files"></a>dot_a_files |  Depset[File]: Generated <code>.a</code> files    |
 | <a id="StdLibInfo-self_contained_files"></a>self_contained_files |  List[File]: All <code>.o</code> files from the <code>self-contained</code> directory.    |
-| <a id="StdLibInfo-srcs"></a>srcs |  List[Target]: The original <code>src</code> attribute.    |
 | <a id="StdLibInfo-std_files"></a>std_files |  Depset[File]: <code>.a</code> files associated with the <code>std</code> module.    |
 | <a id="StdLibInfo-std_rlibs"></a>std_rlibs |  List[File]: All <code>.rlib</code> files    |
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -66,8 +66,8 @@ A provider containing information about a Crate's dependencies.
 ## StdLibInfo
 
 <pre>
-StdLibInfo(<a href="#StdLibInfo-all_targets">all_targets</a>, <a href="#StdLibInfo-alloc_files">alloc_files</a>, <a href="#StdLibInfo-between_alloc_and_core_files">between_alloc_and_core_files</a>, <a href="#StdLibInfo-between_core_and_std_files">between_core_and_std_files</a>,
-           <a href="#StdLibInfo-core_files">core_files</a>, <a href="#StdLibInfo-dot_a_files">dot_a_files</a>, <a href="#StdLibInfo-self_contained_files">self_contained_files</a>, <a href="#StdLibInfo-std_files">std_files</a>, <a href="#StdLibInfo-std_rlibs">std_rlibs</a>)
+StdLibInfo(<a href="#StdLibInfo-alloc_files">alloc_files</a>, <a href="#StdLibInfo-between_alloc_and_core_files">between_alloc_and_core_files</a>, <a href="#StdLibInfo-between_core_and_std_files">between_core_and_std_files</a>, <a href="#StdLibInfo-core_files">core_files</a>,
+           <a href="#StdLibInfo-dot_a_files">dot_a_files</a>, <a href="#StdLibInfo-self_contained_files">self_contained_files</a>, <a href="#StdLibInfo-srcs">srcs</a>, <a href="#StdLibInfo-std_files">std_files</a>, <a href="#StdLibInfo-std_rlibs">std_rlibs</a>)
 </pre>
 
 A collection of files either found within the `rust-stdlib` artifact or generated based on existing files.
@@ -77,13 +77,13 @@ A collection of files either found within the `rust-stdlib` artifact or generate
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="StdLibInfo-all_targets"></a>all_targets |  List[Target]: All targets from the original <code>srcs</code> attribute.    |
 | <a id="StdLibInfo-alloc_files"></a>alloc_files |  List[File]: <code>.a</code> files related to the <code>alloc</code> module.    |
 | <a id="StdLibInfo-between_alloc_and_core_files"></a>between_alloc_and_core_files |  List[File]: <code>.a</code> files related to the <code>compiler_builtins</code> module.    |
 | <a id="StdLibInfo-between_core_and_std_files"></a>between_core_and_std_files |  List[File]: <code>.a</code> files related to all modules except <code>adler</code>, <code>alloc</code>, <code>compiler_builtins</code>, <code>core</code>, and <code>std</code>.    |
 | <a id="StdLibInfo-core_files"></a>core_files |  List[File]: <code>.a</code> files related to the <code>core</code> and <code>adler</code> modules    |
 | <a id="StdLibInfo-dot_a_files"></a>dot_a_files |  Depset[File]: Generated <code>.a</code> files    |
 | <a id="StdLibInfo-self_contained_files"></a>self_contained_files |  List[File]: All <code>.o</code> files from the <code>self-contained</code> directory.    |
+| <a id="StdLibInfo-srcs"></a>srcs |  List[Target]: All targets from the original <code>srcs</code> attribute.    |
 | <a id="StdLibInfo-std_files"></a>std_files |  Depset[File]: <code>.a</code> files associated with the <code>std</code> module.    |
 | <a id="StdLibInfo-std_rlibs"></a>std_rlibs |  List[File]: All <code>.rlib</code> files    |
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -66,8 +66,8 @@ A provider containing information about a Crate's dependencies.
 ## StdLibInfo
 
 <pre>
-StdLibInfo(<a href="#StdLibInfo-alloc_files">alloc_files</a>, <a href="#StdLibInfo-between_alloc_and_core_files">between_alloc_and_core_files</a>, <a href="#StdLibInfo-between_core_and_std_files">between_core_and_std_files</a>, <a href="#StdLibInfo-core_files">core_files</a>,
-           <a href="#StdLibInfo-dot_a_files">dot_a_files</a>, <a href="#StdLibInfo-self_contained_files">self_contained_files</a>, <a href="#StdLibInfo-srcs">srcs</a>, <a href="#StdLibInfo-std_files">std_files</a>, <a href="#StdLibInfo-std_rlibs">std_rlibs</a>)
+StdLibInfo(<a href="#StdLibInfo-all_targets">all_targets</a>, <a href="#StdLibInfo-alloc_files">alloc_files</a>, <a href="#StdLibInfo-between_alloc_and_core_files">between_alloc_and_core_files</a>, <a href="#StdLibInfo-between_core_and_std_files">between_core_and_std_files</a>,
+           <a href="#StdLibInfo-core_files">core_files</a>, <a href="#StdLibInfo-dot_a_files">dot_a_files</a>, <a href="#StdLibInfo-self_contained_files">self_contained_files</a>, <a href="#StdLibInfo-std_files">std_files</a>, <a href="#StdLibInfo-std_rlibs">std_rlibs</a>)
 </pre>
 
 A collection of files either found within the `rust-stdlib` artifact or generated based on existing files.
@@ -77,13 +77,13 @@ A collection of files either found within the `rust-stdlib` artifact or generate
 
 | Name  | Description |
 | :------------- | :------------- |
+| <a id="StdLibInfo-all_targets"></a>all_targets |  List[Target]: All targets from the original <code>srcs</code> attribute.    |
 | <a id="StdLibInfo-alloc_files"></a>alloc_files |  List[File]: <code>.a</code> files related to the <code>alloc</code> module.    |
 | <a id="StdLibInfo-between_alloc_and_core_files"></a>between_alloc_and_core_files |  List[File]: <code>.a</code> files related to the <code>compiler_builtins</code> module.    |
 | <a id="StdLibInfo-between_core_and_std_files"></a>between_core_and_std_files |  List[File]: <code>.a</code> files related to all modules except <code>adler</code>, <code>alloc</code>, <code>compiler_builtins</code>, <code>core</code>, and <code>std</code>.    |
 | <a id="StdLibInfo-core_files"></a>core_files |  List[File]: <code>.a</code> files related to the <code>core</code> and <code>adler</code> modules    |
 | <a id="StdLibInfo-dot_a_files"></a>dot_a_files |  Depset[File]: Generated <code>.a</code> files    |
 | <a id="StdLibInfo-self_contained_files"></a>self_contained_files |  List[File]: All <code>.o</code> files from the <code>self-contained</code> directory.    |
-| <a id="StdLibInfo-srcs"></a>srcs |  List[Target]: The original <code>src</code> attribute.    |
 | <a id="StdLibInfo-std_files"></a>std_files |  Depset[File]: <code>.a</code> files associated with the <code>std</code> module.    |
 | <a id="StdLibInfo-std_rlibs"></a>std_rlibs |  List[File]: All <code>.rlib</code> files    |
 

--- a/docs/rust_repositories.md
+++ b/docs/rust_repositories.md
@@ -102,7 +102,7 @@ See @rules_rust//rust:repositories.bzl for examples of defining the @rust_cpuX r
 | <a id="rust_toolchain-rustc_srcs"></a>rustc_srcs |  The source code of rustc.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-rustfmt"></a>rustfmt |  The location of the <code>rustfmt</code> binary. Can be a direct source or a filegroup containing one item.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-staticlib_ext"></a>staticlib_ext |  The extension for static libraries created from rustc.   | String | required |  |
-| <a id="rust_toolchain-stdlib_linkflags"></a>stdlib_linkflags |  Additional linker flags to use when Rust std lib is linked by a C++ linker (rustc will deal with these automatically), see https://github.com/rust-lang/rust/blob/master/src/libstd/build.rs   | List of strings | required |  |
+| <a id="rust_toolchain-stdlib_linkflags"></a>stdlib_linkflags |  Additional linker flags to use when Rust std lib is linked by a C++ linker (rustc will deal with these automatically). Subject to location expansion with respect to the srcs of the rust_lib attribute.   | List of strings | required |  |
 | <a id="rust_toolchain-target_json"></a>target_json |  Override the target_triple with a custom target specification. For more details see: https://doc.rust-lang.org/rustc/targets/custom.html   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_toolchain-target_triple"></a>target_triple |  The platform triple for the toolchains target environment. For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations   | String | optional | "" |
 

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -82,13 +82,13 @@ StdLibInfo = provider(
         "generated based on existing files."
     ),
     fields = {
-        "all_targets": "List[Target]: All targets from the original `srcs` attribute.",
         "alloc_files": "List[File]: `.a` files related to the `alloc` module.",
         "between_alloc_and_core_files": "List[File]: `.a` files related to the `compiler_builtins` module.",
         "between_core_and_std_files": "List[File]: `.a` files related to all modules except `adler`, `alloc`, `compiler_builtins`, `core`, and `std`.",
         "core_files": "List[File]: `.a` files related to the `core` and `adler` modules",
         "dot_a_files": "Depset[File]: Generated `.a` files",
         "self_contained_files": "List[File]: All `.o` files from the `self-contained` directory.",
+        "srcs": "List[Target]: All targets from the original `srcs` attribute.",
         "std_files": "Depset[File]: `.a` files associated with the `std` module.",
         "std_rlibs": "List[File]: All `.rlib` files",
     },

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -82,13 +82,13 @@ StdLibInfo = provider(
         "generated based on existing files."
     ),
     fields = {
+        "all_targets": "List[Target]: All targets from the original `srcs` attribute.",
         "alloc_files": "List[File]: `.a` files related to the `alloc` module.",
         "between_alloc_and_core_files": "List[File]: `.a` files related to the `compiler_builtins` module.",
         "between_core_and_std_files": "List[File]: `.a` files related to all modules except `adler`, `alloc`, `compiler_builtins`, `core`, and `std`.",
         "core_files": "List[File]: `.a` files related to the `core` and `adler` modules",
         "dot_a_files": "Depset[File]: Generated `.a` files",
         "self_contained_files": "List[File]: All `.o` files from the `self-contained` directory.",
-        "all_targets": "List[Target]: All targets from the original `srcs` attribute.",
         "std_files": "Depset[File]: `.a` files associated with the `std` module.",
         "std_rlibs": "List[File]: All `.rlib` files",
     },

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -88,7 +88,7 @@ StdLibInfo = provider(
         "core_files": "List[File]: `.a` files related to the `core` and `adler` modules",
         "dot_a_files": "Depset[File]: Generated `.a` files",
         "self_contained_files": "List[File]: All `.o` files from the `self-contained` directory.",
-        "srcs": "List[Target]: The original `src` attribute.",
+        "all_targets": "List[Target]: All targets from the original `srcs` attribute.",
         "std_files": "Depset[File]: `.a` files associated with the `std` module.",
         "std_rlibs": "List[File]: All `.rlib` files",
     },

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -60,6 +60,7 @@ def _rust_stdlib_filegroup_impl(ctx):
             std_files = std_files,
             alloc_files = alloc_files,
             self_contained_files = self_contained_files,
+            all_targets = ctx.attr.srcs,
         ),
     ]
 
@@ -231,11 +232,21 @@ def _rust_toolchain_impl(ctx):
         fail("Do not specify both target_triple and target_json, either use a builtin triple or provide a custom specification file.")
 
     make_rust_providers_target_independent = ctx.attr._incompatible_make_rust_providers_target_independent[IncompatibleFlagInfo]
+
+    expanded_stdlib_linkflags = []
+    for flag in ctx.attr.stdlib_linkflags:
+        expanded_stdlib_linkflags.append(
+            ctx.expand_location(
+                flag,
+                targets = ctx.attr.rust_lib[rust_common.stdlib_info].all_targets,
+            ),
+        )
+
     linking_context = cc_common.create_linking_context(
         linker_inputs = depset([
             cc_common.create_linker_input(
                 owner = ctx.label,
-                user_link_flags = depset(ctx.attr.stdlib_linkflags),
+                user_link_flags = depset(expanded_stdlib_linkflags),
             ),
         ]),
     )
@@ -363,8 +374,8 @@ rust_toolchain = rule(
         "stdlib_linkflags": attr.string_list(
             doc = (
                 "Additional linker flags to use when Rust std lib is linked by a C++ linker " +
-                "(rustc will deal with these automatically), " +
-                "see https://github.com/rust-lang/rust/blob/master/src/libstd/build.rs"
+                "(rustc will deal with these automatically). " +
+                "Subject to location expansion with respect to the srcs of the rust_lib attribute."
             ),
             mandatory = True,
         ),

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -60,7 +60,7 @@ def _rust_stdlib_filegroup_impl(ctx):
             std_files = std_files,
             alloc_files = alloc_files,
             self_contained_files = self_contained_files,
-            all_targets = ctx.attr.srcs,
+            srcs = ctx.attr.srcs,
         ),
     ]
 
@@ -238,7 +238,7 @@ def _rust_toolchain_impl(ctx):
         expanded_stdlib_linkflags.append(
             ctx.expand_location(
                 flag,
-                targets = ctx.attr.rust_lib[rust_common.stdlib_info].all_targets,
+                targets = ctx.attr.rust_lib[rust_common.stdlib_info].srcs,
             ),
         )
 

--- a/test/unit/toolchain/config.txt
+++ b/test/unit/toolchain/config.txt
@@ -1,0 +1,1 @@
+a source of the stdlib


### PR DESCRIPTION
This adds location expansion of stdlib_linkflags with respect to the
rust_lib attribute. This allows us to, e.g., have a linker flag that
refers to a native dependency target label declared in rust_lib.