### PR TITLE
cargo_build_script: Populate LD and LDFLAGS

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -92,8 +92,10 @@ def _build_script_impl(ctx):
     # Pull in env vars which may be required for the cc_toolchain to work (e.g. on OSX, the SDK version).
     # We hope that the linker env is sufficient for the whole cc_toolchain.
     cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
-    _, _, linker_env = get_linker_and_args(ctx, ctx.attr, cc_toolchain, feature_configuration, None)
+    linker, link_args, linker_env = get_linker_and_args(ctx, ctx.attr, cc_toolchain, feature_configuration, None)
     env.update(**linker_env)
+    env["LD"] = linker
+    env["LDFLAGS"] = " ".join(link_args)
 
     # MSVC requires INCLUDE to be set
     cc_env = get_cc_compile_env(cc_toolchain, feature_configuration)

--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -110,6 +110,10 @@ fn run_buildrs() -> Result<(), String> {
         }
     }
 
+    if let Some(ld_path) = env::var_os("LD") {
+        command.env("LD", exec_root.join(ld_path));
+    }
+
     // replace env vars with a ${pwd} prefix with the exec_root
     for (key, value) in env::vars() {
         let exec_root_str = exec_root.to_str().expect("exec_root not in utf8");


### PR DESCRIPTION
These are sometimes invoked by -sys crates.