### PR TITLE
Fixed errors with non-absolute labels

### DIFF
--- a/rust/private/transitions.bzl
+++ b/rust/private/transitions.bzl
@@ -68,13 +68,13 @@ with_import_macro_bootstrapping_mode = rule(
 def _without_process_wrapper_transition_impl(_settings, _attr):
     """This transition allows rust_* rules to invoke rustc without process_wrapper."""
     return {
-        "//rust/settings:use_process_wrapper": False,
+        "@rules_rust//rust/settings:use_process_wrapper": False,
     }
 
 without_process_wrapper_transition = transition(
     implementation = _without_process_wrapper_transition_impl,
     inputs = [],
-    outputs = ["//rust/settings:use_process_wrapper"],
+    outputs = ["@rules_rust//rust/settings:use_process_wrapper"],
 )
 
 def _without_process_wrapper_impl(ctx):

--- a/util/process_wrapper/BUILD.bazel
+++ b/util/process_wrapper/BUILD.bazel
@@ -22,7 +22,7 @@ cc_binary(
 config_setting(
     name = "use_fake_process_wrapper",
     flag_values = {
-        "//rust/settings:use_process_wrapper": "False",
+        "@rules_rust//rust/settings:use_process_wrapper": "False",
     },
 )
 


### PR DESCRIPTION
This fixes the following errors when building post https://github.com/bazelbuild/rules_rust/pull/1159
```
Repository rule http_archive defined at:
  /private/var/tmp/_bazel_user/c4900dc498759a5aae30fdfe5c69c114/external/bazel_tools/tools/build_defs/repo/http.bzl:336:31: in <toplevel>
ERROR: Analysis of target '//docs:cargo_bazel_rustdoc' failed; build aborted: no such package 'rust/settings': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /Users/user/Code/cargo-bazel/rust/settings
```