### PR TITLE
pin buildifier

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -302,5 +302,9 @@ tasks:
     # TODO: fix test targets in `crate_universe_windows_targets`
     test_targets: *crate_universe_windows_targets
 buildifier:
-  version: latest
+  # TODO: Version 5.0.0 introduced a ton of unused variable warnings in cases
+  # that should have been accounted for by `_` prefixes on the variable. Buildifier
+  # should ignore `_` prefixed variables when checking if something is unused
+  # https://github.com/bazelbuild/buildtools/issues/1044
+  version: 4.2.5
   warnings: "all"


### PR DESCRIPTION
https://github.com/bazelbuild/buildtools/issues/1044 tracks what I feel is more of a bug in the new [unused-variable](https://github.com/bazelbuild/buildtools/blob/5.0.0/WARNINGS.md#unused-variable) defect. I would like to avoid stamping things with `@unused` and creating cases where dead code can be forgotten about (see the issue for more details).