### PR TITLE
"sandwich" rlibs between native deps in linker order

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1301,8 +1301,26 @@ def _portable_link_flags(lib, use_pic, ambiguous_libs, experimental_use_whole_ar
         modifiers = ""
         if experimental_use_whole_archive_for_native_deps:
             modifiers = ":+whole-archive"
+
+        # To ensure appropriate linker library argument order, in the presence
+        # of both native libraries that depend on rlibs and rlibs that depend
+        # on native libraries, we use an approach where we "sandwich" the
+        # rust libraries between two similar sections of all of native
+        # libraries:
+        # n1 n2 ... r1 r2 ... n1 n2 ...
+        # A         B         C
+        # This way any dependency from a native library to a rust library
+        # is resolved from A to B, and any dependency from a rust library to
+        # a native one is resolved from B to C.
+        # The question of resolving dependencies from a native library from A
+        # to any rust library is addressed in a different place, where we
+        # create symlinks to the rlibs, pretending they are native libraries,
+        # and adding references to these symlinks in the native section A.
+        # We rely in the behavior of -Clink-arg to put the give linker args
+        # at the end of the linker invocation constructed by rustc.
         return [
             "-lstatic%s=%s" % (modifiers, get_lib_name(artifact)),
+            "-Clink-arg=-l%s" % get_lib_name(artifact),
         ]
     elif _is_dylib(lib):
         return [

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1316,7 +1316,7 @@ def _portable_link_flags(lib, use_pic, ambiguous_libs, experimental_use_whole_ar
         # to any rust library is addressed in a different place, where we
         # create symlinks to the rlibs, pretending they are native libraries,
         # and adding references to these symlinks in the native section A.
-        # We rely in the behavior of -Clink-arg to put the give linker args
+        # We rely in the behavior of -Clink-arg to put the linker args
         # at the end of the linker invocation constructed by rustc.
         return [
             "-lstatic%s=%s" % (modifiers, get_lib_name(artifact)),

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -27,9 +27,11 @@ def _cdylib_has_native_libs_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
     action = tut.actions[0]
+    print(action.argv)
     assert_argv_contains_prefix_suffix(env, action, "-Lnative=", "/native_deps")
     assert_argv_contains(env, action, "--crate-type=cdylib")
     assert_argv_contains(env, action, "-lstatic=native_dep")
+    assert_argv_contains(env, action, "-Clink-arg=-lnative_dep")
     assert_argv_contains_prefix(env, action, "--codegen=linker=")
     return analysistest.end(env)
 
@@ -40,6 +42,7 @@ def _staticlib_has_native_libs_test_impl(ctx):
     assert_argv_contains_prefix_suffix(env, action, "-Lnative=", "/native_deps")
     assert_argv_contains(env, action, "--crate-type=staticlib")
     assert_argv_contains(env, action, "-lstatic=native_dep")
+    assert_argv_contains(env, action, "-Clink-arg=-lnative_dep")
     assert_argv_contains_prefix(env, action, "--codegen=linker=")
     return analysistest.end(env)
 
@@ -51,6 +54,7 @@ def _proc_macro_has_native_libs_test_impl(ctx):
     assert_argv_contains_prefix_suffix(env, action, "-Lnative=", "/native_deps")
     assert_argv_contains(env, action, "--crate-type=proc-macro")
     assert_argv_contains(env, action, "-lstatic=native_dep")
+    assert_argv_contains(env, action, "-Clink-arg=-lnative_dep")
     assert_argv_contains_prefix(env, action, "--codegen=linker=")
     return analysistest.end(env)
 
@@ -60,6 +64,7 @@ def _bin_has_native_libs_test_impl(ctx):
     action = tut.actions[0]
     assert_argv_contains_prefix_suffix(env, action, "-Lnative=", "/native_deps")
     assert_argv_contains(env, action, "-lstatic=native_dep")
+    assert_argv_contains(env, action, "-Clink-arg=-lnative_dep")
     assert_argv_contains_prefix(env, action, "--codegen=linker=")
     return analysistest.end(env)
 

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -27,7 +27,6 @@ def _cdylib_has_native_libs_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
     action = tut.actions[0]
-    print(action.argv)
     assert_argv_contains_prefix_suffix(env, action, "-Lnative=", "/native_deps")
     assert_argv_contains(env, action, "--crate-type=cdylib")
     assert_argv_contains(env, action, "-lstatic=native_dep")


### PR DESCRIPTION
This is part of the work on https://github.com/bazelbuild/rules_rust/issues/1268.

Consider a case where we have a rust binary B that depends on a rust library R that depends on a native library N. With a recent nightly rustc that passes the native library via `-l` to the linker (not using `--whole-archive` as it used to) and a linker that checks for backward references, we can run into backward reference errors when N appears before R on the linker invocation. Example at https://github.com/rust-lang/rust/issues/81490#issuecomment-1116042481.

We came up with two approaches to deal with such cases: a "sandwich" one and one where we'd pass appropriate `-l` flags to rustc when building rust_libraries. This PR implements the "sandwich" one.

Under the "sandwich" approach, we modify the rustc command link for building B in a way that the native libraries section on the linker invocation is repeated once more after the rlib section: 
```
ld ... n1 n2 ... r1 r2 ... n1 n2 ...
        X          Y         Z
```
By doing this, we allow the linker to resolve a dependency from an rlib to a native lib from `Y` to `Z`.

This should allow us to remove the `experimental_use_whole_archive_for_native_deps` stopgap feature, while additionally allowing us to take advantage of the new rustc no-whole-archive behaviour.

The approach to pass appropriate `-l` when building rust_libraries also seems plausible, but we've got some concerns about  scaling in some cases, e.g., where we have deeply nested "ladder-like" dependency graphs composed of mixed rust and native libraries. Embedding the transitive set of native library names in the rlib also means we may need to build multiple variants of rlibs to work, e.g., in pic/no-pic mode, whereas now a single rlib is sufficient for both modes. We'll continue to investigate.