### PR TITLE
add ARM Cortex M3 triple mappings

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -54,6 +54,7 @@ _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX = {
     "powerpc64le": None,
     "s390": None,
     "s390x": "s390x",
+    "thumbv7m": "armv7",
     "wasm32": None,
     "x86_64": "x86_64",
 }
@@ -64,6 +65,7 @@ _SYSTEM_TO_BUILTIN_SYS_SUFFIX = {
     "bitrig": None,
     "darwin": "osx",
     "dragonfly": None,
+    "eabi": "none",
     "emscripten": None,
     "freebsd": "freebsd",
     "ios": "ios",
@@ -80,6 +82,7 @@ _SYSTEM_TO_BUILTIN_SYS_SUFFIX = {
 _SYSTEM_TO_BINARY_EXT = {
     "android": "",
     "darwin": "",
+    "eabi": "",
     "emscripten": ".js",
     "freebsd": "",
     "ios": "",
@@ -95,6 +98,7 @@ _SYSTEM_TO_BINARY_EXT = {
 _SYSTEM_TO_STATICLIB_EXT = {
     "android": ".a",
     "darwin": ".a",
+    "eabi": ".a",
     "emscripten": ".js",
     "freebsd": ".a",
     "ios": ".a",
@@ -107,6 +111,7 @@ _SYSTEM_TO_STATICLIB_EXT = {
 _SYSTEM_TO_DYLIB_EXT = {
     "android": ".so",
     "darwin": ".dylib",
+    "eabi": ".so",
     "emscripten": ".js",
     "freebsd": ".so",
     "ios": ".dylib",
@@ -128,6 +133,7 @@ _SYSTEM_TO_STDLIB_LINKFLAGS = {
     "cloudabi": ["-lunwind", "-lc", "-lcompiler_rt"],
     "darwin": ["-lSystem", "-lresolv"],
     "dragonfly": ["-lpthread"],
+    "eabi": [],
     "emscripten": [],
     # TODO(bazelbuild/rules_cc#75):
     #


### PR DESCRIPTION
Hello. Thanks maintainers. 
I made a demo that runs on an ARM Cortex M3 inside QEMU. I needed to add a few lines to `rules_rust` to correctly download the Cortex M3 (`thumbv7m-none-eabi`) rustlib.

Demo:
https://github.com/driftregion/bazel-c-rust-x86_linux-armv7_baremetal/blob/master/WORKSPACE#L32 

Related:
https://github.com/bazelbuild/rules_rust/issues/256