### PR TITLE
Fix proc_macro_dylib_path when they are built in both opt and debug

### DIFF
--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -525,11 +525,9 @@ mod test {
 
     #[test]
     fn consolidate_proc_macro_prefer_exec() {
-        // mylib.rs is a library but has tests and an entry point, and mylib2.rs
-        // depends on mylib.rs. The display_name of the library target mylib.rs
-        // should be "mylib" no matter what order the crate specs is in.
-        // Otherwise Rust Analyzer will not be able to resolve references to
-        // mylib in mylib2.rs.
+        // proc macro crates should prefer the -opt-exec- path which is always generated
+        // during builds where it is used, while the fastbuild version would only be built
+        // when explicitly building that target.
         let crate_specs = vec![
             CrateSpec {
                 crate_id: "ID-myproc_macro.rs".into(),

--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -177,6 +177,16 @@ fn consolidate_crate_specs(crate_specs: Vec<CrateSpec>) -> anyhow::Result<BTreeS
                 existing.display_name = spec.display_name;
                 existing.crate_type = "rlib".into();
             }
+
+            // For proc-macro crates that exist within the workspace, there will be a
+            // generated crate-spec in both the fastbuild and opt-exec configuration.
+            // Prefer proc macro paths with an opt-exec component in the path.
+            if let Some(dylib_path) = spec.proc_macro_dylib_path.as_ref() {
+                const OPT_PATH_COMPONENT: &str = "-opt-exec-";
+                if dylib_path.contains(OPT_PATH_COMPONENT) {
+                    existing.proc_macro_dylib_path.replace(dylib_path.clone());
+                }
+            }
         } else {
             consolidated_specs.insert(spec.crate_id.clone(), spec);
         }
@@ -512,4 +522,66 @@ mod test {
             );
         }
     }
+
+    #[test]
+    fn consolidate_proc_macro_prefer_exec() {
+        // mylib.rs is a library but has tests and an entry point, and mylib2.rs
+        // depends on mylib.rs. The display_name of the library target mylib.rs
+        // should be "mylib" no matter what order the crate specs is in.
+        // Otherwise Rust Analyzer will not be able to resolve references to
+        // mylib in mylib2.rs.
+        let crate_specs = vec![
+            CrateSpec {
+                crate_id: "ID-myproc_macro.rs".into(),
+                display_name: "myproc_macro".into(),
+                edition: "2018".into(),
+                root_module: "myproc_macro.rs".into(),
+                is_workspace_member: true,
+                deps: BTreeSet::new(),
+                proc_macro_dylib_path: Some("bazel-out/k8-opt-exec-F005BA11/bin/myproc_macro/libmyproc_macro-12345.so".into()),
+                source: None,
+                cfg: vec!["test".into(), "debug_assertions".into()],
+                env: BTreeMap::new(),
+                target: "x86_64-unknown-linux-gnu".into(),
+                crate_type: "proc_macro".into(),
+            },
+            CrateSpec {
+                crate_id: "ID-myproc_macro.rs".into(),
+                display_name: "myproc_macro".into(),
+                edition: "2018".into(),
+                root_module: "myproc_macro.rs".into(),
+                is_workspace_member: true,
+                deps: BTreeSet::new(),
+                proc_macro_dylib_path: Some("bazel-out/k8-fastbuild/bin/myproc_macro/libmyproc_macro-12345.so".into()),
+                source: None,
+                cfg: vec!["test".into(), "debug_assertions".into()],
+                env: BTreeMap::new(),
+                target: "x86_64-unknown-linux-gnu".into(),
+                crate_type: "proc_macro".into(),
+            },
+        ];
+
+        for perm in crate_specs.into_iter().permutations(2) {
+            assert_eq!(
+                consolidate_crate_specs(perm).unwrap(),
+                BTreeSet::from([
+                    CrateSpec {
+                        crate_id: "ID-myproc_macro.rs".into(),
+                        display_name: "myproc_macro".into(),
+                        edition: "2018".into(),
+                        root_module: "myproc_macro.rs".into(),
+                        is_workspace_member: true,
+                        deps: BTreeSet::new(),
+                        proc_macro_dylib_path: Some("bazel-out/k8-opt-exec-F005BA11/bin/myproc_macro/libmyproc_macro-12345.so".into()),
+                        source: None,
+                        cfg: vec!["test".into(), "debug_assertions".into()],
+                        env: BTreeMap::new(),
+                        target: "x86_64-unknown-linux-gnu".into(),
+                        crate_type: "proc_macro".into(),
+                    },
+                ])
+            );
+        }
+    }
+
 }

