### PR TITLE
Allow `cargo_build_script` to forward rustc args to build scripts

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -119,7 +119,7 @@ def _build_script_impl(ctx):
 
     # In form build scripts of rustc flags
     # https://github.com/rust-lang/cargo/issues/9600
-    env["CARGO_ENCODED_RUSTFLAGS"] = " ".join([
+    env["CARGO_ENCODED_RUSTFLAGS"] = "\x1f".join([
         # Allow build scripts to locate the generated sysroot
         "--sysroot=${{pwd}}/{}".format(toolchain.sysroot),
     ])

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -117,7 +117,7 @@ def _build_script_impl(ctx):
         if cc_toolchain.sysroot:
             env["SYSROOT"] = cc_toolchain.sysroot
 
-    # In form build scripts of rustc flags
+    # Inform build scripts of rustc flags
     # https://github.com/rust-lang/cargo/issues/9600
     env["CARGO_ENCODED_RUSTFLAGS"] = "\x1f".join([
         # Allow build scripts to locate the generated sysroot

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -7,7 +7,7 @@ load("//rust:defs.bzl", "rust_binary", "rust_common")
 load("//rust/private:rustc.bzl", "BuildInfo", "get_compilation_mode_opts", "get_linker_and_args")
 
 # buildifier: disable=bzl-visibility
-load("//rust/private:utils.bzl", "expand_dict_value_locations", "find_cc_toolchain", "find_toolchain", "name_to_crate_name")
+load("//rust/private:utils.bzl", "dedent", "expand_dict_value_locations", "find_cc_toolchain", "find_toolchain", "name_to_crate_name")
 
 def get_cc_compile_env(cc_toolchain, feature_configuration):
     """Gather cc environment variables from the given `cc_toolchain`
@@ -119,10 +119,10 @@ def _build_script_impl(ctx):
 
     # Inform build scripts of rustc flags
     # https://github.com/rust-lang/cargo/issues/9600
-    env["CARGO_ENCODED_RUSTFLAGS"] = "\x1f".join([
+    env["CARGO_ENCODED_RUSTFLAGS"] = "\\x1f".join([
         # Allow build scripts to locate the generated sysroot
         "--sysroot=${{pwd}}/{}".format(toolchain.sysroot),
-    ])
+    ] + ctx.attr.rustc_flags)
 
     for f in ctx.attr.crate_features:
         env["CARGO_FEATURE_" + f.upper().replace("-", "_")] = "1"
@@ -219,6 +219,16 @@ _build_script_run = rule(
         "links": attr.string(
             doc = "The name of the native library this crate links against.",
         ),
+        "rustc_flags": attr.string_list(
+            doc = dedent("""\
+                List of compiler flags passed to `rustc`.
+
+                These strings are subject to Make variable expansion for predefined
+                source/output path variables like `$location`, `$execpath`, and 
+                `$rootpath`. This expansion is useful if you wish to pass a generated
+                file of arguments to rustc: `@$(location //package:target)`.
+            """),
+        ),
         # The source of truth will be the `cargo_build_script` macro until stardoc
         # implements documentation inheritence. See https://github.com/bazelbuild/stardoc/issues/27
         "script": attr.label(
@@ -264,6 +274,7 @@ def cargo_build_script(
         tools = [],
         links = None,
         rustc_env = {},
+        rustc_flags = [],
         visibility = None,
         tags = None,
         **kwargs):
@@ -335,6 +346,7 @@ def cargo_build_script(
         tools (list, optional): Tools (executables) needed by the build script.
         links (str, optional): Name of the native library this crate links against.
         rustc_env (dict, optional): Environment variables to set in rustc when compiling the build script.
+        rustc_flags (list, optional): List of compiler flags passed to `rustc`.
         visibility (list of label, optional): Visibility to apply to the generated build script output.
         tags: (list of str, optional): Tags to apply to the generated build script output.
         **kwargs: Forwards to the underlying `rust_binary` rule.
@@ -359,6 +371,7 @@ def cargo_build_script(
         deps = deps,
         data = data,
         rustc_env = rustc_env,
+        rustc_flags = rustc_flags,
         tags = binary_tags,
         **kwargs
     )
@@ -372,6 +385,7 @@ def cargo_build_script(
         deps = deps,
         data = data,
         tools = tools,
+        rustc_flags = rustc_flags,
         visibility = visibility,
         tags = tags,
     )

--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -100,6 +100,12 @@ fn run_buildrs() -> Result<(), String> {
         }
     }
 
+    // Bazel does not support byte strings so in order to correctly represent `CARGO_ENCODED_RUSTFLAGS`
+    // the escaped `\x1f` sequences need to be unescaped
+    if let Ok(encoded_rustflags) = env::var("CARGO_ENCODED_RUSTFLAGS") {
+        command.env("CARGO_ENCODED_RUSTFLAGS", encoded_rustflags.replace("\\x1f", "\x1f"));
+    }
+
     if let Some(ar_path) = env::var_os("AR") {
         // The default OSX toolchain uses libtool as ar_executable not ar.
         // This doesn't work when used as $AR, so simply don't set it - tools will probably fall back to

--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -100,15 +100,6 @@ fn run_buildrs() -> Result<(), String> {
         }
     }
 
-    // Bazel does not support byte strings so in order to correctly represent `CARGO_ENCODED_RUSTFLAGS`
-    // the escaped `\x1f` sequences need to be unescaped
-    if let Ok(encoded_rustflags) = env::var("CARGO_ENCODED_RUSTFLAGS") {
-        command.env(
-            "CARGO_ENCODED_RUSTFLAGS",
-            encoded_rustflags.replace("\\x1f", "\x1f"),
-        );
-    }
-
     if let Some(ar_path) = env::var_os("AR") {
         // The default OSX toolchain uses libtool as ar_executable not ar.
         // This doesn't work when used as $AR, so simply don't set it - tools will probably fall back to
@@ -130,6 +121,15 @@ fn run_buildrs() -> Result<(), String> {
         if value.contains("${pwd}") {
             env::set_var(key, value.replace("${pwd}", exec_root_str));
         }
+    }
+
+    // Bazel does not support byte strings so in order to correctly represent `CARGO_ENCODED_RUSTFLAGS`
+    // the escaped `\x1f` sequences need to be unescaped
+    if let Ok(encoded_rustflags) = env::var("CARGO_ENCODED_RUSTFLAGS") {
+        command.env(
+            "CARGO_ENCODED_RUSTFLAGS",
+            encoded_rustflags.replace("\\x1f", "\x1f"),
+        );
     }
 
     let (buildrs_outputs, process_output) = BuildScriptOutput::outputs_from_command(&mut command)

--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -103,7 +103,10 @@ fn run_buildrs() -> Result<(), String> {
     // Bazel does not support byte strings so in order to correctly represent `CARGO_ENCODED_RUSTFLAGS`
     // the escaped `\x1f` sequences need to be unescaped
     if let Ok(encoded_rustflags) = env::var("CARGO_ENCODED_RUSTFLAGS") {
-        command.env("CARGO_ENCODED_RUSTFLAGS", encoded_rustflags.replace("\\x1f", "\x1f"));
+        command.env(
+            "CARGO_ENCODED_RUSTFLAGS",
+            encoded_rustflags.replace("\\x1f", "\x1f"),
+        );
     }
 
     if let Some(ar_path) = env::var_os("AR") {

--- a/docs/cargo.md
+++ b/docs/cargo.md
@@ -46,7 +46,7 @@ A rule for bootstrapping a Rust binary using [Cargo](https://doc.rust-lang.org/c
 
 <pre>
 cargo_build_script(<a href="#cargo_build_script-name">name</a>, <a href="#cargo_build_script-crate_features">crate_features</a>, <a href="#cargo_build_script-version">version</a>, <a href="#cargo_build_script-deps">deps</a>, <a href="#cargo_build_script-build_script_env">build_script_env</a>, <a href="#cargo_build_script-data">data</a>, <a href="#cargo_build_script-tools">tools</a>, <a href="#cargo_build_script-links">links</a>,
-                   <a href="#cargo_build_script-rustc_env">rustc_env</a>, <a href="#cargo_build_script-visibility">visibility</a>, <a href="#cargo_build_script-tags">tags</a>, <a href="#cargo_build_script-kwargs">kwargs</a>)
+                   <a href="#cargo_build_script-rustc_env">rustc_env</a>, <a href="#cargo_build_script-rustc_flags">rustc_flags</a>, <a href="#cargo_build_script-visibility">visibility</a>, <a href="#cargo_build_script-tags">tags</a>, <a href="#cargo_build_script-kwargs">kwargs</a>)
 </pre>
 
 Compile and execute a rust build script to generate build attributes
@@ -121,6 +121,7 @@ The `hello_lib` target will be build with the flags and the environment variable
 | <a id="cargo_build_script-tools"></a>tools |  Tools (executables) needed by the build script.   |  <code>[]</code> |
 | <a id="cargo_build_script-links"></a>links |  Name of the native library this crate links against.   |  <code>None</code> |
 | <a id="cargo_build_script-rustc_env"></a>rustc_env |  Environment variables to set in rustc when compiling the build script.   |  <code>{}</code> |
+| <a id="cargo_build_script-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   |  <code>[]</code> |
 | <a id="cargo_build_script-visibility"></a>visibility |  Visibility to apply to the generated build script output.   |  <code>None</code> |
 | <a id="cargo_build_script-tags"></a>tags |  (list of str, optional): Tags to apply to the generated build script output.   |  <code>None</code> |
 | <a id="cargo_build_script-kwargs"></a>kwargs |  Forwards to the underlying <code>rust_binary</code> rule.   |  none |

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1389,7 +1389,7 @@ A collection of files either found within the `rust-stdlib` artifact or generate
 
 <pre>
 cargo_build_script(<a href="#cargo_build_script-name">name</a>, <a href="#cargo_build_script-crate_features">crate_features</a>, <a href="#cargo_build_script-version">version</a>, <a href="#cargo_build_script-deps">deps</a>, <a href="#cargo_build_script-build_script_env">build_script_env</a>, <a href="#cargo_build_script-data">data</a>, <a href="#cargo_build_script-tools">tools</a>, <a href="#cargo_build_script-links">links</a>,
-                   <a href="#cargo_build_script-rustc_env">rustc_env</a>, <a href="#cargo_build_script-visibility">visibility</a>, <a href="#cargo_build_script-tags">tags</a>, <a href="#cargo_build_script-kwargs">kwargs</a>)
+                   <a href="#cargo_build_script-rustc_env">rustc_env</a>, <a href="#cargo_build_script-rustc_flags">rustc_flags</a>, <a href="#cargo_build_script-visibility">visibility</a>, <a href="#cargo_build_script-tags">tags</a>, <a href="#cargo_build_script-kwargs">kwargs</a>)
 </pre>
 
 Compile and execute a rust build script to generate build attributes
@@ -1464,6 +1464,7 @@ The `hello_lib` target will be build with the flags and the environment variable
 | <a id="cargo_build_script-tools"></a>tools |  Tools (executables) needed by the build script.   |  <code>[]</code> |
 | <a id="cargo_build_script-links"></a>links |  Name of the native library this crate links against.   |  <code>None</code> |
 | <a id="cargo_build_script-rustc_env"></a>rustc_env |  Environment variables to set in rustc when compiling the build script.   |  <code>{}</code> |
+| <a id="cargo_build_script-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   |  <code>[]</code> |
 | <a id="cargo_build_script-visibility"></a>visibility |  Visibility to apply to the generated build script output.   |  <code>None</code> |
 | <a id="cargo_build_script-tags"></a>tags |  (list of str, optional): Tags to apply to the generated build script output.   |  <code>None</code> |
 | <a id="cargo_build_script-kwargs"></a>kwargs |  Forwards to the underlying <code>rust_binary</code> rule.   |  none |

--- a/test/cargo_build_script/BUILD.bazel
+++ b/test/cargo_build_script/BUILD.bazel
@@ -8,6 +8,8 @@ cargo_build_script(
     name = "tools_exec_build_rs",
     srcs = ["build.rs"],
     build_script_env = {"TOOL": "$(execpath :tool)"},
+    # Add a flag to test that they're exposed to the build script
+    rustc_flags = ["--verbose"],
     tools = [":tool"],
 )
 

--- a/test/cargo_build_script/build.rs
+++ b/test/cargo_build_script/build.rs
@@ -11,7 +11,7 @@ fn test_encoded_rustflags() {
     assert_eq!(flags.len(), 2);
 
     assert!(flags[0].starts_with("--sysroot"));
-    assert!(flags[1].starts_with("--verbose"));
+    assert_eq!(flags[1], "--verbose");
 }
 
 fn main() {

--- a/test/cargo_build_script/build.rs
+++ b/test/cargo_build_script/build.rs
@@ -1,4 +1,24 @@
+//! A Cargo build script binary used in unit tests for the Bazel `cargo_build_script` rule
+
+/// `cargo_build_script` should always set `CARGO_ENCODED_RUSTFLAGS`
+fn test_encoded_rustflags() {
+    let encoded_rustflags = std::env::var("CARGO_ENCODED_RUSTFLAGS").unwrap();
+
+    let flags: Vec<String> = encoded_rustflags
+        .split('\x1f')
+        .map(str::to_string)
+        .collect();
+    assert_eq!(flags.len(), 2);
+
+    assert!(flags[0].starts_with("--sysroot"));
+    assert!(flags[1].starts_with("--verbose"));
+}
+
 fn main() {
+
+    // Perform some unit testing
+    test_encoded_rustflags();
+
     // Pass the TOOL_PATH along to the rust_test so we can assert on it.
     println!(
         "cargo:rustc-env=TOOL_PATH={}",

--- a/test/cargo_build_script/build.rs
+++ b/test/cargo_build_script/build.rs
@@ -11,11 +11,14 @@ fn test_encoded_rustflags() {
     assert_eq!(flags.len(), 2);
 
     assert!(flags[0].starts_with("--sysroot"));
+
+    // Ensure the `pwd` template has been resolved
+    assert!(!flags[0].contains("${pwd}"));
+
     assert_eq!(flags[1], "--verbose");
 }
 
 fn main() {
-
     // Perform some unit testing
     test_encoded_rustflags();
 


### PR DESCRIPTION
https://github.com/rust-lang/cargo/issues/9600 lead to the introduction of `CARGO_ENCODED_RUSTFLAGS` which was introduced to allow build scripts to access rust flags. This PR add this flag and sets `--sysroot` so crates like `autocfg` (which makes use of this flag [here](https://github.com/cuviper/autocfg/blob/1.1.0/src/lib.rs#L420-L426)) is correctly able to make use of the generated `rust_toolchain`. This avoids issues like the following for users who create toolchains from separate `rustc` and `rust_std` artifacts.
```
Use --sandbox_debug to see verbose messages from the sandbox
error[E0107]: this struct takes 3 generic arguments but 2 generic arguments were supplied
  --> external/cargo_aliases__clap-3.0.0-beta.2/src/parse/matches/arg_matches.rs:77:22
   |
77 |     pub(crate) args: IndexMap<Id, MatchedArg>,
   |                      ^^^^^^^^ --  ---------- supplied 2 generic arguments
   |                      |
   |                      expected 3 generic arguments
   |
help: add missing generic argument
   |
77 |     pub(crate) args: IndexMap<Id, MatchedArg, S>,
   |                                             +++
 
error: aborting due to previous error
```