### PR TITLE
Workaround for issue in linux Cargo binaries

### DIFF
--- a/crate_universe/3rdparty/crates/BUILD.atty-0.2.14.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.atty-0.2.14.bazel
@@ -104,7 +104,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
         ],

--- a/crate_universe/3rdparty/crates/BUILD.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bazel
@@ -64,7 +64,7 @@ alias(
 
 alias(
     name = "clap",
-    actual = "@crate_universe_crate_index__clap-3.1.6//:clap",
+    actual = "@crate_universe_crate_index__clap-3.1.8//:clap",
     tags = ["manual"],
 )
 
@@ -119,6 +119,12 @@ alias(
 alias(
     name = "spectral",
     actual = "@crate_universe_crate_index__spectral-0.6.0//:spectral",
+    tags = ["manual"],
+)
+
+alias(
+    name = "syn",
+    actual = "@crate_universe_crate_index__syn-1.0.90//:syn",
     tags = ["manual"],
 )
 

--- a/crate_universe/3rdparty/crates/BUILD.chrono-0.4.19.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-0.4.19.bazel
@@ -91,12 +91,12 @@ rust_library(
             "@crate_universe_crate_index__winapi-0.3.9//:winapi",
 
             # Common Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
             "@crate_universe_crate_index__num-integer-0.1.44//:num_integer",
             "@crate_universe_crate_index__num-traits-0.2.14//:num_traits",
         ],
         "//conditions:default": [
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
             "@crate_universe_crate_index__num-integer-0.1.44//:num_integer",
             "@crate_universe_crate_index__num-traits-0.2.14//:num_traits",
         ],

--- a/crate_universe/3rdparty/crates/BUILD.clap-3.1.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clap-3.1.8.bazel
@@ -62,7 +62,7 @@ rust_library(
     proc_macro_deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__clap_derive-3.1.4//:clap_derive",
+            "@crate_universe_crate_index__clap_derive-3.1.7//:clap_derive",
         ],
     }),
     rustc_env = {
@@ -87,13 +87,13 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "3.1.6",
+    version = "3.1.8",
     deps = [
     ] + select_with_or({
         "//conditions:default": [
             "@crate_universe_crate_index__atty-0.2.14//:atty",
             "@crate_universe_crate_index__bitflags-1.3.2//:bitflags",
-            "@crate_universe_crate_index__indexmap-1.8.0//:indexmap",
+            "@crate_universe_crate_index__indexmap-1.8.1//:indexmap",
             "@crate_universe_crate_index__lazy_static-1.4.0//:lazy_static",
             "@crate_universe_crate_index__os_str_bytes-6.0.0//:os_str_bytes",
             "@crate_universe_crate_index__strsim-0.10.0//:strsim",

--- a/crate_universe/3rdparty/crates/BUILD.clap_derive-3.1.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clap_derive-3.1.7.bazel
@@ -76,13 +76,13 @@ rust_proc_macro(
         "noclippy",
         "norustfmt",
     ],
-    version = "3.1.4",
+    version = "3.1.7",
     deps = [
     ] + select_with_or({
         "//conditions:default": [
             "@crate_universe_crate_index__heck-0.4.0//:heck",
             "@crate_universe_crate_index__proc-macro-error-1.0.4//:proc_macro_error",
-            "@crate_universe_crate_index__proc-macro2-1.0.36//:proc_macro2",
+            "@crate_universe_crate_index__proc-macro2-1.0.37//:proc_macro2",
             "@crate_universe_crate_index__quote-1.0.17//:quote",
             "@crate_universe_crate_index__syn-1.0.90//:syn",
         ],

--- a/crate_universe/3rdparty/crates/BUILD.cpufeatures-0.2.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cpufeatures-0.2.2.bazel
@@ -83,7 +83,7 @@ rust_library(
             "@rules_rust//rust/platform:aarch64-apple-darwin",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
         ],
@@ -92,7 +92,7 @@ rust_library(
             "@rules_rust//rust/platform:aarch64-linux-android",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
         ],
@@ -101,7 +101,7 @@ rust_library(
             "@rules_rust//rust/platform:aarch64-unknown-linux-gnu",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
         ],

--- a/crate_universe/3rdparty/crates/BUILD.getrandom-0.2.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.getrandom-0.2.6.bazel
@@ -110,7 +110,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
             "@crate_universe_crate_index__cfg-if-1.0.0//:cfg_if",

--- a/crate_universe/3rdparty/crates/BUILD.git2-0.14.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.git2-0.14.2.bazel
@@ -80,7 +80,7 @@ rust_library(
     ] + select_with_or({
         "//conditions:default": [
             "@crate_universe_crate_index__bitflags-1.3.2//:bitflags",
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
             "@crate_universe_crate_index__libgit2-sys-0.13.2-1.4.2//:libgit2_sys",
             "@crate_universe_crate_index__log-0.4.16//:log",
             "@crate_universe_crate_index__url-2.2.2//:url",

--- a/crate_universe/3rdparty/crates/BUILD.hermit-abi-0.1.19.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.hermit-abi-0.1.19.bazel
@@ -80,7 +80,7 @@ rust_library(
     deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
         ],
     }),
 )

--- a/crate_universe/3rdparty/crates/BUILD.indexmap-1.8.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.indexmap-1.8.1.bazel
@@ -24,11 +24,11 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT OR Apache-2.0
+#     "TODO",  # Apache-2.0/MIT
 # ])
 
 rust_library(
-    name = "proc_macro2",
+    name = "indexmap",
     srcs = glob(
         include = [
             "**/*.rs",
@@ -45,8 +45,7 @@ rust_library(
         ],
     }),
     crate_features = [
-        "default",
-        "proc-macro",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = select_with_or({
@@ -81,19 +80,19 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.0.36",
+    version = "1.8.1",
     deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__proc-macro2-1.0.36//:build_script_build",
-            "@crate_universe_crate_index__unicode-xid-0.2.2//:unicode_xid",
+            "@crate_universe_crate_index__hashbrown-0.11.2//:hashbrown",
+            "@crate_universe_crate_index__indexmap-1.8.1//:build_script_build",
         ],
     }),
 )
 
 cargo_build_script(
     # See comment associated with alias. Do not change this name
-    name = "proc-macro2_build_script",
+    name = "indexmap_build_script",
     srcs = glob(
         include = [
             "**/*.rs",
@@ -112,8 +111,7 @@ cargo_build_script(
         ],
     }),
     crate_features = [
-        "default",
-        "proc-macro",
+        "std",
     ],
     crate_name = "build_script_build",
     crate_root = "build.rs",
@@ -153,11 +151,12 @@ cargo_build_script(
         "//conditions:default": [
         ],
     }),
-    version = "1.0.36",
+    version = "1.8.1",
     visibility = ["//visibility:private"],
     deps = [
     ] + select_with_or({
         "//conditions:default": [
+            "@crate_universe_crate_index__autocfg-1.1.0//:autocfg",
         ],
     }),
 )
@@ -169,7 +168,7 @@ alias(
     # of `build_script_build` without losing out on having certain Cargo
     # environment variables set.
     name = "build_script_build",
-    actual = "proc-macro2_build_script",
+    actual = "indexmap_build_script",
     tags = [
         "manual",
     ],

--- a/crate_universe/3rdparty/crates/BUILD.jobserver-0.1.24.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.jobserver-0.1.24.bazel
@@ -99,7 +99,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
         ],

--- a/crate_universe/3rdparty/crates/BUILD.libc-0.2.122.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libc-0.2.122.bazel
@@ -81,11 +81,11 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.2.121",
+    version = "0.2.122",
     deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__libc-0.2.121//:build_script_build",
+            "@crate_universe_crate_index__libc-0.2.122//:build_script_build",
         ],
     }),
 )
@@ -152,7 +152,7 @@ cargo_build_script(
         "//conditions:default": [
         ],
     }),