--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -538,7 +538,10 @@ mod test {
                 root_module: "myproc_macro.rs".into(),
                 is_workspace_member: true,
                 deps: BTreeSet::new(),
-                proc_macro_dylib_path: Some("bazel-out/k8-opt-exec-F005BA11/bin/myproc_macro/libmyproc_macro-12345.so".into()),
+                proc_macro_dylib_path: Some(
+                    "bazel-out/k8-opt-exec-F005BA11/bin/myproc_macro/libmyproc_macro-12345.so"
+                        .into(),
+                ),
                 source: None,
                 cfg: vec!["test".into(), "debug_assertions".into()],
                 env: BTreeMap::new(),
@@ -552,7 +555,9 @@ mod test {
                 root_module: "myproc_macro.rs".into(),
                 is_workspace_member: true,
                 deps: BTreeSet::new(),
-                proc_macro_dylib_path: Some("bazel-out/k8-fastbuild/bin/myproc_macro/libmyproc_macro-12345.so".into()),
+                proc_macro_dylib_path: Some(
+                    "bazel-out/k8-fastbuild/bin/myproc_macro/libmyproc_macro-12345.so".into(),
+                ),
                 source: None,
                 cfg: vec!["test".into(), "debug_assertions".into()],
                 env: BTreeMap::new(),
@@ -564,24 +569,24 @@ mod test {
         for perm in crate_specs.into_iter().permutations(2) {
             assert_eq!(
                 consolidate_crate_specs(perm).unwrap(),
-                BTreeSet::from([
-                    CrateSpec {
-                        crate_id: "ID-myproc_macro.rs".into(),
-                        display_name: "myproc_macro".into(),
-                        edition: "2018".into(),
-                        root_module: "myproc_macro.rs".into(),
-                        is_workspace_member: true,
-                        deps: BTreeSet::new(),
-                        proc_macro_dylib_path: Some("bazel-out/k8-opt-exec-F005BA11/bin/myproc_macro/libmyproc_macro-12345.so".into()),
-                        source: None,
-                        cfg: vec!["test".into(), "debug_assertions".into()],
-                        env: BTreeMap::new(),
-                        target: "x86_64-unknown-linux-gnu".into(),
-                        crate_type: "proc_macro".into(),
-                    },
-                ])
+                BTreeSet::from([CrateSpec {
+                    crate_id: "ID-myproc_macro.rs".into(),
+                    display_name: "myproc_macro".into(),
+                    edition: "2018".into(),
+                    root_module: "myproc_macro.rs".into(),
+                    is_workspace_member: true,
+                    deps: BTreeSet::new(),
+                    proc_macro_dylib_path: Some(
+                        "bazel-out/k8-opt-exec-F005BA11/bin/myproc_macro/libmyproc_macro-12345.so"
+                            .into()
+                    ),
+                    source: None,
+                    cfg: vec!["test".into(), "debug_assertions".into()],
+                    env: BTreeMap::new(),
+                    target: "x86_64-unknown-linux-gnu".into(),
+                    crate_type: "proc_macro".into(),
+                },])
             );
         }
     }
-
 }


### PR DESCRIPTION
For workspace members, a crate_spec is generated for both opt and debug configurations, but when a build is executed, proc-macros are built and used only in the opt configuration. This can result in rust-analyzer looking for the proc macro in the fastbuild location when it was only created in the opt location. Rust analyzer will then be unable to find and use the dylib and code generated by the proc-macro will not have annotations.

This PR fixes the issue by preferring the proc_macro_dylib_path with the `-opt-exec-` path component when merging CrateSpecs.