### PR TITLE
Fixed tests which relied on the git checkout's newline endings

### DIFF
--- a/test/build_env/tests/manifest_dir.rs
+++ b/test/build_env/tests/manifest_dir.rs
@@ -3,7 +3,8 @@ pub fn test_manifest_dir() {
     let actual = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/src/manifest_dir_file.txt"
-    ));
-    let expected = "This file tests that CARGO_MANIFEST_DIR is set for the build environment\n";
+    ))
+    .trim_end();
+    let expected = "This file tests that CARGO_MANIFEST_DIR is set for the build environment";
     assert_eq!(actual, expected);
 }

--- a/test/unit/compile_data/compile_data.rs
+++ b/test/unit/compile_data/compile_data.rs
@@ -9,7 +9,7 @@ mod test {
     /// directly populate the `compile_data` attribute
     #[test]
     fn test_compile_data_contents() {
-        assert_eq!(COMPILE_DATA, "compile data contents\n");
+        assert_eq!(COMPILE_DATA.trim_end(), "compile data contents");
     }
 
     /// An extra module that tests the `rust_test` rule wrapping the
@@ -20,7 +20,7 @@ mod test {
 
         #[test]
         fn test_compile_data_contents() {
-            assert_eq!(TEST_COMPILE_DATA, "test compile data contents\n");
+            assert_eq!(TEST_COMPILE_DATA.trim_end(), "test compile data contents");
         }
     }
 }


### PR DESCRIPTION
These tests would fail on windows if you checked out the repo on a windows machine that used native line endings (`CRLF`, [see git documentation](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration)).