### PR TITLE
Clean up outdated comments in `transform_deps`.

### DIFF
--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -378,19 +378,16 @@ def is_exec_configuration(ctx):
     return ctx.genfiles_dir.path.find("-exec-") != -1
 
 def transform_deps(deps):
-    """Conditionally transform a [Target] into [DepVariantInfo].
+    """Transforms a [Target] into [DepVariantInfo].
 
     This helper function is used to transform ctx.attr.deps and ctx.attr.proc_macro_deps into
-    [DepVariantInfo] when --//rust/settings:incompatible_make_rust_providers_target_independent
-    is set to true (https://github.com/bazelbuild/rules_rust/issues/966).
-    Do not rely on this function - it will be removed after the flag is flipped.
+    [DepVariantInfo].
 
     Args:
-        deps (list of Targets): Dependencies comming from ctx.attr.deps or ctx.attr.proc_macro_deps
+        deps (list of Targets): Dependencies coming from ctx.attr.deps or ctx.attr.proc_macro_deps
 
     Returns:
-        list of DepVariantInfos if --//rust/settings:incompatible_make_rust_providers_target has
-        been flipped, list of Targets otherwise.
+        list of DepVariantInfos.
     """
     return [DepVariantInfo(
         crate_info = dep[CrateInfo] if CrateInfo in dep else None,


### PR DESCRIPTION
These comments are related to the migration described in #966. This issue is closed, so it looks like the migration is finished - so these comments are out of date.