### PR TITLE
Deleted deprecated `rust_analyzer` rule.

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -70,7 +70,6 @@ PAGES = dict([
         name = "rust_analyzer",
         header_template = ":rust_analyzer.vm",
         symbols = [
-            "rust_analyzer",
             "rust_analyzer_aspect",
         ],
     ),

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -12,7 +12,6 @@
 * [fail_when_enabled](#fail_when_enabled)
 * [incompatible_flag](#incompatible_flag)
 * [rules_rust_dependencies](#rules_rust_dependencies)
-* [rust_analyzer](#rust_analyzer)
 * [rust_analyzer_aspect](#rust_analyzer_aspect)
 * [rust_binary](#rust_binary)
 * [rust_bindgen](#rust_bindgen)
@@ -156,26 +155,6 @@ A rule defining an incompatible flag.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="incompatible_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="incompatible_flag-issue"></a>issue |  The link to the github issue associated with this flag   | String | required |  |
-
-
-<a id="#rust_analyzer"></a>
-
-## rust_analyzer
-
-<pre>
-rust_analyzer(<a href="#rust_analyzer-name">name</a>, <a href="#rust_analyzer-targets">targets</a>)
-</pre>
-
-Deprecated: gen_rust_project can now create a rust-project.json without a rust_analyzer rule.
-
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="rust_analyzer-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="rust_analyzer-targets"></a>targets |  List of all targets to be included in the index   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#rust_binary"></a>

--- a/docs/rust_analyzer.md
+++ b/docs/rust_analyzer.md
@@ -1,7 +1,6 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 # Rust Analyzer
 
-* [rust_analyzer](#rust_analyzer)
 * [rust_analyzer_aspect](#rust_analyzer_aspect)
 
 
@@ -69,26 +68,6 @@ to ensure a `rust-project.json` file is created and up to date when the editor i
     ]
 }
 ```
-
-
-<a id="#rust_analyzer"></a>
-
-## rust_analyzer
-
-<pre>
-rust_analyzer(<a href="#rust_analyzer-name">name</a>, <a href="#rust_analyzer-targets">targets</a>)
-</pre>
-
-Deprecated: gen_rust_project can now create a rust-project.json without a rust_analyzer rule.
-
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="rust_analyzer-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="rust_analyzer-targets"></a>targets |  List of all targets to be included in the index   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#rust_analyzer_aspect"></a>

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -49,7 +49,6 @@ load(
     _capture_clippy_output = "capture_clippy_output",
     _error_format = "error_format",
     _extra_rustc_flags = "extra_rustc_flags",
-    _rust_analyzer = "rust_analyzer",
     _rust_analyzer_aspect = "rust_analyzer_aspect",
     _rust_binary = "rust_binary",
     _rust_clippy = "rust_clippy",
@@ -146,7 +145,6 @@ rust_toolchain_repository_proxy = _rust_toolchain_repository_proxy
 
 rust_clippy = _rust_clippy
 rust_clippy_aspect = _rust_clippy_aspect
-rust_analyzer = _rust_analyzer
 rust_analyzer_aspect = _rust_analyzer_aspect
 
 crate = _crate

--- a/examples/hello_lib/BUILD.bazel
+++ b/examples/hello_lib/BUILD.bazel
@@ -1,4 +1,12 @@
-load("@rules_rust//rust:defs.bzl", "rust_analyzer", "rust_doc", "rust_doc_test", "rust_library", "rust_shared_library", "rust_static_library", "rust_test")
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_doc",
+    "rust_doc_test",
+    "rust_library",
+    "rust_shared_library",
+    "rust_static_library",
+    "rust_test",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -65,9 +73,4 @@ rust_doc(
 rust_doc_test(
     name = "hello_lib_doc_test",
     crate = ":hello_lib",
-)
-
-rust_analyzer(
-    name = "hello_rust_analyzer",
-    targets = [":hello_lib"],
 )

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -38,7 +38,6 @@ load(
 )
 load(
     "//rust/private:rust_analyzer.bzl",
-    _rust_analyzer = "rust_analyzer",
     _rust_analyzer_aspect = "rust_analyzer_aspect",
 )
 load(
@@ -113,9 +112,6 @@ rust_common = _rust_common
 # See @rules_rust//rust/private:common.bzl for a complete description.
 
 rust_analyzer_aspect = _rust_analyzer_aspect
-# See @rules_rust//rust/private:rust_analyzer.bzl for a complete description.
-
-rust_analyzer = _rust_analyzer
 # See @rules_rust//rust/private:rust_analyzer.bzl for a complete description.
 
 rustfmt_aspect = _rustfmt_aspect

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -220,21 +220,3 @@ rust_analyzer_detect_sysroot = rule(
         Detect the sysroot and store in a file for use by the gen_rust_project tool.
     """),
 )
-
-def _rust_analyzer_impl(_ctx):
-    pass
-
-rust_analyzer = rule(
-    attrs = {
-        "targets": attr.label_list(
-            aspects = [rust_analyzer_aspect],
-            doc = "List of all targets to be included in the index",
-        ),
-    },
-    implementation = _rust_analyzer_impl,
-    toolchains = [str(Label("//rust:toolchain"))],
-    incompatible_use_toolchain_transition = True,
-    doc = dedent("""\
-        Deprecated: gen_rust_project can now create a rust-project.json without a rust_analyzer rule.
-    """),
-)


### PR DESCRIPTION
The old `rust_analyzer` rule is no longer necessary. Documentation for it's replacement can be found [here](https://bazelbuild.github.io/rules_rust/rust_analyzer.html).