### PR TITLE
Remove unnecessary `crate_name` usage in `rust_test_suite`.

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -23,7 +23,6 @@ load(
     "expand_dict_value_locations",
     "find_toolchain",
     "get_import_macro_deps",
-    "name_to_crate_name",
     "transform_deps",
 )
 
@@ -1185,7 +1184,6 @@ def rust_test_suite(name, srcs, **kwargs):
         test_name = name + "_" + src[:-3]
         rust_test(
             name = test_name,
-            crate_name = name_to_crate_name(test_name.replace("/", "_")),
             srcs = [src],
             **kwargs
         )


### PR DESCRIPTION
This usage of `crate_name` is not needed, and should be removed, so that the underlying `rust_test` targets participate in the same naming scheme as is used by normal invocations of `rust_test`.

Proof that `crate_name` is not needed here:
First, note that `name_to_crate_name` just replaces "/" and "-" characters in the provided string with underscores. So, we can immediately replace `name_to_crate_name(test_name.replace("/", "_"))` with just `name_to_crate_name(test_name)`. Next, we trace through the call to `rust_test`: since this target does not use the `crate` attribute, it will go through the call to `compute_crate_name(...)` on line 381. Assuming we have removed the `crate_name` attribute, that function will skip the first if statement on utils.bzl:303, and compute the crate name as usual: `crate_name = name_to_crate_name(label.name)`. Since the `rust_test` was created with `name = test_name,`, this means `compute_crate_name` will end up returning the same string that is currently assigned to the target's `crate_name` attribute, which makes the attribute unnecessary.