### PR TITLE
Recognize `edition = "required"` idiom

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -119,7 +119,7 @@ def get_edition(attr, toolchain, label):
     """
     if getattr(attr, "edition"):
         return attr.edition
-    elif not toolchain.default_edition:
+    elif toolchain.default_edition == "required" or not toolchain.default_edition:
         fail("Attribute `edition` is required for {}.".format(label))
     else:
         return toolchain.default_edition


### PR DESCRIPTION
Due to https://github.com/bazelbuild/rules_rust/issues/1251, I have chosen not to define a usable default `edition` for my workspace. See https://github.com/dtolnay/cxx/pull/1035.

This PR is not required in order for the idiom in https://github.com/dtolnay/cxx/pull/1035 to work, but it simply provides a better error message when some target is missing an edition attribute:

#### Before:

```console
$ bazel build ...
INFO: Analyzed 48 targets (5 packages loaded, 548 targets configured).
INFO: Found 48 targets...
ERROR: /git/cxx/BUILD:4:13: Compiling Rust rlib cxx (34 files) failed: (Exit 1): process_wrapper failed: error executing command bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_rust/util/process_wrapper/process_wrapper --arg-file bazel-out/k8-opt-exec-2B5CBBC6/bin/third-party/proc-macro2@build.linksearchpaths --arg-file ... (remaining 28 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
error: argument for `--edition` must be one of: 2015|2018|2021. (instead was `required`)

INFO: Elapsed time: 1.251s, Critical Path: 0.14s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
```

#### After:

```console
$ bazel build ...
ERROR: /git/cxx/BUILD:4:13: in rust_library rule //:cxx: 
Traceback (most recent call last):
	File "/home/david/.cache/bazel/_bazel_david/ebce1d0721fb68dda9c70c0dd1405803/external/rules_rust/rust/private/rust.bzl", line 187, column 32, in _rust_library_impl
		return _rust_library_common(ctx, "rlib")
	File "/home/david/.cache/bazel/_bazel_david/ebce1d0721fb68dda9c70c0dd1405803/external/rules_rust/rust/private/rust.bzl", line 285, column 34, in _rust_library_common
		edition = get_edition(ctx, toolchain),
	File "/home/david/.cache/bazel/_bazel_david/ebce1d0721fb68dda9c70c0dd1405803/external/rules_rust/rust/private/rust.bzl", line 122, column 13, in get_edition
		fail("Attribute `edition` is required for {}.".format(ctx.label))
Error in fail: Attribute `edition` is required for //:cxx.
ERROR: Analysis of target '//:cxx' failed; build aborted: Analysis of target '//:cxx' failed
INFO: Elapsed time: 1.206s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (45 packages loaded, 1063 targets configured)
```