### PR TITLE
Error calling `all_crate_deps` without `Cargo.toml`

### DIFF
--- a/crate_universe/src/rendering/templates/module_bzl.j2
+++ b/crate_universe/src/rendering/templates/module_bzl.j2
@@ -195,7 +195,10 @@ def all_crate_deps(
     dependencies = _flatten_dependency_maps(all_dependency_maps).pop(package_name, None)
 
     if not dependencies:
-        return []
+        if dependencies == None:
+            fail("Tried to get all_crate_deps for package " + package_name + " but that package had no Cargo.toml file")
+        else:
+            return []
 
     crate_deps = list(dependencies.pop(_COMMON_CONDITION, {}).values())
     for condition, deps in dependencies.items():


### PR DESCRIPTION
Previously, we would silently return `[]`. This is incorrect; a user
should not be attempting to get deps which weren't declared, and
silently doing so can lead to some frustrating debugging.

Fixes #1322.