### PR TITLE
Updated wasm_bindgen dependencies API

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -134,7 +134,8 @@ PAGES = dict([
         name = "rust_wasm_bindgen",
         header_template = ":rust_wasm_bindgen.vm",
         symbols = [
-            "rust_wasm_bindgen_repositories",
+            "rust_wasm_bindgen_dependencies",
+            "rust_wasm_bindgen_register_toolchains",
             "rust_wasm_bindgen_toolchain",
             "rust_wasm_bindgen",
         ],

--- a/docs/WORKSPACE.bazel
+++ b/docs/WORKSPACE.bazel
@@ -23,9 +23,15 @@ load("@rules_rust//proto:transitive_repositories.bzl", "rust_proto_transitive_re
 
 rust_proto_transitive_repositories()
 
-load("@rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_repositories")
+load(
+    "@rules_rust//wasm_bindgen:repositories.bzl",
+    "rust_wasm_bindgen_dependencies",
+    "rust_wasm_bindgen_register_toolchains",
+)
 
-rust_wasm_bindgen_repositories()
+rust_wasm_bindgen_dependencies()
+
+rust_wasm_bindgen_register_toolchains()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -42,7 +42,8 @@
 * [rust_toolchain_repository](#rust_toolchain_repository)
 * [rust_toolchain_repository_proxy](#rust_toolchain_repository_proxy)
 * [rust_wasm_bindgen](#rust_wasm_bindgen)
-* [rust_wasm_bindgen_repositories](#rust_wasm_bindgen_repositories)
+* [rust_wasm_bindgen_dependencies](#rust_wasm_bindgen_dependencies)
+* [rust_wasm_bindgen_register_toolchains](#rust_wasm_bindgen_register_toolchains)
 * [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
 * [rustfmt_aspect](#rustfmt_aspect)
 * [rustfmt_test](#rustfmt_test)
@@ -1707,22 +1708,39 @@ rust_test_suite(
 | <a id="rust_test_suite-kwargs"></a>kwargs |  Additional keyword arguments for the underyling [rust_test](#rust_test) targets. The <code>tags</code> argument is also passed to the generated <code>test_suite</code> target.   |  none |
 
 
-<a id="#rust_wasm_bindgen_repositories"></a>
+<a id="#rust_wasm_bindgen_dependencies"></a>
 
-## rust_wasm_bindgen_repositories
+## rust_wasm_bindgen_dependencies
 
 <pre>
-rust_wasm_bindgen_repositories(<a href="#rust_wasm_bindgen_repositories-register_default_toolchain">register_default_toolchain</a>)
+rust_wasm_bindgen_dependencies()
 </pre>
 
-Declare dependencies needed for [rust_wasm_bindgen](#rust_wasm_bindgen).
+Declare dependencies needed for the `rules_rust` [wasm-bindgen][wb] rules.
+
+[wb]: https://github.com/rustwasm/wasm-bindgen
+
+
+
+<a id="#rust_wasm_bindgen_register_toolchains"></a>
+
+## rust_wasm_bindgen_register_toolchains
+
+<pre>
+rust_wasm_bindgen_register_toolchains(<a href="#rust_wasm_bindgen_register_toolchains-register_toolchains">register_toolchains</a>)
+</pre>
+
+Registers the default toolchains for the `rules_rust` [wasm-bindgen][wb] rules.
+
+[wb]: https://github.com/rustwasm/wasm-bindgen
+
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="rust_wasm_bindgen_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain) (<code>@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
+| <a id="rust_wasm_bindgen_register_toolchains-register_toolchains"></a>register_toolchains |  Whether or not to register toolchains.   |  <code>True</code> |
 
 
 <a id="#rust_analyzer_aspect"></a>

--- a/docs/rust_wasm_bindgen.md
+++ b/docs/rust_wasm_bindgen.md
@@ -1,7 +1,8 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Rust Wasm Bindgen
 
-* [rust_wasm_bindgen_repositories](#rust_wasm_bindgen_repositories)
+* [rust_wasm_bindgen_dependencies](#rust_wasm_bindgen_dependencies)
+* [rust_wasm_bindgen_register_toolchains](#rust_wasm_bindgen_register_toolchains)
 * [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
 * [rust_wasm_bindgen](#rust_wasm_bindgen)
 
@@ -109,21 +110,38 @@ For additional information, see the [Bazel toolchains documentation][toolchains]
 | <a id="rust_wasm_bindgen_toolchain-bindgen"></a>bindgen |  The label of a <code>wasm-bindgen-cli</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
-<a id="#rust_wasm_bindgen_repositories"></a>
+<a id="#rust_wasm_bindgen_dependencies"></a>
 
-## rust_wasm_bindgen_repositories
+## rust_wasm_bindgen_dependencies
 
 <pre>
-rust_wasm_bindgen_repositories(<a href="#rust_wasm_bindgen_repositories-register_default_toolchain">register_default_toolchain</a>)
+rust_wasm_bindgen_dependencies()
 </pre>
 
-Declare dependencies needed for [rust_wasm_bindgen](#rust_wasm_bindgen).
+Declare dependencies needed for the `rules_rust` [wasm-bindgen][wb] rules.
+
+[wb]: https://github.com/rustwasm/wasm-bindgen
+
+
+
+<a id="#rust_wasm_bindgen_register_toolchains"></a>
+
+## rust_wasm_bindgen_register_toolchains
+
+<pre>
+rust_wasm_bindgen_register_toolchains(<a href="#rust_wasm_bindgen_register_toolchains-register_toolchains">register_toolchains</a>)
+</pre>
+
+Registers the default toolchains for the `rules_rust` [wasm-bindgen][wb] rules.
+
+[wb]: https://github.com/rustwasm/wasm-bindgen
+
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="rust_wasm_bindgen_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain) (<code>@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
+| <a id="rust_wasm_bindgen_register_toolchains-register_toolchains"></a>register_toolchains |  Whether or not to register toolchains.   |  <code>True</code> |
 
 

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -88,7 +88,8 @@ load(
 )
 load(
     "@rules_rust//wasm_bindgen:repositories.bzl",
-    _rust_wasm_bindgen_repositories = "rust_wasm_bindgen_repositories",
+    _rust_wasm_bindgen_dependencies = "rust_wasm_bindgen_dependencies",
+    _rust_wasm_bindgen_register_toolchains = "rust_wasm_bindgen_register_toolchains",
 )
 load(
     "@rules_rust//wasm_bindgen:wasm_bindgen.bzl",
@@ -125,8 +126,9 @@ cargo_bootstrap_repository = _cargo_bootstrap_repository
 cargo_env = _cargo_env
 
 rust_wasm_bindgen = _rust_wasm_bindgen
+rust_wasm_bindgen_dependencies = _rust_wasm_bindgen_dependencies
+rust_wasm_bindgen_register_toolchains = _rust_wasm_bindgen_register_toolchains
 rust_wasm_bindgen_toolchain = _rust_wasm_bindgen_toolchain
-rust_wasm_bindgen_repositories = _rust_wasm_bindgen_repositories
 
 rust_repositories = _rust_repositories
 rust_repository_set = _rust_repository_set

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -29,9 +29,11 @@ load("@rules_rust//proto:transitive_repositories.bzl", "rust_proto_transitive_re
 
 rust_proto_transitive_repositories()
 
-load("@rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_repositories")
+load("@rules_rust//wasm_bindgen:repositories.bzl", "rust_wasm_bindgen_dependencies", "rust_wasm_bindgen_register_toolchains")
 
-rust_wasm_bindgen_repositories()
+rust_wasm_bindgen_dependencies()
+
+rust_wasm_bindgen_register_toolchains()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/wasm_bindgen/repositories.bzl
+++ b/wasm_bindgen/repositories.bzl
@@ -18,13 +18,10 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//wasm_bindgen/raze:crates.bzl", "rules_rust_wasm_bindgen_fetch_remote_crates")
 
 # buildifier: disable=unnamed-macro
-def rust_wasm_bindgen_repositories(register_default_toolchain = True):
-    """Declare dependencies needed for [rust_wasm_bindgen](#rust_wasm_bindgen).
+def rust_wasm_bindgen_dependencies():
+    """Declare dependencies needed for the `rules_rust` [wasm-bindgen][wb] rules.
 
-    Args:
-        register_default_toolchain (bool, optional): If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
-            (`@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain`) is registered. This toolchain requires a set of dependencies
-            that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.
+    [wb]: https://github.com/rustwasm/wasm-bindgen
     """
 
     maybe(
@@ -34,7 +31,33 @@ def rust_wasm_bindgen_repositories(register_default_toolchain = True):
         urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.4.2/rules_nodejs-core-5.4.2.tar.gz"],
     )
 
-    # Load dependencies of the default toolchain and register it.
-    if register_default_toolchain:
-        rules_rust_wasm_bindgen_fetch_remote_crates()
+    rules_rust_wasm_bindgen_fetch_remote_crates()
+
+# buildifier: disable=unnamed-macro
+def rust_wasm_bindgen_register_toolchains(register_toolchains = True):
+    """Registers the default toolchains for the `rules_rust` [wasm-bindgen][wb] rules.
+
+    [wb]: https://github.com/rustwasm/wasm-bindgen
+
+    Args:
+        register_toolchains (bool, optional): Whether or not to register toolchains.
+    """
+
+    if register_toolchains:
         native.register_toolchains(str(Label("//wasm_bindgen:default_wasm_bindgen_toolchain")))
+
+# buildifier: disable=unnamed-macro
+def rust_wasm_bindgen_repositories(register_default_toolchain = True):
+    """Declare dependencies needed for [rust_wasm_bindgen](#rust_wasm_bindgen).
+
+    **Deprecated**: Use [rust_wasm_bindgen_dependencies](#rust_wasm_bindgen_depednencies) and [rust_wasm_bindgen_register_toolchains](#rust_wasm_bindgen_register_toolchains).
+
+    Args:
+        register_default_toolchain (bool, optional): If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
+            (`@rules_rust//wasm_bindgen:default_wasm_bindgen_toolchain`) is registered. This toolchain requires a set of dependencies
+            that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.
+    """
+
+    rust_wasm_bindgen_dependencies()
+
+    rust_wasm_bindgen_register_toolchains(register_toolchains = register_default_toolchain)


### PR DESCRIPTION
This conforms to the changes made in https://github.com/bazelbuild/rules_rust/pull/1105

Note that the previous API of `rust_wasm_bindgen_repositories` is still supported but users should migrate off of this