### PR TITLE
disable advanced features in cargo build script context

### DIFF
--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -17,6 +17,14 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", find_rules_cc_toolchain = "find_cpp_toolchain")
 load(":providers.bzl", "BuildInfo", "CrateInfo", "DepInfo", "DepVariantInfo")
 
+UNSUPPORTED_FEATURES = [
+    "thin_lto",
+    "module_maps",
+    "use_header_modules",
+    "fdo_instrument",
+    "fdo_optimize",
+]
+
 def find_toolchain(ctx):
     """Finds the first rust toolchain that is configured.
 
@@ -43,7 +51,7 @@ def find_cc_toolchain(ctx):
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
+        unsupported_features = UNSUPPORTED_FEATURES + ctx.disabled_features,
     )
     return cc_toolchain, feature_configuration
 


### PR DESCRIPTION
C++ rules in Bazel have many advanced features such as ThinLTO or Clang
modules support that don't make sense in the cargo build script context
(and cargo build script doesn't implement support for these correctly).
This PR disables these features so Bazel workspaces using these advanced
features don't see a build failure.

This PR fixes a regression introduced by https://github.com/bazelbuild/rules_rust/commit/97fd3295401021e1afd20575b375e36c47f27b67.