### PR TITLE
add support for targeting iOS simulator on Apple Silicon

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -181,9 +181,13 @@ def system_to_constraints(system):
     return ["@platforms//os:{}".format(sys_suffix)]
 
 def abi_to_constraints(abi):
-    # TODO(acmcarther): Implement when C++ toolchain is more mature and we
-    # figure out how they're doing this
-    return []
+    # iOS simulator
+    if abi == "sim":
+        return ["@build_bazel_apple_support//constraints:simulator"]
+    else:
+        # TODO(acmcarther): Implement when C++ toolchain is more mature and we
+        # figure out how they're doing this
+        return []
 
 def triple_to_system(triple):
     """Returns a system name for a given platform triple

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -94,6 +94,15 @@ def rust_repositories(
         sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
     )
 
+    # Make the iOS simulator constraint available, which is referenced in abi_to_constraints()
+    # rules_rust does not require this dependency; it is just imported as a convenience for users.
+    maybe(
+        http_archive,
+        name = "build_bazel_apple_support",
+        sha256 = "76df040ade90836ff5543888d64616e7ba6c3a7b33b916aa3a4b68f342d1b447",
+        url = "https://github.com/bazelbuild/apple_support/releases/download/0.11.0/apple_support.0.11.0.tar.gz",
+    )
+
     for exec_triple, name in DEFAULT_TOOLCHAIN_TRIPLES.items():
         maybe(
             rust_repository_set,


### PR DESCRIPTION
When building on an Apple Silicon machine, a different target triple
is required to target the simulator:
https://doc.rust-lang.org/rustc/platform-support/aarch64-apple-ios-sim.html

As rules_rust currently ignores abi in triples, listing device
and simulator triples in a rust_repository_set() ends up always using
the first one. Adding this constraint allows a build to be switched
between targeting a device and targeting the simulator.