### PR TITLE
Replace Targets and lists of files in `rust_toolchain` with depsets

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -57,8 +57,8 @@ def _build_script_impl(ctx):
 
     toolchain_tools = [
         # Needed for rustc to function.
-        toolchain.rustc_lib.files,
-        toolchain.rust_std.files,
+        toolchain.rustc_lib,
+        toolchain.rust_std,
     ]
 
     cc_toolchain = find_cpp_toolchain(ctx)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
@@ -20,7 +21,6 @@ load(
 load("//rust/private:common.bzl", "rust_common")
 load("//rust/private:providers.bzl", _BuildInfo = "BuildInfo")
 load("//rust/private:stamp.bzl", "is_stamping_enabled")
-load("//rust/private:toolchain_utils.bzl", "find_sysroot")
 load(
     "//rust/private:utils.bzl",
     "expand_dict_value_locations",
@@ -680,7 +680,7 @@ def construct_arguments(
     ))
 
     # Set the SYSROOT to the directory of the rust_std files passed to the toolchain
-    env["SYSROOT"] = find_sysroot(toolchain)
+    env["SYSROOT"] = paths.dirname(toolchain.rust_std.to_list()[0].short_path)
 
     # extra_rustc_flags apply to the target configuration, not the exec configuration.
     if hasattr(ctx.attr, "_extra_rustc_flags") and not is_exec_configuration(ctx):

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -408,8 +408,8 @@ def collect_inputs(
         ([toolchain.target_json] if toolchain.target_json else []) +
         ([] if linker_script == None else [linker_script]),
         transitive = [
-            toolchain.rustc_lib.files,
-            toolchain.rust_std.files,
+            toolchain.rustc_lib,
+            toolchain.rust_std,
             linker_depset,
             crate_info.srcs,
             dep_info.transitive_crate_outputs,
@@ -617,7 +617,7 @@ def construct_arguments(
         rustc_flags.add(linker_script.path, format = "--codegen=link-arg=-T%s")
 
     # Gets the paths to the folders containing the standard library (or libcore)
-    rust_std_paths = depset([file.dirname for file in toolchain.rust_std.files.to_list()]).to_list()
+    rust_std_paths = depset([file.dirname for file in toolchain.rust_std.to_list()]).to_list()
 
     # Tell Rustc where to find the standard library
     rustc_flags.add_all(rust_std_paths, before_each = "-L", format_each = "%s")
@@ -675,7 +675,7 @@ def construct_arguments(
     ))
 
     # Set the SYSROOT to the directory of the rust_std files passed to the toolchain
-    env["SYSROOT"] = paths.dirname(toolchain.rust_std.files.to_list()[0].short_path)
+    env["SYSROOT"] = paths.dirname(toolchain.rust_std.to_list()[0].short_path)
 
     # extra_rustc_flags apply to the target configuration, not the exec configuration.
     if hasattr(ctx.attr, "_extra_rustc_flags") and is_exec_configuration(ctx):

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # buildifier: disable=module-docstring
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
@@ -21,6 +20,7 @@ load(
 load("//rust/private:common.bzl", "rust_common")
 load("//rust/private:providers.bzl", _BuildInfo = "BuildInfo")
 load("//rust/private:stamp.bzl", "is_stamping_enabled")
+load("//rust/private:toolchain_utils.bzl", "find_sysroot")
 load(
     "//rust/private:utils.bzl",
     "expand_dict_value_locations",
@@ -675,7 +675,7 @@ def construct_arguments(
     ))
 
     # Set the SYSROOT to the directory of the rust_std files passed to the toolchain
-    env["SYSROOT"] = paths.dirname(toolchain.rust_std.to_list()[0].short_path)
+    env["SYSROOT"] = find_sysroot(toolchain)
 
     # extra_rustc_flags apply to the target configuration, not the exec configuration.
     if hasattr(ctx.attr, "_extra_rustc_flags") and is_exec_configuration(ctx):

--- a/rust/private/toolchain_utils.bzl
+++ b/rust/private/toolchain_utils.bzl
@@ -9,7 +9,7 @@ def find_sysroot(rust_toolchain):
     Returns:
         str: A path assignable as `SYSROOT` for an action.
     """
-    sysroot_anchor = rust_toolchain.rust_std.files.to_list()[0]
+    sysroot_anchor = rust_toolchain.rust_std.to_list()[0]
     directory = sysroot_anchor.path.split(sysroot_anchor.short_path, 1)[0]
     return directory.rstrip("/")
 
@@ -24,7 +24,7 @@ def _toolchain_files_impl(ctx):
                 toolchain.cargo,
                 toolchain.rustc,
             ],
-            transitive_files = toolchain.rustc_lib.files,
+            transitive_files = toolchain.rustc_lib,
         )
     elif ctx.attr.tool == "clippy":
         files = depset([toolchain.clippy_driver])
@@ -33,32 +33,32 @@ def _toolchain_files_impl(ctx):
                 toolchain.clippy_driver,
                 toolchain.rustc,
             ],
-            transitive_files = toolchain.rustc_lib.files,
+            transitive_files = toolchain.rustc_lib,
         )
     elif ctx.attr.tool == "rustc":
         files = depset([toolchain.rustc])
         runfiles = ctx.runfiles(
             files = [toolchain.rustc],
-            transitive_files = toolchain.rustc_lib.files,
+            transitive_files = toolchain.rustc_lib,
         )
     elif ctx.attr.tool == "rustdoc":
         files = depset([toolchain.rust_doc])
         runfiles = ctx.runfiles(
             files = [toolchain.rust_doc],
-            transitive_files = toolchain.rustc_lib.files,
+            transitive_files = toolchain.rustc_lib,
         )
     elif ctx.attr.tool == "rustfmt":
         files = depset([toolchain.rustfmt])
         runfiles = ctx.runfiles(
             files = [toolchain.rustfmt],
-            transitive_files = toolchain.rustc_lib.files,
+            transitive_files = toolchain.rustc_lib,
         )
     elif ctx.attr.tool == "rustc_lib":
-        files = toolchain.rustc_lib.files
+        files = toolchain.rustc_lib
     elif ctx.attr.tool == "rustc_srcs":
         files = toolchain.rustc_srcs.files
     elif ctx.attr.tool == "rust_std" or ctx.attr.tool == "rust_stdlib" or ctx.attr.tool == "rust_lib":
-        files = toolchain.rust_std.files
+        files = toolchain.rust_std
     else:
         fail("Unsupported tool: ", ctx.attr.tool)
 

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -278,8 +278,8 @@ def _rust_toolchain_impl(ctx):
         target_flag_value = ctx.file.target_json.path if ctx.file.target_json else ctx.attr.target_triple,
         rustc_lib = depset(ctx.files.rustc_lib),
         rustc_srcs = ctx.attr.rustc_srcs,
-        rust_std = rust_std[DefaultInfo].files,
-        rust_lib = rust_std[DefaultInfo].files,  # `rust_lib` is deprecated and only exists for legacy support.
+        rust_std = rust_std.files,
+        rust_lib = rust_std.files,  # `rust_lib` is deprecated and only exists for legacy support.
         binary_ext = ctx.attr.binary_ext,
         staticlib_ext = ctx.attr.staticlib_ext,
         dylib_ext = ctx.attr.dylib_ext,

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -268,6 +268,11 @@ def _rust_toolchain_impl(ctx):
         linking_context = linking_context,
     )
 
+    rust_std_files = depset(transitive = [
+        rust_std[DefaultInfo].files,
+        rust_std[DefaultInfo].default_runfiles.files,
+    ])
+
     toolchain = platform_common.ToolchainInfo(
         rustc = ctx.file.rustc,
         rust_doc = ctx.file.rust_doc,
@@ -276,10 +281,10 @@ def _rust_toolchain_impl(ctx):
         clippy_driver = ctx.file.clippy_driver,
         target_json = ctx.file.target_json,
         target_flag_value = ctx.file.target_json.path if ctx.file.target_json else ctx.attr.target_triple,
-        rustc_lib = ctx.attr.rustc_lib,
+        rustc_lib = depset(ctx.files.rustc_lib),
         rustc_srcs = ctx.attr.rustc_srcs,
-        rust_std = rust_std,
-        rust_lib = rust_std,  # `rust_lib` is deprecated and only exists for legacy support.
+        rust_std = rust_std_files,
+        rust_lib = rust_std_files,  # `rust_lib` is deprecated and only exists for legacy support.
         binary_ext = ctx.attr.binary_ext,
         staticlib_ext = ctx.attr.staticlib_ext,
         dylib_ext = ctx.attr.dylib_ext,

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -268,11 +268,6 @@ def _rust_toolchain_impl(ctx):
         linking_context = linking_context,
     )
 
-    rust_std_files = depset(transitive = [
-        rust_std[DefaultInfo].files,
-        rust_std[DefaultInfo].default_runfiles.files,
-    ])
-
     toolchain = platform_common.ToolchainInfo(
         rustc = ctx.file.rustc,
         rust_doc = ctx.file.rust_doc,
@@ -283,8 +278,8 @@ def _rust_toolchain_impl(ctx):
         target_flag_value = ctx.file.target_json.path if ctx.file.target_json else ctx.attr.target_triple,
         rustc_lib = depset(ctx.files.rustc_lib),
         rustc_srcs = ctx.attr.rustc_srcs,
-        rust_std = rust_std_files,
-        rust_lib = rust_std_files,  # `rust_lib` is deprecated and only exists for legacy support.
+        rust_std = rust_std[DefaultInfo].files,
+        rust_lib = rust_std[DefaultInfo].files,  # `rust_lib` is deprecated and only exists for legacy support.
         binary_ext = ctx.attr.binary_ext,
         staticlib_ext = ctx.attr.staticlib_ext,
         dylib_ext = ctx.attr.dylib_ext,


### PR DESCRIPTION
This should simplify the API of `rust_toolchain` and help avoid confusion for users defining their own toolchains and rules.