### PR TITLE
rust_test_suite: ensure crate names are valid

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -23,6 +23,7 @@ load(
     "expand_dict_value_locations",
     "find_toolchain",
     "get_import_macro_deps",
+    "name_to_crate_name",
     "transform_deps",
 )
 
@@ -1179,7 +1180,7 @@ def rust_test_suite(name, srcs, **kwargs):
         test_name = name + "_" + src[:-3]
         rust_test(
             name = test_name,
-            crate_name = test_name.replace("/", "_"),
+            crate_name = name_to_crate_name(test_name.replace("/", "_")),
             srcs = [src],
             **kwargs
         )


### PR DESCRIPTION
I noticed this while setting up rust_test_suite auto-generation at
work. Seems like a simple enough fix.