### PR TITLE
Remove `triple` field from triple struct in favor of `str`

### DIFF
--- a/cargo/cargo_bootstrap.bzl
+++ b/cargo/cargo_bootstrap.bzl
@@ -204,7 +204,7 @@ def _cargo_bootstrap_repository_impl(repository_ctx):
 
     # In addition to platform specific environment variables, a common set (indicated by `*`) will always
     # be gathered.
-    environment = dict(_collect_environ(repository_ctx, "*").items() + _collect_environ(repository_ctx, host_triple.triple).items())
+    environment = dict(_collect_environ(repository_ctx, "*").items() + _collect_environ(repository_ctx, host_triple.str).items())
 
     built_binary = cargo_bootstrap(
         repository_ctx = repository_ctx,

--- a/cargo/private/cargo_utils.bzl
+++ b/cargo/private/cargo_utils.bzl
@@ -66,7 +66,7 @@ def get_rust_tools(cargo_template, rustc_template, host_triple, version):
     cargo_label = Label(_resolve_repository_template(
         template = cargo_template,
         version = version,
-        triple = host_triple.triple,
+        triple = host_triple.str,
         arch = host_triple.arch,
         vendor = host_triple.vendor,
         system = host_triple.system,
@@ -77,7 +77,7 @@ def get_rust_tools(cargo_template, rustc_template, host_triple, version):
     rustc_label = Label(_resolve_repository_template(
         template = rustc_template,
         version = version,
-        triple = host_triple.triple,
+        triple = host_triple.str,
         arch = host_triple.arch,
         vendor = host_triple.vendor,
         system = host_triple.system,

--- a/crate_universe/private/crates_repository.bzl
+++ b/crate_universe/private/crates_repository.bzl
@@ -25,7 +25,7 @@ def _crates_repository_impl(repository_ctx):
     host_triple = get_host_triple(repository_ctx)
 
     # Locate the generator to use
-    generator, generator_sha256 = get_generator(repository_ctx, host_triple.triple)
+    generator, generator_sha256 = get_generator(repository_ctx, host_triple.str)
 
     # Generate a config file for all settings
     config_path = generate_config(repository_ctx)

--- a/rust/platform/triple.bzl
+++ b/rust/platform/triple.bzl
@@ -20,7 +20,6 @@ def triple(triple):
             - system (str): The name of the system
             - abi (str, optional): The abi to use or None if abi does not apply.
             - str (str): Original string representation of the triple
-            - triple (str): Deprecated; same as str
     """
     if triple == "wasm32-wasi":
         return struct(
@@ -29,7 +28,6 @@ def triple(triple):
             vendor = "wasi",
             abi = None,
             str = triple,
-            triple = triple,
         )
 
     component_parts = triple.split("-")
@@ -54,7 +52,6 @@ def triple(triple):
         system = system,
         abi = abi,
         str = triple,
-        triple = triple,
     )
 
 _CPU_ARCH_ERROR_MSG = """\


### PR DESCRIPTION
If I have:

```python
triple = get_host_triple(repository_ctx)

f(triple.triple)
```

then `triple.triple` does not do a good job conveying what is going on; how the two things called `triple` (actually 3 if you count the function named `triple` as well) are different from one another.

To improve this in #1289 I added a `str` field to the triple struct, just duplicating the contents of the `triple` field but with a clearer name. In contrast to `triple.triple`, writing `f(triple.str)` is clearer to me and conveys "oh yeah `f` takes a string argument (as opposed to a struct) and `triple.str` is the string representation of the triple".

This PR removes the field `triple.triple` in favor of `triple.str` since there is no longer a reason to use the former.