### PR TITLE
Remove CrateInfo expectation from rust_binary

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -840,7 +840,6 @@ _rust_binary_attrs = {
 
 rust_binary = rule(
     implementation = _rust_binary_impl,
-    provides = _common_providers,
     attrs = dict(_common_attrs.items() + _rust_binary_attrs.items()),
     executable = True,
     fragments = ["cpp"],


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_rust/issues/1330