### PR TITLE
add extra_exec_rustc_flags build config

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//rust:defs.bzl", "capture_clippy_output", "error_format", "extra_rustc_flags")
+load("//rust:defs.bzl", "capture_clippy_output", "error_format", "extra_exec_rustc_flags", "extra_rustc_flags")
 
 exports_files(["LICENSE"])
 
@@ -25,11 +25,22 @@ error_format(
     visibility = ["//visibility:public"],
 )
 
-# This setting may be used to pass extra options to rustc from the command line.
+# This setting may be used to pass extra options to rustc from the command line
+# in non-exec configuration.
 # It applies across all targets whereas the rustc_flags option on targets applies only
 # to that target. This can be useful for passing build-wide options such as LTO.
 extra_rustc_flags(
     name = "extra_rustc_flags",
+    build_setting_default = [],
+    visibility = ["//visibility:public"],
+)
+
+# This setting may be used to pass extra options to rustc from the command line
+# in exec configuration.
+# It applies across all targets whereas the rustc_flags option on targets applies only
+# to that target. This can be useful for passing build-wide options such as LTO.
+extra_exec_rustc_flags(
+    name = "extra_exec_rustc_flags",
     build_setting_default = [],
     visibility = ["//visibility:public"],
 )

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -56,7 +56,7 @@ Change the [--error-format](https://doc.rust-lang.org/rustc/command-line-argumen
 extra_rustc_flags(<a href="#extra_rustc_flags-name">name</a>)
 </pre>
 
-Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags are currently excluded from the exec configuration (proc-macros, cargo_build_script, etc).
+Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use --@rules_rust//:extra_exec_rustc_flags to apply flags to the exec configuration.
 
 **ATTRIBUTES**
 

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -56,7 +56,7 @@ Change the [--error-format](https://doc.rust-lang.org/rustc/command-line-argumen
 extra_rustc_flags(<a href="#extra_rustc_flags-name">name</a>)
 </pre>
 
-Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use --@rules_rust//:extra_exec_rustc_flags to apply flags to the exec configuration.
+Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration.
 
 **ATTRIBUTES**
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -177,7 +177,7 @@ Change the [--error-format](https://doc.rust-lang.org/rustc/command-line-argumen
 extra_rustc_flags(<a href="#extra_rustc_flags-name">name</a>)
 </pre>
 
-Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use --@rules_rust//:extra_exec_rustc_flags to apply flags to the exec configuration.
+Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration.
 
 **ATTRIBUTES**
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -177,7 +177,7 @@ Change the [--error-format](https://doc.rust-lang.org/rustc/command-line-argumen
 extra_rustc_flags(<a href="#extra_rustc_flags-name">name</a>)
 </pre>
 
-Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags are currently excluded from the exec configuration (proc-macros, cargo_build_script, etc).
+Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use --@rules_rust//:extra_exec_rustc_flags to apply flags to the exec configuration.
 
 **ATTRIBUTES**
 

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -43,6 +43,7 @@ load(
 load(
     "//rust/private:rustc.bzl",
     _error_format = "error_format",
+    _extra_exec_rustc_flags = "extra_exec_rustc_flags",
     _extra_rustc_flags = "extra_rustc_flags",
 )
 load(
@@ -99,6 +100,9 @@ error_format = _error_format
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 extra_rustc_flags = _extra_rustc_flags
+# See @rules_rust//rust/private:rustc.bzl for a complete description.
+
+extra_exec_rustc_flags = _extra_exec_rustc_flags
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 rust_common = _rust_common

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -589,6 +589,7 @@ _common_attrs = {
         default = "@bazel_tools//tools/cpp:current_cc_toolchain",
     ),
     "_error_format": attr.label(default = "//:error_format"),
+    "_extra_exec_rustc_flags": attr.label(default = "//:extra_exec_rustc_flags"),
     "_extra_rustc_flags": attr.label(default = "//:extra_rustc_flags"),
     "_process_wrapper": attr.label(
         default = Label("//util/process_wrapper"),

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1263,7 +1263,7 @@ extra_rustc_flags = rule(
         "This flag should only be used for flags that need to be applied across the entire build. For options that " +
         "apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: " +
         "These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); " +
-        "use --@rules_rust//:extra_exec_rustc_flags to apply flags to the exec configuration."
+        "use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration."
     ),
     implementation = _extra_rustc_flags_impl,
     build_setting = config.string_list(flag = True),

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -51,8 +51,13 @@ ErrorFormatInfo = provider(
 )
 
 ExtraRustcFlagsInfo = provider(
-    doc = "Pass each value as an additional flag to rustc invocations",
-    fields = {"extra_rustc_flags": "List[string] Extra flags to pass to rustc"},
+    doc = "Pass each value as an additional flag to non-exec rustc invocations",
+    fields = {"extra_rustc_flags": "List[string] Extra flags to pass to rustc in non-exec configuration"},
+)
+
+ExtraExecRustcFlagsInfo = provider(
+    doc = "Pass each value as an additional flag to exec rustc invocations",
+    fields = {"extra_exec_rustc_flags": "List[string] Extra flags to pass to rustc in exec configuration"},
 )
 
 def _get_rustc_env(attr, toolchain, crate_name):
@@ -681,6 +686,9 @@ def construct_arguments(
     if hasattr(ctx.attr, "_extra_rustc_flags") and not is_exec_configuration(ctx):
         rustc_flags.add_all(ctx.attr._extra_rustc_flags[ExtraRustcFlagsInfo].extra_rustc_flags)
 
+    if hasattr(ctx.attr, "_extra_exec_rustc_flags") and is_exec_configuration(ctx):
+        rustc_flags.add_all(ctx.attr._extra_exec_rustc_flags[ExtraExecRustcFlagsInfo].extra_exec_rustc_flags)
+
     # Create a struct which keeps the arguments separate so each may be tuned or
     # replaced where necessary
     args = struct(
@@ -1254,8 +1262,22 @@ extra_rustc_flags = rule(
         "Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. " +
         "This flag should only be used for flags that need to be applied across the entire build. For options that " +
         "apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: " +
-        "These flags are currently excluded from the exec configuration (proc-macros, cargo_build_script, etc)."
+        "These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); " +
+        "use --@rules_rust//:extra_exec_rustc_flags to apply flags to the exec configuration."
     ),
     implementation = _extra_rustc_flags_impl,
+    build_setting = config.string_list(flag = True),
+)
+
+def _extra_exec_rustc_flags_impl(ctx):
+    return ExtraExecRustcFlagsInfo(extra_exec_rustc_flags = ctx.build_setting_value)
+
+extra_exec_rustc_flags = rule(
+    doc = (
+        "Add additional rustc_flags in the exec configuration from the command line with `--@rules_rust//:extra_exec_rustc_flags`. " +
+        "This flag should only be used for flags that need to be applied across the entire build. " +
+        "These flags only apply to the exec configuration (proc-macros, cargo_build_script, etc)."
+    ),
+    implementation = _extra_exec_rustc_flags_impl,
     build_setting = config.string_list(flag = True),
 )

--- a/test/extra_exec_rustc_flags/BUILD.bazel
+++ b/test/extra_exec_rustc_flags/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_rust//rust:defs.bzl", "rust_library")
+load("defs.bzl", "with_exec_cfg", "with_extra_exec_rustc_flags_cfg")
+
+package(default_visibility = ["//test:__subpackages__"])
+
+# Checks that extra_exec_rustc_flags are passed in exec configuration.
+# lib.rs is a sample source file that requires a `--cfg=bazel_exec` flag to build.
+# These targets set up transitions so that building :lib triggers building
+# lib.rs in exec configuration with //:extra_exec_rustc_flags=[--cfg=bazel_exec].
+# The intermediate targets are tagged "manual" as they are not meant to be built
+# on their own.
+
+rust_library(
+    name = "lib_do_not_build_directly",
+    srcs = ["lib.rs"],
+    tags = ["manual"],
+)
+
+with_extra_exec_rustc_flags_cfg(
+    name = "lib_with_exec_flags_do_not_build_directly",
+    srcs = ["lib_do_not_build_directly"],
+    extra_exec_rustc_flags = ["--cfg=bazel_exec"],
+    tags = ["manual"],
+)
+
+with_exec_cfg(
+    name = "lib",
+    srcs = ["lib_with_exec_flags_do_not_build_directly"],
+)
+
+build_test(
+    name = "lib_build",
+    targets = [":lib"],
+)

--- a/test/extra_exec_rustc_flags/BUILD.bazel
+++ b/test/extra_exec_rustc_flags/BUILD.bazel
@@ -29,7 +29,26 @@ with_exec_cfg(
     srcs = ["lib_with_exec_flags_do_not_build_directly"],
 )
 
+# Checks that extra_exec_rustc_flags are not passed in non-exec configurations.
+# lib_no_exec.rs is a sample source file that fails to build if
+# `--cfg=bazel_exec` is present. The targets below are built in non-exec configurations,
+# so they should build just fine with //:extra_exec_rustc_flags=[--cfg=bazel_exec].
+rust_library(
+    name = "lib_no_exec",
+    srcs = ["lib_no_exec.rs"],
+)
+
+with_extra_exec_rustc_flags_cfg(
+    name = "lib_no_exec_with_extra_build_flags",
+    srcs = ["lib_no_exec"],
+    extra_exec_rustc_flags = ["--cfg=bazel_exec"],
+)
+
 build_test(
     name = "lib_build",
-    targets = [":lib"],
+    targets = [
+        ":lib",
+        ":lib_no_exec",
+        ":lib_no_exec_with_extra_build_flags",
+    ],
 )

--- a/test/extra_exec_rustc_flags/defs.bzl
+++ b/test/extra_exec_rustc_flags/defs.bzl
@@ -1,0 +1,44 @@
+"""Test transitions to test extra_exec_rustc_flags."""
+
+def _extra_exec_rustc_flags_transition_impl(settings, attr):
+    return {
+        "//:extra_exec_rustc_flags": attr.extra_exec_rustc_flags,
+    }
+
+_extra_exec_rustc_flags_transition = transition(
+    implementation = _extra_exec_rustc_flags_transition_impl,
+    inputs = [],
+    outputs = ["//:extra_exec_rustc_flags"],
+)
+
+def _with_extra_exec_rustc_flags_cfg_impl(ctx):
+    return [DefaultInfo(files = depset(ctx.files.srcs))]
+
+with_extra_exec_rustc_flags_cfg = rule(
+    implementation = _with_extra_exec_rustc_flags_cfg_impl,
+    attrs = {
+        "extra_exec_rustc_flags": attr.string_list(
+            mandatory = True,
+        ),
+        "srcs": attr.label_list(
+            allow_files = True,
+            cfg = _extra_exec_rustc_flags_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = Label("//tools/allowlists/function_transition_allowlist"),
+        ),
+    },
+)
+
+def _with_exec_cfg_impl(ctx):
+    return [DefaultInfo(files = depset(ctx.files.srcs))]
+
+with_exec_cfg = rule(
+    implementation = _with_exec_cfg_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/test/extra_exec_rustc_flags/lib.rs
+++ b/test/extra_exec_rustc_flags/lib.rs
@@ -1,0 +1,7 @@
+// Sample source that fails to compile unless `--cfg=bazel_exec` is passed to rustc.
+#[cfg(bazel_exec)]
+fn exec() {}
+
+pub fn f() {
+    exec();
+}

--- a/test/extra_exec_rustc_flags/lib_no_exec.rs
+++ b/test/extra_exec_rustc_flags/lib_no_exec.rs
@@ -1,0 +1,7 @@
+// Sample source that fails to compile if `--cfg=bazel_exec` is passed to rustc.
+#[cfg(not(bazel_exec))]
+fn exec() {}
+
+pub fn f() {
+    exec();
+}


### PR DESCRIPTION
This is analogous to https://github.com/bazelbuild/rules_rust/commit/52e3ba4c99692b5354faff0fb1aa62ddf884024c but for the exec configuration. This is useful, e.g., when working in an environment similar to [the stage0 bootstrapping one](https://rustc-dev-guide.rust-lang.org/building/bootstrapping.html#complications-of-bootstrapping), where the beta (stable) toolchain is used to compile unstable sources with an additional `--cfg=bootstrap` flag to be passed everywhere in the exec configuration.

One tricky thing was testing: I didn't find a good way to emulate the testing for `extra_rustc_flags` from the above commit: checking that flags get applied in exec configuration requires digging through the actions of transitive dependencies of the target under test, and I didn't find a way to get to those via the analysistest APIs. Instead I defined a chain of transitions and a library rule on top that will only build if the `extra_exec_rustc_flags` are indeed passed to exec transitions.