### PR TITLE
Calculate path values in the rust_toolchain construction

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# buildifier: disable=module-docstring
-load("@bazel_skylib//lib:paths.bzl", "paths")
+"""Functionality for constructing actions that invoke the Rust compiler"""
+
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     "CPP_LINK_EXECUTABLE_ACTION_NAME",
@@ -622,7 +622,7 @@ def construct_arguments(
         rustc_flags.add(linker_script.path, format = "--codegen=link-arg=-T%s")
 
     # Gets the paths to the folders containing the standard library (or libcore)
-    rust_std_paths = depset([file.dirname for file in toolchain.rust_std.to_list()]).to_list()
+    rust_std_paths = toolchain.rust_std_paths.to_list()
 
     # Tell Rustc where to find the standard library
     rustc_flags.add_all(rust_std_paths, before_each = "-L", format_each = "%s")
@@ -680,7 +680,7 @@ def construct_arguments(
     ))
 
     # Set the SYSROOT to the directory of the rust_std files passed to the toolchain
-    env["SYSROOT"] = paths.dirname(toolchain.rust_std.to_list()[0].short_path)
+    env["SYSROOT"] = toolchain.sysroot
 
     # extra_rustc_flags apply to the target configuration, not the exec configuration.
     if hasattr(ctx.attr, "_extra_rustc_flags") and not is_exec_configuration(ctx):

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -16,7 +16,6 @@
 
 load("//rust/private:common.bzl", "rust_common")
 load("//rust/private:rustdoc.bzl", "rustdoc_compile_action")
-load("//rust/private:toolchain_utils.bzl", "find_sysroot")
 load("//rust/private:utils.bzl", "dedent", "find_toolchain")
 
 def _construct_writer_arguments(ctx, test_runner, action, crate_info, rust_toolchain):
@@ -41,7 +40,7 @@ def _construct_writer_arguments(ctx, test_runner, action, crate_info, rust_toolc
 
     # Set the SYSROOT to the directory of the rust_lib files passed to the toolchain
     env = {
-        "SYSROOT": "${{pwd}}/{}".format(find_sysroot(rust_toolchain)),
+        "SYSROOT": "${{pwd}}/{}".format(rust_toolchain.sysroot),
     }
 
     writer_args = ctx.actions.args()

--- a/rust/private/toolchain_utils.bzl
+++ b/rust/private/toolchain_utils.bzl
@@ -1,18 +1,5 @@
 """A module defining toolchain utilities"""
 
-def find_sysroot(rust_toolchain):
-    """Locate the rustc sysroot from the `rust_toolchain`
-
-    Args:
-        rust_toolchain (rust_toolchain): The currently configured `rust_toolchain`.
-
-    Returns:
-        str: A path assignable as `SYSROOT` for an action.
-    """
-    sysroot_anchor = rust_toolchain.rust_std.to_list()[0]
-    directory = sysroot_anchor.path.split(sysroot_anchor.short_path, 1)[0]
-    return directory.rstrip("/")
-
 def _toolchain_files_impl(ctx):
     toolchain = ctx.toolchains[str(Label("//rust:toolchain"))]
 

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -268,14 +268,14 @@ def _rust_toolchain_impl(ctx):
         linking_context = linking_context,
     )
 
-    # Calculate the rustc sysroot path by using a file from the rust-std bundle
-    rust_std_files_list = rust_std.files.to_list()
-    sysroot_anchor = rust_std_files_list[0]
-    sysroot_path_parts = sysroot_anchor.path.split("/")
-    sysroot_path = ""
-    if len(sysroot_path_parts) > 0:
-        # Drop the last part of the split which is expected to be the filename
-        sysroot_path = "/".join(sysroot_path_parts[:-1])
+    # In cases where the toolchain uses the Rust standard library, calculate sysroot path
+    sysroot_path = None
+    if rust_std:
+        # Calculate the rustc sysroot path by using a file from the rust-std bundle
+        rust_std_files_list = rust_std.files.to_list()
+        if not rust_std_files_list:
+            fail("The `rust_std` cannot be represented by an empty list")
+        sysroot_path = rust_std_files_list[0].dirname
 
     toolchain = platform_common.ToolchainInfo(
         rustc = ctx.file.rustc,

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -268,6 +268,15 @@ def _rust_toolchain_impl(ctx):
         linking_context = linking_context,
     )
 
+    # Calculate the rustc sysroot path by using a file from the rust-std bundle
+    rust_std_files_list = rust_std.files.to_list()
+    sysroot_anchor = rust_std_files_list[0]
+    sysroot_path_parts = sysroot_anchor.path.split("/")
+    sysroot_path = ""
+    if len(sysroot_path_parts) > 0:
+        # Drop the last part of the split which is expected to be the filename
+        sysroot_path = "/".join(sysroot_path_parts[:-1])
+
     toolchain = platform_common.ToolchainInfo(
         rustc = ctx.file.rustc,
         rust_doc = ctx.file.rust_doc,
@@ -279,7 +288,9 @@ def _rust_toolchain_impl(ctx):
         rustc_lib = depset(ctx.files.rustc_lib),
         rustc_srcs = ctx.attr.rustc_srcs,
         rust_std = rust_std.files,
+        rust_std_paths = depset([file.dirname for file in rust_std_files_list]),
         rust_lib = rust_std.files,  # `rust_lib` is deprecated and only exists for legacy support.
+        sysroot = sysroot_path,
         binary_ext = ctx.attr.binary_ext,
         staticlib_ext = ctx.attr.staticlib_ext,
         dylib_ext = ctx.attr.dylib_ext,


### PR DESCRIPTION
This change updates the `rust_toolchain` to calculate some paths instead of having each `Rustc` action do it.