### PR TITLE
Fix target name in `rust_test` example.

### DIFF
--- a/docs/defs.md
+++ b/docs/defs.md
@@ -539,7 +539,7 @@ rust_test(
 )
 ```
 
-Run the test with `bazel build //hello_lib:hello_lib_test`.
+Run the test with `bazel build //hello_lib:greeting_test`.
 
 **ATTRIBUTES**
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1027,7 +1027,7 @@ rust_test(
 )
 ```
 
-Run the test with `bazel build //hello_lib:hello_lib_test`.
+Run the test with `bazel build //hello_lib:greeting_test`.
 
 **ATTRIBUTES**
 

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1125,7 +1125,7 @@ rust_test = rule(
         )
         ```
 
-        Run the test with `bazel build //hello_lib:hello_lib_test`.
+        Run the test with `bazel build //hello_lib:greeting_test`.
 """),
 )
 


### PR DESCRIPTION
The example talks about `:hello_lib_test` which doesn't exist; the right name is `:greeting_test`.