-    version = "0.2.121",
+    version = "0.2.122",
     visibility = ["//visibility:private"],
     deps = [
     ] + select_with_or({

--- a/crate_universe/3rdparty/crates/BUILD.libgit2-sys-0.13.2+1.4.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libgit2-sys-0.13.2+1.4.2.bazel
@@ -80,7 +80,7 @@ rust_library(
         "@libgit2",
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
             "@crate_universe_crate_index__libz-sys-1.1.5//:libz_sys",
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.libz-sys-1.1.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libz-sys-1.1.5.bazel
@@ -81,7 +81,7 @@ rust_library(
         "@zlib",
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
         ],
     }),
 )

--- a/crate_universe/3rdparty/crates/BUILD.num_cpus-1.13.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num_cpus-1.13.1.bazel
@@ -106,7 +106,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
         ],

--- a/crate_universe/3rdparty/crates/BUILD.pest_generator-2.1.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pest_generator-2.1.3.bazel
@@ -81,7 +81,7 @@ rust_library(
         "//conditions:default": [
             "@crate_universe_crate_index__pest-2.1.3//:pest",
             "@crate_universe_crate_index__pest_meta-2.1.3//:pest_meta",
-            "@crate_universe_crate_index__proc-macro2-1.0.36//:proc_macro2",
+            "@crate_universe_crate_index__proc-macro2-1.0.37//:proc_macro2",
             "@crate_universe_crate_index__quote-1.0.17//:quote",
             "@crate_universe_crate_index__syn-1.0.90//:syn",
         ],

--- a/crate_universe/3rdparty/crates/BUILD.pkg-config-0.3.25.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pkg-config-0.3.25.bazel
@@ -20,11 +20,11 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT
+#     "TODO",  # MIT OR Apache-2.0
 # ])
 
 rust_library(
-    name = "syscall",
+    name = "pkg_config",
     srcs = glob(
         include = [
             "**/*.rs",
@@ -47,7 +47,7 @@ rust_library(
         "//conditions:default": [
         ],
     }),
-    edition = "2018",
+    edition = "2015",
     proc_macro_deps = [
     ] + select_with_or({
         "//conditions:default": [
@@ -75,11 +75,10 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.2.12",
+    version = "0.3.25",
     deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__bitflags-1.3.2//:bitflags",
         ],
     }),
 )

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro-error-1.0.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro-error-1.0.4.bazel
@@ -88,7 +88,7 @@ rust_library(
     ] + select_with_or({
         "//conditions:default": [
             "@crate_universe_crate_index__proc-macro-error-1.0.4//:build_script_build",
-            "@crate_universe_crate_index__proc-macro2-1.0.36//:proc_macro2",
+            "@crate_universe_crate_index__proc-macro2-1.0.37//:proc_macro2",
             "@crate_universe_crate_index__quote-1.0.17//:quote",
             "@crate_universe_crate_index__syn-1.0.90//:syn",
         ],

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -84,7 +84,7 @@ rust_proc_macro(
     ] + select_with_or({
         "//conditions:default": [
             "@crate_universe_crate_index__proc-macro-error-attr-1.0.4//:build_script_build",
-            "@crate_universe_crate_index__proc-macro2-1.0.36//:proc_macro2",
+            "@crate_universe_crate_index__proc-macro2-1.0.37//:proc_macro2",
             "@crate_universe_crate_index__quote-1.0.17//:quote",
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.37.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.37.bazel
@@ -24,11 +24,11 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # Apache-2.0/MIT
+#     "TODO",  # MIT OR Apache-2.0
 # ])
 
 rust_library(
-    name = "indexmap",
+    name = "proc_macro2",
     srcs = glob(
         include = [
             "**/*.rs",
@@ -45,7 +45,8 @@ rust_library(
         ],
     }),
     crate_features = [
-        "std",
+        "default",
+        "proc-macro",
     ],
     crate_root = "src/lib.rs",
     data = select_with_or({
@@ -80,19 +81,19 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "1.8.0",
+    version = "1.0.37",
     deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__hashbrown-0.11.2//:hashbrown",
-            "@crate_universe_crate_index__indexmap-1.8.0//:build_script_build",
+            "@crate_universe_crate_index__proc-macro2-1.0.37//:build_script_build",
+            "@crate_universe_crate_index__unicode-xid-0.2.2//:unicode_xid",
         ],
     }),
 )
 
 cargo_build_script(
     # See comment associated with alias. Do not change this name
-    name = "indexmap_build_script",
+    name = "proc-macro2_build_script",
     srcs = glob(
         include = [
             "**/*.rs",
@@ -111,7 +112,8 @@ cargo_build_script(
         ],
     }),
     crate_features = [
-        "std",
+        "default",
+        "proc-macro",
     ],
     crate_name = "build_script_build",
     crate_root = "build.rs",
@@ -151,12 +153,11 @@ cargo_build_script(
         "//conditions:default": [
         ],
     }),
-    version = "1.8.0",
+    version = "1.0.37",
     visibility = ["//visibility:private"],
     deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__autocfg-1.1.0//:autocfg",
         ],
     }),
 )
@@ -168,7 +169,7 @@ alias(
     # of `build_script_build` without losing out on having certain Cargo
     # environment variables set.
     name = "build_script_build",
-    actual = "indexmap_build_script",
+    actual = "proc-macro2_build_script",
     tags = [
         "manual",
     ],

--- a/crate_universe/3rdparty/crates/BUILD.quote-1.0.17.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.quote-1.0.17.bazel
@@ -81,7 +81,7 @@ rust_library(
     deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__proc-macro2-1.0.36//:proc_macro2",
+            "@crate_universe_crate_index__proc-macro2-1.0.37//:proc_macro2",
         ],
     }),
 )

--- a/crate_universe/3rdparty/crates/BUILD.rand-0.4.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand-0.4.6.bazel
@@ -112,7 +112,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
         ],

--- a/crate_universe/3rdparty/crates/BUILD.rand-0.8.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand-0.8.5.bazel
@@ -107,7 +107,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
             "@crate_universe_crate_index__rand_chacha-0.3.1//:rand_chacha",

