### PR TITLE
Support `cargo:rustc-link-arg=FLAG` instruction in build script runner

### DIFF
--- a/cargo/cargo_build_script_runner/lib.rs
+++ b/cargo/cargo_build_script_runner/lib.rs
@@ -34,6 +34,8 @@ pub enum BuildScriptOutput {
     Cfg(String),
     /// cargo:rustc-flags
     Flags(String),
+    /// cargo:rustc-link-arg
+    LinkArg(String),
     /// cargo:rustc-env
     Env(String),
     /// cargo:VAR=VALUE
@@ -59,11 +61,13 @@ impl BuildScriptOutput {
             // Not a cargo directive.
             return None;
         }
+
         match key_split[1] {
             "rustc-link-lib" => Some(BuildScriptOutput::LinkLib(param)),
             "rustc-link-search" => Some(BuildScriptOutput::LinkSearch(param)),
             "rustc-cfg" => Some(BuildScriptOutput::Cfg(param)),
             "rustc-flags" => Some(BuildScriptOutput::Flags(param)),
+            "rustc-link-arg" => Some(BuildScriptOutput::LinkArg(param)),
             "rustc-env" => Some(BuildScriptOutput::Env(param)),
             "rerun-if-changed" | "rerun-if-env-changed" =>
             // Ignored because Bazel will re-run if those change all the time.
@@ -74,8 +78,10 @@ impl BuildScriptOutput {
                 eprint!("Build Script Warning: {}", split[1]);
                 None
             }
-            "rustc-cdylib-link-arg" => {
+            "rustc-cdylib-link-arg" | "rustc-link-arg-bin" | "rustc-link-arg-bins" => {
                 // cargo:rustc-cdylib-link-arg=FLAG — Passes custom flags to a linker for cdylib crates.
+                // cargo:rustc-link-arg-bin=BIN=FLAG – Passes custom flags to a linker for the binary BIN.
+                // cargo:rustc-link-arg-bins=FLAG – Passes custom flags to a linker for binaries.
                 eprint!(
                     "Warning: build script returned unsupported directive `{}`",
                     split[0]
@@ -170,6 +176,7 @@ impl BuildScriptOutput {
             match flag {
                 BuildScriptOutput::Cfg(e) => compile_flags.push(format!("--cfg={}", e)),
                 BuildScriptOutput::Flags(e) => compile_flags.push(e.to_owned()),
+                BuildScriptOutput::LinkArg(e) => compile_flags.push(format!("-Clink-arg={}", e)),
                 BuildScriptOutput::LinkLib(e) => link_flags.push(format!("-l{}", e)),
                 BuildScriptOutput::LinkSearch(e) => link_flags.push(format!("-L{}", e)),
                 _ => {}
@@ -219,11 +226,13 @@ cargo:version=123
 cargo:version_number=1010107f
 cargo:include_path=/some/absolute/path/include
 cargo:rustc-env=SOME_PATH=/some/absolute/path/beep
+cargo:rustc-link-arg=-weak_framework
+cargo:rustc-link-arg=Metal
 ",
         );
         let reader = BufReader::new(buff);
         let result = BuildScriptOutput::outputs_from_reader(reader);
-        assert_eq!(result.len(), 10);
+        assert_eq!(result.len(), 12);
         assert_eq!(result[0], BuildScriptOutput::LinkLib("sdfsdf".to_owned()));
         assert_eq!(result[1], BuildScriptOutput::Env("FOO=BAR".to_owned()));
         assert_eq!(
@@ -248,6 +257,11 @@ cargo:rustc-env=SOME_PATH=/some/absolute/path/beep
             result[9],
             BuildScriptOutput::Env("SOME_PATH=/some/absolute/path/beep".to_owned())
         );
+        assert_eq!(
+            result[10],
+            BuildScriptOutput::LinkArg("-weak_framework".to_owned())
+        );
+        assert_eq!(result[11], BuildScriptOutput::LinkArg("Metal".to_owned()));
 
         assert_eq!(
             BuildScriptOutput::outputs_to_dep_env(&result, "ssh2", "/some/absolute/path"),
@@ -262,7 +276,9 @@ cargo:rustc-env=SOME_PATH=/some/absolute/path/beep
             CompileAndLinkFlags {
                 // -Lblah was output as a rustc-flags, so even though it probably _should_ be a link
                 // flag, we don't treat it like one.
-                compile_flags: "-Lblah\n--cfg=feature=awesome".to_owned(),
+                compile_flags:
+                    "-Lblah\n--cfg=feature=awesome\n-Clink-arg=-weak_framework\n-Clink-arg=Metal"
+                        .to_owned(),
                 link_flags: "-lsdfsdf\n-L${pwd}/bleh".to_owned(),
             }
         );


### PR DESCRIPTION
Cargo 1.50 added support for `cargo:rustc-link-arg` and `cargo:rust-link-arg-bins` instructions in build script output (`rustc-cdylib-link-arg` has been supported since 1.35 and `cargo:rustc-link-arg-bin` was later added in 1.54).

The build script runner currently prints a warning when `rustc-cdylib-link-arg` is used but entirely ignores the other ones (likely setting them as `BuildScriptOutput::DepEnv` since this is the default branch).

This patch adds support for the `cargo:rustc-link-arg` instruction and prints an warning when `cargo:rust-link-arg-bins` and `cargo:rust-link-arg-bin` are used, just like `rustc-cdylib-link-arg`.

Note that `cargo:rustc-link-arg` is important because `cargo` errors when `cargo:rustc-flags` is used for anything that isn't a `-l` or `-L` flag (nb: this is enforced by cargo so it'd work with Bazel). There are cases (such as linking a `-weak_framework` or `-weak_library` on macos) that cannot use `cargo:rustc-link-lib` and passing a custom `-Clink-arg` is required)

I think that we should also support `cargo:rust-link-arg-bins`, `rustc-cdylib-link-arg` and `cargo:rustc-link-arg-bin` but that's a bigger task since it requires knowing the crate type the build output will apply to. I've made issue https://github.com/bazelbuild/rules_rust/issues/1062 for it.

Ref: https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script