### PR TITLE
Fixed `crate.spec` being ignored in `crate_universe` rules.

### DIFF
--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -1,7 +1,7 @@
 """Rules for vendoring Bazel targets into existing workspaces"""
 
 load("//crate_universe/private:generate_utils.bzl", "collect_crate_annotations", "render_config")
-load("//crate_universe/private:splicing_utils.bzl", "splicing_config")
+load("//crate_universe/private:splicing_utils.bzl", "kebab_case_keys", "splicing_config")
 load("//crate_universe/private:urls.bzl", "CARGO_BAZEL_LABEL")
 load("//rust/platform:triple_mappings.bzl", "SUPPORTED_PLATFORM_TRIPLES")
 
@@ -58,7 +58,8 @@ def _write_data_file(ctx, name, data):
 def _write_splicing_manifest(ctx):
     # Deserialize information about direct packges
     direct_packages_info = {
-        pkg: json.decode(data)
+        # Ensure the data is using kebab-case as that's what `cargo_toml::DependencyDetail` expects.
+        pkg: kebab_case_keys(dict(json.decode(data)))
         for (pkg, data) in ctx.attr.packages.items()
     }
 

--- a/crate_universe/private/splicing_utils.bzl
+++ b/crate_universe/private/splicing_utils.bzl
@@ -76,6 +76,20 @@ def download_extra_workspace_members(repository_ctx, cache_dir, render_template_
 
     return manifests
 
+def kebab_case_keys(data):
+    """Ensure the key value of the data given are kebab-case
+
+    Args:
+        data (dict): A deserialized json blob
+
+    Returns:
+        dict: The same `data` but with kebab-case keys
+    """
+    return {
+        key.lower().replace("_", "-"): val
+        for (key, val) in data.items()
+    }
+
 def create_splicing_manifest(repository_ctx):
     """Produce a manifest containing required components for splciing a new Cargo workspace
 
@@ -89,7 +103,8 @@ def create_splicing_manifest(repository_ctx):
 
     # Deserialize information about direct packges
     direct_packages_info = {
-        pkg: json.decode(data)
+        # Ensure the data is using kebab-case as that's what `cargo_toml::DependencyDetail` expects.
+        pkg: kebab_case_keys(dict(json.decode(data)))
         for (pkg, data) in repository_ctx.attr.packages.items()
     }
 

--- a/examples/crate_universe/extra_workspace_members/Cargo.Bazel.lock
+++ b/examples/crate_universe/extra_workspace_members/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "0c378937b8cfb3069017bc9680db9d94bd12d7569f71ea00fa3c75421b893560",
+  "checksum": "e3970ece78ced37e01b3e8d70f9b1350e9d902a2be78f8c08789b05242583bef",
   "crates": {
     "adler32 1.2.0": {
       "name": "adler32",
@@ -462,7 +462,7 @@
               "target": "libc"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             },
             {
@@ -1588,13 +1588,13 @@
       },
       "license": "MIT"
     },
-    "once_cell 1.9.0": {
+    "once_cell 1.10.0": {
       "name": "once_cell",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/once_cell/1.9.0/download",
-          "sha256": "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+          "url": "https://crates.io/api/v1/crates/once_cell/1.10.0/download",
+          "sha256": "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
         }
       },
       "targets": [
@@ -1623,7 +1623,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "1.9.0"
+        "version": "1.10.0"
       },
       "license": "MIT OR Apache-2.0"
     },

--- a/examples/crate_universe/multi_package/Cargo.Bazel.lock
+++ b/examples/crate_universe/multi_package/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "135d4cd85352bc3c007d7fc87097f5b8ad2b002a44a5febd26aaa8b6fdf7d37a",
+  "checksum": "cba62ac1869a36d1f714ffd077e59f027e78a09a85df999006e21db814f938f4",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -279,7 +279,7 @@
         "deps": {
           "common": [
             {
-              "id": "async-task 4.1.0",
+              "id": "async-task 4.2.0",
               "target": "async_task"
             },
             {
@@ -295,7 +295,7 @@
               "target": "futures_lite"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             },
             {
@@ -373,7 +373,7 @@
               "target": "num_cpus"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             }
           ],
@@ -427,7 +427,7 @@
               "target": "log"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             },
             {
@@ -640,7 +640,7 @@
               "target": "futures_lite"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             }
           ],
@@ -769,7 +769,7 @@
               "target": "num_cpus"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             },
             {
@@ -825,13 +825,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "async-task 4.1.0": {
+    "async-task 4.2.0": {
       "name": "async-task",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-task/4.1.0/download",
-          "sha256": "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
+          "url": "https://crates.io/api/v1/crates/async-task/4.2.0/download",
+          "sha256": "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
         }
       },
       "targets": [
@@ -858,7 +858,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "4.1.0"
+        "version": "4.2.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -1356,7 +1356,7 @@
               "target": "async_channel"
             },
             {
-              "id": "async-task 4.1.0",
+              "id": "async-task 4.2.0",
               "target": "async_task"
             },
             {
@@ -1372,7 +1372,7 @@
               "target": "futures_lite"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             }
           ],
@@ -2084,7 +2084,7 @@
               "target": "libnghttp2_sys"
             },
             {
-              "id": "libz-sys 1.1.3",
+              "id": "libz-sys 1.1.4",
               "target": "libz_sys"
             }
           ],
@@ -4295,13 +4295,13 @@
       },
       "license": "BSD-3-Clause"
     },
-    "ipnet 2.3.1": {
+    "ipnet 2.4.0": {
       "name": "ipnet",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ipnet/2.3.1/download",
-          "sha256": "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+          "url": "https://crates.io/api/v1/crates/ipnet/2.4.0/download",
+          "sha256": "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
         }
       },
       "targets": [
@@ -4323,8 +4323,11 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": [
+          "default"
+        ],
         "edition": "2015",
-        "version": "2.3.1"
+        "version": "2.4.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4427,7 +4430,7 @@
               "target": "mime"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             },
             {
@@ -5006,13 +5009,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libz-sys 1.1.3": {
+    "libz-sys 1.1.4": {
       "name": "libz-sys",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libz-sys/1.1.3/download",
-          "sha256": "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+          "url": "https://crates.io/api/v1/crates/libz-sys/1.1.4/download",
+          "sha256": "df2bf61678a0a521c3f7daf815d2e6717d85a272a7dcd02c9768272b32bd1e2a"
         }
       },
       "targets": [
@@ -5056,14 +5059,14 @@
               "target": "libc"
             },
             {
-              "id": "libz-sys 1.1.3",
+              "id": "libz-sys 1.1.4",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.1.3"
+        "version": "1.1.4"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5756,13 +5759,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "once_cell 1.9.0": {
+    "once_cell 1.10.0": {
       "name": "once_cell",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/once_cell/1.9.0/download",
-          "sha256": "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+          "url": "https://crates.io/api/v1/crates/once_cell/1.10.0/download",
+          "sha256": "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
         }
       },
       "targets": [
@@ -5791,7 +5794,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "1.9.0"
+        "version": "1.10.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -5887,7 +5890,7 @@
               "target": "libc"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             },
             {
@@ -6357,7 +6360,7 @@
         "deps": {
           "common": [
             {
-              "id": "siphasher 0.3.9",
+              "id": "siphasher 0.3.10",
               "target": "siphasher"
             }
           ],
@@ -7284,7 +7287,7 @@
                 "target": "hyper_tls"
               },
               {
-                "id": "ipnet 2.3.1",
+                "id": "ipnet 2.4.0",
                 "target": "ipnet"
               },
               {
@@ -8112,13 +8115,13 @@
       },
       "license": "Apache-2.0"
     },
-    "siphasher 0.3.9": {
+    "siphasher 0.3.10": {
       "name": "siphasher",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/siphasher/0.3.9/download",
-          "sha256": "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
+          "url": "https://crates.io/api/v1/crates/siphasher/0.3.10/download",
+          "sha256": "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
         }
       },
       "targets": [
@@ -8145,7 +8148,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.3.9"
+        "version": "0.3.10"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -8811,7 +8814,7 @@
               "target": "num_cpus"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             },
             {

--- a/examples/crate_universe/no_cargo_manifests/Cargo.Bazel.lock
+++ b/examples/crate_universe/no_cargo_manifests/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "8eeaecba1dc454ef2e41ffa0071049af54e659c4a65c9989eb3433dab5947222",
+  "checksum": "5c8bd4f7527784376a1667a00ecf8f9ddd398a2a3ccefee5201b383f56d2c99b",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -260,7 +260,7 @@
               "target": "tower"
             },
             {
-              "id": "tower-http 0.2.3",
+              "id": "tower-http 0.2.4",
               "target": "tower_http"
             },
             {
@@ -511,7 +511,7 @@
               "target": "tower"
             },
             {
-              "id": "tower-http 0.2.3",
+              "id": "tower-http 0.2.4",
               "target": "tower_http"
             },
             {
@@ -2135,13 +2135,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "once_cell 1.9.0": {
+    "once_cell 1.10.0": {
       "name": "once_cell",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/once_cell/1.9.0/download",
-          "sha256": "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+          "url": "https://crates.io/api/v1/crates/once_cell/1.10.0/download",
+          "sha256": "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
         }
       },
       "targets": [
@@ -2170,7 +2170,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "1.9.0"
+        "version": "1.10.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3269,7 +3269,7 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             }
           ],
@@ -3353,7 +3353,7 @@
               "target": "num_cpus"
             },
             {
-              "id": "once_cell 1.9.0",
+              "id": "once_cell 1.10.0",
               "target": "once_cell"
             },
             {
@@ -3669,13 +3669,13 @@
       },
       "license": "MIT"
     },
-    "tower-http 0.2.3": {
+    "tower-http 0.2.4": {
       "name": "tower-http",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tower-http/0.2.3/download",
-          "sha256": "2bb284cac1883d54083a0edbdc9cabf931dfed87455f8c7266c01ece6394a43a"
+          "url": "https://crates.io/api/v1/crates/tower-http/0.2.4/download",
+          "sha256": "90c125fdea84614a4368fd35786b51d0682ab8d42705e061e92f0b955dea40fb"
         }
       },
       "targets": [
@@ -3759,7 +3759,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.3"
+        "version": "0.2.4"
       },
       "license": "MIT"
     },


### PR DESCRIPTION
[cargo_toml::DependencyDetail](https://gitlab.com/crates.rs/cargo_toml/-/blob/v0.11.3/src/cargo_toml.rs#L504) currently looks for kebab-case variables to deserialize since that's the expectation from Cargo manifests. This change fixes splicing manifests to correctly contain `kebab-case` key values for crate specs.

This addresses part of https://github.com/bazelbuild/rules_rust/issues/1168