--- a/crate_universe/3rdparty/crates/BUILD.redox_syscall-0.2.13.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.redox_syscall-0.2.13.bazel
@@ -20,11 +20,11 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 # licenses([
-#     "TODO",  # MIT/Apache-2.0
+#     "TODO",  # MIT
 # ])
 
 rust_library(
-    name = "pkg_config",
+    name = "syscall",
     srcs = glob(
         include = [
             "**/*.rs",
@@ -47,7 +47,7 @@ rust_library(
         "//conditions:default": [
         ],
     }),
-    edition = "2015",
+    edition = "2018",
     proc_macro_deps = [
     ] + select_with_or({
         "//conditions:default": [
@@ -75,10 +75,11 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.3.24",
+    version = "0.2.13",
     deps = [
     ] + select_with_or({
         "//conditions:default": [
+            "@crate_universe_crate_index__bitflags-1.3.2//:bitflags",
         ],
     }),
 )

--- a/crate_universe/3rdparty/crates/BUILD.serde_derive-1.0.136.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_derive-1.0.136.bazel
@@ -84,7 +84,7 @@ rust_proc_macro(
     deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__proc-macro2-1.0.36//:proc_macro2",
+            "@crate_universe_crate_index__proc-macro2-1.0.37//:proc_macro2",
             "@crate_universe_crate_index__quote-1.0.17//:quote",
             "@crate_universe_crate_index__serde_derive-1.0.136//:build_script_build",
             "@crate_universe_crate_index__syn-1.0.90//:syn",

--- a/crate_universe/3rdparty/crates/BUILD.syn-1.0.90.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.syn-1.0.90.bazel
@@ -91,7 +91,7 @@ rust_library(
     deps = [
     ] + select_with_or({
         "//conditions:default": [
-            "@crate_universe_crate_index__proc-macro2-1.0.36//:proc_macro2",
+            "@crate_universe_crate_index__proc-macro2-1.0.37//:proc_macro2",
             "@crate_universe_crate_index__quote-1.0.17//:quote",
             "@crate_universe_crate_index__syn-1.0.90//:build_script_build",
             "@crate_universe_crate_index__unicode-xid-0.2.2//:unicode_xid",

--- a/crate_universe/3rdparty/crates/BUILD.tempfile-3.3.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tempfile-3.3.0.bazel
@@ -100,7 +100,7 @@ rust_library(
             "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
         ): [
             # Target Deps
-            "@crate_universe_crate_index__libc-0.2.121//:libc",
+            "@crate_universe_crate_index__libc-0.2.122//:libc",
 
             # Common Deps
             "@crate_universe_crate_index__cfg-if-1.0.0//:cfg_if",
@@ -110,7 +110,7 @@ rust_library(
         # cfg(target_os = "redox")
         #
         # No supported platform triples for cfg: 'cfg(target_os = "redox")'
-        # Skipped dependencies: [{"id":"redox_syscall 0.2.12","target":"syscall"}]
+        # Skipped dependencies: [{"id":"redox_syscall 0.2.13","target":"syscall"}]
         #
         # cfg(windows)
         (

--- a/crate_universe/3rdparty/crates/defs.bzl
+++ b/crate_universe/3rdparty/crates/defs.bzl
@@ -293,7 +293,7 @@ _NORMAL_DEPENDENCIES = {
             "cargo_metadata": "@crate_universe_crate_index__cargo_metadata-0.14.2//:cargo_metadata",
             "cargo_toml": "@crate_universe_crate_index__cargo_toml-0.11.5//:cargo_toml",
             "cfg-expr": "@crate_universe_crate_index__cfg-expr-0.10.2//:cfg_expr",
-            "clap": "@crate_universe_crate_index__clap-3.1.6//:clap",
+            "clap": "@crate_universe_crate_index__clap-3.1.8//:clap",
             "crates-index": "@crate_universe_crate_index__crates-index-0.18.7//:crates_index",
             "hex": "@crate_universe_crate_index__hex-0.4.3//:hex",
             "pathdiff": "@crate_universe_crate_index__pathdiff-0.2.1//:pathdiff",
@@ -302,6 +302,7 @@ _NORMAL_DEPENDENCIES = {
             "serde": "@crate_universe_crate_index__serde-1.0.136//:serde",
             "serde_json": "@crate_universe_crate_index__serde_json-1.0.79//:serde_json",
             "sha2": "@crate_universe_crate_index__sha2-0.10.2//:sha2",
+            "syn": "@crate_universe_crate_index__syn-1.0.90//:syn",
             "tempfile": "@crate_universe_crate_index__tempfile-3.3.0//:tempfile",
             "tera": "@crate_universe_crate_index__tera-1.15.0//:tera",
             "textwrap": "@crate_universe_crate_index__textwrap-0.15.0//:textwrap",
@@ -310,12 +311,12 @@ _NORMAL_DEPENDENCIES = {
     },
     "crate_universe/tools/cross_installer": {
         _COMMON_CONDITION: {
-            "clap": "@crate_universe_crate_index__clap-3.1.6//:clap",
+            "clap": "@crate_universe_crate_index__clap-3.1.8//:clap",
         },
     },
     "crate_universe/tools/urls_generator": {
         _COMMON_CONDITION: {
-            "clap": "@crate_universe_crate_index__clap-3.1.6//:clap",
+            "clap": "@crate_universe_crate_index__clap-3.1.8//:clap",
             "hex": "@crate_universe_crate_index__hex-0.4.3//:hex",
             "serde_json": "@crate_universe_crate_index__serde_json-1.0.79//:serde_json",
             "sha2": "@crate_universe_crate_index__sha2-0.10.2//:sha2",
@@ -681,22 +682,22 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crate_universe_crate_index__clap-3.1.6",
-        sha256 = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123",
+        name = "crate_universe_crate_index__clap-3.1.8",
+        sha256 = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/clap/3.1.6/download"],
-        strip_prefix = "clap-3.1.6",
-        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.clap-3.1.6.bazel"),
+        urls = ["https://crates.io/api/v1/crates/clap/3.1.8/download"],
+        strip_prefix = "clap-3.1.8",
+        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.clap-3.1.8.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crate_universe_crate_index__clap_derive-3.1.4",
-        sha256 = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16",
+        name = "crate_universe_crate_index__clap_derive-3.1.7",
+        sha256 = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/clap_derive/3.1.4/download"],
-        strip_prefix = "clap_derive-3.1.4",
-        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.clap_derive-3.1.4.bazel"),
+        urls = ["https://crates.io/api/v1/crates/clap_derive/3.1.7/download"],
+        strip_prefix = "clap_derive-3.1.7",
+        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.clap_derive-3.1.7.bazel"),
     )
 
     maybe(
@@ -961,12 +962,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crate_universe_crate_index__indexmap-1.8.0",
-        sha256 = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223",
+        name = "crate_universe_crate_index__indexmap-1.8.1",
+        sha256 = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/indexmap/1.8.0/download"],
-        strip_prefix = "indexmap-1.8.0",
-        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.indexmap-1.8.0.bazel"),
+        urls = ["https://crates.io/api/v1/crates/indexmap/1.8.1/download"],
+        strip_prefix = "indexmap-1.8.1",
+        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.indexmap-1.8.1.bazel"),
     )
 
     maybe(
@@ -1011,12 +1012,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crate_universe_crate_index__libc-0.2.121",
-        sha256 = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f",
+        name = "crate_universe_crate_index__libc-0.2.122",
+        sha256 = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/libc/0.2.121/download"],
-        strip_prefix = "libc-0.2.121",
-        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.libc-0.2.121.bazel"),
+        urls = ["https://crates.io/api/v1/crates/libc/0.2.122/download"],
+        strip_prefix = "libc-0.2.122",
+        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.libc-0.2.122.bazel"),
     )
 
     maybe(
@@ -1301,12 +1302,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crate_universe_crate_index__pkg-config-0.3.24",
-        sha256 = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe",
+        name = "crate_universe_crate_index__pkg-config-0.3.25",
+        sha256 = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/pkg-config/0.3.24/download"],
-        strip_prefix = "pkg-config-0.3.24",
-        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.pkg-config-0.3.24.bazel"),
+        urls = ["https://crates.io/api/v1/crates/pkg-config/0.3.25/download"],
+        strip_prefix = "pkg-config-0.3.25",
+        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.pkg-config-0.3.25.bazel"),
     )
 
     maybe(
@@ -1341,12 +1342,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crate_universe_crate_index__proc-macro2-1.0.36",
-        sha256 = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029",
+        name = "crate_universe_crate_index__proc-macro2-1.0.37",
+        sha256 = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.36/download"],
-        strip_prefix = "proc-macro2-1.0.36",
-        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.proc-macro2-1.0.36.bazel"),
+        urls = ["https://crates.io/api/v1/crates/proc-macro2/1.0.37/download"],
+        strip_prefix = "proc-macro2-1.0.37",
+        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.proc-macro2-1.0.37.bazel"),
     )
 
     maybe(
@@ -1431,12 +1432,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crate_universe_crate_index__redox_syscall-0.2.12",
-        sha256 = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0",
+        name = "crate_universe_crate_index__redox_syscall-0.2.13",
+        sha256 = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/redox_syscall/0.2.12/download"],
-        strip_prefix = "redox_syscall-0.2.12",
-        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.2.12.bazel"),
+        urls = ["https://crates.io/api/v1/crates/redox_syscall/0.2.13/download"],
+        strip_prefix = "redox_syscall-0.2.13",
+        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.2.13.bazel"),
     )
 
     maybe(

--- a/crate_universe/BUILD.bazel
+++ b/crate_universe/BUILD.bazel
@@ -117,9 +117,10 @@ rust_doc(
 rust_doc_test(
     name = "rustdoc_test",
     crate = ":cargo_bazel",
-    # TODO: This target fails on windows with the error tracked in:
+    # TODO: This target fails on some platforms with the error tracked in:
     # https://github.com/bazelbuild/rules_rust/issues/1233
     target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),

--- a/crate_universe/Cargo.Bazel.lock
+++ b/crate_universe/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d40826d42e08cce6c275643f032045db73ed0ca8df3df0247455727c58d590ca",
+  "checksum": "0a6242f7bd2ce6f7adf071110f944b64f30020876270fa45dad1f3ab2a949953",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -551,9 +551,9 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cargo-bazel 0.2.0": {
+    "cargo-bazel 0.2.1": {
       "name": "cargo-bazel",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "repository": null,
       "targets": [
         {
@@ -685,7 +685,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.0"
+        "version": "0.2.1"
       },
       "license": null
     },
@@ -7923,7 +7923,7 @@
     "phf_generator 0.10.0"
   ],
   "workspace_members": {
-    "cargo-bazel 0.2.0": "crate_universe",
+    "cargo-bazel 0.2.1": "crate_universe",
     "cross_installer 0.1.0": "crate_universe/tools/cross_installer",
     "urls_generator 0.1.0": "crate_universe/tools/urls_generator"
   },

--- a/crate_universe/Cargo.Bazel.lock
+++ b/crate_universe/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "11267310abfa7829699b9a5a7317b101ce2a6c6da6c5a2996f2e62e203566709",
+  "checksum": "d40826d42e08cce6c275643f032045db73ed0ca8df3df0247455727c58d590ca",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -149,7 +149,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -617,7 +617,7 @@
               "target": "cfg_expr"
             },
             {
-              "id": "clap 3.1.6",
+              "id": "clap 3.1.8",
               "target": "clap"
             },
             {
@@ -651,6 +651,10 @@
             {
               "id": "sha2 0.10.2",
               "target": "sha2"
+            },
+            {
+              "id": "syn 1.0.90",
+              "target": "syn"
             },
             {
               "id": "tempfile 3.3.0",
@@ -1082,7 +1086,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -1238,13 +1242,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "clap 3.1.6": {
+    "clap 3.1.8": {
       "name": "clap",
-      "version": "3.1.6",
+      "version": "3.1.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap/3.1.6/download",
-          "sha256": "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+          "url": "https://crates.io/api/v1/crates/clap/3.1.8/download",
+          "sha256": "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
         }
       },
       "targets": [
@@ -1290,7 +1294,7 @@
               "target": "bitflags"
             },
             {
-              "id": "indexmap 1.8.0",
+              "id": "indexmap 1.8.1",
               "target": "indexmap"
             },
             {
@@ -1320,23 +1324,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "clap_derive 3.1.4",
+              "id": "clap_derive 3.1.7",
               "target": "clap_derive"
             }
           ],
           "selects": {}
         },
-        "version": "3.1.6"
+        "version": "3.1.8"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_derive 3.1.4": {
+    "clap_derive 3.1.7": {
       "name": "clap_derive",
-      "version": "3.1.4",
+      "version": "3.1.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_derive/3.1.4/download",
-          "sha256": "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+          "url": "https://crates.io/api/v1/crates/clap_derive/3.1.7/download",
+          "sha256": "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
         }
       },
       "targets": [
@@ -1372,7 +1376,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -1387,7 +1391,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "3.1.4"
+        "version": "3.1.7"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1424,19 +1428,19 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -1560,7 +1564,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 3.1.6",
+              "id": "clap 3.1.8",
               "target": "clap"
             }
           ],
@@ -2177,7 +2181,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -2223,7 +2227,7 @@
               "target": "bitflags"
             },
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -2460,7 +2464,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -2727,13 +2731,13 @@
       },
       "license": "Unlicense/MIT"
     },
-    "indexmap 1.8.0": {
+    "indexmap 1.8.1": {
       "name": "indexmap",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/indexmap/1.8.0/download",
-          "sha256": "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+          "url": "https://crates.io/api/v1/crates/indexmap/1.8.1/download",
+          "sha256": "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
         }
       },
       "targets": [
@@ -2777,14 +2781,14 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 1.8.0",
+              "id": "indexmap 1.8.1",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.8.0"
+        "version": "1.8.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2910,7 +2914,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -2954,13 +2958,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.121": {
+    "libc 0.2.122": {
       "name": "libc",
-      "version": "0.2.121",
+      "version": "0.2.122",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.121/download",
-          "sha256": "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.122/download",
+          "sha256": "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
         }
       },
       "targets": [
@@ -3001,14 +3005,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.121"
+        "version": "0.2.122"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3048,7 +3052,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -3100,7 +3104,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -3814,7 +3818,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -4179,7 +4183,7 @@
               "target": "pest_meta"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -4444,13 +4448,13 @@
       },
       "license": "MIT"
     },
-    "pkg-config 0.3.24": {
+    "pkg-config 0.3.25": {
       "name": "pkg-config",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pkg-config/0.3.24/download",
-          "sha256": "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+          "url": "https://crates.io/api/v1/crates/pkg-config/0.3.25/download",
+          "sha256": "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
         }
       },
       "targets": [
@@ -4473,9 +4477,9 @@
           "**"
         ],
         "edition": "2015",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "ppv-lite86 0.2.16": {
       "name": "ppv-lite86",
@@ -4566,7 +4570,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -4655,7 +4659,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -4684,13 +4688,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.36": {
+    "proc-macro2 1.0.37": {
       "name": "proc-macro2",
-      "version": "1.0.36",
+      "version": "1.0.37",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
-          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.37/download",
+          "sha256": "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
         }
       },
       "targets": [
@@ -4731,7 +4735,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "build_script_build"
             },
             {
@@ -4742,7 +4746,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.36"
+        "version": "1.0.37"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4786,7 +4790,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             }
           ],
@@ -4851,7 +4855,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -4920,7 +4924,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -5148,13 +5152,13 @@
       },
       "license": "ISC"
     },
-    "redox_syscall 0.2.12": {
+    "redox_syscall 0.2.13": {
       "name": "redox_syscall",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/redox_syscall/0.2.12/download",
-          "sha256": "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
+          "url": "https://crates.io/api/v1/crates/redox_syscall/0.2.13/download",
+          "sha256": "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
         }
       },
       "targets": [
@@ -5186,7 +5190,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.12"
+        "version": "0.2.13"
       },
       "license": "MIT"
     },
@@ -5683,7 +5687,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -6293,7 +6297,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -6367,13 +6371,13 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"redox\")": [
               {
-                "id": "redox_syscall 0.2.12",
+                "id": "redox_syscall 0.2.13",
                 "target": "syscall"
               }
             ],
@@ -7481,7 +7485,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 3.1.6",
+              "id": "clap 3.1.8",
               "target": "clap"
             },
             {

--- a/crate_universe/Cargo.lock
+++ b/crate_universe/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bazel"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "cargo-lock",

--- a/crate_universe/Cargo.lock
+++ b/crate_universe/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "spectral",
+ "syn",
  "tempfile",
  "tera",
  "textwrap",
@@ -231,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -248,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -519,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -559,9 +560,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "libgit2-sys"
@@ -828,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -864,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -949,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]

--- a/crate_universe/Cargo.toml
+++ b/crate_universe/Cargo.toml
@@ -39,5 +39,10 @@ tera = "1.15.0"
 textwrap = "0.15.0"
 toml = "0.5.8"
 
+# TODO: The 1.0.91 release causes build issues for windows where rustc seems to
+# run infinitely. This dependency should not be pinned.
+# https://github.com/bazelbuild/rules_rust/issues/1253
+syn = "=1.0.90"
+
 [dev-dependencies]
 spectral = "0.6.0"

--- a/crate_universe/Cargo.toml
+++ b/crate_universe/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "cargo-bazel"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "Andre Brisco - andre.brisco@protonmail.com",
 ]

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -198,8 +198,20 @@ impl Digest {
             bail!("Failed to query cargo version")
         }
 
-        let version = String::from_utf8(output.stdout)?;
-        Ok(version)
+        let version = String::from_utf8(output.stdout)?.trim().to_owned();
+
+        // TODO: There is a bug in the linux binary for Cargo 1.60.0 where
+        // the commit hash reported by the version is shorter than what's
+        // reported on other platforms. This conditional here is a hack to
+        // correct for this difference and ensure lockfile hashes can be
+        // computed consistently. If a new binary is released then this
+        // condition should be removed
+        // https://github.com/rust-lang/cargo/issues/10547
+        if version == "cargo 1.60.0 (d1fd9fe 2022-03-01)" {
+            Ok("cargo 1.60.0 (d1fd9fe2c 2022-03-01)".to_owned())
+        } else {
+            Ok(version)
+        }
     }
 }
 

--- a/crate_universe/version.bzl
+++ b/crate_universe/version.bzl
@@ -1,3 +1,3 @@
 """ Version info for the `cargo-bazel` repository """
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"

--- a/examples/crate_universe/cargo_aliases/Cargo.Bazel.lock
+++ b/examples/crate_universe/cargo_aliases/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3ccbb0ec4fba59758ba1a1571828372a44e31bbb8fe61c4c627c8e3bb808d397",
+  "checksum": "a114fa1a49ce5b93d08ce526ec77584705fa0e71d3810b85b6afb35db8cbff95",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -150,7 +150,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -269,13 +269,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "clap 3.1.6": {
+    "clap 3.1.8": {
       "name": "clap",
-      "version": "3.1.6",
+      "version": "3.1.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap/3.1.6/download",
-          "sha256": "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+          "url": "https://crates.io/api/v1/crates/clap/3.1.8/download",
+          "sha256": "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
         }
       },
       "targets": [
@@ -350,23 +350,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "clap_derive 3.1.4",
+              "id": "clap_derive 3.1.7",
               "target": "clap_derive"
             }
           ],
           "selects": {}
         },
-        "version": "3.1.6"
+        "version": "3.1.8"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_derive 3.1.4": {
+    "clap_derive 3.1.7": {
       "name": "clap_derive",
-      "version": "3.1.4",
+      "version": "3.1.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_derive/3.1.4/download",
-          "sha256": "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+          "url": "https://crates.io/api/v1/crates/clap_derive/3.1.7/download",
+          "sha256": "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
         }
       },
       "targets": [
@@ -402,7 +402,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -410,14 +410,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "3.1.4"
+        "version": "3.1.7"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -456,7 +456,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -579,7 +579,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -696,7 +696,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -848,13 +848,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.121": {
+    "libc 0.2.122": {
       "name": "libc",
-      "version": "0.2.121",
+      "version": "0.2.122",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.121/download",
-          "sha256": "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.122/download",
+          "sha256": "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
         }
       },
       "targets": [
@@ -891,14 +891,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.121"
+        "version": "0.2.122"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1145,7 +1145,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 3.1.6",
+              "id": "clap 3.1.8",
               "target": "clap"
             },
             {
@@ -1229,7 +1229,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 3.1.6",
+              "id": "clap 3.1.8",
               "target": "clap"
             },
             {
@@ -1389,7 +1389,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -1397,7 +1397,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -1478,7 +1478,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -1507,13 +1507,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.36": {
+    "proc-macro2 1.0.37": {
       "name": "proc-macro2",
-      "version": "1.0.36",
+      "version": "1.0.37",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
-          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.37/download",
+          "sha256": "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
         }
       },
       "targets": [
@@ -1554,7 +1554,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "build_script_build"
             },
             {
@@ -1565,7 +1565,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.36"
+        "version": "1.0.37"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1609,7 +1609,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             }
           ],
