### PR TITLE
Added more "ignore" tags to rustfmt and clippy rules.

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1938,8 +1938,8 @@ used at runtime.
 [cs]: https://rust-lang.github.io/rustfmt/
 
 This aspect is executed on any target which provides the `CrateInfo` provider. However
-users may tag a target with `norustfmt` to have it skipped. Additionally, generated
-source files are also ignored by this aspect.
+users may tag a target with `no-rustfmt` or `no-format` to have it skipped. Additionally,
+generated source files are also ignored by this aspect.
 
 
 **ASPECT ATTRIBUTES**

--- a/docs/rust_clippy.md
+++ b/docs/rust_clippy.md
@@ -27,7 +27,7 @@ build --output_groups=+clippy_checks
 
 This will enable clippy on all [Rust targets](./defs.md).
 
-Note that targets tagged with `noclippy` will not perform clippy checks
+Note that targets tagged with `no-clippy` will not perform clippy checks
 
 To use a local clippy.toml, add the following flag to your `.bazelrc`. Note that due to
 the upstream implementation of clippy, this file must be named either `.clippy.toml` or

--- a/docs/rust_clippy.vm
+++ b/docs/rust_clippy.vm
@@ -21,7 +21,7 @@ build --output_groups=+clippy_checks
 
 This will enable clippy on all [Rust targets](./defs.md).
 
-Note that targets tagged with `noclippy` will not perform clippy checks
+Note that targets tagged with `no-clippy` will not perform clippy checks
 
 To use a local clippy.toml, add the following flag to your `.bazelrc`. Note that due to
 the upstream implementation of clippy, this file must be named either `.clippy.toml` or

--- a/docs/rust_fmt.md
+++ b/docs/rust_fmt.md
@@ -86,8 +86,8 @@ used at runtime.
 [cs]: https://rust-lang.github.io/rustfmt/
 
 This aspect is executed on any target which provides the `CrateInfo` provider. However
-users may tag a target with `norustfmt` to have it skipped. Additionally, generated
-source files are also ignored by this aspect.
+users may tag a target with `no-rustfmt` or `no-format` to have it skipped. Additionally,
+generated source files are also ignored by this aspect.
 
 
 **ASPECT ATTRIBUTES**

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -60,9 +60,16 @@ def _get_clippy_ready_crate_info(target, aspect_ctx):
     if target.label.workspace_root.startswith("external"):
         return None
 
-    # Targets annotated with `noclippy` will not be formatted
-    if aspect_ctx and "noclippy" in aspect_ctx.rule.attr.tags:
-        return None
+    # Targets with specific will not be formatted
+    if aspect_ctx:
+        ignore_tags = [
+            "noclippy",
+            "no-clippy",
+        ] 
+
+        for tag in ignore_tags:
+            if tag in aspect_ctx.rule.attr.tags:
+                return None
 
     # Obviously ignore any targets that don't contain `CrateInfo`
     if rust_common.crate_info not in target:

--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -20,9 +20,17 @@ def _find_rustfmtable_srcs(target, aspect_ctx = None):
     if target.label.workspace_root.startswith("external"):
         return []
 
-    # Targets annotated with `norustfmt` will not be formatted
-    if aspect_ctx and "norustfmt" in aspect_ctx.rule.attr.tags:
-        return []
+    if aspect_ctx:
+        # Targets with specifc tags will not be formatted
+        ignore_tags = [
+            "no-format",
+            "no-rustfmt",
+            "norustfmt",
+        ] 
+        
+        for tag in ignore_tags:
+            if tag in aspect_ctx.rule.attr.tags:
+                return []
 
     crate_info = target[rust_common.crate_info]
 
@@ -110,8 +118,8 @@ used at runtime.
 [cs]: https://rust-lang.github.io/rustfmt/
 
 This aspect is executed on any target which provides the `CrateInfo` provider. However
-users may tag a target with `norustfmt` to have it skipped. Additionally, generated
-source files are also ignored by this aspect.
+users may tag a target with `no-rustfmt` or `no-format` to have it skipped. Additionally,
+generated source files are also ignored by this aspect.
 """,
     attrs = {
         "_config": attr.label(

--- a/tools/rustfmt/src/main.rs
+++ b/tools/rustfmt/src/main.rs
@@ -78,7 +78,7 @@ fn edition_query(bazel_bin: &Path, edition: &str, scope: &str, current_dir: &Pat
         //             Except for targets tagged with `norustfmt`.
         //             And except for targets with a populated `crate` attribute since `crate` defines edition for this target
         format!(
-            r#"let scope = set({scope}) in filter("^//.*\.rs$", kind("source file", deps(attr(edition, "{edition}", $scope) except attr(tags, "(^\[|, )norustfmt(, |\]$)", $scope) + attr(crate, ".*", $scope), 1)))"#,
+            r#"let scope = set({scope}) in filter("^//.*\.rs$", kind("source file", deps(attr(edition, "{edition}", $scope) except attr(tags, "(^\[|, )(no-format|no-rustfmt|norustfmt)(, |\]$)", $scope) + attr(crate, ".*", $scope), 1)))"#,
             edition = edition,
             scope = scope,
         ),


### PR DESCRIPTION
The advertised tags in [Bazel docs](https://bazel.build/reference/be/common-definitions#common-attributes) are all hyphen delimited. This PR updates the `rustfmt` and `clippy` rules to support this style and avoid confusion in BUILD files.