### PR TITLE
Remove toolchain._crosstool attribute

### DIFF
--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -303,7 +303,7 @@ def _rust_toolchain_impl(ctx):
         target_arch = ctx.attr.target_triple.split("-")[0],
         default_edition = ctx.attr.default_edition,
         compilation_mode_opts = compilation_mode_opts,
-        crosstool_files = ctx.files._crosstool,
+        crosstool_files = ctx.files._cc_toolchain,
         libstd_and_allocator_ccinfo = _make_libstd_and_allocator_ccinfo(ctx, rust_std, ctx.attr.allocator_library),
         _rename_first_party_crates = rename_first_party_crates,
         _third_party_dir = third_party_dir,
@@ -421,9 +421,6 @@ rust_toolchain = rule(
         ),
         "_cc_toolchain": attr.label(
             default = "@bazel_tools//tools/cpp:current_cc_toolchain",
-        ),
-        "_crosstool": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
         "_rename_first_party_crates": attr.label(
             default = "@rules_rust//rust/settings:rename_first_party_crates",


### PR DESCRIPTION
We use the equivalent toolchain._cc_toolchain attribute instead