### PR TITLE
Allow specifying additional target triples in rust_register_toolchains() and fix androideabi system

### DIFF
--- a/rust/platform/triple.bzl
+++ b/rust/platform/triple.bzl
@@ -38,6 +38,10 @@ def triple(triple):
     system = component_parts[2]
     abi = None
 
+    if system == "androideabi":
+        system = "android"
+        abi = "eabi"
+
     if len(component_parts) == 4:
         abi = component_parts[3]
 

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -212,7 +212,10 @@ def triple_to_system(triple):
     if len(component_parts) < 3:
         fail("Expected target triple to contain at least three sections separated by '-'")
 
-    return component_parts[2]
+    system = component_parts[2]
+    if (system == "androideabi"):
+        system = "android"
+    return system
 
 def triple_to_arch(triple):
     """Returns a system architecture name for a given platform triple
@@ -289,6 +292,10 @@ def triple_to_constraint_set(triple):
     vendor = component_parts[1]
     system = component_parts[2]
     abi = None
+
+    if system == "androideabi":
+        system = "android"
+        cpu_arch = "arm"
 
     if len(component_parts) == 4:
         abi = component_parts[3]

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -201,11 +201,39 @@ def abi_to_constraints(abi):
 def triple_to_system(target_triple):
     """Returns a system name for a given platform triple
 
+    **Deprecated**: Use triple() from triple.bzl directly.
+
     Args:
         target_triple (str): A platform triple. eg: `x86_64-unknown-linux-gnu`
 
     Returns:
         str: A system name
+    """
+    return triple(target_triple).system
+
+def triple_to_arch(target_triple):
+    """Returns a system architecture name for a given platform triple
+
+    **Deprecated**: Use triple() from triple.bzl directly.
+
+    Args:
+        target_triple (str): A platform triple. eg: `x86_64-unknown-linux-gnu`
+
+    Returns:
+        str: A cpu architecture
+    """
+    return triple(target_triple).arch
+
+def triple_to_abi(target_triple):
+    """Returns a system abi name for a given platform triple
+
+    **Deprecated**: Use triple() from triple.bzl directly.
+
+    Args:
+        target_triple (str): A platform triple. eg: `x86_64-unknown-linux-gnu`
+
+    Returns:
+        str: The triple's abi
     """
     return triple(target_triple).system
 

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -68,6 +68,7 @@ def rust_register_toolchains(
         register_toolchains = True,
         rustfmt_version = None,
         sha256s = None,
+        extra_target_triples = ["wasm32-unknown-unknown", "wasm32-wasi"],
         urls = DEFAULT_STATIC_RUST_URL_TEMPLATES,
         version = rust_common.default_version):
     """Emits a default set of toolchains for Linux, MacOS, and Freebsd
@@ -97,6 +98,7 @@ def rust_register_toolchains(
         register_toolchains (bool): If true, repositories will be generated to produce and register `rust_toolchain` targets.
         rustfmt_version (str, optional): The version of rustfmt. Either "nightly", "beta", or an exact version. Defaults to `version` if not specified.
         sha256s (str, optional): A dict associating tool subdirectories to sha256 hashes.
+        extra_target_triples (list, optional): Additional rust-style targets that rust toolchains should support.
         urls (list, optional): A list of mirror urls containing the tools from the Rust-lang static file server. These must contain the '{}' used to substitute the tool being fetched (using .format).
         version (str, optional): The version of Rust. Either "nightly", "beta", or an exact version. Defaults to a modern version.
     """
@@ -113,7 +115,7 @@ def rust_register_toolchains(
             dev_components = dev_components,
             edition = edition,
             exec_triple = exec_triple,
-            extra_target_triples = ["wasm32-unknown-unknown", "wasm32-wasi"],
+            extra_target_triples = extra_target_triples,
             include_rustc_srcs = include_rustc_srcs,
             iso_date = iso_date,
             register_toolchain = register_toolchains,


### PR DESCRIPTION
In addition to host target, "wasm32-unknown-unknown" and "wasm32-wasi" targets are being installed, which includes downloading corresponding rust-std libraries. This CL allow specifying custom additional target triples by introducing a new parameter to rust_register_toolchains(), which defaults to ["wasm32-unknown-unknown" and "wasm32-wasi"] for compatibility. As an example, it is now possible to compile for Android if ["armv7-linux-androideabi"] is specified as an extra_target_triples.

Specifically for Android, most of the required infrastructure was already in place. For example, @rules_rust//rust/platform:triple_mappings.bzl already has all the necessary information to compile Android libraries (e.g. _SYSTEM_TO_STDLIB_LINKFLAGS). However, "armv7-linux-androideabi" is not a 'proper' target tripple because 'androideabi' is not a proper system. As such, special handling is required to map 'androideabi' back to 'android'.
