### PR TITLE
fix `stamp = 0` in rust_binary_without_process_wrapper

### DIFF
--- a/util/process_wrapper/BUILD.bazel
+++ b/util/process_wrapper/BUILD.bazel
@@ -7,6 +7,9 @@ rust_binary_without_process_wrapper(
     name = "process_wrapper",
     srcs = glob(["*.rs"]),
     visibility = ["//visibility:public"],
+    # Stamping is not supported when building without process_wrapper:
+    # https://github.com/bazelbuild/rules_rust/blob/8df4517d370b0c543a01ba38b63e1d5a4104b035/rust/private/rustc.bzl#L955
+    stamp = 0,
 )
 
 rust_test(

--- a/util/process_wrapper/BUILD.bazel
+++ b/util/process_wrapper/BUILD.bazel
@@ -6,10 +6,10 @@ load("//rust/private:rust.bzl", "rust_binary_without_process_wrapper")
 rust_binary_without_process_wrapper(
     name = "process_wrapper",
     srcs = glob(["*.rs"]),
-    visibility = ["//visibility:public"],
     # Stamping is not supported when building without process_wrapper:
     # https://github.com/bazelbuild/rules_rust/blob/8df4517d370b0c543a01ba38b63e1d5a4104b035/rust/private/rustc.bzl#L955
     stamp = 0,
+    visibility = ["//visibility:public"],
 )
 
 rust_test(

--- a/util/process_wrapper/BUILD.bazel
+++ b/util/process_wrapper/BUILD.bazel
@@ -6,9 +6,6 @@ load("//rust/private:rust.bzl", "rust_binary_without_process_wrapper")
 rust_binary_without_process_wrapper(
     name = "process_wrapper",
     srcs = glob(["*.rs"]),
-    # Stamping is not supported when building without process_wrapper:
-    # https://github.com/bazelbuild/rules_rust/blob/8df4517d370b0c543a01ba38b63e1d5a4104b035/rust/private/rustc.bzl#L955
-    stamp = 0,
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Stamping is not supported when building without process_wrapper:
https://github.com/bazelbuild/rules_rust/blob/8df4517d370b0c543a01ba38b63e1d5a4104b035/rust/private/rustc.bzl#L955