### PR TITLE
Use a vec, not set for rustc_flags for crate_universe annotations

### DIFF
--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -421,8 +421,6 @@ impl CrateContext {
             }
 
             // Rustc flags
-            // TODO: SelectList is currently backed by `BTreeSet` which is generally incorrect
-            // for rustc flags. Should SelectList be refactored?
             if let Some(extra) = &crate_extra.rustc_flags {
                 self.common_attrs.rustc_flags.append(&mut extra.clone());
             }

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -101,8 +101,8 @@ pub struct CommonAttributes {
     #[serde(skip_serializing_if = "SelectStringList::should_skip_serializing")]
     pub rustc_env_files: SelectStringList,
 
-    #[serde(skip_serializing_if = "SelectStringList::should_skip_serializing")]
-    pub rustc_flags: SelectStringList,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub rustc_flags: Vec<String>,
 
     pub version: String,
 
@@ -424,9 +424,7 @@ impl CrateContext {
             // TODO: SelectList is currently backed by `BTreeSet` which is generally incorrect
             // for rustc flags. Should SelectList be refactored?
             if let Some(extra) = &crate_extra.rustc_flags {
-                for data in extra.iter() {
-                    self.common_attrs.rustc_flags.insert(data.clone(), None);
-                }
+                self.common_attrs.rustc_flags.append(&mut extra.clone());
             }
 
             // Rustc env

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -211,7 +211,7 @@ mod test {
 
     use crate::config::{Config, CrateId, VendorMode};
     use crate::context::crate_context::{CrateContext, Rule};
-    use crate::context::{BuildScriptAttributes, Context, TargetAttributes};
+    use crate::context::{BuildScriptAttributes, CommonAttributes, Context, TargetAttributes};
     use crate::metadata::Annotations;
     use crate::test;
 
@@ -466,5 +466,55 @@ mod test {
 
         // Local vendoring does not produce a `crates.bzl` file.
         assert!(output.get(&PathBuf::from("crates.bzl")).is_none());
+    }
+
+    #[test]
+    fn duplicate_rustc_flags() {
+        let mut context = Context::default();
+        let crate_id = CrateId::new("mock_crate".to_owned(), "0.1.0".to_owned());
+
+        let rustc_flags = vec![
+            "-l".to_owned(),
+            "dylib=ssl".to_owned(),
+            "-l".to_owned(),
+            "dylib=crypto".to_owned(),
+        ];
+
+        context.crates.insert(
+            crate_id.clone(),
+            CrateContext {
+                name: crate_id.name,
+                version: crate_id.version,
+                targets: vec![Rule::Library(mock_target_attributes())],
+                common_attrs: CommonAttributes {
+                    rustc_flags: rustc_flags.clone(),
+                    ..CommonAttributes::default()
+                },
+                ..CrateContext::default()
+            },
+        );
+
+        // Enable local vendor mode
+        let config = RenderConfig {
+            vendor_mode: Some(VendorMode::Local),
+            ..mock_render_config()
+        };
+
+        let renderer = Renderer::new(config);
+        let output = renderer.render(&context).unwrap();
+
+        let build_file_content = output
+            .get(&PathBuf::from("BUILD.mock_crate-0.1.0.bazel"))
+            .unwrap();
+
+        // Strip all spaces from the generated BUILD file and ensure it has the flags
+        // represented by `rustc_flags` in the same order.
+        assert!(build_file_content.replace(' ', "").contains(
+            &rustc_flags
+                .iter()
+                .map(|s| format!("\"{}\",", s))
+                .collect::<Vec<String>>()
+                .join("\n")
+        ));
     }
 }

--- a/crate_universe/src/rendering/templates/partials/crate/build_script.j2
+++ b/crate_universe/src/rendering/templates/partials/crate/build_script.j2
@@ -39,7 +39,14 @@ cargo_build_script(
         # warnings. For more details see: 
         # https://doc.rust-lang.org/rustc/lints/levels.html
         "--cap-lints=allow",
-    ] + {% set selectable = crate.build_script_attrs | get(key="rustc_flags", default=Null) %}{% include "partials/starlark/selectable_list.j2" %},
+        {%- if crate.common_attrs | get(key="rustc_flags", default=Null) %}
+
+        # User provided rustc_flags
+        {%- for rustc_flag in crate.common_attrs.rustc_flags %}
+        "{{ rustc_flag }}",
+        {%- endfor %}
+        {%- endif %}
+    ],
     srcs = {% set glob = target.srcs %}{% include "partials/starlark/glob.j2" -%},
     tools = {% set selectable = crate.build_script_attrs | get(key="tools", default=Null) %}{% include "partials/starlark/selectable_list.j2" %},
     version = "{{ crate.common_attrs.version }}",

--- a/crate_universe/src/rendering/templates/partials/crate/common_attrs.j2
+++ b/crate_universe/src/rendering/templates/partials/crate/common_attrs.j2
@@ -18,7 +18,14 @@
         # warnings. For more details see: 
         # https://doc.rust-lang.org/rustc/lints/levels.html
         "--cap-lints=allow",
-    ] + {% set selectable = crate.common_attrs | get(key="rustc_flags", default=Null) %}{% include "partials/starlark/selectable_list.j2" -%},
+        {%- if crate.common_attrs | get(key="rustc_flags", default=Null) %}
+
+        # User provided rustc_flags
+        {%- for rustc_flag in crate.common_attrs.rustc_flags %}
+        "{{ rustc_flag }}",
+        {%- endfor %}
+        {%- endif %}
+    ],
     srcs = {% set glob = target.srcs %}{% include "partials/starlark/glob.j2" -%},
     version = "{{ crate.common_attrs.version }}",
     tags = [


### PR DESCRIPTION
This solves for issues where users might be using the following [crate annotation](https://bazelbuild.github.io/rules_rust/crate_universe.html#crateannotation)
```starlark
"openssl-sys": [crate.annotation(
    rustc_flags = [
        "-l",
        "dylib=ssl",
        "-l",
        "dylib=crypto",
    ],
)],
```

Before this would render to a list that omitted the second `-l` argument and result in an invalid build command.
```starlark
rustc_flags = [
    "-l",
    "dylib=ssl",
    "dylib=crypto",
],
```
This is now fixed and the list renders correctly
```starlark
rustc_flags = [
    "-l",
    "dylib=ssl",
    "-l",
    "dylib=crypto",
],
```