@@ -1671,7 +1671,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -1904,13 +1904,13 @@
       },
       "license": "MIT"
     },
-    "syn 1.0.90": {
+    "syn 1.0.91": {
       "name": "syn",
-      "version": "1.0.90",
+      "version": "1.0.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.90/download",
-          "sha256": "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.91/download",
+          "sha256": "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
         }
       },
       "targets": [
@@ -1957,7 +1957,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -1965,7 +1965,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "build_script_build"
             },
             {
@@ -1976,7 +1976,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.90"
+        "version": "1.0.91"
       },
       "build_script_attrs": {
         "data_glob": [

--- a/examples/crate_universe/cargo_workspace/Cargo.Bazel.lock
+++ b/examples/crate_universe/cargo_workspace/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1cb49557f6fb5d2d490756b19689d3433b214ae11dfd30819c9f4eae6a230d77",
+  "checksum": "5a2c3273614bb677a90c62917d21d339c43d36808d7248a24b4b3eb183fae4ee",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -84,7 +84,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -389,7 +389,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -439,7 +439,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -450,13 +450,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.121": {
+    "libc 0.2.122": {
       "name": "libc",
-      "version": "0.2.121",
+      "version": "0.2.122",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.121/download",
-          "sha256": "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.122/download",
+          "sha256": "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
         }
       },
       "targets": [
@@ -493,14 +493,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.121"
+        "version": "0.2.122"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -683,7 +683,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]

--- a/examples/crate_universe/extra_workspace_members/Cargo.Bazel.lock
+++ b/examples/crate_universe/extra_workspace_members/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "cb915ce9c13c77d98109928337118eb33fa0a330b62080310db45353acfadd3d",
+  "checksum": "ffefc431b4beda07270e75284be07d280fba62608e89b253c129f384e32d994b",
   "crates": {
     "adler32 1.2.0": {
       "name": "adler32",
@@ -121,7 +121,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -207,13 +207,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "bytemuck 1.9.0": {
+    "bytemuck 1.9.1": {
       "name": "bytemuck",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytemuck/1.9.0/download",
-          "sha256": "ee1e0e2125faccb856bf10b0a9dfa89c4c718d05ef85580dfefbdf1c422ef801"
+          "url": "https://crates.io/api/v1/crates/bytemuck/1.9.1/download",
+          "sha256": "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc"
         }
       },
       "targets": [
@@ -236,7 +236,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.9.0"
+        "version": "1.9.1"
       },
       "license": "Zlib OR Apache-2.0 OR MIT"
     },
@@ -458,7 +458,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -881,7 +881,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -928,7 +928,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytemuck 1.9.0",
+              "id": "bytemuck 1.9.1",
               "target": "bytemuck"
             },
             {
@@ -1091,13 +1091,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.121": {
+    "libc 0.2.122": {
       "name": "libc",
-      "version": "0.2.121",
+      "version": "0.2.122",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.121/download",
-          "sha256": "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.122/download",
+          "sha256": "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
         }
       },
       "targets": [
@@ -1138,14 +1138,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.121"
+        "version": "0.2.122"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1540,7 +1540,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -1771,7 +1771,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -1779,7 +1779,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -1860,7 +1860,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -1889,13 +1889,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.36": {
+    "proc-macro2 1.0.37": {
       "name": "proc-macro2",
-      "version": "1.0.36",
+      "version": "1.0.37",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
-          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.37/download",
+          "sha256": "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
         }
       },
       "targets": [
@@ -1936,7 +1936,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "build_script_build"
             },
             {
@@ -1947,7 +1947,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.36"
+        "version": "1.0.37"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1991,7 +1991,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             }
           ],
