### PR TITLE
fix: distribute /tools/rust_analyzer

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -7,6 +7,7 @@ filegroup(
         "//tools/runfiles:distro",
         "//tools/rustdoc:distro",
         "//tools/rustfmt:distro",
+        "//tools/rust_analyzer:distro",
     ],
     visibility = ["//:__subpackages__"],
 )


### PR DESCRIPTION
It seems that https://github.com/bazelbuild/rules_rust/pull/1194 accidentally excluded //tools/rust_analyzer from the distribution.
This change adds rust_analyzer back.