### PR TITLE
Add `user.bazelrc` support to each workspace.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 # `.bazelrc` is a Bazel configuration file.
-# https://docs.bazel.build/versions/master/best-practices.html#using-the-bazelrc-file
+# https://bazel.build/docs/best-practices#bazelrc-file
 
 # Enable rustfmt for all targets in the workspace
 build:rustfmt --aspects=//rust:defs.bzl%rustfmt_aspect
@@ -9,5 +9,9 @@ build:rustfmt --output_groups=+rustfmt_checks
 build:clippy --aspects=//rust:defs.bzl%rust_clippy_aspect
 build:clippy --output_groups=+clippy_checks
 
-# https://bazel.googlesource.com/bazel/+/master/site/docs/windows.md#enable-symlink-support
+# https://bazel.build/docs/windows#symlink
 startup --windows_enable_symlinks
+
+# This import should always be last to allow users to override
+# settings for local development.
+try-import %workspace%/user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /examples/bazel-*
 /examples/crate_universe/*/bazel-*
 /docs/bazel-*
+user.bazelrc
 
 # rustfmt
 *.rs.bk

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,5 +1,5 @@
 # `.bazelrc` is a Bazel configuration file.
-# https://docs.bazel.build/versions/master/best-practices.html#using-the-bazelrc-file
+# https://bazel.build/docs/best-practices#bazelrc-file
 
 # Enable rustfmt for all targets in the workspace
 build:rustfmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
@@ -8,3 +8,7 @@ build:rustfmt --output_groups=+rustfmt_checks
 # Enable clippy for all targets in the workspace
 build:clippy --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:clippy --output_groups=+clippy_checks
+
+# This import should always be last to allow users to override
+# settings for local development.
+try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/.bazelrc
+++ b/examples/crate_universe/.bazelrc
@@ -1,5 +1,5 @@
 # `.bazelrc` is a Bazel configuration file.
-# https://docs.bazel.build/versions/master/best-practices.html#using-the-bazelrc-file
+# https://bazel.build/docs/best-practices#bazelrc-file
 
 # Enable rustfmt for all targets in the workspace
 build:rustfmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
@@ -8,3 +8,7 @@ build:rustfmt --output_groups=+rustfmt_checks
 # Enable clippy for all targets in the workspace
 build:clippy --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:clippy --output_groups=+clippy_checks
+
+# This import should always be last to allow users to override
+# settings for local development.
+try-import %workspace%/user.bazelrc


### PR DESCRIPTION
This allows for easier local development and follows Bazel's recommended practices:
https://bazel.build/docs/best-practices#bazelrc-file

> If you want to support per-user options for your project that you do not want to check into source control, include the line:
> ```
> try-import %workspace%/user.bazelrc
> ```
> (or any other file name) in your workspace/.bazelrc and add user.bazelrc to your .gitignore.