### PR TITLE
Renamed toolchain files targets

### DIFF
--- a/crate_universe/BUILD.bazel
+++ b/crate_universe/BUILD.bazel
@@ -94,16 +94,16 @@ rust_test(
     aliases = aliases(),
     crate = ":cargo_bazel",
     data = glob(["test_data/**"]) + [
-        "@rules_rust//rust/toolchain:current_exec_cargo_files",
-        "@rules_rust//rust/toolchain:current_exec_rustc_files",
+        "@rules_rust//rust/toolchain:current_cargo_files",
+        "@rules_rust//rust/toolchain:current_rustc_files",
         "//crate_universe/test_data/serialized_configs",
     ],
     proc_macro_deps = all_crate_deps(
         proc_macro_dev = True,
     ),
     rustc_env = {
-        "CARGO": "$(rootpath @rules_rust//rust/toolchain:current_exec_cargo_files)",
-        "RUSTC": "$(rootpath @rules_rust//rust/toolchain:current_exec_rustc_files)",
+        "CARGO": "$(rootpath @rules_rust//rust/toolchain:current_cargo_files)",
+        "RUSTC": "$(rootpath @rules_rust//rust/toolchain:current_rustc_files)",
     },
     deps = [
         "@rules_rust//tools/runfiles",

--- a/crate_universe/test_data/private/BUILD.bazel
+++ b/crate_universe/test_data/private/BUILD.bazel
@@ -4,11 +4,11 @@ py_binary(
     name = "metadata_generator",
     srcs = ["metadata_generator.py"],
     data = [
-        "@rules_rust//rust/toolchain:current_exec_cargo_files",
-        "@rules_rust//rust/toolchain:current_exec_rustc_files",
+        "@rules_rust//rust/toolchain:current_cargo_files",
+        "@rules_rust//rust/toolchain:current_rustc_files",
     ],
     env = {
-        "CARGO": "$(rootpath @rules_rust//rust/toolchain:current_exec_cargo_files)",
-        "RUSTC": "$(rootpath @rules_rust//rust/toolchain:current_exec_rustc_files)",
+        "CARGO": "$(rootpath @rules_rust//rust/toolchain:current_cargo_files)",
+        "RUSTC": "$(rootpath @rules_rust//rust/toolchain:current_rustc_files)",
     },
 )

--- a/crate_universe/tools/cross_installer/BUILD.bazel
+++ b/crate_universe/tools/cross_installer/BUILD.bazel
@@ -14,12 +14,12 @@ rust_binary(
     data = [
         "Cross.toml",
         ":cross",
-        "@rules_rust//rust/toolchain:current_exec_cargo_files",
+        "@rules_rust//rust/toolchain:current_cargo_files",
     ],
     edition = "2018",
     proc_macro_deps = all_crate_deps(proc_macro = True),
     rustc_env = {
-        "CARGO": "$(rootpath @rules_rust//rust/toolchain:current_exec_cargo_files)",
+        "CARGO": "$(rootpath @rules_rust//rust/toolchain:current_cargo_files)",
         "CROSS_BIN": "$(rootpath :cross)",
         "CROSS_CONFIG": "$(rootpath :Cross.toml)",
     },

--- a/rust/toolchain/BUILD.bazel
+++ b/rust/toolchain/BUILD.bazel
@@ -3,43 +3,91 @@ load("//rust/private:toolchain_utils.bzl", "toolchain_files")
 package(default_visibility = ["//visibility:public"])
 
 toolchain_files(
-    name = "current_exec_cargo_files",
+    name = "current_cargo_files",
     tool = "cargo",
 )
 
+alias(
+    name = "current_exec_cargo_files",
+    actual = "current_cargo_files",
+    deprecation = "instead use `@rules_rust//rust/toolchain:current_cargo_files`",
+)
+
 toolchain_files(
-    name = "current_exec_clippy_files",
+    name = "current_clippy_files",
     tool = "clippy",
 )
 
+alias(
+    name = "current_exec_clippy_files",
+    actual = "current_clippy_files",
+    deprecation = "instead use `@rules_rust//rust/toolchain:current_clippy_files`",
+)
+
 toolchain_files(
-    name = "current_exec_rustc_files",
+    name = "current_rustc_files",
     tool = "rustc",
 )
 
+alias(
+    name = "current_exec_rustc_files",
+    actual = "current_rustc_files",
+    deprecation = "instead use `@rules_rust//rust/toolchain:current_rustc_files`",
+)
+
 toolchain_files(
-    name = "current_exec_rustdoc_files",
+    name = "current_rustdoc_files",
     tool = "rustdoc",
 )
 
+alias(
+    name = "current_exec_rustdoc_files",
+    actual = "current_rustdoc_files",
+    deprecation = "instead use `@rules_rust//rust/toolchain:current_rustdoc_files`",
+)
+
 toolchain_files(
-    name = "current_exec_rustfmt_files",
+    name = "current_rustfmt_files",
     tool = "rustfmt",
 )
 
+alias(
+    name = "current_exec_rustfmt_files",
+    actual = "current_rustfmt_files",
+    deprecation = "instead use `@rules_rust//rust/toolchain:current_rustfmt_files`",
+)
+
 toolchain_files(
-    name = "current_exec_rustc_lib_files",
+    name = "current_rustc_lib_files",
     tool = "rustc_lib",
 )
 
-toolchain_files(
-    name = "current_exec_rustc_srcs_files",
-    tool = "rustc_srcs",
+alias(
+    name = "current_exec_rustc_lib_files",
+    actual = "current_rustc_lib_files",
+    deprecation = "instead use `@rules_rust//rust/toolchain:current_rustc_lib_files`",
 )
 
 toolchain_files(
-    name = "current_exec_rust_stdlib_files",
+    name = "current_rustc_srcs_files",
+    tool = "rustc_srcs",
+)
+
+alias(
+    name = "current_exec_rustc_srcs_files",
+    actual = "current_rustc_srcs_files",
+    deprecation = "instead use `@rules_rust//rust/toolchain:current_rustc_srcs_files`",
+)
+
+toolchain_files(
+    name = "current_rust_stdlib_files",
     tool = "rust_stdlib",
+)
+
+alias(
+    name = "current_exec_rust_stdlib_files",
+    actual = "current_rust_stdlib_files",
+    deprecation = "instead use `@rules_rust//rust/toolchain:current_rust_stdlib_files`",
 )
 
 filegroup(

--- a/test/current_toolchain_files/BUILD.bazel
+++ b/test/current_toolchain_files/BUILD.bazel
@@ -15,9 +15,9 @@ _FILES = {
 [
     genrule(
         name = "{}_manifest_genrule".format(files),
-        srcs = ["//rust/toolchain:current_exec_{}_files".format(files)],
+        srcs = ["//rust/toolchain:current_{}_files".format(files)],
         outs = ["{}_manifest".format(files)],
-        cmd = "for file in $(rootpaths //rust/toolchain:current_exec_{}_files); do echo $$file >> $@; done".format(files),
+        cmd = "for file in $(rootpaths //rust/toolchain:current_{}_files); do echo $$file >> $@; done".format(files),
     )
     for files in _FILES
     if "--files" in _FILES[files]
@@ -29,12 +29,12 @@ _FILES = {
         name = tool + "_test",
         srcs = ["current_exec_files_test.sh"],
         args = [
-            "$(rootpath //rust/toolchain:current_exec_{}_files)".format(tool) if "--executable" == arg else "$(rootpath {}_manifest)".format(tool),
+            "$(rootpath //rust/toolchain:current_{}_files)".format(tool) if "--executable" == arg else "$(rootpath {}_manifest)".format(tool),
             arg,
             "'{}'".format(pattern),
         ],
         data = [
-            "//rust/toolchain:current_exec_{}_files".format(tool),
+            "//rust/toolchain:current_{}_files".format(tool),
         ] + (
             ["{}_manifest".format(tool)] if "--files" == arg else []
         ),


### PR DESCRIPTION
The configuration of the `toolchain_tool` targets is up to however they're consumed. Claiming they're `exec` is misleading.