### PR TITLE
Always use a param file when calling into rustc

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -474,7 +474,8 @@ def construct_arguments(
         force_all_deps_direct = False,
         force_link = False,
         stamp = False,
-        remap_path_prefix = "."):
+        remap_path_prefix = ".",
+        use_param_file_for_rustc_args = True):
     """Builds an Args object containing common rustc flags
 
     Args:
@@ -500,6 +501,7 @@ def construct_arguments(
         stamp (bool, optional): Whether or not workspace status stamping is enabled. For more details see
             https://docs.bazel.build/versions/main/user-manual.html#flag--stamp
         remap_path_prefix (str, optional): A value used to remap `${pwd}` to. If set to a falsey value, no prefix will be set.
+        use_param_file_for_rustc_args(bool, optional): Whether Bazel should use a param file to pass the arguments to rustc.
 
     Returns:
         tuple: A tuple of the following items
@@ -574,8 +576,11 @@ def construct_arguments(
 
     # Rustc arguments
     rustc_flags = ctx.actions.args()
-    rustc_flags.set_param_file_format("multiline")
-    rustc_flags.use_param_file("@%s", use_always = False)
+
+    if use_param_file_for_rustc_args:
+        rustc_flags.set_param_file_format("multiline")
+        rustc_flags.use_param_file("@%s", use_always = True)
+
     rustc_flags.add(crate_info.root)
     rustc_flags.add("--crate-name=" + crate_info.name)
     rustc_flags.add("--crate-type=" + crate_info.type)

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -49,7 +49,8 @@ def rustdoc_compile_action(
         crate_info,
         output = None,
         rustdoc_flags = [],
-        is_test = False):
+        is_test = False,
+        use_param_file_for_rustc_args = True):
     """Create a struct of information needed for a `rustdoc` compile action based on crate passed to the rustdoc rule.
 
     Args:
@@ -59,6 +60,7 @@ def rustdoc_compile_action(
         output (File, optional): An optional output a `rustdoc` action is intended to produce.
         rustdoc_flags (list, optional): A list of `rustdoc` specific flags.
         is_test (bool, optional): If True, the action will be configured for `rust_doc_test` targets
+        use_param_file_for_rustc_args(bool, optional): Whether Bazel should use a param file to pass the arguments to rustc.
 
     Returns:
         struct: A struct of some `ctx.actions.run` arguments.
@@ -118,6 +120,7 @@ def rustdoc_compile_action(
         emit = [],
         remap_path_prefix = None,
         force_link = True,
+        use_param_file_for_rustc_args = use_param_file_for_rustc_args,
     )
 
     return struct(

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -117,6 +117,9 @@ def _rust_doc_test_impl(ctx):
         crate_info = crate_info,
         rustdoc_flags = rustdoc_flags,
         is_test = True,
+        # The arguments are written to a script file that is used to run the
+        # tests and the args point to a param file outside of the `runfiles`.
+        use_param_file_for_rustc_args = False,
     )
 
     tools = action.tools + [ctx.executable._process_wrapper]

--- a/util/process_wrapper/utils.h
+++ b/util/process_wrapper/utils.h
@@ -21,16 +21,20 @@
 
 namespace process_wrapper {
 
+using Subst = std::pair<System::StrType, System::StrType>;
+
 // Converts to and frin the system string format
 System::StrType FromUtf8(const std::string& string);
 std::string ToUtf8(const System::StrType& string);
 
-// Replaces a token in str by replacement
-void ReplaceToken(System::StrType& str, const System::StrType& token,
-                  const System::StrType& replacement);
+// Replaces tokens in str by replacement
+void ReplaceTokens(System::StrType& str, const std::vector<Subst>& substs);
 
 // Reads a file in text mode and feeds each line to item in the vec output
-bool ReadFileToArray(const System::StrType& file_path, System::StrVecType& vec);
+bool ReadFileToVec(const System::StrType& file_path, System::StrVecType& vec);
+
+// Write the content of an array file as lines in a file
+bool WriteVecToFile(const System::StrType& file_path, const System::StrVecType& vec);
 
 // Reads a workspace status stamp file to an array of key value pairs
 bool ReadStampStatusToArray(


### PR DESCRIPTION
Transitive crate dependencies are passed to rustc by specifying the folder they live in as a library search path (an `-Ldependency=path` flag). Given that bazel builds all libraries into their own folders, this means passing potentially hundreds of paths to rustc which can lead to overflowing the rather short limit for command arguments on Windows.

For this reason, this patch creates symlinks to all the transitive crates into a single directory that it then sets as the `-Ldependency=` flag to rustc. This dramatically shortens the command arguments length when calling rustc. Note that we only do that on Windows since it introduces some prep actions that need to do IO and there is no need to regress other platforms that support much longer command args.

I opted for declaring these files as inputs and creating the symlinks via `ctx.actions.symlink` but another option would have been to do that in the process wrapper instead.

For context, here is the size returned by `getconf ARG_MAX` on my following machines:
```
macos (12 x86_64):      1,048,576
linux (arch x86_64):    2,097,152  // obviously somewhat lower on 32-bit but
I don't have a machine handy
windows (10 x86_64):    32,000
```