### PR TITLE
Added support for producing distribution archives

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,6 +18,25 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "//bindgen:distro",
+        "//cargo:distro",
+        "//crate_universe:distro",
+        "//proto:distro",
+        "//rust:distro",
+        "//tools:distro",
+        "//util:distro",
+        "//wasm_bindgen:distro",
+        "BUILD.bazel",
+        "README.md",
+        "LICENSE.txt",
+        "WORKSPACE.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
 # This setting may be changed from the command line to generate machine readable errors.
 error_format(
     name = "error_format",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -57,3 +57,16 @@ http_archive(
 #
 # load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 # rbe_preconfig(name = "buildkite_config", toolchain = "ubuntu1604-bazel-java8")
+
+http_archive(
+    name = "rules_pkg",
+    sha256 = "62eeb544ff1ef41d786e329e1536c1d541bb9bcad27ae984d57f18f314018e66",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
+    ],
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()

--- a/bindgen/BUILD.bazel
+++ b/bindgen/BUILD.bazel
@@ -17,6 +17,16 @@ alias(
     deprecation = "Please use the `@rules_rust//bindgen:bzl_lib` target instead",
 )
 
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "//bindgen/raze:srcs",
+        "//bindgen/raze/remote:srcs",
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
 rust_bindgen_toolchain(
     name = "default_bindgen_toolchain_impl",
     bindgen = "//bindgen/raze:cargo_bin_bindgen",

--- a/cargo/BUILD.bazel
+++ b/cargo/BUILD.bazel
@@ -13,3 +13,14 @@ alias(
     actual = ":bzl_lib",
     deprecation = "Please use the `@rules_rust//cargo:bzl_lib` target instead",
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "//cargo/bootstrap:distro",
+        "//cargo/cargo_build_script_runner:distro",
+        "//cargo/private:distro",
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/cargo/bootstrap/BUILD.bazel
+++ b/cargo/bootstrap/BUILD.bazel
@@ -18,3 +18,12 @@ rust_binary(
         "RULES_RUST_CARGO_BOOTSTRAP_BINARY": "$(rootpath bootstrap_installer.rs)",
     },
 )
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+        "bootstrap_installer.rs",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/cargo/cargo_build_script_runner/BUILD.bazel
+++ b/cargo/cargo_build_script_runner/BUILD.bazel
@@ -22,3 +22,11 @@ rust_test(
     crate = ":cargo_build_script_runner",
     deps = [":cargo_build_script_runner"],
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob(["*.rs"]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/cargo/private/BUILD.bazel
+++ b/cargo/private/BUILD.bazel
@@ -5,3 +5,11 @@ bzl_library(
     srcs = glob(["**/*.bzl"]),
     visibility = ["//:__subpackages__"],
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/distro/BUILD.bazel
+++ b/distro/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "rules_rust",
+    srcs = ["//:distro"],
+    extension = "tar.gz",
+    mode = "0444",
+    # Make it owned by root so it does not have the uid of the CI robot.
+    owner = "0.0",
+    package_dir = ".",
+    strip_prefix = ".",
+    visibility = ["//:__subpackages__"],
+)
+
+# This filegroup allows the tar file to appear in runfiles
+# https://github.com/bazelbuild/bazel/issues/12348
+filegroup(
+    name = "distro",
+    srcs = [":rules_rust"],
+    visibility = ["//:__subpackages__"],
+)
+
+sh_binary(
+    name = "publish",
+    srcs = ["publisher.sh"],
+    data = [":distro"],
+    env = {"ARCHIVE": "$(rootpath :distro)"},
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)

--- a/distro/publisher.sh
+++ b/distro/publisher.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ABS_ARCHIVE="$(pwd)/${ARCHIVE}"
+cd "${BUILD_WORKING_DIRECTORY}"
+mkdir -p "$@"
+
+set -x
+cp -fp "${ABS_ARCHIVE}" "$@"/"$(basename "${ARCHIVE}")"

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -14,6 +14,20 @@ alias(
     actual = "//proto/raze:cargo_bin_protoc_gen_rust_grpc",
 )
 
+filegroup(
+    name = "distro",
+    srcs = glob([
+        "*.bzl",
+        "*.rs",
+    ]) + [
+        "//proto/raze:srcs",
+        "//proto/raze/remote:srcs",
+        "//proto/patches:distro",
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
 toolchain_type(name = "toolchain")
 
 rust_binary(

--- a/proto/patches/BUILD.bazel
+++ b/proto/patches/BUILD.bazel
@@ -3,3 +3,12 @@ package(default_visibility = ["//visibility:public"])
 exports_files([
     "com_google_protobuf-v3.10.0-bzl_visibility.patch",
 ])
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+        "com_google_protobuf-v3.10.0-bzl_visibility.patch",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -28,3 +28,15 @@ alias(
     actual = ":bzl_lib",
     deprecation = "Please use the `@rules_rust//rust:bzl_lib` target instead",
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "//rust/platform:distro",
+        "//rust/private:distro",
+        "//rust/settings:distro",
+        "//rust/toolchain:distro",
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/rust/platform/BUILD.bazel
+++ b/rust/platform/BUILD.bazel
@@ -24,3 +24,14 @@ alias(
     deprecation = "Please use the `@rules_rust//platform:bzl_lib` target instead",
     visibility = ["//rust:__subpackages__"],
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "//rust/platform/channel:distro",
+        "//rust/platform/cpu:distro",
+        "//rust/platform/os:distro",
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/rust/platform/channel/BUILD.bazel
+++ b/rust/platform/channel/BUILD.bazel
@@ -20,3 +20,11 @@ constraint_value(
     name = "stable",
     constraint_setting = ":channel",
 )
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/rust/platform/cpu/BUILD.bazel
+++ b/rust/platform/cpu/BUILD.bazel
@@ -3,3 +3,11 @@ constraint_value(
     constraint_setting = "@platforms//cpu",
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/rust/platform/os/BUILD.bazel
+++ b/rust/platform/os/BUILD.bazel
@@ -9,3 +9,11 @@ constraint_value(
     constraint_setting = "@platforms//os",
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/rust/private/BUILD.bazel
+++ b/rust/private/BUILD.bazel
@@ -16,6 +16,15 @@ alias(
     visibility = ["//rust:__subpackages__"],
 )
 
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "//rust/private/dummy_cc_toolchain:distro",
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
 stamp_build_setting(name = "stamp")
 
 rust_analyzer_detect_sysroot(

--- a/rust/private/dummy_cc_toolchain/BUILD.bazel
+++ b/rust/private/dummy_cc_toolchain/BUILD.bazel
@@ -11,3 +11,11 @@ toolchain(
     toolchain = ":dummy_cc_wasm32",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -40,3 +40,11 @@ alias(
     deprecation = "Please use the `@rules_rust//settings:bzl_lib` target instead",
     visibility = ["//rust:__subpackages__"],
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/rust/toolchain/BUILD.bazel
+++ b/rust/toolchain/BUILD.bazel
@@ -41,3 +41,11 @@ toolchain_files(
     name = "current_exec_rust_stdlib_files",
     tool = "rust_stdlib",
 )
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,0 +1,12 @@
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "BUILD.bazel",
+        "//tools/allowlists/function_transition_allowlist:distro",
+        "//tools/clippy:distro",
+        "//tools/runfiles:distro",
+        "//tools/rustdoc:distro",
+        "//tools/rustfmt:distro",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/allowlists/function_transition_allowlist/BUILD.bazel
+++ b/tools/allowlists/function_transition_allowlist/BUILD.bazel
@@ -2,3 +2,11 @@ package_group(
     name = "function_transition_allowlist",
     packages = ["//..."],
 )
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/clippy/BUILD.bazel
+++ b/tools/clippy/BUILD.bazel
@@ -1,1 +1,10 @@
 exports_files(["clippy.toml"])
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+        "clippy.toml",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/runfiles/BUILD.bazel
+++ b/tools/runfiles/BUILD.bazel
@@ -21,3 +21,14 @@ rust_doc_test(
     name = "runfiles_doc_test",
     crate = ":runfiles",
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob([
+        "data/**",
+        "**/*.rs",
+    ]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/rust_analyzer/BUILD.bazel
+++ b/tools/rust_analyzer/BUILD.bazel
@@ -54,3 +54,16 @@ rust_clippy(
         ":gen_rust_project",
     ],
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob([
+        "*.bzl",
+        "**/*.rs",
+    ]) + [
+        "//tools/rust_analyzer/raze:srcs",
+        "//tools/rust_analyzer/raze/remote:srcs",
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/rustdoc/BUILD.bazel
+++ b/tools/rustdoc/BUILD.bazel
@@ -10,3 +10,13 @@ rust_binary(
         "//tools/runfiles",
     ],
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob([
+        "**/*.rs",
+    ]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/rustfmt/BUILD.bazel
+++ b/tools/rustfmt/BUILD.bazel
@@ -63,3 +63,15 @@ rust_clippy(
         ":rustfmt",
     ],
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob([
+        "*.bzl",
+        "**/*.rs",
+    ]) + [
+        "rustfmt.toml",
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -2,3 +2,16 @@ sh_binary(
     name = "fetch_shas",
     srcs = ["fetch_shas.sh"],
 )
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+        "fetch_shas.sh",
+        "//util/dir_zipper:distro",
+        "//util/import:distro",
+        "//util/label:distro",
+        "//util/process_wrapper:distro",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/util/dir_zipper/BUILD.bazel
+++ b/util/dir_zipper/BUILD.bazel
@@ -6,3 +6,11 @@ rust_binary(
     edition = "2018",
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob(["*.rs"]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/util/import/BUILD.bazel
+++ b/util/import/BUILD.bazel
@@ -71,3 +71,17 @@ sh_binary(
     name = "fake_import_macro_impl",
     srcs = ["fake_import_macro_impl.sh"],
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob([
+        "*.bzl",
+        "**/*.rs",
+    ]) + [
+        "//util/import/raze:srcs",
+        "//util/import/raze/remote:srcs",
+        "fake_import_macro_impl.sh",
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/util/label/BUILD.bazel
+++ b/util/label/BUILD.bazel
@@ -14,3 +14,13 @@ rust_test(
     name = "label_test",
     crate = ":label",
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob([
+        "**/*.rs",
+    ]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/util/process_wrapper/BUILD.bazel
+++ b/util/process_wrapper/BUILD.bazel
@@ -13,3 +13,14 @@ rust_test(
     name = "process_wrapper_test",
     crate = ":process_wrapper",
 )
+
+filegroup(
+    name = "distro",
+    srcs = glob([
+        "**/*.cc",
+        "**/*.rs",
+    ]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/wasm_bindgen/BUILD.bazel
+++ b/wasm_bindgen/BUILD.bazel
@@ -17,6 +17,15 @@ alias(
     deprecation = "Please use the `@rules_rust//wasm_bindgen:bzl_lib` target instead",
 )
 
+filegroup(
+    name = "distro",
+    srcs = glob(["*.bzl"]) + [
+        "//wasm_bindgen/raze:srcs",
+        "//wasm_bindgen/raze/remote:srcs",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
 rust_wasm_bindgen_toolchain(
     name = "default_wasm_bindgen_toolchain_impl",
     bindgen = "//wasm_bindgen/raze:cargo_bin_wasm_bindgen",


### PR DESCRIPTION
This change introduces the `//distro:rules_rust` target which produces a minimal archive of `rules_rust`. This archive is one of the final stepping stones to closing out https://github.com/bazelbuild/rules_rust/issues/415 which is something I'd like to see done this week.