### PR TITLE
Updating `rules_rust` version to `0.1.0`.

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.0.7"
+VERSION = "0.1.0"


### PR DESCRIPTION
Based on some of the rationale in https://github.com/bazelbuild/rules_rust/issues/415, this PR updates the version of `rules_rust` to a `0.X` version so the rules can begin to adopt proper semantic versioning with the end goal of eventually getting to a `1.0`.