@@ -2446,7 +2446,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -2454,7 +2454,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -2465,13 +2465,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "syn 1.0.90": {
+    "syn 1.0.91": {
       "name": "syn",
-      "version": "1.0.90",
+      "version": "1.0.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.90/download",
-          "sha256": "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.91/download",
+          "sha256": "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
         }
       },
       "targets": [
@@ -2518,7 +2518,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -2526,7 +2526,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "build_script_build"
             },
             {
@@ -2537,7 +2537,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.90"
+        "version": "1.0.91"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2579,7 +2579,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],

--- a/examples/crate_universe/multi_package/Cargo.Bazel.lock
+++ b/examples/crate_universe/multi_package/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "e078fdfdb1aedcceef9ddf849db2b899d2cb956c64acef2e8f67b6c93299eb37",
+  "checksum": "a0fb85aec3e72e155508fd755dd80ec38fac9f27bebe620c44c4109a9319ba1c",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -299,7 +299,7 @@
               "target": "once_cell"
             },
             {
-              "id": "slab 0.4.5",
+              "id": "slab 0.4.6",
               "target": "slab"
             }
           ],
@@ -310,13 +310,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "async-global-executor 2.0.3": {
+    "async-global-executor 2.0.4": {
       "name": "async-global-executor",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/async-global-executor/2.0.3/download",
-          "sha256": "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
+          "url": "https://crates.io/api/v1/crates/async-global-executor/2.0.4/download",
+          "sha256": "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
         }
       },
       "targets": [
@@ -380,7 +380,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.0.3"
+        "version": "2.0.4"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -439,7 +439,7 @@
               "target": "polling"
             },
             {
-              "id": "slab 0.4.5",
+              "id": "slab 0.4.6",
               "target": "slab"
             },
             {
@@ -454,7 +454,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -651,7 +651,7 @@
                 "target": "async_io"
               },
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               },
               {
@@ -781,14 +781,14 @@
               "target": "pin_utils"
             },
             {
-              "id": "slab 0.4.5",
+              "id": "slab 0.4.6",
               "target": "slab"
             }
           ],
           "selects": {
             "cfg(not(target_os = \"unknown\"))": [
               {
-                "id": "async-global-executor 2.0.3",
+                "id": "async-global-executor 2.0.4",
                 "target": "async_global_executor"
               },
               {
@@ -814,7 +814,7 @@
                 "target": "gloo_timers"
               },
               {
-                "id": "wasm-bindgen-futures 0.4.29",
+                "id": "wasm-bindgen-futures 0.4.30",
                 "target": "wasm_bindgen_futures"
               }
             ]
@@ -909,7 +909,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -917,7 +917,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -1005,7 +1005,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -1677,7 +1677,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -1917,7 +1917,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -1987,7 +1987,7 @@
               "target": "curl_sys"
             },
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -2076,7 +2076,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -2304,7 +2304,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -2396,13 +2396,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "encoding_rs 0.8.30": {
+    "encoding_rs 0.8.31": {
       "name": "encoding_rs",
-      "version": "0.8.30",
+      "version": "0.8.31",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/encoding_rs/0.8.30/download",
-          "sha256": "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+          "url": "https://crates.io/api/v1/crates/encoding_rs/0.8.31/download",
+          "sha256": "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
         }
       },
       "targets": [
@@ -2447,21 +2447,21 @@
               "target": "cfg_if"
             },
             {
-              "id": "encoding_rs 0.8.30",
+              "id": "encoding_rs 0.8.31",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.30"
+        "version": "0.8.31"
       },
       "build_script_attrs": {
         "data_glob": [
           "**"
         ]
       },
