### PR TITLE
fix for using a nightly channel after commit 841fc6fb82141576d91aecb1d3f2656d58b0ab71

### DIFF
--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -570,7 +570,7 @@ def load_arbitrary_tool(ctx, tool_name, tool_subdirectories, version, iso_date, 
         ctx.extract(
             archive_path,
             output = "",
-            stripPrefix = "{}/{}".format(tool_suburl, subdirectory),
+            stripPrefix = "{}/{}".format(tool_path, subdirectory),
         )
 
 def _make_auth_dict(ctx, urls):


### PR DESCRIPTION
The commit https://github.com/bazelbuild/rules_rust/commit/841fc6fb82141576d91aecb1d3f2656d58b0ab71 for https://github.com/bazelbuild/rules_rust/pull/1284 broke the ability to use rust_register_toolchains with a nightly channel, see https://github.com/bazelbuild/rules_rust/commit/841fc6fb82141576d91aecb1d3f2656d58b0ab71#commitcomment-72310891.
I tracked the issue down to this line which was updated there. While using a dated nightly, these variables look like:
* tool_path:  `rust-nightly-x86_64-unknown-linux-gnu`
* tool_suburl:  `2022-04-06/rust-nightly-x86_64-unknown-linux-gnu`

Using tool_suburl causes the extract to fail like in the comment above:
`Prefix "2022-04-06/rust-nightly-x86_64-unknown-linux-gnu/rustc" was given, but not found in the archive. Here are possible prefixes for this archive: "rust-nightly-x86_64-unknown-linux-gnu".`

Switching back to the old behaviour fixes the glitch. I'm not sure if this breaks novel use cases introduced by https://github.com/bazelbuild/rules_rust/commit/841fc6fb82141576d91aecb1d3f2656d58b0ab71; @wt, could you please take a look.

On a sidenote, this is an instance where having some some build bot CI that uses nightly would have noticed this.