### PR TITLE
Add specific Bazel version for rbe_ubuntu1604_with_aspects job

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -65,6 +65,7 @@ tasks:
       - "-//test/incompatible_changes/..."
       - "-//test/conflicting_deps:conflicting_deps_test"
     build_flags: *aspects_flags
+    bazel: "4.2.2"
   rbe_ubuntu1604_rolling_with_aspects:
     name: RBE Rolling Bazel Version With Aspects
     platform: rbe_ubuntu1604

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -34,6 +34,7 @@ tasks:
       - "//test/..."
       - "-//test/conflicting_deps:conflicting_deps_test"
       - "-//test/incompatible_changes/..."
+    bazel: "4.2.2"      
   macos:
     build_targets: *default_macos_targets
     test_targets: *default_macos_targets


### PR DESCRIPTION
This change will disable `rbe_ubuntu1604` and `rbe_ubuntu1604_with_aspects` in Bazel's downstream pipeline because they don't work with Bazel@HEAD yet, just like the `rbe_ubuntu1604_rolling_with_aspects` job.

Feel free to rollback this when it's fixed.

https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2268#1835c44f-e39c-4a6c-a31f-d9566f8c5ff6
```
(04:08:25) INFO: Invocation ID: be911914-634f-4535-86c6-dd3b95f6f5c6
(04:08:25) INFO: Reading 'startup' options from /var/lib/buildkite-agent/builds/bk-docker-2gzn/bazel-downstream-projects/rules_rust/.bazelrc: --windows_enable_symlinks
(04:08:25) INFO: Options provided by the client:
  Inherited 'common' options: --isatty=1 --terminal_columns=0
(04:08:25) INFO: Found applicable config definition build:rustfmt in file /var/lib/buildkite-agent/builds/bk-docker-2gzn/bazel-downstream-projects/rules_rust/.bazelrc: --aspects=//rust:defs.bzl%rustfmt_aspect --output_groups=+rustfmt_checks
(04:08:25) INFO: Found applicable config definition build:clippy in file /var/lib/buildkite-agent/builds/bk-docker-2gzn/bazel-downstream-projects/rules_rust/.bazelrc: --aspects=//rust:defs.bzl%rust_clippy_aspect --output_groups=+clippy_checks
(04:08:25) INFO: Current date is 2021-12-01
(04:08:26) INFO: Repository buildkite_config instantiated at:
  /var/lib/buildkite-agent/builds/bk-docker-2gzn/bazel-downstream-projects/rules_rust/WORKSPACE.bazel:49:14: in <toplevel>
Repository rule rbe_preconfig defined at:
  /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/bazelci_rules/rbe_repo.bzl:71:32: in <toplevel>
(04:08:26) DEBUG: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/bazelci_rules/rbe_repo.bzl:35:14:
rbe_preconfig: Unsupported version 'UNKNOWN' (Values: '5.0.0-pre.20211011.2', '4.2.2', '4.2.2rc1', '4.2.1', '4.2.0', '4.1.0', '4.0.0'), using '5.0.0-pre.20211011.2'.
(04:08:26) ERROR: An error occurred during the fetch of repository 'buildkite_config':
   Traceback (most recent call last):
	File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/bazelci_rules/rbe_repo.bzl", line 64, column 13, in _rbe_preconfig_impl
		fail("\nrbe_preconfig: Unsupported toolchain '{}' (Values: {}).\n".format(toolchain_name, _available_toolchain_names(manifest)))
Error in fail:
rbe_preconfig: Unsupported toolchain 'ubuntu1604-bazel-java8' (Values: 'ubuntu1804-bazel-java11', 'ubuntu1804-java11', 'ubuntu2004-bazel-java11', 'ubuntu2004-java11').
(04:08:26) ERROR: /var/lib/buildkite-agent/builds/bk-docker-2gzn/bazel-downstream-projects/rules_rust/WORKSPACE.bazel:49:14: fetching rbe_preconfig rule //external:buildkite_config: Traceback (most recent call last):
	File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/bazelci_rules/rbe_repo.bzl", line 64, column 13, in _rbe_preconfig_impl
		fail("\nrbe_preconfig: Unsupported toolchain '{}' (Values: {}).\n".format(toolchain_name, _available_toolchain_names(manifest)))
Error in fail:
rbe_preconfig: Unsupported toolchain 'ubuntu1604-bazel-java8' (Values: 'ubuntu1804-bazel-java11', 'ubuntu1804-java11', 'ubuntu2004-bazel-java11', 'ubuntu2004-java11').
(04:08:26) INFO: Repository rules_rust_proto__grpc_compiler__0_6_2 instantiated at:
  /var/lib/buildkite-agent/builds/bk-docker-2gzn/bazel-downstream-projects/rules_rust/WORKSPACE.bazel:9:24: in <toplevel>
  /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/rules_rust/proto/repositories.bzl:55:41: in rust_proto_repositories
  /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/rules_rust/proto/raze/crates.bzl:184:10: in rules_rust_proto_fetch_remote_crates
  /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/bazel_tools/tools/build_defs/repo/utils.bzl:233:18: in maybe
Repository rule http_archive defined at:
  /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/bazel_tools/tools/build_defs/repo/http.bzl:364:31: in <toplevel>
(04:08:26) INFO: Repository rules_rust_proto__protobuf_codegen__2_8_2 instantiated at:
  /var/lib/buildkite-agent/builds/bk-docker-2gzn/bazel-downstream-projects/rules_rust/WORKSPACE.bazel:9:24: in <toplevel>
  /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/rules_rust/proto/repositories.bzl:55:41: in rust_proto_repositories
  /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/rules_rust/proto/raze/crates.bzl:390:10: in rules_rust_proto_fetch_remote_crates
  /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/bazel_tools/tools/build_defs/repo/utils.bzl:233:18: in maybe
Repository rule http_archive defined at:
  /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/771876ff452e5e87acebd1b92db61189/external/bazel_tools/tools/build_defs/repo/http.bzl:364:31: in <toplevel>
(04:08:26) ERROR: /var/lib/buildkite-agent/builds/bk-docker-2gzn/bazel-downstream-projects/rules_rust/rust/platform/BUILD.bazel:6:24: While resolving toolchains for target //rust/platform:unix_3: com.google.devtools.build.lib.packages.RepositoryFetchException: no such package '@buildkite_config//config':
rbe_preconfig: Unsupported toolchain 'ubuntu1604-bazel-java8' (Values: 'ubuntu1804-bazel-java11', 'ubuntu1804-java11', 'ubuntu2004-bazel-java11', 'ubuntu2004-java11').
(04:08:26) ERROR: Analysis of target '//rust/platform:unix_3' failed; build aborted:
(04:08:26) INFO: Elapsed time: 1.478s
(04:08:26) INFO: 0 processes.
(04:08:26) FAILED: Build did NOT complete successfully (99 packages loaded, 16 targets configured)
    Fetching https://crates.io/api/v1/crates/grpc-compiler/0.6.2/download
    Fetching https://crates.io/api/v1/crates/protobuf-codegen/2.8.2/download
bazel build failed with exit code 1
🚨 Error: The command exited with status 1
```