### PR TITLE
Restrucutred `crate_universe` dependency macros

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -6,9 +6,9 @@ rules_rust_dependencies()
 
 rust_register_toolchains(include_rustc_srcs = True)
 
-load("@rules_rust//crate_universe:crates.bzl", "crate_deps_repository")
+load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 
-crate_deps_repository(bootstrap = True)
+crate_universe_dependencies(bootstrap = True)
 
 load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 

--- a/crate_universe/3rdparty/BUILD.bazel
+++ b/crate_universe/3rdparty/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//crate_universe:crates.bzl", "crate_deps_target")
+load("//crate_universe:repositories.bzl", "crate_deps_target")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/crate_universe/crates.bzl
+++ b/crate_universe/crates.bzl
@@ -1,70 +1,8 @@
-"""A module defining dependencies of the `cargo-bazel` Rust target"""
+"""**DEPRECATED** - Instead, use `@rules_rust//crate_universe:repositories.bzl"""
 
-load("@rules_rust//rust:defs.bzl", "rust_common")
-load("//crate_universe:deps_bootstrap.bzl", "cargo_bazel_bootstrap")
-load("//crate_universe/3rdparty:third_party_deps.bzl", "third_party_deps")
-load("//crate_universe/3rdparty/crates:crates.bzl", _vendor_crate_repositories = "crate_repositories")
-load("//crate_universe/private:crate.bzl", "crate")
-load("//crate_universe/private:crates_repository.bzl", "crates_repository")
-load("//crate_universe/private:crates_vendor.bzl", "crates_vendor")
-load("//crate_universe/private:vendor_utils.bzl", "crates_vendor_deps")
-load("//crate_universe/tools/cross_installer:cross_installer_deps.bzl", "cross_installer_deps")
+load(":repositories.bzl", "crate_universe_dependencies")
 
-USE_CRATES_REPOSITORY = False
-
-_REPOSITORY_NAME = "crate_index"
-
-_ANNOTATIONS = {
-    "libgit2-sys": [crate.annotation(
-        gen_build_script = False,
-        deps = ["@libgit2"],
-    )],
-    "libz-sys": [crate.annotation(
-        gen_build_script = False,
-        deps = ["@zlib"],
-    )],
-}
-
-_MANIFESTS = [
-    "@rules_rust//crate_universe:Cargo.toml",
-    "@rules_rust//crate_universe/tools/cross_installer:Cargo.toml",
-    "@rules_rust//crate_universe/tools/urls_generator:Cargo.toml",
-]
-
-def crate_deps_repository(rust_version = rust_common.default_version, bootstrap = False):
-    """Define dependencies of the `cargo-bazel` Rust target
-
-    Args:
-        rust_version (str, optional): The version of rust to use when generating dependencies.
-        bootstrap (bool, optional): If true, a `cargo_bootstrap_repository` target will be generated.
-    """
-    third_party_deps()
-
-    cargo_bazel_bootstrap(rust_version = rust_version)
-
-    if USE_CRATES_REPOSITORY:
-        crates_repository(
-            name = _REPOSITORY_NAME,
-            annotations = _ANNOTATIONS,
-            generator = "@cargo_bazel_bootstrap//:cargo-bazel" if bootstrap else None,
-            lockfile = "@rules_rust//crate_universe:Cargo.Bazel.lock",
-            manifests = _MANIFESTS,
-            rust_version = rust_version,
-        )
-
-    else:
-        _vendor_crate_repositories()
-
-    crates_vendor_deps()
-    cross_installer_deps()
-
-def crate_deps_target(name = "crates_vendor", vendor_path = "crates"):
-    crates_vendor(
-        name = name,
-        repository_name = _REPOSITORY_NAME,
-        annotations = _ANNOTATIONS,
-        manifests = _MANIFESTS,
-        vendor_path = vendor_path,
-        mode = "remote",
-        tags = ["manual"],
-    )
+def crate_deps_repository(**kwargs):
+    # buildifier: disable=print
+    print("`crate_deps_repository` is deprecated. See setup instructions for how to update: https://bazelbuild.github.io/rules_rust/crate_universe.html#setup")
+    crate_universe_dependencies(**kwargs)

--- a/crate_universe/crates_deps.bzl
+++ b/crate_universe/crates_deps.bzl
@@ -1,7 +1,7 @@
 """Transitive dependencies of the `cargo-bazel` Rust target"""
 
 load("@crate_index//:defs.bzl", _repository_crate_repositories = "crate_repositories")
