### PR TITLE
Replaced CI flags with compatibility flags for incompatible targets

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -225,8 +225,6 @@ tasks:
     test_targets:
       - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
       - "//..."
-      # This test requires --incompatible_macos_set_install_name and Bazel 4.2.0+
-      - "-//ffi/rust_calling_c:matrix_dylib_test"
     build_flags: *aspects_flags
   windows_examples:
     name: Examples
@@ -239,8 +237,6 @@ tasks:
     windows_targets: &windows_targets
       - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
       - "//..."
-      - "-//ffi/rust_calling_c:matrix_dylib_test"
-      - "-//ffi/rust_calling_c:matrix_dynamically_linked"
       # The bindgen rules currently do not work on windows
       # see: https://github.com/bazelbuild/rules_rust/issues/919
       - "-//bindgen/..."

--- a/examples/ffi/rust_calling_c/BUILD.bazel
+++ b/examples/ffi/rust_calling_c/BUILD.bazel
@@ -33,6 +33,11 @@ rust_library(
         "src/matrix.rs",
     ],
     crate_root = "src/matrix.rs",
+    target_compatible_with = select({
+        # TODO: Make this work on windows
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//ffi/rust_calling_c/c:native_matrix_so",
         "@libc",
@@ -42,6 +47,13 @@ rust_library(
 rust_test(
     name = "matrix_dylib_test",
     crate = ":matrix_dynamically_linked",
+    target_compatible_with = select({
+        # TODO: This test requires --incompatible_macos_set_install_name and Bazel 4.2.0+
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        # TODO: Make this work on windows
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 rust_doc(


### PR DESCRIPTION
Since moving to Bazel 4.0 as the min target, we can now use `target_compatible_with` to filter incompatible targets. This allows the target definitions themselves to describe what they currently support and makes it easier for contributors to test changes as they don't need to worry about targets that are known to not work for the platform failing.

The MacOS side of this can likely be removed in https://github.com/bazelbuild/rules_rust/pull/921 but since that's been there for some time, I think it's fine to add the flag here.