### PR TITLE
Fix incorrect assertion in test_env_launcher test

### DIFF
--- a/test/test_env_launcher/tests/run.rs
+++ b/test/test_env_launcher/tests/run.rs
@@ -28,6 +28,6 @@ fn run() {
 
     // Ensure `execpath` expanded variables map to real files and have absolute paths
     let hello_world_src = std::path::PathBuf::from(std::env::var("HELLO_WORLD_SRC").unwrap());
-    assert!(!hello_world_bin.is_absolute());
+    assert!(!hello_world_src.is_absolute());
     assert!(hello_world_src.exists());
 }


### PR DESCRIPTION
This appears to be a copy-paste error in #1079, since the assertion is
already is currently duplicated on line 26.