-      "license": null
+      "license": "(Apache-2.0 OR MIT) AND BSD-3-Clause"
     },
     "event-listener 2.5.2": {
       "name": "event-listener",
@@ -3007,7 +3007,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -3015,7 +3015,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -3210,7 +3210,7 @@
               "target": "pin_utils"
             },
             {
-              "id": "slab 0.4.5",
+              "id": "slab 0.4.6",
               "target": "slab"
             }
           ],
@@ -3354,7 +3354,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -3410,11 +3410,11 @@
               "target": "futures_core"
             },
             {
-              "id": "js-sys 0.3.56",
+              "id": "js-sys 0.3.57",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.79",
+              "id": "wasm-bindgen 0.2.80",
               "target": "wasm_bindgen"
             }
           ],
@@ -3425,13 +3425,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "h2 0.3.12": {
+    "h2 0.3.13": {
       "name": "h2",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/h2/0.3.12/download",
-          "sha256": "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+          "url": "https://crates.io/api/v1/crates/h2/0.3.13/download",
+          "sha256": "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
         }
       },
       "targets": [
@@ -3484,7 +3484,7 @@
               "target": "indexmap"
             },
             {
-              "id": "slab 0.4.5",
+              "id": "slab 0.4.6",
               "target": "slab"
             },
             {
@@ -3492,7 +3492,7 @@
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.6.9",
+              "id": "tokio-util 0.7.1",
               "target": "tokio_util"
             },
             {
@@ -3503,7 +3503,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.12"
+        "version": "0.3.13"
       },
       "license": "MIT"
     },
@@ -3577,7 +3577,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -4015,7 +4015,7 @@
               "target": "futures_util"
             },
             {
-              "id": "h2 0.3.12",
+              "id": "h2 0.3.13",
               "target": "h2"
             },
             {
@@ -4402,7 +4402,7 @@
               "target": "curl_sys"
             },
             {
-              "id": "encoding_rs 0.8.30",
+              "id": "encoding_rs 0.8.31",
               "target": "encoding_rs"
             },
             {
@@ -4438,7 +4438,7 @@
               "target": "polling"
             },
             {
-              "id": "slab 0.4.5",
+              "id": "slab 0.4.6",
               "target": "slab"
             },
             {
@@ -4553,13 +4553,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "js-sys 0.3.56": {
+    "js-sys 0.3.57": {
       "name": "js-sys",
-      "version": "0.3.56",
+      "version": "0.3.57",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/js-sys/0.3.56/download",
-          "sha256": "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+          "url": "https://crates.io/api/v1/crates/js-sys/0.3.57/download",
+          "sha256": "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
         }
       },
       "targets": [
@@ -4584,14 +4584,14 @@
         "deps": {
           "common": [
             {
-              "id": "wasm-bindgen 0.2.79",
+              "id": "wasm-bindgen 0.2.80",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.56"
+        "version": "0.3.57"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -4869,13 +4869,13 @@
       },
       "license": "MIT"
     },
-    "libc 0.2.121": {
+    "libc 0.2.122": {
       "name": "libc",
-      "version": "0.2.121",
+      "version": "0.2.122",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.121/download",
-          "sha256": "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.122/download",
+          "sha256": "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
         }
       },
       "targets": [
@@ -4916,14 +4916,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.121"
+        "version": "0.2.122"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4978,7 +4978,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -5055,7 +5055,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -5079,7 +5079,7 @@
               "target": "cc"
             },
             {
-              "id": "pkg-config 0.3.24",
+              "id": "pkg-config 0.3.25",
               "target": "pkg_config"
             }
           ],
@@ -5466,7 +5466,7 @@
           "selects": {
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               },
               {
@@ -5476,7 +5476,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -5597,7 +5597,7 @@
                 "target": "lazy_static"
               },
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               },
               {
@@ -5788,7 +5788,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -5926,7 +5926,7 @@
               "target": "foreign_types"
             },
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -6047,7 +6047,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -6086,7 +6086,7 @@
               "target": "cc"
             },
             {
-              "id": "pkg-config 0.3.24",
+              "id": "pkg-config 0.3.25",
               "target": "pkg_config"
             }
           ],
@@ -6256,7 +6256,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -6509,7 +6509,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -6517,7 +6517,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -6594,13 +6594,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "pkg-config 0.3.24": {
+    "pkg-config 0.3.25": {
       "name": "pkg-config",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pkg-config/0.3.24/download",
-          "sha256": "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+          "url": "https://crates.io/api/v1/crates/pkg-config/0.3.25/download",
+          "sha256": "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
         }
       },
       "targets": [
@@ -6623,9 +6623,9 @@
           "**"
         ],
         "edition": "2015",
-        "version": "0.3.24"
+        "version": "0.3.25"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "pkg_a 0.1.0": {
       "name": "pkg_a",
@@ -6806,7 +6806,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"fuchsia\", target_os = \"vxworks\"))": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -6860,13 +6860,13 @@
       },
       "license": "MIT"
     },
-    "proc-macro2 1.0.36": {
+    "proc-macro2 1.0.37": {
       "name": "proc-macro2",
-      "version": "1.0.36",
+      "version": "1.0.37",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
-          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.37/download",
+          "sha256": "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
         }
       },
       "targets": [
@@ -6907,7 +6907,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "build_script_build"
             },
             {
@@ -6918,7 +6918,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.36"
+        "version": "1.0.37"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6962,7 +6962,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             }
           ],
