### PR TITLE
Fix some unit tests to run from another workspace

### DIFF
--- a/test/unit/linkstamps/linkstamps_test.bzl
+++ b/test/unit/linkstamps/linkstamps_test.bzl
@@ -20,7 +20,8 @@ def _supports_linkstamps_test(ctx):
     linkstamp_out = linkstamp_action.outputs.to_list()[0]
     asserts.equals(env, linkstamp_out.basename, "linkstamp.o")
     tut_out = tut.files.to_list()[0]
-    expected_linkstamp_path = tut_out.dirname + "/_objs/" + tut_out.basename + "/test/unit/linkstamps/linkstamp.o"
+    workspace_prefix = "" if ctx.workspace_name == "rules_rust" else "/external/rules_rust"
+    expected_linkstamp_path = tut_out.dirname + "/_objs/" + tut_out.basename + workspace_prefix + "/test/unit/linkstamps/linkstamp.o"
     asserts.equals(
         env,
         linkstamp_out.path,

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -78,21 +78,22 @@ def _bin_has_native_dep_and_alwayslink_test_impl(ctx):
     action = tut.actions[0]
 
     compilation_mode = ctx.var["COMPILATION_MODE"]
+    workspace_prefix = "" if ctx.workspace_name == "rules_rust" else "external/rules_rust/"
     if ctx.target_platform_has_constraint(ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]):
         want = [
             "-lstatic=native_dep",
-            "link-arg=-Wl,-force_load,bazel-out/darwin-{}/bin/test/unit/native_deps/libalwayslink.lo".format(compilation_mode),
+            "link-arg=-Wl,-force_load,bazel-out/darwin-{}/bin/{}test/unit/native_deps/libalwayslink.lo".format(compilation_mode, workspace_prefix),
         ]
     elif ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]):
         want = [
             "-lstatic=native_dep",
-            "link-arg=/WHOLEARCHIVE:bazel-out/x64_windows-{}/bin/test/unit/native_deps/alwayslink.lo.lib".format(compilation_mode),
+            "link-arg=/WHOLEARCHIVE:bazel-out/x64_windows-{}/bin/{}test/unit/native_deps/alwayslink.lo.lib".format(compilation_mode, workspace_prefix),
         ]
     else:
         want = [
             "-lstatic=native_dep",
             "link-arg=-Wl,--whole-archive",
-            "link-arg=bazel-out/k8-{}/bin/test/unit/native_deps/libalwayslink.lo".format(compilation_mode),
+            "link-arg=bazel-out/k8-{}/bin/{}test/unit/native_deps/libalwayslink.lo".format(compilation_mode, workspace_prefix),
             "link-arg=-Wl,--no-whole-archive",
         ]
     individual_link_args = [
@@ -112,22 +113,23 @@ def _cdylib_has_native_dep_and_alwayslink_test_impl(ctx):
     linker_args = _extract_linker_args(action.argv)[1:]
 
     compilation_mode = ctx.var["COMPILATION_MODE"]
+    workspace_prefix = "" if ctx.workspace_name == "rules_rust" else "external/rules_rust/"
     pic_suffix = ".pic" if compilation_mode == "opt" else ""
     if ctx.target_platform_has_constraint(ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]):
         want = [
             "-lstatic=native_dep",
-            "link-arg=-Wl,-force_load,bazel-out/darwin-{}/bin/test/unit/native_deps/libalwayslink{}.lo".format(compilation_mode, pic_suffix),
+            "link-arg=-Wl,-force_load,bazel-out/darwin-{}/bin/{}test/unit/native_deps/libalwayslink{}.lo".format(compilation_mode, workspace_prefix, pic_suffix),
         ]
     elif ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]):
         want = [
             "-lstatic=native_dep",
-            "link-arg=/WHOLEARCHIVE:bazel-out/x64_windows-{}/bin/test/unit/native_deps/alwayslink.lo.lib".format(compilation_mode),
+            "link-arg=/WHOLEARCHIVE:bazel-out/x64_windows-{}/bin/{}test/unit/native_deps/alwayslink.lo.lib".format(compilation_mode, workspace_prefix),
         ]
     else:
         want = [
             "-lstatic=native_dep",
             "link-arg=-Wl,--whole-archive",
-            "link-arg=bazel-out/k8-{}/bin/test/unit/native_deps/libalwayslink{}.lo".format(compilation_mode, pic_suffix),
+            "link-arg=bazel-out/k8-{}/bin/{}test/unit/native_deps/libalwayslink{}.lo".format(compilation_mode, workspace_prefix, pic_suffix),
             "link-arg=-Wl,--no-whole-archive",
         ]
     asserts.equals(env, want, linker_args)


### PR DESCRIPTION
Some tests assume that they are running in the rules_rust workspace.
Removing these assumptions allow us to run these tests from other bazel
workspaces.

For example, I help maintain https://github.com/grailbio/bazel-toolchain
and we check if cc toolchain that we configure is compatible with
rules_rust by running the unit tests in this repo.
