### PR TITLE
rustc: fix a conditional

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -119,7 +119,7 @@ def _are_linkstamps_supported(feature_configuration, has_grep_includes):
             has_grep_includes)
 
 def _should_use_pic(cc_toolchain, feature_configuration, crate_type):
-    if crate_type in ("cdylib" or "dylib"):
+    if crate_type in ("cdylib", "dylib"):
         return cc_toolchain.needs_pic_for_dynamic_libraries(feature_configuration = feature_configuration)
     return False
 


### PR DESCRIPTION
`("bar" or "baz")` always evaluates to "bar", so this conditional ignores `"dylib"`. This seems unintended.

I don't have a particular test-case in mind for this; just noticed the oddity as I was browsing through the code.

cc @krasimirgg, who seems to have tweaked things around here recentlyish?