### PR TITLE
Set edition for process_wrapper and cargo_build_script_runner

### DIFF
--- a/cargo/cargo_build_script_runner/BUILD.bazel
+++ b/cargo/cargo_build_script_runner/BUILD.bazel
@@ -3,16 +3,19 @@ load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 rust_library(
     name = "cargo_build_script_output_parser",
     srcs = ["lib.rs"],
+    edition = "2018",
 )
 
 rust_test(
     name = "test",
     crate = ":cargo_build_script_output_parser",
+    edition = "2018",
 )
 
 rust_binary(
     name = "cargo_build_script_runner",
     srcs = ["bin.rs"],
+    edition = "2018",
     visibility = ["//visibility:public"],
     deps = [":cargo_build_script_output_parser"],
 )
@@ -20,6 +23,7 @@ rust_binary(
 rust_test(
     name = "bin_test",
     crate = ":cargo_build_script_runner",
+    edition = "2018",
     deps = [":cargo_build_script_runner"],
 )
 

--- a/util/process_wrapper/BUILD.bazel
+++ b/util/process_wrapper/BUILD.bazel
@@ -6,12 +6,14 @@ load("//rust/private:rust.bzl", "rust_binary_without_process_wrapper")
 rust_binary_without_process_wrapper(
     name = "process_wrapper",
     srcs = glob(["*.rs"]),
+    edition = "2018",
     visibility = ["//visibility:public"],
 )
 
 rust_test(
     name = "process_wrapper_test",
     crate = ":process_wrapper",
+    edition = "2018",
 )
 
 filegroup(


### PR DESCRIPTION
These otherwise get built with the downstream repo's default edition, which is not necessarily correct.

Related to #1251.