### PR TITLE
Define remote repositories with maybe

### DIFF
--- a/crate_universe/src/renderer.rs
+++ b/crate_universe/src/renderer.rs
@@ -578,9 +578,11 @@ mod tests {
 
         let expected_repository_rule = indoc! { r#"
             load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+            load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
             def pinned_rust_install():
-                http_archive(
+                maybe(
+                    http_archive,
                     name = "rule_prefix__lazy_static__1_4_0",
                     build_file = Label("//:BUILD.lazy_static-1.4.0.bazel"),
                     sha256 = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
@@ -608,9 +610,11 @@ mod tests {
 
         let expected_repository_rule = indoc! { r#"
             load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+            load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
             def pinned_rust_install():
-                new_git_repository(
+                maybe(
+                    new_git_repository,
                     name = "rule_prefix__lazy_static__1_4_0",
                     strip_prefix = "",
                     build_file = Label("//:BUILD.lazy_static-1.4.0.bazel"),
@@ -650,9 +654,11 @@ mod tests {
         let expected_repository_rule = indoc! { r#"
             load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
             load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+            load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
             def pinned_rust_install():
-                new_git_repository(
+                maybe(
+                    new_git_repository,
                     name = "rule_prefix__lazy_static__1_4_0",
                     strip_prefix = "",
                     build_file = Label("//:BUILD.lazy_static-1.4.0.bazel"),
@@ -661,7 +667,8 @@ mod tests {
                     commit = "421669662b35fcb455f2902daed2e20bbbba79b6",
                 )
 
-                http_archive(
+                maybe(
+                    http_archive,
                     name = "rule_prefix__maplit__1_0_2",
                     build_file = Label("//:BUILD.maplit-1.0.2.bazel"),
                     sha256 = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d",

--- a/crate_universe/src/templates/defs.bzl.template
+++ b/crate_universe/src/templates/defs.bzl.template
@@ -10,7 +10,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 {% break %}
 {%- endif %}
 {%- endfor %}
-{%- if crates %}
+{%- if crates -%}
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
 {% endif -%}
 def pinned_rust_install():
 {%- if not crates %}

--- a/crate_universe/src/templates/partials/git_repository.template
+++ b/crate_universe/src/templates/partials/git_repository.template
@@ -1,4 +1,5 @@
-    new_git_repository(
+    maybe(
+        new_git_repository,
         name = "{{ repository_name }}",
         strip_prefix = "{{ repo.path_to_crate_root }}",
         build_file = Label("//:BUILD.{{crate.pkg_name}}-{{crate.pkg_version}}.bazel"),

--- a/crate_universe/src/templates/partials/http_archive.template
+++ b/crate_universe/src/templates/partials/http_archive.template
@@ -1,4 +1,5 @@
-    http_archive(
+    maybe(
+        http_archive,
         name = "{{repository_name}}",
         build_file = Label("//:BUILD.{{crate.pkg_name}}-{{crate.pkg_version}}.bazel"),
         {%- if crate.sha256 %}


### PR DESCRIPTION
This allows individual repositories to be overridden by binding
replacement repositories as long as the same name is used.

The names we give to repositories are not currently part of the API
contract of crate_universe, but this can still be useful.