### PR TITLE
Add DEBUG env var for running build scripts

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -73,12 +73,15 @@ def _build_script_impl(ctx):
         "CARGO_PKG_NAME": pkg_name,
         "HOST": toolchain.exec_triple,
         "OPT_LEVEL": compilation_mode_opt_level,
-        # This isn't exactly right, but Bazel doesn't have exact views of "debug" and "release", so...
-        "PROFILE": {"dbg": "debug", "fastbuild": "debug", "opt": "release"}.get(ctx.var["COMPILATION_MODE"], "unknown"),
-        "DEBUG": {"dbg": "true", "fastbuild": "true", "opt": "false"}.get(ctx.var["COMPILATION_MODE"], "true"),
         "RUSTC": toolchain.rustc.path,
         "TARGET": toolchain.target_flag_value,
         # OUT_DIR is set by the runner itself, rather than on the action.
+    })
+
+    # This isn't exactly right, but Bazel doesn't have exact views of "debug" and "release", so...
+    env.update({
+        "DEBUG": {"dbg": "true", "fastbuild": "true", "opt": "false"}.get(ctx.var["COMPILATION_MODE"], "true"),
+        "PROFILE": {"dbg": "debug", "fastbuild": "debug", "opt": "release"}.get(ctx.var["COMPILATION_MODE"], "unknown"),
     })
 
     if ctx.attr.version:

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -75,6 +75,7 @@ def _build_script_impl(ctx):
         "OPT_LEVEL": compilation_mode_opt_level,
         # This isn't exactly right, but Bazel doesn't have exact views of "debug" and "release", so...
         "PROFILE": {"dbg": "debug", "fastbuild": "debug", "opt": "release"}.get(ctx.var["COMPILATION_MODE"], "unknown"),
+        "DEBUG": {"dbg": "true", "fastbuild": "true", "opt": "false"}.get(ctx.var["COMPILATION_MODE"], "true"),
         "RUSTC": toolchain.rustc.path,
         "TARGET": toolchain.target_flag_value,
         # OUT_DIR is set by the runner itself, rather than on the action.


### PR DESCRIPTION
This variable is set for the default profiles as described in https://doc.rust-lang.org/cargo/reference/profiles.html -- true for dev and false for release.

This is an environment variable cargo sets for build scripts documented here https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts