### PR TITLE
Fix Windows long path issue in examples

### DIFF
--- a/examples/crate_universe/WORKSPACE.bazel
+++ b/examples/crate_universe/WORKSPACE.bazel
@@ -1,4 +1,4 @@
-workspace(name = "rules_rust_examples_crate_universe")
+workspace(name = "crate_universe_examples")
 
 local_repository(
     name = "rules_rust",


### PR DESCRIPTION
Relates to https://github.com/bazelbuild/rules_rust/issues/1120 and was the cause of a failure in https://buildkite.com/bazel/rules-rust-rustlang/builds/5283#7ad6df85-3e3e-4d17-b6dc-d9e806f04f9e