### PR TITLE
fix: distribute `//tools/rust_analyzer`

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -5,6 +5,7 @@ filegroup(
         "//tools/allowlists/function_transition_allowlist:distro",
         "//tools/clippy:distro",
         "//tools/runfiles:distro",
+        "//tools/rust_analyzer:distro",
         "//tools/rustdoc:distro",
         "//tools/rustfmt:distro",
     ],


### PR DESCRIPTION
This is a reimplementation of https://github.com/bazelbuild/rules_rust/pull/1229 (credit goes to @roman-kashitsyn, thank you!) that I'd like to get merged so I can begin preparing a new release.

closes https://github.com/bazelbuild/rules_rust/pull/1229