### PR TITLE
Add alias for `cargo_bootstrap_repository` binaries

### DIFF
--- a/cargo/cargo_bootstrap.bzl
+++ b/cargo/cargo_bootstrap.bzl
@@ -116,6 +116,11 @@ exports_files([
     "{binary}"
 ])
 
+alias(
+    name = "binary",
+    actual = "{binary}",
+)
+
 rust_binary(
     name = "install",
     rustc_env = {{


### PR DESCRIPTION
This should help users access the bootstrapped binary in a consistent way.