### PR TITLE
Add workaround for arm vs armv7 android issue

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -269,6 +269,13 @@ def triple_to_constraint_set(target_triple):
             "@rules_rust//rust/platform/os:unknown",
         ]
 
+    # Workaround for https://github.com/bazelbuild/bazel/issues/14982
+    if target_triple in ("armv7-linux-androideabi", "thumbv7neon-linux-androideabi"):
+        return [
+            "@platforms//cpu:arm",
+            "@platforms//os:android",
+        ]
+
     triple_struct = triple(target_triple)
 
     constraint_set = []


### PR DESCRIPTION
When building for the armv7 android target, we would ideally specify a
cpu:armv7 constraint, but because of the linked bazel issue this is
currently hardcoded as arm in bazel's NDK setup. As far as I can tell
the platform we request for use with rules rust has to match the
constraints in bazel, otherwise it won't discover the NDK CC toolchain
for linking.