### PR TITLE
Updated `bzl_library` targets to have a more discoverable name

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,10 +4,17 @@ load("//rust:defs.bzl", "capture_clippy_output", "error_format", "extra_rustc_fl
 exports_files(["LICENSE"])
 
 bzl_library(
-    name = "rules",
+    name = "bzl_lib",
     srcs = [
         ":workspace.bzl",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//:bzl_lib` target instead",
     visibility = ["//visibility:public"],
 )
 

--- a/bindgen/BUILD.bazel
+++ b/bindgen/BUILD.bazel
@@ -6,9 +6,15 @@ package(default_visibility = ["//visibility:public"])
 toolchain_type(name = "bindgen_toolchain")
 
 bzl_library(
-    name = "rules",
+    name = "bzl_lib",
     srcs = glob(["**/*.bzl"]) + ["//bindgen/raze:crates.bzl"],
-    deps = ["//rust:rules"],
+    deps = ["//rust:bzl_lib"],
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//bindgen:bzl_lib` target instead",
 )
 
 rust_bindgen_toolchain(

--- a/cargo/BUILD.bazel
+++ b/cargo/BUILD.bazel
@@ -3,7 +3,13 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 package(default_visibility = ["//visibility:public"])
 
 bzl_library(
-    name = "rules",
+    name = "bzl_lib",
     srcs = glob(["**/*.bzl"]),
     deps = ["//cargo/private:bzl_lib"],
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//cargo:bzl_lib` target instead",
 )

--- a/crate_universe/BUILD.bazel
+++ b/crate_universe/BUILD.bazel
@@ -8,9 +8,15 @@ exports_files([
 ])
 
 bzl_library(
-    name = "rules",
+    name = "bzl_lib",
     srcs = glob(["**/*.bzl"]),
-    deps = ["//crate_universe/private:bzl_srcs"],
+    deps = ["//crate_universe/private:bzl_lib"],
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//crate_universe:bzl_lib` target instead",
 )
 
 filegroup(

--- a/crate_universe/private/BUILD.bazel
+++ b/crate_universe/private/BUILD.bazel
@@ -3,6 +3,6 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 package(default_visibility = ["//visibility:public"])
 
 bzl_library(
-    name = "bzl_srcs",
+    name = "bzl_lib",
     srcs = glob(["**/*.bzl"]),
 )

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -23,13 +23,13 @@ bzl_library(
     name = "all_docs",
     deps = [
         ":docs_deps",
-        "@rules_rust//:rules",
-        "@rules_rust//bindgen:rules",
-        "@rules_rust//cargo:rules",
-        "@rules_rust//crate_universe:rules",
-        "@rules_rust//proto:rules",
-        "@rules_rust//rust:rules",
-        "@rules_rust//wasm_bindgen:rules",
+        "@rules_rust//:bzl_lib",
+        "@rules_rust//bindgen:bzl_lib",
+        "@rules_rust//cargo:bzl_lib",
+        "@rules_rust//crate_universe:bzl_lib",
+        "@rules_rust//proto:bzl_lib",
+        "@rules_rust//rust:bzl_lib",
+        "@rules_rust//wasm_bindgen:bzl_lib",
     ],
 )
 

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -31,6 +31,12 @@ toolchain(
 rust_proto_toolchain(name = "default-proto-toolchain-impl")
 
 bzl_library(
-    name = "rules",
+    name = "bzl_lib",
     srcs = glob(["**/*.bzl"]) + ["//proto/raze:crates.bzl"],
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//proto:bzl_lib` target instead",
 )

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -14,11 +14,17 @@ toolchain_type(
 )
 
 bzl_library(
-    name = "rules",
+    name = "bzl_lib",
     srcs = glob(["**/*.bzl"]),
     deps = [
-        "//rust/platform:rules",
-        "//rust/private:rules",
-        "//rust/settings:rules",
+        "//rust/platform:bzl_lib",
+        "//rust/private:bzl_lib",
+        "//rust/settings:bzl_lib",
     ],
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//rust:bzl_lib` target instead",
 )

--- a/rust/platform/BUILD.bazel
+++ b/rust/platform/BUILD.bazel
@@ -13,7 +13,14 @@ package_group(
 )
 
 bzl_library(
-    name = "rules",
+    name = "bzl_lib",
     srcs = glob(["**/*.bzl"]),
+    visibility = ["//rust:__subpackages__"],
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//platform:bzl_lib` target instead",
     visibility = ["//rust:__subpackages__"],
 )

--- a/rust/private/BUILD.bazel
+++ b/rust/private/BUILD.bazel
@@ -3,14 +3,17 @@ load("//rust/private:rust_analyzer.bzl", "rust_analyzer_detect_sysroot")
 load("//rust/private:stamp.bzl", "stamp_build_setting")
 
 bzl_library(
-    name = "rules",
-    srcs = glob(
-        ["**/*.bzl"],
-    ),
+    name = "bzl_lib",
+    srcs = glob(["**/*.bzl"]),
     visibility = ["//rust:__subpackages__"],
-    deps = [
-        "//rust/platform:rules",
-    ],
+    deps = ["//rust/platform:bzl_lib"],
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//private:bzl_lib` target instead",
+    visibility = ["//rust:__subpackages__"],
 )
 
 stamp_build_setting(name = "stamp")

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -36,6 +36,13 @@ string_flag(
 )
 
 bzl_library(
-    name = "rules",
+    name = "bzl_lib",
     srcs = glob(["**/*.bzl"]),
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//settings:bzl_lib` target instead",
+    visibility = ["//rust:__subpackages__"],
 )

--- a/wasm_bindgen/BUILD.bazel
+++ b/wasm_bindgen/BUILD.bazel
@@ -6,9 +6,15 @@ package(default_visibility = ["//visibility:public"])
 toolchain_type(name = "wasm_bindgen_toolchain")
 
 bzl_library(
-    name = "rules",
+    name = "bzl_lib",
     srcs = glob(["**/*.bzl"]) + ["//wasm_bindgen/raze:crates.bzl"],
-    deps = ["//rust:rules"],
+    deps = ["//rust:bzl_lib"],
+)
+
+alias(
+    name = "rules",
+    actual = ":bzl_lib",
+    deprecation = "Please use the `@rules_rust//wasm_bindgen:bzl_lib` target instead",
 )
 
 rust_wasm_bindgen_toolchain(


### PR DESCRIPTION
To help improve the discoverability of the [bzl_library](https://github.com/bazelbuild/bazel-skylib/blob/1.1.1/bzl_library.bzl) targets `rules_rust` provides, I think they should use a naming scheme similar to the `bzl_srcs` targets found in [Bazel itself](https://github.com/bazelbuild/bazel/blob/4.2.1/tools/BUILD#L71-L85). This PR renames the `rules` targets to `bzl_lib` and leaves an alias to allow for backwards compatibility.