### PR TITLE
crate_universe: propagate build_script_tools

### DIFF
--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -65,6 +65,7 @@ def _annotation(
         additive_build_file = None,
         additive_build_file_content = None,
         build_script_data = None,
+        build_script_tools = None,
         build_script_data_glob = None,
         build_script_deps = None,
         build_script_env = None,
@@ -93,6 +94,7 @@ def _annotation(
         additive_build_file (str, optional): A file containing extra contents to write to the bottom of
             generated BUILD files.
         build_script_data (list, optional): A list of labels to add to a crate's `cargo_build_script::data` attribute.
+        build_script_tools (list, optional): A list of labels to add to a crate's `cargo_build_script::tools` attribute.
         build_script_data_glob (list, optional): A list of glob patterns to add to a crate's `cargo_build_script::data`
             attribute.
         build_script_deps (list, optional): A list of labels to add to a crate's `cargo_build_script::deps` attribute.
@@ -142,6 +144,7 @@ def _annotation(
             additive_build_file = additive_build_file,
             additive_build_file_content = additive_build_file_content,
             build_script_data = build_script_data,
+            build_script_tools = build_script_tools,
             build_script_data_glob = build_script_data_glob,
             build_script_deps = build_script_deps,
             build_script_env = build_script_env,

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -456,6 +456,13 @@ impl CrateContext {
                     }
                 }
 
+                // Tools
+                if let Some(extra) = &crate_extra.build_script_tools {
+                    for data in extra {
+                        attrs.tools.insert(data.clone(), None);
+                    }
+                }
+
                 // Data glob
                 if let Some(extra) = &crate_extra.build_script_data_glob {
                     attrs.data_glob.extend(extra.clone());

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -285,7 +285,7 @@ string: A json encoded string of all inputs
 
 <pre>
 crate.annotation(<a href="#crate.annotation-version">version</a>, <a href="#crate.annotation-additive_build_file">additive_build_file</a>, <a href="#crate.annotation-additive_build_file_content">additive_build_file_content</a>, <a href="#crate.annotation-build_script_data">build_script_data</a>,
-                 <a href="#crate.annotation-build_script_data_glob">build_script_data_glob</a>, <a href="#crate.annotation-build_script_deps">build_script_deps</a>, <a href="#crate.annotation-build_script_env">build_script_env</a>,
+                 <a href="#crate.annotation-build_script_tools">build_script_tools</a>, <a href="#crate.annotation-build_script_data_glob">build_script_data_glob</a>, <a href="#crate.annotation-build_script_deps">build_script_deps</a>, <a href="#crate.annotation-build_script_env">build_script_env</a>,
                  <a href="#crate.annotation-build_script_proc_macro_deps">build_script_proc_macro_deps</a>, <a href="#crate.annotation-build_script_rustc_env">build_script_rustc_env</a>, <a href="#crate.annotation-compile_data">compile_data</a>,
                  <a href="#crate.annotation-compile_data_glob">compile_data_glob</a>, <a href="#crate.annotation-crate_features">crate_features</a>, <a href="#crate.annotation-data">data</a>, <a href="#crate.annotation-data_glob">data_glob</a>, <a href="#crate.annotation-deps">deps</a>, <a href="#crate.annotation-gen_build_script">gen_build_script</a>,
                  <a href="#crate.annotation-patch_args">patch_args</a>, <a href="#crate.annotation-patch_tool">patch_tool</a>, <a href="#crate.annotation-patches">patches</a>, <a href="#crate.annotation-proc_macro_deps">proc_macro_deps</a>, <a href="#crate.annotation-rustc_env">rustc_env</a>, <a href="#crate.annotation-rustc_env_files">rustc_env_files</a>,
@@ -303,6 +303,7 @@ A collection of extra attributes and settings for a particular crate
 | <a id="crate.annotation-additive_build_file"></a>additive_build_file |  A file containing extra contents to write to the bottom of generated BUILD files.   |  <code>None</code> |
 | <a id="crate.annotation-additive_build_file_content"></a>additive_build_file_content |  Extra contents to write to the bottom of generated BUILD files.   |  <code>None</code> |
 | <a id="crate.annotation-build_script_data"></a>build_script_data |  A list of labels to add to a crate's <code>cargo_build_script::data</code> attribute.   |  <code>None</code> |
+| <a id="crate.annotation-build_script_tools"></a>build_script_tools |  A list of labels to add to a crate's <code>cargo_build_script::tools</code> attribute.   |  <code>None</code> |
 | <a id="crate.annotation-build_script_data_glob"></a>build_script_data_glob |  A list of glob patterns to add to a crate's <code>cargo_build_script::data</code> attribute.   |  <code>None</code> |
 | <a id="crate.annotation-build_script_deps"></a>build_script_deps |  A list of labels to add to a crate's <code>cargo_build_script::deps</code> attribute.   |  <code>None</code> |
 | <a id="crate.annotation-build_script_env"></a>build_script_env |  Additional environment variables to set on a crate's <code>cargo_build_script::env</code> attribute.   |  <code>None</code> |


### PR DESCRIPTION
Propagate the build_script_tools attribute from the crate annotations to
the generated cargo_build_script rule.
