### PR TITLE
Replace slashes with underscores in default crate names.

### DIFF
--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -272,7 +272,9 @@ def name_to_crate_name(name):
     Returns:
         str: The name of the crate for this target.
     """
-    return name.replace("-", "_")
+    for illegal in ("-", "/"):
+        name = name.replace(illegal, "_")
+    return name
 
 def _invalid_chars_in_crate_name(name):
     """Returns any invalid chars in the given crate name.

--- a/test/unit/crate_name/crate_name_test.bzl
+++ b/test/unit/crate_name/crate_name_test.bzl
@@ -48,7 +48,7 @@ def _custom_crate_name_test_test_impl(ctx):
 
 def _invalid_default_crate_name_test_impl(ctx):
     env = analysistest.begin(ctx)
-    asserts.expect_failure(env, "contains invalid character(s): /")
+    asserts.expect_failure(env, "contains invalid character(s): @")
     return analysistest.end(env)
 
 def _invalid_custom_crate_name_test_impl(ctx):
@@ -158,7 +158,7 @@ def _crate_name_test():
     )
 
     rust_library(
-        name = "invalid/default-crate-name",
+        name = "invalid@default-crate-name",
         srcs = ["lib.rs"],
         edition = "2018",
         tags = ["manual", "norustfmt"],
@@ -227,7 +227,7 @@ def _crate_name_test():
 
     invalid_default_crate_name_test(
         name = "invalid_default_crate_name_test",
-        target_under_test = ":invalid/default-crate-name",
+        target_under_test = ":invalid@default-crate-name",
     )
 
     invalid_custom_crate_name_test(


### PR DESCRIPTION
This change is consistent with the existing documentation, which says that all illegal characters will be converted to underscores (but in reality, only hyphens were converted).

This change has no risk of breakage, since it turns broken builds into passing ones, but not vice versa.