-load("//crate_universe:crates.bzl", "USE_CRATES_REPOSITORY")
+load("//crate_universe:repositories.bzl", "USE_CRATES_REPOSITORY")
 
 def crate_repositories():
     if USE_CRATES_REPOSITORY:

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -11,18 +11,18 @@ Crate Universe is a set of Bazel rule for generating Rust targets using Cargo.
 After loading `rules_rust` in your workspace, set the following to begin using `crate_universe`:
 
 ```python
-load("@rules_rust//crate_universe:crates.bzl", "crate_deps_repository")
+load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 
-crate_deps_repository()
+crate_universe_dependencies()
 ```
 
 Note that if the current version of `rules_rust` is not a release artifact, you may need to set additional
-flags such as [`bootstrap = True`](#crate_deps_repository-bootstrap) on the `crate_deps_repository`
+flags such as [`bootstrap = True`](#crate_universe_dependencies-bootstrap) on the `crate_universe_dependencies`
 call above or [crates_repository::generator_urls](#crates_repository-generator_urls) in uses of `crates_repository`.
 
 ## Rules
 
-- [crate_deps_repository](#crate_deps_repository)
+- [crate_universe_dependencies](#crate_universe_dependencies)
 - [crates_repository](#crates_repository)
 - [crates_vendor](#crates_vendor)
 - [crate.annotation](#crateannotation)
@@ -161,8 +161,8 @@ rust_test(
 """
 
 load(
-    "//crate_universe:crates.bzl",
-    _crate_deps_repository = "crate_deps_repository",
+    "//crate_universe:repositories.bzl",
+    _crate_universe_dependencies = "crate_universe_dependencies",
 )
 load(
     "//crate_universe/private:crate.bzl",
@@ -186,7 +186,7 @@ load(
 )
 
 crate = _crate
-crate_deps_repository = _crate_deps_repository
+crate_universe_dependencies = _crate_universe_dependencies
 crates_repository = _crates_repository
 crates_vendor = _crates_vendor
 render_config = _render_config

--- a/crate_universe/repositories.bzl
+++ b/crate_universe/repositories.bzl
@@ -1,0 +1,70 @@
+"""A module defining dependencies of the `cargo-bazel` Rust target"""
+
+load("@rules_rust//rust:defs.bzl", "rust_common")
+load("//crate_universe:deps_bootstrap.bzl", "cargo_bazel_bootstrap")
+load("//crate_universe/3rdparty:third_party_deps.bzl", "third_party_deps")
+load("//crate_universe/3rdparty/crates:crates.bzl", _vendor_crate_repositories = "crate_repositories")
+load("//crate_universe/private:crate.bzl", "crate")
+load("//crate_universe/private:crates_repository.bzl", "crates_repository")
+load("//crate_universe/private:crates_vendor.bzl", "crates_vendor")
+load("//crate_universe/private:vendor_utils.bzl", "crates_vendor_deps")
+load("//crate_universe/tools/cross_installer:cross_installer_deps.bzl", "cross_installer_deps")
+
+USE_CRATES_REPOSITORY = False
+
+_REPOSITORY_NAME = "crate_index"
+
+_ANNOTATIONS = {
+    "libgit2-sys": [crate.annotation(
+        gen_build_script = False,
+        deps = ["@libgit2"],
+    )],
+    "libz-sys": [crate.annotation(
+        gen_build_script = False,
+        deps = ["@zlib"],
+    )],
+}
+
+_MANIFESTS = [
+    "@rules_rust//crate_universe:Cargo.toml",
+    "@rules_rust//crate_universe/tools/cross_installer:Cargo.toml",
+    "@rules_rust//crate_universe/tools/urls_generator:Cargo.toml",
+]
+
+def crate_universe_dependencies(rust_version = rust_common.default_version, bootstrap = False):
+    """Define dependencies of the `cargo-bazel` Rust target
+
+    Args:
+        rust_version (str, optional): The version of rust to use when generating dependencies.
+        bootstrap (bool, optional): If true, a `cargo_bootstrap_repository` target will be generated.
+    """
+    third_party_deps()
+
+    cargo_bazel_bootstrap(rust_version = rust_version)
+
+    if USE_CRATES_REPOSITORY:
+        crates_repository(
+            name = _REPOSITORY_NAME,
+            annotations = _ANNOTATIONS,
+            generator = "@cargo_bazel_bootstrap//:cargo-bazel" if bootstrap else None,
+            lockfile = "@rules_rust//crate_universe:Cargo.Bazel.lock",
+            manifests = _MANIFESTS,
+            rust_version = rust_version,
+        )
+
+    else:
+        _vendor_crate_repositories()
+
+    crates_vendor_deps()
+    cross_installer_deps()
+
+def crate_deps_target(name = "crates_vendor", vendor_path = "crates"):
+    crates_vendor(
+        name = name,
+        repository_name = _REPOSITORY_NAME,
+        annotations = _ANNOTATIONS,
+        manifests = _MANIFESTS,
+        vendor_path = vendor_path,
+        mode = "remote",
+        tags = ["manual"],
+    )

--- a/crate_universe/tools/cross_installer/BUILD.bazel
+++ b/crate_universe/tools/cross_installer/BUILD.bazel
@@ -32,6 +32,7 @@ filegroup(
     srcs = [
         "BUILD.bazel",
         "Cargo.toml",
+        "cross_installer_deps.bzl",
     ],
     visibility = ["//crate_universe/tools:__pkg__"],
 )

--- a/docs/WORKSPACE.bazel
+++ b/docs/WORKSPACE.bazel
@@ -11,9 +11,9 @@ rules_rust_dependencies()
 
 rust_register_toolchains(include_rustc_srcs = True)
 
-load("@rules_rust//crate_universe:crates.bzl", "crate_deps_repository")
+load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 
-crate_deps_repository()
+crate_universe_dependencies()
 
 load("@rules_rust//proto:repositories.bzl", "rust_proto_repositories")
 

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -13,18 +13,18 @@ Crate Universe is a set of Bazel rule for generating Rust targets using Cargo.
 After loading `rules_rust` in your workspace, set the following to begin using `crate_universe`:
 
 ```python
-load("@rules_rust//crate_universe:crates.bzl", "crate_deps_repository")
+load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 
-crate_deps_repository()
+crate_universe_dependencies()
 ```
 
 Note that if the current version of `rules_rust` is not a release artifact, you may need to set additional
-flags such as [`bootstrap = True`](#crate_deps_repository-bootstrap) on the `crate_deps_repository`
+flags such as [`bootstrap = True`](#crate_universe_dependencies-bootstrap) on the `crate_universe_dependencies`
 call above or [crates_repository::generator_urls](#crates_repository-generator_urls) in uses of `crates_repository`.
 
 ## Rules
 
-- [crate_deps_repository](#crate_deps_repository)
+- [crate_universe_dependencies](#crate_universe_dependencies)
 - [crates_repository](#crates_repository)
 - [crates_vendor](#crates_vendor)
 - [crate.annotation](#crateannotation)
@@ -352,12 +352,12 @@ Define information for extra workspace members
 string: A json encoded string of all inputs
 
 
-<a id="#crate_deps_repository"></a>
+<a id="#crate_universe_dependencies"></a>
 
-## crate_deps_repository
+## crate_universe_dependencies
 
 <pre>
-crate_deps_repository(<a href="#crate_deps_repository-rust_version">rust_version</a>, <a href="#crate_deps_repository-bootstrap">bootstrap</a>)
+crate_universe_dependencies(<a href="#crate_universe_dependencies-rust_version">rust_version</a>, <a href="#crate_universe_dependencies-bootstrap">bootstrap</a>)
 </pre>
 
 Define dependencies of the `cargo-bazel` Rust target
@@ -367,8 +367,8 @@ Define dependencies of the `cargo-bazel` Rust target
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="crate_deps_repository-rust_version"></a>rust_version |  The version of rust to use when generating dependencies.   |  <code>"1.59.0"</code> |
-| <a id="crate_deps_repository-bootstrap"></a>bootstrap |  If true, a <code>cargo_bootstrap_repository</code> target will be generated.   |  <code>False</code> |
+| <a id="crate_universe_dependencies-rust_version"></a>rust_version |  The version of rust to use when generating dependencies.   |  <code>"1.59.0"</code> |
+| <a id="crate_universe_dependencies-bootstrap"></a>bootstrap |  If true, a <code>cargo_bootstrap_repository</code> target will be generated.   |  <code>False</code> |
 
 
 <a id="#render_config"></a>

--- a/examples/crate_universe/WORKSPACE.bazel
+++ b/examples/crate_universe/WORKSPACE.bazel
@@ -11,9 +11,9 @@ rules_rust_dependencies()
 
 rust_register_toolchains(include_rustc_srcs = True)
 
-load("@rules_rust//crate_universe:crates.bzl", "crate_deps_repository")
+load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 
-crate_deps_repository()
+crate_universe_dependencies()
 
 load("@rules_rust//crate_universe:crates_deps.bzl", "crate_repositories")
 


### PR DESCRIPTION
This makes setup more consistent with `rules_rust` itself.