### PR TITLE
Fixed proto package in release artifact

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -20,9 +20,10 @@ filegroup(
         "*.bzl",
         "*.rs",
     ]) + [
-        "//proto/raze:srcs",
-        "//proto/raze/remote:srcs",
         "//proto/patches:distro",
+        "//proto/raze:srcs",
+        "//proto/raze/patch:distro",
+        "//proto/raze/remote:srcs",
         "BUILD.bazel",
     ],
     visibility = ["//:__subpackages__"],

--- a/proto/raze/patch/BUILD.bazel
+++ b/proto/raze/patch/BUILD.bazel
@@ -6,3 +6,14 @@ filegroup(
         "protobuf-2.8.2.patch",
     ],
 )
+
+filegroup(
+    name = "distro",
+    srcs = [
+        "BUILD.bazel",
+        "README.md",
+    ] + glob([
+        "*.patch",
+    ]),
+    visibility = ["//proto:__subpackages__"],
+)


### PR DESCRIPTION
This error was observed using the release package:
```
INFO: Repository rules_rust_proto__protobuf__2_8_2 instantiated at:
  /var/lib/buildkite-agent/builds/buildkite-linux-x86-64-1-6/metawork/metawork/WORKSPACE:87:24: in <toplevel>
  /var/lib/buildkite-agent/.cache/bazel/buildkite-linux-x86-64-1-6/external/rules_rust/proto/repositories.bzl:55:41: in rust_proto_repositories
  /var/lib/buildkite-agent/.cache/bazel/buildkite-linux-x86-64-1-6/external/rules_rust/proto/raze/crates.bzl:374:10: in rules_rust_proto_fetch_remote_crates
  /var/lib/buildkite-agent/.cache/bazel/buildkite-linux-x86-64-1-6/external/bazel_tools/tools/build_defs/repo/utils.bzl:233:18: in maybe
Repository rule http_archive defined at:
  /var/lib/buildkite-agent/.cache/bazel/buildkite-linux-x86-64-1-6/external/bazel_tools/tools/build_defs/repo/http.bzl:353:31: in <toplevel>
INFO: Repository 'rules_rust_proto__protobuf__2_8_2' used the following cache hits instead of downloading the corresponding file.
 * Hash '70731852eec72c56d11226c8a5f96ad5058a3dab73647ca5f7ee351e464f2571' for https://crates.io/api/v1/crates/protobuf/2.8.2/download
If the definition of 'rules_rust_proto__protobuf__2_8_2' was updated, verify that the hashes were also updated.
ERROR: An error occurred during the fetch of repository 'rules_rust_proto__protobuf__2_8_2':
   Traceback (most recent call last):
	File "/var/lib/buildkite-agent/.cache/bazel/buildkite-linux-x86-64-1-6/external/bazel_tools/tools/build_defs/repo/http.bzl", line 111, column 10, in _http_archive_impl
		patch(ctx, auth = auth)
	File "/var/lib/buildkite-agent/.cache/bazel/buildkite-linux-x86-64-1-6/external/bazel_tools/tools/build_defs/repo/utils.bzl", line 167, column 22, in patch
		ctx.patch(patchfile, strip)
Error in patch: Unable to load package for @rules_rust//proto/raze/patch:protobuf-2.8.2.patch: BUILD file not found in directory 'proto/raze/patch' of external repository @rules_rust. Add a BUILD file to a directory to mark it as a package.
```