### PR TITLE
add static_library to get_preferred_artifact with pic

### DIFF
--- a/examples/shared_libs/BUILD.bazel
+++ b/examples/shared_libs/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_rust//rust:defs.bzl", "rust_shared_library")
+
+# A rust_shared_library (forcing the use of pic) that depends on a native
+# linker library with only a static_library member.
+rust_shared_library(
+    name = "rust_shared_lib_with_static_dep",
+    srcs = ["rust_shared_lib_with_static_dep.rs"],
+    deps = [":static_cclib"],
+)
+
+cc_library(
+    name = "nonstandard_name_cc_lib",
+    srcs = ["cc_library_with_func.cc"],
+)
+
+genrule(
+    name = "nonstandard_name_gen",
+    srcs = [":nonstandard_name_cc_lib"],
+    outs = ["nonstandard_name_gen.a"],
+    # Copy the first member (libnonstandard_name_cc_lib.a) from the srcs to the
+    # output nonstandard_name_gen.a.
+    cmd = "cp $$(awk '{print $$1}' <<< '$(SRCS)') $@",
+)
+
+cc_import(
+    name = "static_cclib",
+    static_library = "nonstandard_name_gen.a",
+)

--- a/examples/shared_libs/BUILD.bazel
+++ b/examples/shared_libs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
 load("@rules_rust//rust:defs.bzl", "rust_shared_library")
 
 # A rust_shared_library (forcing the use of pic) that depends on a native

--- a/examples/shared_libs/cc_library_with_func.cc
+++ b/examples/shared_libs/cc_library_with_func.cc
@@ -1,0 +1,3 @@
+extern "C" int func() {
+  return 123;
+}

--- a/examples/shared_libs/rust_shared_lib_with_static_dep.rs
+++ b/examples/shared_libs/rust_shared_lib_with_static_dep.rs
@@ -1,0 +1,9 @@
+use std::os::raw::c_int;
+
+extern "C" {
+    pub fn func() -> c_int;
+}
+
+fn f() {
+    println!("hi {}", unsafe { func() });
+}

--- a/examples/shared_libs/rust_shared_lib_with_static_dep.rs
+++ b/examples/shared_libs/rust_shared_lib_with_static_dep.rs
@@ -4,6 +4,6 @@ extern "C" {
     pub fn func() -> c_int;
 }
 
-fn f() {
+pub fn f() {
     println!("hi {}", unsafe { func() });
 }

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -162,8 +162,10 @@ def get_preferred_artifact(library_to_link, use_pic):
         File: Returns the first valid library type (only one is expected)
     """
     if use_pic:
+        # Order consistent with https://github.com/bazelbuild/bazel/blob/815dfdabb7df31d4e99b6fc7616ff8e2f9385d98/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingContext.java#L437.
         return (
             library_to_link.pic_static_library or
+            library_to_link.static_library or
             library_to_link.interface_library or
             library_to_link.dynamic_library
         )


### PR DESCRIPTION
We were missing the static_library case while building under pic, as
demonstrated by the added example that was previously failing with an
error after get_preferred_artifact returned None.