@@ -7295,7 +7295,7 @@
                 "target": "base64"
               },
               {
-                "id": "encoding_rs 0.8.30",
+                "id": "encoding_rs 0.8.31",
                 "target": "encoding_rs"
               },
               {
@@ -7307,7 +7307,7 @@
                 "target": "futures_util"
               },
               {
-                "id": "h2 0.3.12",
+                "id": "h2 0.3.13",
                 "target": "h2"
               },
               {
@@ -7362,7 +7362,7 @@
             ],
             "cfg(target_arch = \"wasm32\")": [
               {
-                "id": "js-sys 0.3.56",
+                "id": "js-sys 0.3.57",
                 "target": "js_sys"
               },
               {
@@ -7370,15 +7370,15 @@
                 "target": "serde_json"
               },
               {
-                "id": "wasm-bindgen 0.2.79",
+                "id": "wasm-bindgen 0.2.80",
                 "target": "wasm_bindgen"
               },
               {
-                "id": "wasm-bindgen-futures 0.4.29",
+                "id": "wasm-bindgen-futures 0.4.30",
                 "target": "wasm_bindgen_futures"
               },
               {
-                "id": "web-sys 0.3.56",
+                "id": "web-sys 0.3.57",
                 "target": "web_sys"
               }
             ],
@@ -7613,7 +7613,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -7667,7 +7667,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -7798,7 +7798,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -7810,7 +7810,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -8048,7 +8048,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             },
             {
@@ -8103,7 +8103,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -8188,13 +8188,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "slab 0.4.5": {
+    "slab 0.4.6": {
       "name": "slab",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/slab/0.4.5/download",
-          "sha256": "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+          "url": "https://crates.io/api/v1/crates/slab/0.4.6/download",
+          "sha256": "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
         }
       },
       "targets": [
@@ -8221,7 +8221,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.4.5"
+        "version": "0.4.6"
       },
       "license": "MIT"
     },
@@ -8344,7 +8344,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -8419,13 +8419,13 @@
       },
       "license": "MIT / Apache-2.0"
     },
-    "syn 1.0.90": {
+    "syn 1.0.91": {
       "name": "syn",
-      "version": "1.0.90",
+      "version": "1.0.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.90/download",
-          "sha256": "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.91/download",
+          "sha256": "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
         }
       },
       "targets": [
@@ -8475,7 +8475,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -8483,7 +8483,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "build_script_build"
             },
             {
@@ -8494,7 +8494,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.90"
+        "version": "1.0.91"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8549,7 +8549,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -8708,7 +8708,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -8716,7 +8716,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -8957,7 +8957,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               },
               {
@@ -9018,7 +9018,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -9026,7 +9026,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -9083,13 +9083,13 @@
       },
       "license": "MIT"
     },
-    "tokio-util 0.6.9": {
+    "tokio-util 0.7.1": {
       "name": "tokio-util",
-      "version": "0.6.9",
+      "version": "0.7.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-util/0.6.9/download",
-          "sha256": "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+          "url": "https://crates.io/api/v1/crates/tokio-util/0.7.1/download",
+          "sha256": "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
         }
       },
       "targets": [
@@ -9113,7 +9113,8 @@
         ],
         "crate_features": [
           "codec",
-          "default"
+          "default",
+          "tracing"
         ],
         "deps": {
           "common": [
@@ -9130,22 +9131,22 @@
               "target": "futures_sink"
             },
             {
-              "id": "log 0.4.16",
-              "target": "log"
-            },
-            {
               "id": "pin-project-lite 0.2.8",
               "target": "pin_project_lite"
             },
             {
               "id": "tokio 1.17.0",
               "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.32",
+              "target": "tracing"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.6.9"
+        "version": "0.7.1"
       },
       "license": "MIT"
     },
@@ -9232,7 +9233,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tracing-core 0.1.23",
+              "id": "tracing-core 0.1.24",
               "target": "tracing_core"
             }
           ],
@@ -9283,7 +9284,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -9291,7 +9292,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -9302,13 +9303,13 @@
       },
       "license": "MIT"
     },
-    "tracing-core 0.1.23": {
+    "tracing-core 0.1.24": {
       "name": "tracing-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.23/download",
-          "sha256": "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.24/download",
+          "sha256": "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
         }
       },
       "targets": [
@@ -9344,7 +9345,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.23"
+        "version": "0.1.24"
       },
       "license": "MIT"
     },
@@ -9961,13 +9962,13 @@
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
     },
-    "wasm-bindgen 0.2.79": {
+    "wasm-bindgen 0.2.80": {
       "name": "wasm-bindgen",
-      "version": "0.2.79",
+      "version": "0.2.80",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen/0.2.79/download",
-          "sha256": "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen/0.2.80/download",
+          "sha256": "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
         }
       },
       "targets": [
@@ -10013,7 +10014,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "wasm-bindgen 0.2.79",
+              "id": "wasm-bindgen 0.2.80",
               "target": "build_script_build"
             }
           ],
@@ -10023,13 +10024,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasm-bindgen-macro 0.2.79",
+              "id": "wasm-bindgen-macro 0.2.80",
               "target": "wasm_bindgen_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.2.79"
