### PR TITLE
Replace host with exec configurations for grep_includes

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -635,7 +635,7 @@ _rust_test_attrs = {
     ),
     "_grep_includes": attr.label(
         allow_single_file = True,
-        cfg = "host",
+        cfg = "exec",
         default = Label("@bazel_tools//tools/cpp:grep-includes"),
         executable = True,
     ),
@@ -815,7 +815,7 @@ _rust_binary_attrs = {
     ),
     "_grep_includes": attr.label(
         allow_single_file = True,
-        cfg = "host",
+        cfg = "exec",
         default = Label("@bazel_tools//tools/cpp:grep-includes"),
         executable = True,
     ),


### PR DESCRIPTION
This is to be consistent with C++ rules: https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java;l=478?q=ccincludescanning.