### PR TITLE
Outside of examples, fill in all `edition` attrs

### DIFF
--- a/cargo/bootstrap/BUILD.bazel
+++ b/cargo/bootstrap/BUILD.bazel
@@ -14,6 +14,7 @@ rust_binary(
     srcs = [
         "bootstrap_installer.rs",
     ],
+    edition = "2018",
     rustc_env = {
         "RULES_RUST_CARGO_BOOTSTRAP_BINARY": "$(rootpath bootstrap_installer.rs)",
     },

--- a/crate_universe/BUILD.bazel
+++ b/crate_universe/BUILD.bazel
@@ -66,6 +66,7 @@ rust_library(
         include = ["src/**"],
         exclude = ["src/**/*.rs"],
     ),
+    edition = "2018",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     version = VERSION,
     visibility = ["//visibility:public"],
@@ -75,6 +76,7 @@ rust_library(
 rust_binary(
     name = "cargo_bazel_bin",
     srcs = ["src/main.rs"],
+    edition = "2018",
     version = VERSION,
     visibility = ["//visibility:public"],
     deps = [":cargo_bazel"],

--- a/crate_universe/tools/cross_installer/BUILD.bazel
+++ b/crate_universe/tools/cross_installer/BUILD.bazel
@@ -16,6 +16,7 @@ rust_binary(
         ":cross",
         "@rules_rust//rust/toolchain:current_exec_cargo_files",
     ],
+    edition = "2018",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     rustc_env = {
         "CARGO": "$(rootpath @rules_rust//rust/toolchain:current_exec_cargo_files)",

--- a/crate_universe/tools/urls_generator/BUILD.bazel
+++ b/crate_universe/tools/urls_generator/BUILD.bazel
@@ -22,6 +22,7 @@ rust_binary(
     compile_data = [
         "//crate_universe/private:urls.bzl",
     ],
+    edition = "2018",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     rustc_env = {
         "MODULE_ROOT_PATH": "$(rootpath //crate_universe/private:urls.bzl)",

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -12,7 +12,10 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-rust_register_toolchains(include_rustc_srcs = True)
+rust_register_toolchains(
+    edition = "2018",
+    include_rustc_srcs = True,
+)
 
 load("@rules_rust//bindgen:repositories.bzl", "rust_bindgen_repositories")
 

--- a/examples/cargo_manifest_dir/external_crate/WORKSPACE.bazel
+++ b/examples/cargo_manifest_dir/external_crate/WORKSPACE.bazel
@@ -7,4 +7,4 @@ local_repository(
 
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
-rust_repositories()
+rust_repositories(edition = "2018")

--- a/examples/crate_universe/WORKSPACE.bazel
+++ b/examples/crate_universe/WORKSPACE.bazel
@@ -9,7 +9,10 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-rust_register_toolchains(include_rustc_srcs = True)
+rust_register_toolchains(
+    edition = "2018",
+    include_rustc_srcs = True,
+)
 
 load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -34,6 +34,7 @@ toolchain_type(name = "toolchain")
 rust_binary(
     name = "optional_output_wrapper",
     srcs = ["optional_output_wrapper.rs"],
+    edition = "2018",
     visibility = ["//visibility:public"],
 )
 
@@ -43,7 +44,10 @@ toolchain(
     toolchain_type = "@rules_rust//proto:toolchain",
 )
 
-rust_proto_toolchain(name = "default-proto-toolchain-impl")
+rust_proto_toolchain(
+    name = "default-proto-toolchain-impl",
+    edition = "2018",
+)
 
 bzl_library(
     name = "bzl_lib",

--- a/test/build_env/BUILD.bazel
+++ b/test/build_env/BUILD.bazel
@@ -10,11 +10,13 @@ rust_test(
     name = "conflicting_deps_test",
     srcs = ["tests/manifest_dir.rs"],
     data = ["src/manifest_dir_file.txt"],
+    edition = "2018",
 )
 
 rust_test(
     name = "arbitrary_env_test",
     srcs = ["tests/arbitrary_env.rs"],
+    edition = "2018",
     rustc_env = {
         "USER_DEFINED_KEY": "USER_DEFINED_VALUE",
     },
@@ -24,6 +26,7 @@ rust_test(
     # Intentionally uses a mix of -s and _s because those normalisations are part of what is being tested.
     name = "cargo_env-vars_test",
     srcs = ["tests/cargo.rs"],
+    edition = "2018",
     deps = [":cargo_build_script_env-vars_build_script"],
 )
 
@@ -31,10 +34,12 @@ rust_test(
     name = "cargo-env-vars-custom-crate-name-test",
     srcs = ["tests/custom_crate_name.rs"],
     crate_name = "custom_crate_name",
+    edition = "2018",
     deps = [":cargo_build_script_env-vars_build_script"],
 )
 
 cargo_build_script(
     name = "cargo_build_script_env-vars_build_script",
     srcs = ["src/build.rs"],
+    edition = "2018",
 )

--- a/test/cargo_build_script/BUILD.bazel
+++ b/test/cargo_build_script/BUILD.bazel
@@ -8,6 +8,7 @@ cargo_build_script(
     name = "tools_exec_build_rs",
     srcs = ["build.rs"],
     build_script_env = {"TOOL": "$(execpath :tool)"},
+    edition = "2018",
     # Add a flag to test that they're exposed to the build script
     rustc_flags = ["--verbose"],
     tools = [":tool"],
@@ -23,5 +24,6 @@ genrule(
 rust_test(
     name = "tools_exec",
     srcs = ["tools_exec.rs"],
+    edition = "2018",
     deps = [":tools_exec_build_rs"],
 )

--- a/test/chained_direct_deps/BUILD.bazel
+++ b/test/chained_direct_deps/BUILD.bazel
@@ -3,17 +3,20 @@ load("//rust:defs.bzl", "rust_doc_test", "rust_library", "rust_test")
 rust_library(
     name = "mod1",
     srcs = ["mod1.rs"],
+    edition = "2018",
 )
 
 rust_library(
     name = "mod2",
     srcs = ["mod2.rs"],
+    edition = "2018",
     deps = [":mod1"],
 )
 
 rust_library(
     name = "mod3",
     srcs = ["mod3.rs"],
+    edition = "2018",
     deps = [
         ":mod1",
         ":mod2",
@@ -23,16 +26,19 @@ rust_library(
 rust_test(
     name = "mod1_test",
     crate = ":mod1",
+    edition = "2018",
 )
 
 rust_test(
     name = "mod2_test",
     crate = ":mod2",
+    edition = "2018",
 )
 
 rust_test(
     name = "mod3_test",
     crate = ":mod3",
+    edition = "2018",
 )
 
 rust_doc_test(

--- a/test/extra_exec_rustc_flags/BUILD.bazel
+++ b/test/extra_exec_rustc_flags/BUILD.bazel
@@ -14,6 +14,7 @@ package(default_visibility = ["//test:__subpackages__"])
 rust_library(
     name = "lib_do_not_build_directly",
     srcs = ["lib.rs"],
+    edition = "2018",
     tags = ["manual"],
 )
 
@@ -36,6 +37,7 @@ with_exec_cfg(
 rust_library(
     name = "lib_no_exec",
     srcs = ["lib_no_exec.rs"],
+    edition = "2018",
 )
 
 with_extra_exec_rustc_flags_cfg(

--- a/test/inline_test_with_deps/dep/BUILD.bazel
+++ b/test/inline_test_with_deps/dep/BUILD.bazel
@@ -5,4 +5,5 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "dep",
     srcs = ["src/lib.rs"],
+    edition = "2018",
 )

--- a/test/inline_test_with_deps/test/BUILD.bazel
+++ b/test/inline_test_with_deps/test/BUILD.bazel
@@ -11,5 +11,6 @@ rust_library(
 rust_test(
     name = "inline_test",
     crate = ":inline",
+    edition = "2018",
     deps = ["//test/inline_test_with_deps/dep"],
 )

--- a/test/out_dir_in_tests/BUILD.bazel
+++ b/test/out_dir_in_tests/BUILD.bazel
@@ -4,6 +4,7 @@ load("//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite")
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
+    edition = "2018",
 )
 
 rust_library(
@@ -11,12 +12,14 @@ rust_library(
     srcs = [
         "src/lib.rs",
     ],
+    edition = "2018",
     deps = [":build_script"],
 )
 
 rust_test(
     name = "demo_lib_test",
     crate = ":demo_lib",
+    edition = "2018",
 )
 
 rust_test_suite(
@@ -26,4 +29,5 @@ rust_test_suite(
     # to the underlying rust_test rules. This will make OUT_DIR
     # available when compiling integration tests.
     crate = ":demo_lib",
+    edition = "2018",
 )

--- a/test/process_wrapper/BUILD.bazel
+++ b/test/process_wrapper/BUILD.bazel
@@ -153,6 +153,7 @@ build_test(
 rust_binary(
     name = "fake_rustc",
     srcs = ["fake_rustc.rs"],
+    edition = "2018",
 )
 
 rust_test(
@@ -162,5 +163,6 @@ rust_test(
         ":fake_rustc",
         "//util/process_wrapper",
     ],
+    edition = "2018",
     deps = ["//tools/runfiles"],
 )

--- a/test/renamed_deps/BUILD.bazel
+++ b/test/renamed_deps/BUILD.bazel
@@ -3,11 +3,13 @@ load("//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "mod1",
     srcs = ["mod1.rs"],
+    edition = "2018",
 )
 
 rust_library(
     name = "mod2",
     srcs = ["mod2.rs"],
+    edition = "2018",
     deps = [":mod1"],
 )
 
@@ -18,6 +20,7 @@ rust_library(
         ":mod1": "alias_a",
         ":mod2": "alias_b",
     },
+    edition = "2018",
     deps = [
         ":mod1",
         ":mod2",
@@ -27,11 +30,13 @@ rust_library(
 rust_test(
     name = "mod1_test",
     crate = ":mod1",
+    edition = "2018",
 )
 
 rust_test(
     name = "mod2_test",
     crate = ":mod2",
+    edition = "2018",
 )
 
 rust_test(
@@ -41,4 +46,5 @@ rust_test(
         ":mod2": "alias_b",
     },
     crate = ":mod3",
+    edition = "2018",
 )

--- a/test/rust/BUILD.bazel
+++ b/test/rust/BUILD.bazel
@@ -8,10 +8,12 @@ rust_library(
         "src/greeter.rs",
         "src/lib.rs",
     ],
+    edition = "2018",
 )
 
 rust_binary(
     name = "hello_world",
     srcs = ["src/main.rs"],
+    edition = "2018",
     deps = [":hello_lib"],
 )

--- a/test/rust_analyzer/aspect_traversal_test/BUILD.bazel
+++ b/test/rust_analyzer/aspect_traversal_test/BUILD.bazel
@@ -4,6 +4,7 @@ load(":custom_alias.bzl", "custom_alias")
 rust_library(
     name = "mylib",
     srcs = ["mylib.rs"],
+    edition = "2018",
     proc_macro_deps = [":proc_macro_dep"],
     deps = [
         ":alias_dep",
@@ -15,6 +16,7 @@ rust_library(
 rust_library(
     name = "lib_dep",
     srcs = ["lib_dep.rs"],
+    edition = "2018",
 )
 
 alias(
@@ -25,12 +27,14 @@ alias(
 rust_library(
     name = "actual_dep",
     srcs = ["actual_dep.rs"],
+    edition = "2018",
     deps = [":dep_of_aliased_dep"],
 )
 
 rust_library(
     name = "dep_of_aliased_dep",
     srcs = ["dep_of_aliased_dep.rs"],
+    edition = "2018",
 )
 
 custom_alias(
@@ -41,22 +45,26 @@ custom_alias(
 rust_library(
     name = "custom_actual_dep",
     srcs = ["custom_actual_dep.rs"],
+    edition = "2018",
     deps = [":dep_of_custom_aliased_dep"],
 )
 
 rust_library(
     name = "dep_of_custom_aliased_dep",
     srcs = ["dep_of_custom_aliased_dep.rs"],
+    edition = "2018",
 )
 
 rust_proc_macro(
     name = "proc_macro_dep",
     srcs = ["proc_macro_dep.rs"],
+    edition = "2018",
 )
 
 rust_test(
     name = "mylib_test",
     crate = ":mylib",
+    edition = "2018",
     proc_macro_deps = [":extra_proc_macro_dep"],
     deps = [":extra_test_dep"],
 )
@@ -64,11 +72,13 @@ rust_test(
 rust_library(
     name = "extra_test_dep",
     srcs = ["extra_test_dep.rs"],
+    edition = "2018",
 )
 
 rust_proc_macro(
     name = "extra_proc_macro_dep",
     srcs = ["extra_proc_macro_dep.rs"],
+    edition = "2018",
 )
 
 rust_test(

--- a/test/rust_analyzer/merging_crates_test/BUILD.bazel
+++ b/test/rust_analyzer/merging_crates_test/BUILD.bazel
@@ -3,23 +3,27 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "mylib",
     srcs = ["mylib.rs"],
+    edition = "2018",
     deps = [":lib_dep"],
 )
 
 rust_library(
     name = "lib_dep",
     srcs = ["lib_dep.rs"],
+    edition = "2018",
 )
 
 rust_test(
     name = "mylib_test",
     crate = ":mylib",
+    edition = "2018",
     deps = [":extra_test_dep"],
 )
 
 rust_library(
     name = "extra_test_dep",
     srcs = ["extra_test_dep.rs"],
+    edition = "2018",
 )
 
 rust_test(

--- a/test/rustc_env_files/BUILD.bazel
+++ b/test/rustc_env_files/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "hello_env",
     srcs = ["src/main.rs"],
+    edition = "2018",
     rustc_env_files = [":generate_rustc_env_file"],
 )
 

--- a/test/unit/cc_info/cc_info_test.bzl
+++ b/test/unit/cc_info/cc_info_test.bzl
@@ -105,27 +105,32 @@ def _cc_info_test():
     rust_library(
         name = "rlib",
         srcs = ["foo.rs"],
+        edition = "2018",
     )
 
     rust_library(
         name = "rlib_with_dep",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":rlib"],
     )
 
     rust_binary(
         name = "bin",
         srcs = ["foo.rs"],
+        edition = "2018",
     )
 
     rust_static_library(
         name = "staticlib",
         srcs = ["foo.rs"],
+        edition = "2018",
     )
 
     rust_shared_library(
         name = "cdylib",
         srcs = ["foo.rs"],
+        edition = "2018",
     )
 
     rust_proc_macro(

--- a/test/unit/cdylib_name/cdylib_name_analysis_test.bzl
+++ b/test/unit/cdylib_name/cdylib_name_analysis_test.bzl
@@ -35,6 +35,7 @@ def cdylib_name_analysis_test_suite(name):
     rust_shared_library(
         name = "something",
         srcs = ["lib.rs"],
+        edition = "2018",
     )
 
     cdylib_name_test(

--- a/test/unit/check_runfiles/check_runfiles_test.bzl
+++ b/test/unit/check_runfiles/check_runfiles_test.bzl
@@ -30,24 +30,28 @@ def _check_runfiles_test():
     rust_library(
         name = "foo_lib",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":libbar.so"],
     )
 
     rust_binary(
         name = "foo_bin",
         srcs = ["foo_main.rs"],
+        edition = "2018",
         deps = [":libbar.so"],
     )
 
     rust_shared_library(
         name = "foo_dylib",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":libbar.so"],
     )
 
     rust_static_library(
         name = "foo_static",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":libbar.so"],
     )
 

--- a/test/unit/crate_name/crate_name_test.bzl
+++ b/test/unit/crate_name/crate_name_test.bzl
@@ -121,39 +121,46 @@ def _crate_name_test():
     rust_library(
         name = "default-crate-name-library",
         srcs = ["lib.rs"],
+        edition = "2018",
     )
 
     rust_library(
         name = "custom-crate-name-library",
         crate_name = "custom_name",
         srcs = ["lib.rs"],
+        edition = "2018",
     )
 
     rust_binary(
         name = "default-crate-name-binary",
         srcs = ["main.rs"],
+        edition = "2018",
     )
 
     rust_binary(
         name = "custom-crate-name-binary",
         crate_name = "custom_name",
         srcs = ["main.rs"],
+        edition = "2018",
     )
 
     rust_test(
         name = "default-crate-name-test",
         srcs = ["main.rs"],
+        edition = "2018",
     )
 
     rust_test(
         name = "custom-crate-name-test",
         crate_name = "custom_name",
         srcs = ["main.rs"],
+        edition = "2018",
     )
 
     rust_library(
         name = "invalid/default-crate-name",
         srcs = ["lib.rs"],
+        edition = "2018",
         tags = ["manual", "norustfmt"],
     )
 
@@ -161,22 +168,26 @@ def _crate_name_test():
         name = "invalid-custom-crate-name",
         crate_name = "hyphens-not-allowed",
         srcs = ["lib.rs"],
+        edition = "2018",
         tags = ["manual", "norustfmt"],
     )
 
     rust_library(
         name = "slib",
         srcs = ["slib.rs"],
+        edition = "2018",
     )
 
     rust_shared_library(
         name = "shared_lib",
         srcs = ["lib.rs"],
+        edition = "2018",
     )
 
     rust_static_library(
         name = "static_lib",
         srcs = ["lib.rs"],
+        edition = "2018",
     )
 
     slib_library_name_test(

--- a/test/unit/crate_variants/crate_variants.bzl
+++ b/test/unit/crate_variants/crate_variants.bzl
@@ -18,17 +18,20 @@ def _crate_variants_test():
     rust_library(
         name = "foo",
         srcs = ["foo.rs"],
+        edition = "2018",
     )
 
     rust_library(
         name = "foo2",
         crate_name = "foo",
         srcs = ["foo.rs"],
+        edition = "2018",
     )
 
     rust_library(
         name = "bar",
         srcs = ["bar.rs"],
+        edition = "2018",
         deps = [":foo", ":foo2"],
     )
 

--- a/test/unit/debug_info/debug_info_analysis_test.bzl
+++ b/test/unit/debug_info/debug_info_analysis_test.bzl
@@ -38,6 +38,7 @@ def debug_info_analysis_test_suite(name):
     rust_shared_library(
         name = "mylib",
         srcs = ["lib.rs"],
+        edition = "2018",
     )
 
     native.filegroup(
@@ -67,6 +68,7 @@ def debug_info_analysis_test_suite(name):
     rust_binary(
         name = "myrustbin",
         srcs = ["main.rs"],
+        edition = "2018",
     )
 
     native.filegroup(

--- a/test/unit/interleaved_cc_info/interleaved_cc_info_test.bzl
+++ b/test/unit/interleaved_cc_info/interleaved_cc_info_test.bzl
@@ -29,6 +29,7 @@ def _interleaving_link_order_test():
     rust_library(
         name = "a",
         srcs = ["a.rs"],
+        edition = "2018",
         deps = [":b"],
     )
     cc_library(
@@ -39,6 +40,7 @@ def _interleaving_link_order_test():
     rust_library(
         name = "c",
         srcs = ["c.rs"],
+        edition = "2018",
         deps = [":d"],
     )
     cc_library(
@@ -49,6 +51,7 @@ def _interleaving_link_order_test():
     rust_library(
         name = "e",
         srcs = ["e.rs"],
+        edition = "2018",
     )
 
     interleaving_cc_link_order_test(

--- a/test/unit/linkstamps/linkstamps_test.bzl
+++ b/test/unit/linkstamps/linkstamps_test.bzl
@@ -68,6 +68,7 @@ def _linkstamps_test():
     rust_binary(
         name = "some_rust_binary",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":cc_lib_with_linkstamp"],
     )
 
@@ -79,12 +80,14 @@ def _linkstamps_test():
     rust_library(
         name = "some_rust_library_with_linkstamp_transitively",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":cc_lib_with_linkstamp"],
     )
 
     rust_binary(
         name = "some_rust_binary_with_linkstamp_transitively",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":some_rust_library_with_linkstamp_transitively"],
     )
 
@@ -101,6 +104,7 @@ def _linkstamps_test():
     rust_binary(
         name = "some_rust_binary_with_multiple_paths_to_a_linkstamp",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":cc_lib_with_linkstamp", ":cc_lib_with_linkstamp_transitively"],
     )
 
@@ -112,6 +116,7 @@ def _linkstamps_test():
     rust_test(
         name = "some_rust_test1",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":cc_lib_with_linkstamp"],
     )
 
@@ -123,6 +128,7 @@ def _linkstamps_test():
     rust_test(
         name = "some_rust_test2",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":cc_lib_with_linkstamp"],
     )
 

--- a/test/unit/location_expansion/location_expansion_test.bzl
+++ b/test/unit/location_expansion/location_expansion_test.bzl
@@ -26,6 +26,7 @@ def _location_expansion_test():
     rust_library(
         name = "mylibrary",
         srcs = ["mylibrary.rs"],
+        edition = "2018",
         rustc_flags = [
             "@$(location :flag_generator)",
         ],

--- a/test/unit/native_deps/native_action_inputs_test.bzl
+++ b/test/unit/native_deps/native_action_inputs_test.bzl
@@ -77,30 +77,35 @@ def _native_action_inputs_test():
     rust_library(
         name = "foo_lib",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":bar"],
     )
 
     rust_binary(
         name = "foo_bin",
         srcs = ["foo_main.rs"],
+        edition = "2018",
         deps = [":bar"],
     )
 
     rust_shared_library(
         name = "foo_dylib",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":bar"],
     )
 
     rust_static_library(
         name = "foo_static",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":bar"],
     )
 
     rust_proc_macro(
         name = "foo_proc_macro",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":bar"],
     )
 

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -153,37 +153,42 @@ def _native_dep_test():
     rust_library(
         name = "rlib_has_no_native_dep",
         srcs = ["lib_using_native_dep.rs"],
+        edition = "2018",
         deps = [":native_dep"],
     )
 
     rust_static_library(
         name = "staticlib_has_native_dep",
         srcs = ["lib_using_native_dep.rs"],
+        edition = "2018",
         deps = [":native_dep"],
     )
 
     rust_shared_library(
         name = "cdylib_has_native_dep",
         srcs = ["lib_using_native_dep.rs"],
+        edition = "2018",
         deps = [":native_dep"],
     )
 
     rust_proc_macro(
         name = "proc_macro_has_native_dep",
         srcs = ["proc_macro_using_native_dep.rs"],
-        deps = [":native_dep"],
         edition = "2018",
+        deps = [":native_dep"],
     )
 
     rust_binary(
         name = "bin_has_native_dep",
         srcs = ["bin_using_native_dep.rs"],
+        edition = "2018",
         deps = [":native_dep"],
     )
 
     rust_binary(
         name = "bin_has_native_dep_and_alwayslink",
         srcs = ["bin_using_native_dep.rs"],
+        edition = "2018",
         deps = [":native_dep", ":alwayslink"],
     )
 
@@ -202,6 +207,7 @@ def _native_dep_test():
     rust_shared_library(
         name = "cdylib_has_native_dep_and_alwayslink",
         srcs = ["lib_using_native_dep.rs"],
+        edition = "2018",
         deps = [":native_dep", ":alwayslink"],
     )
 
@@ -262,6 +268,7 @@ def _linkopts_test():
     rust_binary(
         name = "linkopts_rust_bin",
         srcs = ["bin_using_native_dep.rs"],
+        edition = "2018",
         deps = [":linkopts_native_dep_a"],
     )
 
@@ -303,18 +310,21 @@ def _additional_deps_test():
     rust_binary(
         name = "bin_additional_deps",
         srcs = ["bin_using_native_dep.rs"],
+        edition = "2018",
         deps = [":additional_deps_cc"],
     )
 
     rust_shared_library(
         name = "cdylib_additional_deps",
         srcs = ["lib_using_native_dep.rs"],
+        edition = "2018",
         deps = [":additional_deps_cc"],
     )
 
     rust_library(
         name = "lib_additional_deps",
         srcs = ["lib_using_native_dep.rs"],
+        edition = "2018",
         deps = ["additional_deps_cc"],
     )
 

--- a/test/unit/proc_macro/leaks_deps/proc_macro_dep/BUILD.bazel
+++ b/test/unit/proc_macro/leaks_deps/proc_macro_dep/BUILD.bazel
@@ -3,5 +3,6 @@ load("//rust:defs.bzl", "rust_library")
 rust_library(
     name = "proc_macro_dep",
     srcs = ["proc_macro_dep.rs"],
+    edition = "2018",
     visibility = ["//test:__subpackages__"],
 )

--- a/test/unit/proc_macro/leaks_deps/proc_macro_does_not_leak_deps.bzl
+++ b/test/unit/proc_macro/leaks_deps/proc_macro_does_not_leak_deps.bzl
@@ -29,12 +29,14 @@ def _proc_macro_does_not_leak_deps_test():
     rust_proc_macro(
         name = "proc_macro_definition",
         srcs = ["leaks_deps/proc_macro_definition.rs"],
+        edition = "2018",
         deps = ["//test/unit/proc_macro/leaks_deps/proc_macro_dep"],
     )
 
     rust_test(
         name = "deps_not_leaked",
         srcs = ["leaks_deps/proc_macro_user.rs"],
+        edition = "2018",
         proc_macro_deps = [":proc_macro_definition"],
     )
 

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -77,12 +77,14 @@ rustdoc_for_lib_with_cc_lib_test = analysistest.make(_rustdoc_for_lib_with_cc_li
 def _target_maker(rule_fn, name, rustdoc_deps = [], **kwargs):
     rule_fn(
         name = name,
+        edition = "2018",
         **kwargs
     )
 
     rust_test(
         name = "{}_test".format(name),
         crate = ":{}".format(name),
+        edition = "2018",
     )
 
     rust_doc(
@@ -97,7 +99,11 @@ def _target_maker(rule_fn, name, rustdoc_deps = [], **kwargs):
     )
 
 def _define_targets():
-    rust_library(name = "adder", srcs = ["adder.rs"])
+    rust_library(
+        name = "adder",
+        srcs = ["adder.rs"],
+        edition = "2018",
+    )
 
     _target_maker(
         rust_binary,
@@ -116,7 +122,6 @@ def _define_targets():
         rust_proc_macro,
         name = "rustdoc_proc_macro",
         srcs = ["rustdoc_proc_macro.rs"],
-        edition = "2018",
     )
 
     _target_maker(

--- a/test/unit/stamp/stamp_test.bzl
+++ b/test/unit/stamp/stamp_test.bzl
@@ -63,6 +63,7 @@ def _define_test_targets():
         rust_test(
             name = "{}_unit_test".format(name),
             crate = ":{}".format(name),
+            edition = "2018",
             rustc_env_files = [":stamp.env"],
             stamp = stamp_value,
             crate_features = features,
@@ -71,6 +72,7 @@ def _define_test_targets():
         rust_binary(
             name = "{}_bin".format(name),
             srcs = ["stamp_main.rs"],
+            edition = "2018",
             deps = [":{}".format(name)],
             rustc_env_files = [":stamp.env"],
             stamp = stamp_value,

--- a/test/unit/stdlib/stdlib.bzl
+++ b/test/unit/stdlib/stdlib.bzl
@@ -65,6 +65,7 @@ def _native_dep_test():
     rust_library(
         name = "some_rlib",
         srcs = ["some_rlib.rs"],
+        edition = "2018",
     )
 
     libstd_ordering_test(

--- a/test/unit/transitive_crate_outputs/transitive_crate_outputs_test.bzl
+++ b/test/unit/transitive_crate_outputs/transitive_crate_outputs_test.bzl
@@ -21,12 +21,14 @@ def _transitive_crate_outputs_test():
     rust_library(
         name = "foo",
         srcs = ["foo.rs"],
+        edition = "2018",
         deps = [":bar", ":baz"],
     )
 
     rust_library(
         name = "bar",
         srcs = ["bar.rs"],
+        edition = "2018",
     )
 
     # buildifier: disable=native-cc

--- a/test/unit/use_libtest_harness/use_libtest_harness_test.bzl
+++ b/test/unit/use_libtest_harness/use_libtest_harness_test.bzl
@@ -31,11 +31,13 @@ def _use_libtest_harness_test():
     rust_test(
         name = "mytest",
         srcs = ["mytest.rs"],
+        edition = "2018",
     )
 
     rust_test(
         name = "mytest_noharness",
         srcs = ["mytest_noharness.rs"],
+        edition = "2018",
         use_libtest_harness = False,
     )
 

--- a/test/unit/versioned_libs/versioned_libs_analysis_test.bzl
+++ b/test/unit/versioned_libs/versioned_libs_analysis_test.bzl
@@ -45,6 +45,7 @@ def _test_linux():
     rust_shared_library(
         name = "linux_no_version",
         srcs = ["a.rs"],
+        edition = "2018",
         deps = [":import_libsterling.so"],
         target_compatible_with = ["@platforms//os:linux"],
     )
@@ -66,6 +67,7 @@ def _test_linux():
     rust_shared_library(
         name = "linux_suffix_version",
         srcs = ["a.rs"],
+        edition = "2018",
         deps = [":import_libcheryl.so.3.8", ":import_libcheryl.so"],
         target_compatible_with = ["@platforms//os:linux"],
     )
@@ -102,6 +104,7 @@ def _test_macos():
     rust_shared_library(
         name = "no_version",
         srcs = ["a.rs"],
+        edition = "2018",
         deps = [":import_liblana.dylib"],
         target_compatible_with = ["@platforms//os:macos"],
     )
@@ -123,6 +126,7 @@ def _test_macos():
     rust_shared_library(
         name = "prefix_version",
         srcs = ["a.rs"],
+        edition = "2018",
         deps = [":import_libpam3.8.dylib"],
         target_compatible_with = ["@platforms//os:macos"],
     )
@@ -150,6 +154,7 @@ def _test_windows():
     rust_shared_library(
         name = "windows_no_version",
         srcs = ["a.rs"],
+        edition = "2018",
         deps = [":import_malory.dll"],
         target_compatible_with = ["@platforms//os:windows"],
     )
@@ -182,6 +187,7 @@ def _test_windows():
     rust_shared_library(
         name = "windows_prefix_version",
         srcs = ["a.rs"],
+        edition = "2018",
         deps = [":import_cyril3.8.dll"],
         target_compatible_with = ["@platforms//os:windows"],
     )

--- a/test/unit/win_interface_library/win_interface_library_analysis_test.bzl
+++ b/test/unit/win_interface_library/win_interface_library_analysis_test.bzl
@@ -33,6 +33,7 @@ def win_interface_library_analysis_test_suite(name):
     rust_shared_library(
         name = "mylib",
         srcs = ["lib.rs"],
+        edition = "2018",
         target_compatible_with = ["@platforms//os:windows"],
     )
 
@@ -46,6 +47,7 @@ def win_interface_library_analysis_test_suite(name):
     rust_binary(
         name = "myrustbin",
         srcs = ["main.rs"],
+        edition = "2018",
         target_compatible_with = ["@platforms//os:windows"],
     )
 

--- a/test/versioned_dylib/BUILD.bazel
+++ b/test/versioned_dylib/BUILD.bazel
@@ -7,6 +7,7 @@ rust_binary(
     srcs = [
         "src/main.rs",
     ],
+    edition = "2018",
     tags = ["manual"],
     deps = [
         "//test/versioned_dylib/c:libreturn_zero",
@@ -17,5 +18,6 @@ rust_binary(
 rust_test(
     name = "versioned_dylib_test",
     crate = "versioned_dylib",
+    edition = "2018",
     tags = ["manual"],
 )

--- a/tools/runfiles/BUILD.bazel
+++ b/tools/runfiles/BUILD.bazel
@@ -8,6 +8,7 @@ load(
 rust_library(
     name = "runfiles",
     srcs = ["runfiles.rs"],
+    edition = "2018",
     visibility = ["//visibility:public"],
 )
 

--- a/util/import/BUILD.bazel
+++ b/util/import/BUILD.bazel
@@ -14,6 +14,7 @@ rust_proc_macro(
         "import.rs",
     ],
     crate_name = "import",
+    edition = "2018",
     deps = [
         ":import_internal",
         "//util/import/raze:syn",
@@ -25,6 +26,7 @@ rust_library(
     srcs = [
         "import_internal.rs",
     ],
+    edition = "2018",
     deps = [
         "//util/import/raze:aho_corasick",
         "//util/import/raze:lazy_static",
@@ -38,6 +40,7 @@ rust_library(
 rust_test(
     name = "import_internal_test",
     crate = ":import_internal",
+    edition = "2018",
     deps = [
         "//util/import/raze:quickcheck",
     ],

--- a/util/process_wrapper/BUILD.tinyjson.bazel
+++ b/util/process_wrapper/BUILD.tinyjson.bazel
@@ -4,5 +4,6 @@ load("@rules_rust//rust/private:rust.bzl", "rust_library_without_process_wrapper
 rust_library_without_process_wrapper(
     name = "tinyjson",
     srcs = glob(["src/*.rs"]),
+    edition = "2018",
     visibility = ["@rules_rust//util/process_wrapper:__pkg__"],
 )


### PR DESCRIPTION
This is extracted from #1256 in case these changes are easier to review separately.

This is effectively a fully exhaustive version of #1254. Due to #1251, specifying `edition` in each target is required in order for downstream workspaces importing `rules_rust` to get a usable edition for all of `rules_rust`'s targets, instead of attempting to use the downstream workspace's default edition which won't necessarily be appropriate.

Note that under `examples`, I have added `edition` to the `rust_register_toolchains` in various WORKSPACE.bazel files rather than to each individual target. This reduces noise in the example projects. I have not done the same for the top-level WORKSPACE because doing so would mask trouble along the lines of #1254.