### PR TITLE
Revert "Add CI run with -c opt (#1144)"

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -133,15 +133,6 @@ tasks:
     test_targets: *default_linux_targets
     soft_fail: yes
     bazel: "rolling"
-  ubuntu2004_opt:
-    name: With -c opt
-    platform: ubuntu2004
-    build_flags:
-      - "--config=rustfmt"
-      - "--config=clippy"
-      - "--compilation_mode=opt"
-    build_targets: *default_linux_targets
-    test_targets: *default_linux_targets
   ubuntu1804:
     name: "Min Bazel Version"
     bazel: "4.0.0"

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -119,7 +119,7 @@ def _are_linkstamps_supported(feature_configuration, has_grep_includes):
             has_grep_includes)
 
 def _should_use_pic(cc_toolchain, feature_configuration, crate_type):
-    if crate_type in ["cdylib", "dylib", "proc-macro"]:
+    if crate_type in ("cdylib" or "dylib"):
         return cc_toolchain.needs_pic_for_dynamic_libraries(feature_configuration = feature_configuration)
     return False
 
@@ -1321,7 +1321,7 @@ def _add_native_link_flags(args, dep_info, linkstamp_outs, ambiguous_libs, crate
     for linkstamp_out in linkstamp_outs:
         args.add_all(["-C", "link-arg=%s" % linkstamp_out.path])
 
-    if crate_type in ["dylib", "cdylib", "proc-macro"]:
+    if crate_type in ["dylib", "cdylib"]:
         # For shared libraries we want to link C++ runtime library dynamically
         # (for example libstdc++.so or libc++.so).
         args.add_all(

--- a/test/unit/native_deps/bar.cc
+++ b/test/unit/native_deps/bar.cc
@@ -1,3 +1,1 @@
-int native_global = 42;
 
-extern "C" int native_dep() { return native_global; }

--- a/test/unit/native_deps/native_action_inputs_test.bzl
+++ b/test/unit/native_deps/native_action_inputs_test.bzl
@@ -51,8 +51,6 @@ def _native_dep_lib_name(ctx):
         ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
     ):
         return "bar.lib"
-    elif ("dylib" in ctx.label.name or "proc_macro" in ctx.label.name) and ctx.var["COMPILATION_MODE"] == "opt":
-        return "libbar.pic.a"
     else:
         return "libbar.a"
 


### PR DESCRIPTION
This reverts commit 98bbf8d880d04bf00a602568b8ce812aaf68ed2e.

We're seeing some regressions with interactions between proc-macro and shared-libraries, chatted with @hlopko directly.

I left test/unit/native_deps/native_action_inputs_test.bzl as-is, as all the changes look like improvements and there are many conflicts otherwise.