### PR TITLE
Added `incompatible_disable_custom_test_launcher`

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -320,6 +320,9 @@ def _rust_binary_impl(ctx):
 def _create_test_launcher(ctx, toolchain, output, env, providers):
     """Create a process wrapper to ensure runtime environment variables are defined for the test binary
 
+    WARNING: This function is subject to deletion with the removal of
+    incompatible_disable_custom_test_launcher
+
     Args:
         ctx (ctx): The rule's context object
         toolchain (rust_toolchain): The current rust toolchain
@@ -474,7 +477,7 @@ def _rust_test_common(ctx, toolchain, output):
     )
     providers.append(testing.TestEnvironment(env))
 
-    if any(["{pwd}" in v for v in env.values()]):
+    if not toolchain._incompatible_disable_custom_test_launcher and any(["{pwd}" in v for v in env.values()]):
         # Some of the environment variables require expanding {pwd} placeholder at runtime,
         # we need a launcher for that.
         return _create_test_launcher(ctx, toolchain, output, env, providers)

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -15,6 +15,12 @@ incompatible_flag(
     issue = "https://github.com/bazelbuild/rules_rust/issues/1051",
 )
 
+incompatible_flag(
+    name = "incompatible_disable_custom_test_launcher",
+    build_setting_default = False,
+    issue = "https://github.com/bazelbuild/rules_rust/issues/1069",
+)
+
 bzl_library(
     name = "rules",
     srcs = glob(["**/*.bzl"]),

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -233,6 +233,7 @@ def _rust_toolchain_impl(ctx):
 
     make_rust_providers_target_independent = ctx.attr._incompatible_make_rust_providers_target_independent[IncompatibleFlagInfo]
     remove_transitive_libs_from_dep_info = ctx.attr._incompatible_remove_transitive_libs_from_dep_info[IncompatibleFlagInfo]
+    disable_custom_test_launcher = ctx.attr._incompatible_disable_custom_test_launcher[IncompatibleFlagInfo]
 
     expanded_stdlib_linkflags = []
     for flag in ctx.attr.stdlib_linkflags:
@@ -286,6 +287,7 @@ def _rust_toolchain_impl(ctx):
         libstd_and_allocator_ccinfo = _make_libstd_and_allocator_ccinfo(ctx, ctx.attr.rust_lib, ctx.attr.allocator_library),
         _incompatible_make_rust_providers_target_independent = make_rust_providers_target_independent.enabled,
         _incompatible_remove_transitive_libs_from_dep_info = remove_transitive_libs_from_dep_info.enabled,
+        _incompatible_disable_custom_test_launcher = disable_custom_test_launcher.enabled,
     )
     return [toolchain]
 
@@ -397,6 +399,9 @@ rust_toolchain = rule(
         ),
         "_crosstool": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+        "_incompatible_disable_custom_test_launcher": attr.label(
+            default = Label("@rules_rust//rust/settings:incompatible_disable_custom_test_launcher"),
         ),
         "_incompatible_make_rust_providers_target_independent": attr.label(
             default = "@rules_rust//rust/settings:incompatible_make_rust_providers_target_independent",

--- a/test/unit/disable_custom_test_launcher/BUILD.bazel
+++ b/test/unit/disable_custom_test_launcher/BUILD.bazel
@@ -1,0 +1,5 @@
+load(":disable_custom_test_launcher_test.bzl", "disable_custom_test_launcher_test_suite")
+
+disable_custom_test_launcher_test_suite(
+    name = "disable_custom_test_launcher_test_suite",
+)

--- a/test/unit/disable_custom_test_launcher/disable_custom_test_launcher_test.bzl
+++ b/test/unit/disable_custom_test_launcher/disable_custom_test_launcher_test.bzl
@@ -1,0 +1,83 @@
+"""Unittests for rust rules."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//rust:defs.bzl", "rust_test")
+
+def _incompatible_enable_custom_test_launcher_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+
+    executable = tut.files_to_run.executable
+    asserts.true(env, executable.basename.endswith(".launcher") or executable.basename.endswith(".launcher.exe"))
+
+    return analysistest.end(env)
+
+def _incompatible_disable_custom_test_launcher_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+
+    executable = tut.files_to_run.executable
+    asserts.false(env, executable.basename.endswith(".launcher") or executable.basename.endswith(".launcher.exe"))
+
+    return analysistest.end(env)
+
+incompatible_enable_custom_test_launcher_test = analysistest.make(
+    _incompatible_enable_custom_test_launcher_test_impl,
+    config_settings = {
+        "@//rust/settings:incompatible_disable_custom_test_launcher": False,
+    },
+)
+
+incompatible_disable_custom_test_launcher_test = analysistest.make(
+    _incompatible_disable_custom_test_launcher_test_impl,
+    config_settings = {
+        "@//rust/settings:incompatible_disable_custom_test_launcher": True,
+    },
+)
+
+def _disable_custom_test_launcher_test():
+    write_file(
+        name = "src",
+        out = "lib.rs",
+        content = [],
+    )
+
+    write_file(
+        name = "data",
+        out = "data.txt",
+        content = [],
+    )
+
+    rust_test(
+        name = "disable_custom_test_launcher_test",
+        srcs = [":lib.rs"],
+        env = {"CUSTOM_TEST_ENV": "$(execpath :data)"},
+        data = [":data"],
+    )
+
+    incompatible_enable_custom_test_launcher_test(
+        name = "incompatible_enable_custom_test_launcher_test",
+        target_under_test = ":disable_custom_test_launcher_test",
+    )
+
+    incompatible_disable_custom_test_launcher_test(
+        name = "incompatible_disable_custom_test_launcher_test",
+        target_under_test = ":disable_custom_test_launcher_test",
+    )
+
+def disable_custom_test_launcher_test_suite(name):
+    """Entry-point macro called from the BUILD file.
+
+    Args:
+        name: Name of the macro.
+    """
+    _disable_custom_test_launcher_test()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":incompatible_disable_custom_test_launcher_test",
+            ":incompatible_enable_custom_test_launcher_test",
+        ],
+    )

--- a/util/launcher/BUILD.bazel
+++ b/util/launcher/BUILD.bazel
@@ -1,3 +1,6 @@
+# WARNING: This package is subject to deletion with the removal of
+# incompatible_disable_custom_test_launcher
+
 load("//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
relates to https://github.com/bazelbuild/rules_rust/issues/1069