### PR TITLE
Replace `rust_repositories` with `rust_register_toolchains` in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,22 +62,22 @@ You can also browse the [full API in one page](flatten.md).
 
 ## Specifying Rust version
 
-To build with a particular version of the Rust compiler, pass that version to [`rust_repositories`](flatten.md#rust_repositories):
+To build with a particular version of the Rust compiler, pass that version to [`rust_register_toolchains`](flatten.md#rust_register_toolchains):
 
 ```python
-rust_repositories(version = "1.59.0", edition="2018")
+rust_register_toolchains(version = "1.59.0", edition="2018")
 ```
 
 As well as an exact version, `version` can be set to `"nightly"` or `"beta"`. If set to these values, `iso_date` must also be set:
 
 ```python
-rust_repositories(version = "nightly", iso_date = "2022-02-23", edition="2018")
+rust_register_toolchains(version = "nightly", iso_date = "2022-02-23", edition="2018")
 ```
 
 Similarly, `rustfmt_version` may also be configured:
 
 ```python
-rust_repositories(rustfmt_version = "1.59.0")
+rust_register_toolchains(rustfmt_version = "1.59.0")
 ```
 
 ## External Dependencies


### PR DESCRIPTION
Special thanks to @jfirebaugh! 

closes https://github.com/bazelbuild/rules_rust/pull/1225
closes https://github.com/bazelbuild/rules_rust/issues/1224