### PR TITLE
exclude `BUILD` and `WORKSPACE` files from generated crate_universe targets

### DIFF
--- a/crate_universe/3rdparty/crates/BUILD.aho-corasick-0.7.18.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.aho-corasick-0.7.18.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.58.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.58.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.atty-0.2.14.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.atty-0.2.14.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.autocfg-1.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.autocfg-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.bitflags-1.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bitflags-1.3.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.block-buffer-0.10.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.block-buffer-0.10.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.block-buffer-0.7.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.block-buffer-0.7.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.block-padding-0.1.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.block-padding-0.1.5.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.bstr-0.2.17.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bstr-0.2.17.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.byte-tools-0.3.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.byte-tools-0.3.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.byteorder-1.4.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.byteorder-1.4.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.camino-1.0.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.camino-1.0.9.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.cargo-lock-8.0.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cargo-lock-8.0.2.bazel
@@ -37,7 +37,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),
@@ -98,7 +106,15 @@ rust_binary(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.cargo-platform-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cargo-platform-0.1.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.cargo_metadata-0.14.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cargo_metadata-0.14.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.cargo_toml-0.11.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cargo_toml-0.11.5.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.cc-1.0.73.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cc-1.0.73.bazel
@@ -37,7 +37,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),
@@ -97,7 +105,15 @@ rust_binary(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.cfg-expr-0.10.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cfg-expr-0.10.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.cfg-if-1.0.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cfg-if-1.0.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.chrono-0.4.19.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-0.4.19.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.6.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.6.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.chrono-tz-build-0.0.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-tz-build-0.0.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.clap-3.2.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clap-3.2.8.bazel
@@ -37,7 +37,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),
@@ -114,7 +122,15 @@ rust_binary(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.clap_derive-3.2.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clap_derive-3.2.7.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.clap_lex-0.2.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clap_lex-0.2.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.cpufeatures-0.2.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cpufeatures-0.2.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.crates-index-0.18.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crates-index-0.18.8.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.10.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.crypto-common-0.1.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crypto-common-0.1.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.deunicode-0.4.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.deunicode-0.4.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.digest-0.10.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.digest-0.10.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.digest-0.8.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.digest-0.8.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.fake-simd-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.fake-simd-0.1.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.fastrand-1.7.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.fastrand-1.7.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.fnv-1.0.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.fnv-1.0.7.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.form_urlencoded-1.0.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.form_urlencoded-1.0.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.fuchsia-cprng-0.1.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.fuchsia-cprng-0.1.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.generic-array-0.12.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.generic-array-0.12.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.5.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.getrandom-0.2.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.getrandom-0.2.7.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.git2-0.14.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.git2-0.14.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.globset-0.4.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.globset-0.4.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.globwalk-0.8.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.globwalk-0.8.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.hashbrown-0.12.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.hashbrown-0.12.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.heck-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.heck-0.4.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.hermit-abi-0.1.19.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.hermit-abi-0.1.19.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.hex-0.4.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.hex-0.4.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.home-0.5.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.home-0.5.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.humansize-1.1.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.humansize-1.1.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.idna-0.2.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.idna-0.2.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.ignore-0.4.18.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.ignore-0.4.18.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.indexmap-1.9.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.indexmap-1.9.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.instant-0.1.12.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.instant-0.1.12.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.itoa-1.0.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.itoa-1.0.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.jobserver-0.1.24.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.jobserver-0.1.24.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.lazy_static-1.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.lazy_static-1.4.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.libc-0.2.126.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libc-0.2.126.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.libgit2-sys-0.13.4+1.4.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libgit2-sys-0.13.4+1.4.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.libz-sys-1.1.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libz-sys-1.1.8.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.log-0.4.17.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.log-0.4.17.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.maplit-1.0.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.maplit-1.0.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.matches-0.1.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.matches-0.1.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.memchr-2.5.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.memchr-2.5.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.normpath-0.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.normpath-0.3.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.num-0.1.42.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-0.1.42.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.num-bigint-0.1.44.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-bigint-0.1.44.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.num-complex-0.1.43.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-complex-0.1.43.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.num-rational-0.1.42.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-rational-0.1.42.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.num_cpus-1.13.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num_cpus-1.13.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.once_cell-1.13.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.once_cell-1.13.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.opaque-debug-0.2.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.opaque-debug-0.2.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.os_str_bytes-6.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.os_str_bytes-6.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.parse-zoneinfo-0.3.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.parse-zoneinfo-0.3.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.pathdiff-0.2.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pathdiff-0.2.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.percent-encoding-2.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.percent-encoding-2.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.pest-2.1.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pest-2.1.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.pest_derive-2.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pest_derive-2.1.0.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.pest_generator-2.1.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pest_generator-2.1.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.pest_meta-2.1.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pest_meta-2.1.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.phf-0.10.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.phf-0.10.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.phf_codegen-0.10.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.phf_codegen-0.10.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.phf_generator-0.10.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.phf_generator-0.10.0.bazel
@@ -37,7 +37,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),
@@ -96,7 +104,15 @@ rust_binary(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.phf_shared-0.10.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.phf_shared-0.10.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.pkg-config-0.3.25.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pkg-config-0.3.25.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.ppv-lite86-0.2.16.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.ppv-lite86-0.2.16.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro-error-1.0.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro-error-1.0.4.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -40,7 +40,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.40.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.40.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.quote-1.0.20.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.quote-1.0.20.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.rand-0.4.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand-0.4.6.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.rand-0.8.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand-0.8.5.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.rand_chacha-0.3.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand_chacha-0.3.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.rand_core-0.3.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand_core-0.3.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.rand_core-0.4.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand_core-0.4.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.rand_core-0.6.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand_core-0.6.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.rdrand-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rdrand-0.4.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.redox_syscall-0.2.13.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.redox_syscall-0.2.13.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.regex-1.6.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.regex-1.6.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.regex-syntax-0.6.27.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.regex-syntax-0.6.27.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.remove_dir_all-0.5.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.remove_dir_all-0.5.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.rustc-hash-1.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustc-hash-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.rustc-serialize-0.3.24.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustc-serialize-0.3.24.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.ryu-1.0.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.ryu-1.0.10.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.same-file-1.0.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.same-file-1.0.6.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.semver-1.0.12.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.semver-1.0.12.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.serde-1.0.138.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde-1.0.138.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.serde_derive-1.0.138.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_derive-1.0.138.bazel
@@ -40,7 +40,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.82.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.82.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.sha-1-0.8.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.sha-1-0.8.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.sha2-0.10.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.sha2-0.10.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.siphasher-0.3.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.siphasher-0.3.10.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.slug-0.1.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.slug-0.1.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.smallvec-1.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.smallvec-1.9.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.smartstring-1.0.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.smartstring-1.0.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.smawk-0.3.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.smawk-0.3.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.spectral-0.6.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.spectral-0.6.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.static_assertions-1.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.static_assertions-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.strsim-0.10.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.strsim-0.10.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.syn-1.0.98.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.syn-1.0.98.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.tempfile-3.3.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tempfile-3.3.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.tera-1.16.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tera-1.16.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.termcolor-1.1.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.termcolor-1.1.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.textwrap-0.15.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.textwrap-0.15.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.thread_local-1.1.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.thread_local-1.1.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.tinyvec-1.6.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tinyvec-1.6.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.tinyvec_macros-0.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tinyvec_macros-0.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.toml-0.5.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.toml-0.5.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.typenum-1.15.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.typenum-1.15.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.ucd-trie-0.1.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.ucd-trie-0.1.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.uncased-0.9.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.uncased-0.9.7.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unic-char-property-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-char-property-0.9.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unic-char-range-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-char-range-0.9.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unic-common-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-common-0.9.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unic-segment-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-segment-0.9.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unic-ucd-segment-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-ucd-segment-0.9.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unic-ucd-version-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-ucd-version-0.9.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unicode-bidi-0.3.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-bidi-0.3.8.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unicode-ident-1.0.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-ident-1.0.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unicode-linebreak-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-linebreak-0.1.2.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unicode-normalization-0.1.21.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-normalization-0.1.21.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.unicode-width-0.1.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-width-0.1.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.url-2.2.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.url-2.2.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.vcpkg-0.2.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.vcpkg-0.2.15.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.version_check-0.9.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.version_check-0.9.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.walkdir-2.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.walkdir-2.3.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.winapi-util-0.1.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-util-0.1.5.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/crate_universe/src/rendering/templates/partials/crate/common_attrs.j2
+++ b/crate_universe/src/rendering/templates/partials/crate/common_attrs.j2
@@ -1,11 +1,11 @@
-    compile_data = {% if crate.common_attrs | get(key="compile_data_glob") %}glob({{ crate.common_attrs.compile_data_glob | json_encode | safe }}) + {% endif %}{% set selectable = crate.common_attrs | get(key="compile_data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
+    compile_data = {% if crate.common_attrs | get(key="compile_data_glob") %}glob(include = {{ crate.common_attrs.compile_data_glob | json_encode | safe }}, exclude = ["BUILD", "BUILD.bazel", "WORKSPACE", "WORKSPACE.bazel"]) + {% endif %}{% set selectable = crate.common_attrs | get(key="compile_data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
     crate_root = "{{ target.crate_root }}",
     crate_features = [
         {%- for feature in crate.common_attrs | get(key="crate_features", default=[]) %}
         "{{ feature }}",
         {%- endfor %}
     ],
-    data = {% if crate.common_attrs | get(key="data_glob") %}glob({{ crate.common_attrs.data_glob | json_encode | safe }}) + {% endif %}{% set selectable = crate.common_attrs | get(key="data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
+    data = {% if crate.common_attrs | get(key="data_glob") %}glob(include = {{ crate.common_attrs.data_glob | json_encode | safe }}, exclude = ["BUILD", "BUILD.bazel", "WORKSPACE", "WORKSPACE.bazel"]) + {% endif %}{% set selectable = crate.common_attrs | get(key="data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
     edition = "{{ crate.common_attrs.edition }}",
     {%- if crate.common_attrs | get(key="linker_script", default=Null) %}
     linker_script = "{{ crate.common_attrs.linker_script }}",

--- a/examples/crate_universe/vendor_external/crates/BUILD.atty-0.2.14.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.atty-0.2.14.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.autocfg-1.1.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.autocfg-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.bitflags-1.3.2.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.bitflags-1.3.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.cfg-if-1.0.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.clap-3.2.8.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.clap-3.2.8.bazel
@@ -37,7 +37,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),
@@ -113,7 +121,15 @@ rust_binary(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.clap_derive-3.2.7.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.clap_derive-3.2.7.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.clap_lex-0.2.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.clap_lex-0.2.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.form_urlencoded-1.0.1.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.form_urlencoded-1.0.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.getrandom-0.2.7.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.getrandom-0.2.7.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.hashbrown-0.12.1.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.hashbrown-0.12.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.heck-0.4.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.heck-0.4.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.hermit-abi-0.1.19.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.hermit-abi-0.1.19.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.idna-0.2.3.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.idna-0.2.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.indexmap-1.9.1.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.indexmap-1.9.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.libc-0.2.126.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.libc-0.2.126.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.matches-0.1.9.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.matches-0.1.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.memchr-2.5.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.memchr-2.5.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.once_cell-1.13.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.once_cell-1.13.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.os_str_bytes-6.1.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.os_str_bytes-6.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.percent-encoding-2.1.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.percent-encoding-2.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.ppv-lite86-0.2.16.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.ppv-lite86-0.2.16.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-1.0.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-1.0.4.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -40,7 +40,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro2-1.0.40.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro2-1.0.40.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.pulldown-cmark-0.8.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.pulldown-cmark-0.8.0.bazel
@@ -41,7 +41,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),
@@ -102,7 +110,15 @@ rust_binary(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.quote-1.0.20.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.quote-1.0.20.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.rand-0.8.5.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.rand-0.8.5.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.rand_chacha-0.3.1.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.rand_chacha-0.3.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.rand_core-0.6.3.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.rand_core-0.6.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.regex-1.6.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.regex-1.6.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.regex-syntax-0.6.27.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.regex-syntax-0.6.27.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.semver-1.0.12.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.semver-1.0.12.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.serde-1.0.138.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.serde-1.0.138.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.strsim-0.10.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.strsim-0.10.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.syn-1.0.98.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.syn-1.0.98.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.termcolor-1.1.3.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.termcolor-1.1.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.textwrap-0.15.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.textwrap-0.15.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.tinyvec-1.6.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.tinyvec-1.6.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.tinyvec_macros-0.1.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.tinyvec_macros-0.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.toml-0.5.9.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.toml-0.5.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.unicase-2.6.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.unicase-2.6.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.unicode-bidi-0.3.8.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.unicode-bidi-0.3.8.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.unicode-ident-1.0.1.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.unicode-ident-1.0.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.unicode-normalization-0.1.21.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.unicode-normalization-0.1.21.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.url-2.2.2.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.url-2.2.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.version-sync-0.9.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.version-sync-0.9.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.version_check-0.9.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.version_check-0.9.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-0.3.9.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-util-0.1.5.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-util-0.1.5.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/async-stream-0.3.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/async-stream-0.3.3/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/async-stream-impl-0.3.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/async-stream-impl-0.3.3/BUILD.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/autocfg-1.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/autocfg-1.1.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/bitflags-1.3.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/bitflags-1.3.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/bytes-1.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/bytes-1.1.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/cfg-if-1.0.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/cfg-if-1.0.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/fastrand-1.7.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/fastrand-1.7.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/futures-core-0.3.21/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/futures-core-0.3.21/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/hermit-abi-0.1.19/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/hermit-abi-0.1.19/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/instant-0.1.12/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/instant-0.1.12/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/libc-0.2.126/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/libc-0.2.126/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/lock_api-0.4.7/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/lock_api-0.4.7/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/log-0.4.17/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/log-0.4.17/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/memchr-2.5.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/memchr-2.5.0/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/mio-0.7.14/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/mio-0.7.14/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/miow-0.3.7/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/miow-0.3.7/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/ntapi-0.3.7/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/ntapi-0.3.7/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/num_cpus-1.13.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/num_cpus-1.13.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/once_cell-1.13.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/once_cell-1.13.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/parking_lot-0.11.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/parking_lot-0.11.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/parking_lot_core-0.8.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/parking_lot_core-0.8.5/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/pin-project-lite-0.2.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/pin-project-lite-0.2.9/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/proc-macro2-1.0.40/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/proc-macro2-1.0.40/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/quote-1.0.20/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/quote-1.0.20/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/redox_syscall-0.2.13/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/redox_syscall-0.2.13/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/remove_dir_all-0.5.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/remove_dir_all-0.5.3/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/scopeguard-1.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/scopeguard-1.1.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/signal-hook-registry-1.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/signal-hook-registry-1.4.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/smallvec-1.9.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/smallvec-1.9.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/syn-1.0.98/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/syn-1.0.98/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/tempfile-3.3.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/tempfile-3.3.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/tokio-1.16.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/tokio-1.16.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/tokio-macros-1.8.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/tokio-macros-1.8.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/tokio-stream-0.1.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/tokio-stream-0.1.9/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/tokio-test-0.4.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/tokio-test-0.4.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/unicode-ident-1.0.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/unicode-ident-1.0.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/winapi-0.3.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/winapi-0.3.9/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_manifests/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/ansi_term-0.12.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/ansi_term-0.12.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/async-trait-0.1.56/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/async-trait-0.1.56/BUILD.bazel
@@ -40,7 +40,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/autocfg-1.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/autocfg-1.1.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/axum-0.4.8/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/axum-0.4.8/BUILD.bazel
@@ -36,10 +36,18 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob([
-        "**",
-        "**/*.md",
-    ]) + select_with_or({
+    compile_data = glob(
+        include = [
+            "**",
+            "**/*.md",
+        ],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/axum-core-0.1.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/axum-core-0.1.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/bitflags-1.3.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/bitflags-1.3.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/bytes-1.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/bytes-1.1.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/cfg-if-1.0.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/cfg-if-1.0.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/fnv-1.0.7/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/fnv-1.0.7/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/form_urlencoded-1.0.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/form_urlencoded-1.0.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/futures-channel-0.3.21/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/futures-channel-0.3.21/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/futures-core-0.3.21/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/futures-core-0.3.21/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/futures-sink-0.3.21/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/futures-sink-0.3.21/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/futures-task-0.3.21/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/futures-task-0.3.21/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/futures-util-0.3.21/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/futures-util-0.3.21/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/h2-0.3.13/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/h2-0.3.13/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/hashbrown-0.12.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/hashbrown-0.12.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/hermit-abi-0.1.19/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/hermit-abi-0.1.19/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/http-0.2.8/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/http-0.2.8/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/http-body-0.4.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/http-body-0.4.5/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/http-range-header-0.3.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/http-range-header-0.3.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/httparse-1.7.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/httparse-1.7.1/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/httpdate-1.0.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/httpdate-1.0.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/hyper-0.14.19/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/hyper-0.14.19/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/indexmap-1.9.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/indexmap-1.9.1/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/instant-0.1.12/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/instant-0.1.12/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/itoa-1.0.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/itoa-1.0.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/lazy_static-1.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/lazy_static-1.4.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/libc-0.2.126/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/libc-0.2.126/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/lock_api-0.4.7/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/lock_api-0.4.7/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/log-0.4.17/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/log-0.4.17/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/matches-0.1.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/matches-0.1.9/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/matchit-0.4.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/matchit-0.4.6/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/memchr-2.5.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/memchr-2.5.0/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/mime-0.3.16/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/mime-0.3.16/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/mio-0.7.14/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/mio-0.7.14/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/miow-0.3.7/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/miow-0.3.7/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/ntapi-0.3.7/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/ntapi-0.3.7/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/num_cpus-1.13.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/num_cpus-1.13.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/once_cell-1.13.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/once_cell-1.13.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/parking_lot-0.11.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/parking_lot-0.11.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/parking_lot_core-0.8.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/parking_lot_core-0.8.5/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/percent-encoding-2.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/percent-encoding-2.1.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/pin-project-1.0.11/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/pin-project-1.0.11/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/pin-project-internal-1.0.11/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/pin-project-internal-1.0.11/BUILD.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/pin-project-lite-0.2.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/pin-project-lite-0.2.9/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/pin-utils-0.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/pin-utils-0.1.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/proc-macro2-1.0.40/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/proc-macro2-1.0.40/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/quote-1.0.20/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/quote-1.0.20/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/redox_syscall-0.2.13/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/redox_syscall-0.2.13/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/ryu-1.0.10/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/ryu-1.0.10/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/scopeguard-1.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/scopeguard-1.1.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/serde-1.0.138/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/serde-1.0.138/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/serde_json-1.0.82/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/serde_json-1.0.82/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/serde_urlencoded-0.7.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/serde_urlencoded-0.7.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/sharded-slab-0.1.4/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/sharded-slab-0.1.4/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/signal-hook-registry-1.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/signal-hook-registry-1.4.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/slab-0.4.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/slab-0.4.6/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/smallvec-1.9.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/smallvec-1.9.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/socket2-0.4.4/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/socket2-0.4.4/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/syn-1.0.98/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/syn-1.0.98/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/sync_wrapper-0.1.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/sync_wrapper-0.1.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/thread_local-1.1.4/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/thread_local-1.1.4/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tokio-1.16.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tokio-1.16.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tokio-macros-1.8.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tokio-macros-1.8.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tokio-util-0.7.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tokio-util-0.7.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tower-0.4.13/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tower-0.4.13/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tower-http-0.2.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tower-http-0.2.5/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tower-layer-0.3.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tower-layer-0.3.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tower-service-0.3.2/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tower-service-0.3.2/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tracing-0.1.35/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tracing-0.1.35/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tracing-attributes-0.1.22/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tracing-attributes-0.1.22/BUILD.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tracing-core-0.1.28/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tracing-core-0.1.28/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tracing-log-0.1.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tracing-log-0.1.3/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/tracing-subscriber-0.3.14/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/tracing-subscriber-0.3.14/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/try-lock-0.2.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/try-lock-0.2.3/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/unicode-ident-1.0.1/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/unicode-ident-1.0.1/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/valuable-0.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/valuable-0.1.0/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/want-0.3.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/want-0.3.0/BUILD.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-0.3.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-0.3.9/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.async-stream-0.3.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.async-stream-0.3.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.async-stream-impl-0.3.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.async-stream-impl-0.3.3.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.autocfg-1.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.autocfg-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.bitflags-1.3.2.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.bitflags-1.3.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.bytes-1.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.bytes-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.cfg-if-1.0.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.fastrand-1.7.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.fastrand-1.7.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.futures-core-0.3.21.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.futures-core-0.3.21.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.hermit-abi-0.1.19.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.hermit-abi-0.1.19.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.instant-0.1.12.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.instant-0.1.12.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.libc-0.2.126.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.libc-0.2.126.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.lock_api-0.4.7.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.lock_api-0.4.7.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.log-0.4.17.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.log-0.4.17.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.memchr-2.5.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.memchr-2.5.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.mio-0.8.4.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.mio-0.8.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.num_cpus-1.13.1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.num_cpus-1.13.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.once_cell-1.13.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.once_cell-1.13.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot-0.12.1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot-0.12.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.3.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.pin-project-lite-0.2.9.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.pin-project-lite-0.2.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.40.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.40.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.quote-1.0.20.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.quote-1.0.20.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.redox_syscall-0.2.13.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.redox_syscall-0.2.13.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.remove_dir_all-0.5.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.remove_dir_all-0.5.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.scopeguard-1.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.scopeguard-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.signal-hook-registry-1.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.signal-hook-registry-1.4.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.smallvec-1.9.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.smallvec-1.9.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.socket2-0.4.4.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.socket2-0.4.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.syn-1.0.98.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.syn-1.0.98.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tempfile-3.3.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tempfile-3.3.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tokio-1.19.2.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tokio-1.19.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tokio-macros-1.8.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tokio-macros-1.8.0.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tokio-stream-0.1.9.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tokio-stream-0.1.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tokio-test-0.4.2.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.tokio-test-0.4.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.unicode-ident-1.0.1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.unicode-ident-1.0.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.winapi-0.3.9.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows-sys-0.36.1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows-sys-0.36.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.36.1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.36.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.36.1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.36.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.36.1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.36.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.36.1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.36.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.36.1.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.36.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.ansi_term-0.12.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.ansi_term-0.12.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.async-trait-0.1.56.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.async-trait-0.1.56.bazel
@@ -40,7 +40,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.autocfg-1.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.autocfg-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.axum-0.4.8.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.axum-0.4.8.bazel
@@ -36,10 +36,18 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob([
-        "**",
-        "**/*.md",
-    ]) + select_with_or({
+    compile_data = glob(
+        include = [
+            "**",
+            "**/*.md",
+        ],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.axum-core-0.1.2.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.axum-core-0.1.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.bitflags-1.3.2.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.bitflags-1.3.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.bytes-1.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.bytes-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.cfg-if-1.0.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.cfg-if-1.0.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.fnv-1.0.7.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.fnv-1.0.7.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.form_urlencoded-1.0.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.form_urlencoded-1.0.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-channel-0.3.21.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-channel-0.3.21.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-core-0.3.21.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-core-0.3.21.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-sink-0.3.21.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-sink-0.3.21.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-task-0.3.21.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-task-0.3.21.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-util-0.3.21.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.futures-util-0.3.21.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.h2-0.3.13.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.h2-0.3.13.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.hashbrown-0.12.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.hashbrown-0.12.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.hermit-abi-0.1.19.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.hermit-abi-0.1.19.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.http-0.2.8.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.http-0.2.8.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.http-body-0.4.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.http-body-0.4.5.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.http-range-header-0.3.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.http-range-header-0.3.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httparse-1.7.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httparse-1.7.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httpdate-1.0.2.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httpdate-1.0.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.hyper-0.14.19.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.hyper-0.14.19.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.indexmap-1.9.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.indexmap-1.9.1.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.instant-0.1.12.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.instant-0.1.12.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.itoa-1.0.2.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.itoa-1.0.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lazy_static-1.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lazy_static-1.4.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.libc-0.2.126.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.libc-0.2.126.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.7.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.7.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.log-0.4.17.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.log-0.4.17.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.matches-0.1.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.matches-0.1.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.matchit-0.4.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.matchit-0.4.6.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.memchr-2.5.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.memchr-2.5.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.mime-0.3.16.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.mime-0.3.16.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.mio-0.7.14.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.mio-0.7.14.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.miow-0.3.7.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.miow-0.3.7.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.ntapi-0.3.7.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.ntapi-0.3.7.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.num_cpus-1.13.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.num_cpus-1.13.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.once_cell-1.13.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.once_cell-1.13.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot-0.11.2.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot-0.11.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.8.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.8.5.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.percent-encoding-2.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.percent-encoding-2.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.pin-project-1.0.11.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.pin-project-1.0.11.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.pin-project-internal-1.0.11.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.pin-project-internal-1.0.11.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.pin-project-lite-0.2.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.pin-project-lite-0.2.9.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.pin-utils-0.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.pin-utils-0.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.40.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.40.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.quote-1.0.20.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.quote-1.0.20.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.redox_syscall-0.2.13.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.redox_syscall-0.2.13.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.ryu-1.0.10.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.ryu-1.0.10.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.scopeguard-1.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.scopeguard-1.1.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde-1.0.138.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde-1.0.138.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.82.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.82.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_urlencoded-0.7.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_urlencoded-0.7.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.sharded-slab-0.1.4.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.sharded-slab-0.1.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.signal-hook-registry-1.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.signal-hook-registry-1.4.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.slab-0.4.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.slab-0.4.6.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.smallvec-1.9.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.smallvec-1.9.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.socket2-0.4.4.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.socket2-0.4.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.syn-1.0.98.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.syn-1.0.98.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.sync_wrapper-0.1.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.sync_wrapper-0.1.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.thread_local-1.1.4.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.thread_local-1.1.4.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tokio-1.16.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tokio-1.16.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tokio-macros-1.8.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tokio-macros-1.8.0.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tokio-util-0.7.2.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tokio-util-0.7.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tower-0.4.13.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tower-0.4.13.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tower-http-0.2.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tower-http-0.2.5.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tower-layer-0.3.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tower-layer-0.3.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tower-service-0.3.2.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tower-service-0.3.2.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-0.1.35.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-0.1.35.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-attributes-0.1.22.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-attributes-0.1.22.bazel
@@ -36,7 +36,15 @@ rust_proc_macro(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-core-0.1.28.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-core-0.1.28.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-log-0.1.3.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-log-0.1.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-subscriber-0.3.14.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.tracing-subscriber-0.3.14.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.try-lock-0.2.3.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.try-lock-0.2.3.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.unicode-ident-1.0.1.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.unicode-ident-1.0.1.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.want-0.3.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.want-0.3.0.bazel
@@ -36,7 +36,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -40,7 +40,15 @@ rust_library(
         "//conditions:default": {
         },
     }),
-    compile_data = glob(["**"]) + select_with_or({
+    compile_data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ) + select_with_or({
         "//conditions:default": [
         ],
     }),


### PR DESCRIPTION
This should avoid situations where changes to the BUILD files that would not impact a built library force targets to be rebuilt.