### PR TITLE
cache the release archive in release actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,6 +125,12 @@ jobs:
           CARGO_BAZEL_GENERATOR_URL: file://${{ github.workspace }}/crate_universe/target/artifacts/x86_64-unknown-linux-gnu/cargo-bazel
           ARTIFACTS_DIR: ${{ github.workspace }}/crate_universe/target/artifacts
           URL_PREFIX: https://github.com/${{ github.repository_owner }}/rules_rust/releases/download/${{ env.RELEASE_VERSION }}
+      # Upload the artifact in case creating a release fails so all artifacts can then be manually recovered.
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "rules_rust.tar.gz"
+          path: ${{ github.workspace }}/.github/rules_rust.tar.gz
+          if-no-files-found: error
       - name: Generate release notes
         run: |
           # Generate the release notes


### PR DESCRIPTION
We can see in the screenshot below that the `rules_rust.tar.gz` artifact is available as an action artifact.
<img width="1672" alt="Screen Shot 2022-03-18 at 7 30 20 AM" src="https://user-images.githubusercontent.com/26427366/159022039-d839c5b3-8ff4-4074-a902-47c31fac9d24.png">
