### PR TITLE
Remove unused file and use the rules_rust transition allowlist.

### DIFF
--- a/rust/private/transitions.bzl
+++ b/rust/private/transitions.bzl
@@ -105,7 +105,7 @@ without_process_wrapper = rule(
             executable = True,
         ),
         "_allowlist_function_transition": attr.label(
-            default = Label("@bazel_tools//tools/allowlists/function_transition_allowlist"),
+            default = Label("//tools/allowlists/function_transition_allowlist"),
         ),
     },
 )

--- a/util/process_wrapper/process_wrapper_fake.cc
+++ b/util/process_wrapper/process_wrapper_fake.cc
@@ -1,4 +1,0 @@
-int main() {
-    // Noop on purpose.
-    return 0;
-}


### PR DESCRIPTION
This fixes a couple of issues we notice shortly after merging #1159 