### PR TITLE
Address warnings for example/test dependencies

### DIFF
--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -94,6 +94,13 @@ rust_library(
     name = "libc",
     srcs = glob(["src/**/*.rs"]),
     edition = "2015",
+    rustc_flags = [
+        # In most cases, warnings in 3rd party crates are not interesting as
+        # they're out of the control of consumers. The flag here silences
+        # warnings. For more details see:
+        # https://doc.rust-lang.org/rustc/lints/levels.html
+        "--cap-lints=allow",
+    ],
     visibility = ["//visibility:public"],
 )
 """

--- a/test/deps.bzl
+++ b/test/deps.bzl
@@ -11,6 +11,13 @@ rust_library(
     name = "libc",
     srcs = glob(["src/**/*.rs"]),
     edition = "2015",
+    rustc_flags = [
+        # In most cases, warnings in 3rd party crates are not interesting as
+        # they're out of the control of consumers. The flag here silences
+        # warnings. For more details see:
+        # https://doc.rust-lang.org/rustc/lints/levels.html
+        "--cap-lints=allow",
+    ],
     visibility = ["//visibility:public"],
 )
 """


### PR DESCRIPTION
This silences the following warnings (which are out of our control):
```
INFO: From Compiling Rust rlib libc (59 files):
warning: unnecessary trailing semicolon
  --> external/libc/src/macros.rs:58:21
   |
58 |             $($body);*
   |                     ^ help: remove this semicolon
   |
   = note: `#[warn(redundant_semicolons)]` on by default

warning: unnecessary parentheses around assigned value
   --> external/libc/src/unix/bsd/apple/mod.rs:345:38
    |
345 | pub const LC_COLLATE_MASK: ::c_int = (1 << 0);
    |                                      ^      ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
345 - pub const LC_COLLATE_MASK: ::c_int = (1 << 0);
345 + pub const LC_COLLATE_MASK: ::c_int = 1 << 0;
    |

warning: unnecessary parentheses around assigned value
   --> external/libc/src/unix/bsd/apple/mod.rs:346:36
    |
346 | pub const LC_CTYPE_MASK: ::c_int = (1 << 1);
    |                                    ^      ^
    |
help: remove these parentheses
    |
346 - pub const LC_CTYPE_MASK: ::c_int = (1 << 1);
346 + pub const LC_CTYPE_MASK: ::c_int = 1 << 1;
    |

warning: unnecessary parentheses around assigned value
   --> external/libc/src/unix/bsd/apple/mod.rs:347:39
    |
347 | pub const LC_MESSAGES_MASK: ::c_int = (1 << 2);
    |                                       ^      ^
    |
help: remove these parentheses
    |
347 - pub const LC_MESSAGES_MASK: ::c_int = (1 << 2);
347 + pub const LC_MESSAGES_MASK: ::c_int = 1 << 2;
    |

warning: unnecessary parentheses around assigned value
   --> external/libc/src/unix/bsd/apple/mod.rs:348:39
    |
348 | pub const LC_MONETARY_MASK: ::c_int = (1 << 3);
    |                                       ^      ^
    |
help: remove these parentheses
    |
348 - pub const LC_MONETARY_MASK: ::c_int = (1 << 3);
348 + pub const LC_MONETARY_MASK: ::c_int = 1 << 3;
    |

warning: unnecessary parentheses around assigned value
   --> external/libc/src/unix/bsd/apple/mod.rs:349:38
    |
349 | pub const LC_NUMERIC_MASK: ::c_int = (1 << 4);
    |                                      ^      ^
    |
help: remove these parentheses
    |
349 - pub const LC_NUMERIC_MASK: ::c_int = (1 << 4);
349 + pub const LC_NUMERIC_MASK: ::c_int = 1 << 4;
    |

warning: unnecessary parentheses around assigned value
   --> external/libc/src/unix/bsd/apple/mod.rs:350:35
    |
350 | pub const LC_TIME_MASK: ::c_int = (1 << 5);
    |                                   ^      ^
    |
help: remove these parentheses
    |
350 - pub const LC_TIME_MASK: ::c_int = (1 << 5);
350 + pub const LC_TIME_MASK: ::c_int = 1 << 5;
    |

warning: 7 warnings emitted
```