### PR TITLE
Fixed `crate_universe` clippy defects

### DIFF
--- a/crate_universe/BUILD.bazel
+++ b/crate_universe/BUILD.bazel
@@ -55,11 +55,6 @@ filegroup(
     visibility = ["//:__subpackages__"],
 )
 
-TAGS = [
-    # https://github.com/rust-lang/rust-clippy/issues/8470
-    "noclippy",
-]
-
 rust_library(
     name = "cargo_bazel",
     srcs = glob(
@@ -72,7 +67,6 @@ rust_library(
         exclude = ["src/**/*.rs"],
     ),
     proc_macro_deps = all_crate_deps(proc_macro = True),
-    tags = TAGS,
     version = VERSION,
     visibility = ["//visibility:public"],
     deps = all_crate_deps(normal = True),
@@ -81,7 +75,6 @@ rust_library(
 rust_binary(
     name = "cargo_bazel_bin",
     srcs = ["src/main.rs"],
-    tags = TAGS,
     version = VERSION,
     visibility = ["//visibility:public"],
     deps = [":cargo_bazel"],
@@ -108,7 +101,6 @@ rust_test(
         "CARGO": "$(rootpath @rules_rust//rust/toolchain:current_exec_cargo_files)",
         "RUSTC": "$(rootpath @rules_rust//rust/toolchain:current_exec_rustc_files)",
     },
-    tags = TAGS,
     deps = [
         "@rules_rust//tools/runfiles",
     ] + all_crate_deps(

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -563,11 +563,10 @@ impl CrateContext {
                         let crate_name = sanitize_module_name(&target.name);
 
                         // Locate the crate's root source file relative to the package root normalized for unix
-                        let crate_root =
-                            pathdiff::diff_paths(target.src_path.to_string(), package_root).map(
-                                // Normalize the path so that it always renders the same regardless of platform
-                                |root| root.to_string_lossy().replace("\\", "/"),
-                            );
+                        let crate_root = pathdiff::diff_paths(&target.src_path, package_root).map(
+                            // Normalize the path so that it always renders the same regardless of platform
+                            |root| root.to_string_lossy().replace('\\', "/"),
+                        );
 
                         // Conditionally check to see if the dependencies is a build-script target
                         if include_build_scripts && kind == "custom-build" {

--- a/crate_universe/src/splicing/splicer.rs
+++ b/crate_universe/src/splicing/splicer.rs
@@ -96,7 +96,7 @@ impl<'a> SplicerKind<'a> {
                     !manifests.keys().any(|path| {
                         let path_str = path.to_string_lossy().to_string();
                         // Account for windows paths.
-                        let path_str = path_str.replace("\\", "/");
+                        let path_str = path_str.replace('\\', "/");
                         // Workspace members are represented as directories.
                         path_str.trim_end_matches("/Cargo.toml").ends_with(member)
                     })
@@ -1015,7 +1015,7 @@ mod test {
         // On windows, make sure we normalize the path to match what Cargo would
         // otherwise use to populate metadata.
         if cfg!(target_os = "windows") {
-            workspace_root = format!("/{}", workspace_root.replace("\\", "/"))
+            workspace_root = format!("/{}", workspace_root.replace('\\', "/"))
         };
 
         if is_root {


### PR DESCRIPTION
It seems https://github.com/rust-lang/rust-clippy/issues/8470 is no longer an issue in Bazel CI. My understanding is that this only impacts hosts with a particular `libstdc++` install. More details are in that issue.