### PR TITLE
Allow multiple uses of extra_rustc_flags

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -149,13 +149,13 @@ tasks:
     bazel: "rolling"
   ubuntu1804:
     name: "Min Bazel Version"
-    bazel: "4.0.0"
+    bazel: "5.0.0"
     platform: ubuntu1804
     build_targets: *default_linux_targets
     test_targets: *default_linux_targets
   ubuntu1804_with_aspects:
     name: "Min Bazel Version With Aspects"
-    bazel: "4.0.0"
+    bazel: "5.0.0"
     platform: ubuntu1804
     build_targets: *default_linux_targets
     test_targets: *default_linux_targets

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -61,7 +61,7 @@ extra_rustc_flags(
 # to that target. This can be useful for passing build-wide options such as LTO.
 extra_exec_rustc_flags(
     name = "extra_exec_rustc_flags",
-    build_setting_default = [],
+    build_setting_default = "",
     visibility = ["//visibility:public"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,7 +51,7 @@ clippy_flags(
 # to that target. This can be useful for passing build-wide options such as LTO.
 extra_rustc_flags(
     name = "extra_rustc_flags",
-    build_setting_default = [],
+    build_setting_default = "",
     visibility = ["//visibility:public"],
 )
 

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -56,7 +56,7 @@ Change the [--error-format](https://doc.rust-lang.org/rustc/command-line-argumen
 extra_rustc_flags(<a href="#extra_rustc_flags-name">name</a>)
 </pre>
 
-Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration.
+Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration. Accept comma separated strings and multiple uses of this flag are accumulated.
 
 **ATTRIBUTES**
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -129,7 +129,7 @@ Change the [--error-format](https://doc.rust-lang.org/rustc/command-line-argumen
 extra_rustc_flags(<a href="#extra_rustc_flags-name">name</a>)
 </pre>
 
-Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration.
+Add additional rustc_flags from the command line with `--@rules_rust//:extra_rustc_flags`. This flag should only be used for flags that need to be applied across the entire build. For options that apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration. Accept comma separated strings and multiple uses of this flag are accumulated.
 
 **ATTRIBUTES**
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1493,7 +1493,10 @@ error_format = rule(
 )
 
 def _extra_rustc_flags_impl(ctx):
-    return ExtraRustcFlagsInfo(extra_rustc_flags = ctx.build_setting_value)
+    extra_rustc_flags = []
+    for flags in [flags.split(",") for flags in ctx.build_setting_value if flags != ""]:
+        extra_rustc_flags.extend(flags)
+    return ExtraRustcFlagsInfo(extra_rustc_flags = extra_rustc_flags)
 
 extra_rustc_flags = rule(
     doc = (
@@ -1501,10 +1504,11 @@ extra_rustc_flags = rule(
         "This flag should only be used for flags that need to be applied across the entire build. For options that " +
         "apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: " +
         "These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); " +
-        "use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration."
+        "use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration." +
+        "Accept comma separated strings and multiple uses of this flag are accumulated."
     ),
     implementation = _extra_rustc_flags_impl,
-    build_setting = config.string_list(flag = True),
+    build_setting = config.string(flag = True, allow_multiple = True),
 )
 
 def _extra_exec_rustc_flags_impl(ctx):

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1504,7 +1504,7 @@ extra_rustc_flags = rule(
         "This flag should only be used for flags that need to be applied across the entire build. For options that " +
         "apply to individual crates, use the rustc_flags attribute on the individual crate's rule instead. NOTE: " +
         "These flags not applied to the exec configuration (proc-macros, cargo_build_script, etc); " +
-        "use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration." +
+        "use `--@rules_rust//:extra_exec_rustc_flags` to apply flags to the exec configuration. " +
         "Accept comma separated strings and multiple uses of this flag are accumulated."
     ),
     implementation = _extra_rustc_flags_impl,
@@ -1512,14 +1512,18 @@ extra_rustc_flags = rule(
 )
 
 def _extra_exec_rustc_flags_impl(ctx):
-    return ExtraExecRustcFlagsInfo(extra_exec_rustc_flags = ctx.build_setting_value)
+    extra_exec_rustc_flags = []
+    for flags in [flags.split(",") for flags in ctx.build_setting_value if flags != ""]:
+        extra_exec_rustc_flags.extend(flags)
+    return ExtraExecRustcFlagsInfo(extra_exec_rustc_flags = extra_exec_rustc_flags)
 
 extra_exec_rustc_flags = rule(
     doc = (
         "Add additional rustc_flags in the exec configuration from the command line with `--@rules_rust//:extra_exec_rustc_flags`. " +
         "This flag should only be used for flags that need to be applied across the entire build. " +
-        "These flags only apply to the exec configuration (proc-macros, cargo_build_script, etc)."
+        "These flags only apply to the exec configuration (proc-macros, cargo_build_script, etc). " +
+        "Accept comma separated strings and multiple uses of this flag are accumulated."
     ),
     implementation = _extra_exec_rustc_flags_impl,
-    build_setting = config.string_list(flag = True),
+    build_setting = config.string(flag = True, allow_multiple = True),
 )


### PR DESCRIPTION
I would like to support the following use cases.

In `.bazelrc`.
```
build:dev --@rules_rust//:extra_rustc_flags="-C..."
build:test --config=dev
build:test --@rules_rust//:extra_rustc_flags="-C..." # add additional flags
build:fuzz --config=test
build:fuzz --@rules_rust//:extra_rustc_flags="-Cpasses=sancov,-Cllvm-args=-sanitizer-coverage-level=3,-Cllvm-args=-sanitizer-coverage-inline-8bit-counters,-Znew-llvm-pass-manager=no"
```