### PR TITLE
Revert changes to `//tools/runfiles` from #722

### DIFF
--- a/tools/runfiles/runfiles.rs
+++ b/tools/runfiles/runfiles.rs
@@ -108,7 +108,7 @@ impl Runfiles {
 }
 
 /// Returns the .runfiles directory for the currently executing binary.
-pub fn find_runfiles_dir() -> io::Result<PathBuf> {
+fn find_runfiles_dir() -> io::Result<PathBuf> {
     assert_ne!(
         std::env::var_os("RUNFILES_MANIFEST_ONLY").unwrap_or_else(|| OsString::from("0")),
         "1"


### PR DESCRIPTION
In the spirit of https://github.com/bazelbuild/rules_rust/pull/872, some of the changes that were introduced in https://github.com/bazelbuild/rules_rust/pull/722 were not ideal for the `@rules_rust//tools/runfiles` library. This change reverts those to hopefully undo any controversial changes (see https://github.com/bazelbuild/rules_rust/pull/872#discussion_r680411760 for more details).