+        "version": "0.2.80"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -10038,13 +10039,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-backend 0.2.79": {
+    "wasm-bindgen-backend 0.2.80": {
       "name": "wasm-bindgen-backend",
-      "version": "0.2.79",
+      "version": "0.2.80",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.79/download",
-          "sha256": "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.80/download",
+          "sha256": "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
         }
       },
       "targets": [
@@ -10084,7 +10085,7 @@
               "target": "log"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -10092,28 +10093,28 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.79",
+              "id": "wasm-bindgen-shared 0.2.80",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.79"
+        "version": "0.2.80"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-futures 0.4.29": {
+    "wasm-bindgen-futures 0.4.30": {
       "name": "wasm-bindgen-futures",
-      "version": "0.4.29",
+      "version": "0.4.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-futures/0.4.29/download",
-          "sha256": "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-futures/0.4.30/download",
+          "sha256": "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
         }
       },
       "targets": [
@@ -10142,35 +10143,35 @@
               "target": "cfg_if"
             },
             {
-              "id": "js-sys 0.3.56",
+              "id": "js-sys 0.3.57",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.79",
+              "id": "wasm-bindgen 0.2.80",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {
             "cfg(target_feature = \"atomics\")": [
               {
-                "id": "web-sys 0.3.56",
+                "id": "web-sys 0.3.57",
                 "target": "web_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.4.29"
+        "version": "0.4.30"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-macro 0.2.79": {
+    "wasm-bindgen-macro 0.2.80": {
       "name": "wasm-bindgen-macro",
-      "version": "0.2.79",
+      "version": "0.2.80",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.79/download",
-          "sha256": "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.80/download",
+          "sha256": "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
         }
       },
       "targets": [
@@ -10202,24 +10203,24 @@
               "target": "quote"
             },
             {
-              "id": "wasm-bindgen-macro-support 0.2.79",
+              "id": "wasm-bindgen-macro-support 0.2.80",
               "target": "wasm_bindgen_macro_support"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.79"
+        "version": "0.2.80"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-macro-support 0.2.79": {
+    "wasm-bindgen-macro-support 0.2.80": {
       "name": "wasm-bindgen-macro-support",
-      "version": "0.2.79",
+      "version": "0.2.80",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.79/download",
-          "sha256": "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.80/download",
+          "sha256": "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
         }
       },
       "targets": [
@@ -10247,7 +10248,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -10255,32 +10256,32 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-backend 0.2.79",
+              "id": "wasm-bindgen-backend 0.2.80",
               "target": "wasm_bindgen_backend"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.79",
+              "id": "wasm-bindgen-shared 0.2.80",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.79"
+        "version": "0.2.80"
       },
       "license": "MIT/Apache-2.0"
     },
-    "wasm-bindgen-shared 0.2.79": {
+    "wasm-bindgen-shared 0.2.80": {
       "name": "wasm-bindgen-shared",
-      "version": "0.2.79",
+      "version": "0.2.80",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.79/download",
-          "sha256": "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+          "url": "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.80/download",
+          "sha256": "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
         }
       },
       "targets": [
@@ -10317,14 +10318,14 @@
         "deps": {
           "common": [
             {
-              "id": "wasm-bindgen-shared 0.2.79",
+              "id": "wasm-bindgen-shared 0.2.80",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.79"
+        "version": "0.2.80"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -10334,13 +10335,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "web-sys 0.3.56": {
+    "web-sys 0.3.57": {
       "name": "web-sys",
-      "version": "0.3.56",
+      "version": "0.3.57",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/web-sys/0.3.56/download",
-          "sha256": "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+          "url": "https://crates.io/api/v1/crates/web-sys/0.3.57/download",
+          "sha256": "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
         }
       },
       "targets": [
@@ -10384,18 +10385,18 @@
         "deps": {
           "common": [
             {
-              "id": "js-sys 0.3.56",
+              "id": "js-sys 0.3.57",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.79",
+              "id": "wasm-bindgen 0.2.80",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.56"
+        "version": "0.3.57"
       },
       "license": "MIT/Apache-2.0"
     },

--- a/examples/crate_universe/no_cargo_manifests/Cargo.Bazel.lock
+++ b/examples/crate_universe/no_cargo_manifests/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "7d557843f51c15e58462cbe0e6a789b40064b6854877ffcfdc8411850617fef1",
+  "checksum": "3a7b41c8aa6d72b38ee436a36986bd86ead405ee1453bf34239ef7396bbf44e1",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -92,7 +92,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -100,7 +100,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -519,7 +519,7 @@
               "target": "tracing"
             },
             {
-              "id": "tracing-subscriber 0.3.9",
+              "id": "tracing-subscriber 0.3.10",
               "target": "tracing_subscriber"
             }
           ],
@@ -923,13 +923,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "h2 0.3.12": {
+    "h2 0.3.13": {
       "name": "h2",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/h2/0.3.12/download",
-          "sha256": "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+          "url": "https://crates.io/api/v1/crates/h2/0.3.13/download",
+          "sha256": "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
         }
       },
       "targets": [
@@ -982,7 +982,7 @@
               "target": "indexmap"
             },
             {
-              "id": "slab 0.4.5",
+              "id": "slab 0.4.6",
               "target": "slab"
             },
             {
@@ -990,7 +990,7 @@
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.6.9",
+              "id": "tokio-util 0.7.1",
               "target": "tokio_util"
             },
             {
@@ -1001,7 +1001,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.12"
+        "version": "0.3.13"
       },
       "license": "MIT"
     },
@@ -1075,7 +1075,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -1375,7 +1375,7 @@
               "target": "futures_util"
             },
             {
-              "id": "h2 0.3.12",
+              "id": "h2 0.3.13",
               "target": "h2"
             },
             {
@@ -1571,13 +1571,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.121": {
+    "libc 0.2.122": {
       "name": "libc",
-      "version": "0.2.121",
+      "version": "0.2.122",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.121/download",
-          "sha256": "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.122/download",
+          "sha256": "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
         }
       },
       "targets": [
@@ -1618,14 +1618,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.121"
+        "version": "0.2.122"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1981,7 +1981,7 @@
           "selects": {
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               },
               {
@@ -1991,7 +1991,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -2164,7 +2164,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ]
@@ -2327,7 +2327,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -2455,7 +2455,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -2463,7 +2463,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -2540,13 +2540,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.36": {
+    "proc-macro2 1.0.37": {
       "name": "proc-macro2",
-      "version": "1.0.36",
+      "version": "1.0.37",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
-          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.37/download",
+          "sha256": "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
         }
       },
       "targets": [
@@ -2587,7 +2587,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "build_script_build"
             },
             {
@@ -2598,7 +2598,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.36"
+        "version": "1.0.37"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2642,7 +2642,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             }
           ],
@@ -3027,7 +3027,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.121",
+              "id": "libc 0.2.122",
               "target": "libc"
             }
           ],
@@ -3038,13 +3038,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "slab 0.4.5": {
+    "slab 0.4.6": {
       "name": "slab",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/slab/0.4.5/download",
-          "sha256": "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+          "url": "https://crates.io/api/v1/crates/slab/0.4.6/download",
+          "sha256": "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
         }
       },
       "targets": [
@@ -3071,7 +3071,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "0.4.5"
+        "version": "0.4.6"
       },
       "license": "MIT"
     },
@@ -3144,7 +3144,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               }
             ],
@@ -3161,13 +3161,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "syn 1.0.90": {
+    "syn 1.0.91": {
       "name": "syn",
-      "version": "1.0.90",
+      "version": "1.0.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.90/download",
-          "sha256": "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.91/download",
+          "sha256": "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
         }
       },
       "targets": [
@@ -3217,7 +3217,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -3225,7 +3225,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "build_script_build"
             },
             {
@@ -3236,7 +3236,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.90"
+        "version": "1.0.91"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3412,7 +3412,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.121",
+                "id": "libc 0.2.122",
                 "target": "libc"
               },
               {
@@ -3473,7 +3473,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -3481,7 +3481,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -3489,72 +3489,6 @@
         },
         "edition": "2018",
         "version": "1.7.0"
-      },
-      "license": "MIT"
-    },
-    "tokio-util 0.6.9": {
-      "name": "tokio-util",
-      "version": "0.6.9",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-util/0.6.9/download",
-          "sha256": "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tokio_util",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "tokio_util",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": [
-          "codec",
-          "default"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.1.0",
-              "target": "bytes"
-            },
-            {
-              "id": "futures-core 0.3.21",
-              "target": "futures_core"
-            },
-            {
-              "id": "futures-sink 0.3.21",
-              "target": "futures_sink"
-            },
-            {
-              "id": "log 0.4.16",
-              "target": "log"
-            },
-            {
-              "id": "pin-project-lite 0.2.8",
-              "target": "pin_project_lite"
-            },
-            {
-              "id": "tokio 1.17.0",
-              "target": "tokio"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.6.9"
       },
       "license": "MIT"
     },
@@ -3586,6 +3520,11 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": [
+          "codec",
+          "default",
+          "tracing"
+        ],
         "deps": {
           "common": [
             {
@@ -3607,6 +3546,10 @@
             {
               "id": "tokio 1.17.0",
               "target": "tokio"
+            },
+            {
+              "id": "tracing 0.1.32",
+              "target": "tracing"
             }
           ],
           "selects": {}
@@ -3915,7 +3858,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tracing-core 0.1.23",
+              "id": "tracing-core 0.1.24",
               "target": "tracing_core"
             }
           ],
@@ -3966,7 +3909,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.36",
+              "id": "proc-macro2 1.0.37",
               "target": "proc_macro2"
             },
             {
@@ -3974,7 +3917,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 1.0.90",
+              "id": "syn 1.0.91",
               "target": "syn"
             }
           ],
@@ -3985,13 +3928,13 @@
       },
       "license": "MIT"
     },
-    "tracing-core 0.1.23": {
+    "tracing-core 0.1.24": {
       "name": "tracing-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.23/download",
-          "sha256": "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.24/download",
+          "sha256": "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
         }
       },
       "targets": [
@@ -4036,7 +3979,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.1.23"
+        "version": "0.1.24"
       },
       "license": "MIT"
     },
@@ -4083,7 +4026,7 @@
               "target": "log"
             },
             {
-              "id": "tracing-core 0.1.23",
+              "id": "tracing-core 0.1.24",
               "target": "tracing_core"
             }
           ],
@@ -4094,13 +4037,13 @@
       },
       "license": "MIT"
     },
-    "tracing-subscriber 0.3.9": {
+    "tracing-subscriber 0.3.10": {
       "name": "tracing-subscriber",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.9/download",
-          "sha256": "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.10/download",
+          "sha256": "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
         }
       },
       "targets": [
@@ -4154,7 +4097,7 @@
               "target": "thread_local"
             },
             {
-              "id": "tracing-core 0.1.23",
+              "id": "tracing-core 0.1.24",
               "target": "tracing_core"
             },
             {
@@ -4165,7 +4108,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.9"
+        "version": "0.3.10"
       },
       "license": "MIT"
     },


### PR DESCRIPTION
This allows `crate_universe` to handle https://github.com/rust-lang/cargo/issues/10547.

Reviewers should only focus on 2e9facb8920327af37e1e5566f7940903138c2ca