### PR TITLE
Explicitly set `LD_LIBRARY_PATH` in `Rustc` actions.

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -584,6 +584,41 @@ def collect_inputs(
 
     return compile_inputs, out_dir, build_env_files, build_flags_files, linkstamp_outs, ambiguous_libs
 
+def _collect_ld_library_path(env, rust_toolchain, cc_toolchain):
+    """Construct the value of `LD_LIBRARY_PATH` based on the existing environment and registered toolchains.
+
+    Args:
+        env (dict): A dict of existing environment variables
+        rust_toolchain (rust_toolchain): The registered rust_toolchain
+        cc_toolchain (CcToolchainInfo): A cc toolchain provider to be used.
+
+    Returns:
+        str: The value of `LD_LIBRARY_PATH`.
+    """
+    sep = ";"
+    ld_paths = []
+
+    # Maintain existing values
+    if "LD_LIBRARY_PATH" in env:
+        ld_paths.extend(env["LD_LIBRARY_PATH"].split(sep))
+    if "DYLD_LIBRARY_PATH" in env:
+        ld_paths.extend(env["DYLD_LIBRARY_PATH"].split(sep))
+
+    # Add the rustc sysroot
+    ld_paths.append("{}/lib".format(rust_toolchain.sysroot))
+
+    # When possible add the cc sysroot
+    if cc_toolchain.sysroot:
+        ld_paths.extend([
+            "{}/{}".format(cc_toolchain.sysroot, path)
+            for path in [
+                "lib64",
+                "lib",
+            ]
+        ])
+
+    return sep.join(depset(ld_paths).to_list())
+
 def construct_arguments(
         ctx,
         attr,
@@ -809,6 +844,15 @@ def construct_arguments(
 
     # Ensure the sysroot is set for the target platform
     env["SYSROOT"] = toolchain.sysroot
+
+    # Explicitly set the `LD_LIBRARY_PATH` variable to make `rustc` more hermetic.
+    ld_library_path = _collect_ld_library_path(
+        env = env,
+        rust_toolchain = toolchain,
+        cc_toolchain = cc_toolchain,
+    )
+    env["LD_LIBRARY_PATH"] = ld_library_path
+    env["DYLD_LIBRARY_PATH"] = ld_library_path
 
     if toolchain._rename_first_party_crates:
         env["RULES_RUST_THIRD_PARTY_DIR"] = toolchain._third_party_dir


### PR DESCRIPTION
When investigating ways to reduce the time needed to download toolchains (https://github.com/bazelbuild/rules_rust/pull/1163) I found in a couple of cases where `rustc` was either not using the correct libraries (occurs when using `cc_toolchain`s downloaded by Bazel) or not able to find the ones it needs (occurs when the `rust_toolchain` is represented by multiple external repositories). This change explicitly sets `LD_LIBRARY_PATH` to guide `rustc` to using paths in registered toolchains for finding the necessary files.