### PR TITLE
Upgrade stardoc

### DIFF
--- a/docs/WORKSPACE.bazel
+++ b/docs/WORKSPACE.bazel
@@ -37,10 +37,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_stardoc",
-    sha256 = "c9794dcc8026a30ff67cf7cf91ebe245ca294b20b071845d12c192afe243ad72",
+    sha256 = "aa814dae0ac400bbab2e8881f9915c6f47c49664bf087c409a15f90438d2c23e",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
-        "https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
     ],
 )
 

--- a/docs/cargo.md
+++ b/docs/cargo.md
@@ -5,7 +5,7 @@
 * [cargo_build_script](#cargo_build_script)
 * [cargo_env](#cargo_env)
 
-<a id="#cargo_bootstrap_repository"></a>
+<a id="cargo_bootstrap_repository"></a>
 
 ## cargo_bootstrap_repository
 
@@ -40,7 +40,7 @@ A rule for bootstrapping a Rust binary using [Cargo](https://doc.rust-lang.org/c
 | <a id="cargo_bootstrap_repository-version"></a>version |  The version of cargo the resolver should use   | String | optional | "1.62.0" |
 
 
-<a id="#cargo_build_script"></a>
+<a id="cargo_build_script"></a>
 
 ## cargo_build_script
 
@@ -127,7 +127,7 @@ The `hello_lib` target will be build with the flags and the environment variable
 | <a id="cargo_build_script-kwargs"></a>kwargs |  Forwards to the underlying <code>rust_binary</code> rule.   |  none |
 
 
-<a id="#cargo_env"></a>
+<a id="cargo_env"></a>
 
 ## cargo_env
 

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -178,7 +178,7 @@ convenient accessors to larger sections of the dependency graph.
 [ra]: https://rust-analyzer.github.io/
 
 
-<a id="#crates_repository"></a>
+<a id="crates_repository"></a>
 
 ## crates_repository
 
@@ -299,7 +299,7 @@ that is called behind the scenes to update dependencies.
 | <a id="crates_repository-supported_platform_triples"></a>supported_platform_triples |  A set of all platform triples to consider when generating dependencies.   | List of strings | optional | ["i686-apple-darwin", "i686-pc-windows-msvc", "i686-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "aarch64-apple-ios", "aarch64-apple-ios-sim", "aarch64-linux-android", "aarch64-unknown-linux-gnu", "arm-unknown-linux-gnueabi", "armv7-unknown-linux-gnueabi", "armv7-linux-androideabi", "i686-linux-android", "i686-unknown-freebsd", "powerpc-unknown-linux-gnu", "s390x-unknown-linux-gnu", "wasm32-unknown-unknown", "wasm32-wasi", "x86_64-apple-ios", "x86_64-linux-android", "x86_64-unknown-freebsd", "riscv32imc-unknown-none-elf"] |
 
 
-<a id="#crates_vendor"></a>
+<a id="crates_vendor"></a>
 
 ## crates_vendor
 
@@ -402,7 +402,7 @@ call against the generated workspace. The following table describes how to contr
 | <a id="crates_vendor-vendor_path"></a>vendor_path |  The path to a directory to write files into. Absolute paths will be treated as relative to the workspace root   | String | optional | "crates" |
 
 
-<a id="#aliases"></a>
+<a id="aliases"></a>
 
 ## aliases
 
@@ -434,7 +434,7 @@ Setting any one flag will otherwise determine the contents of the returned dict.
 dict: The aliases of all associated packages
 
 
-<a id="#all_crate_deps"></a>
+<a id="all_crate_deps"></a>
 
 ## all_crate_deps
 
@@ -467,7 +467,7 @@ otherwise impact the contents of the returned list.
 list: A list of labels to generated rust targets (str)
 
 
-<a id="#crate.spec"></a>
+<a id="crate.spec"></a>
 
 ## crate.spec
 
@@ -499,7 +499,7 @@ See [specifying dependencies][sd] in the Cargo book for more details.
 string: A json encoded string of all inputs
 
 
-<a id="#crate.annotation"></a>
+<a id="crate.annotation"></a>
 
 ## crate.annotation
 
@@ -551,7 +551,7 @@ A collection of extra attributes and settings for a particular crate
 string: A json encoded string containing the specified version and separately all other inputs.
 
 
-<a id="#crate.workspace_member"></a>
+<a id="crate.workspace_member"></a>
 
 ## crate.workspace_member
 
@@ -574,7 +574,7 @@ Define information for extra workspace members
 string: A json encoded string of all inputs
 
 
-<a id="#crate_deps"></a>
+<a id="crate_deps"></a>
 
 ## crate_deps
 
@@ -597,7 +597,7 @@ Finds the fully qualified label of the requested crates for the package where th
 list: A list of labels to generated rust targets (str)
 
 
-<a id="#crate_repositories"></a>
+<a id="crate_repositories"></a>
 
 ## crate_repositories
 
@@ -609,7 +609,7 @@ A macro for defining repositories for all generated crates
 
 
 
-<a id="#crate_universe_dependencies"></a>
+<a id="crate_universe_dependencies"></a>
 
 ## crate_universe_dependencies
 
@@ -628,7 +628,7 @@ Define dependencies of the `cargo-bazel` Rust target
 | <a id="crate_universe_dependencies-bootstrap"></a>bootstrap |  If true, a <code>cargo_bootstrap_repository</code> target will be generated.   |  <code>False</code> |
 
 
-<a id="#render_config"></a>
+<a id="render_config"></a>
 
 ## render_config
 
@@ -670,7 +670,7 @@ can be found below where the supported keys for each template can be found in th
 string: A json encoded struct to match the Rust `config::RenderConfig` struct
 
 
-<a id="#splicing_config"></a>
+<a id="splicing_config"></a>
 
 ## splicing_config
 

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -12,7 +12,7 @@
 * [extra_rustc_flags](#extra_rustc_flags)
 * [capture_clippy_output](#capture_clippy_output)
 
-<a id="#capture_clippy_output"></a>
+<a id="capture_clippy_output"></a>
 
 ## capture_clippy_output
 
@@ -30,7 +30,7 @@ Control whether to print clippy output or store it to a file, using the configur
 | <a id="capture_clippy_output-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#error_format"></a>
+<a id="error_format"></a>
 
 ## error_format
 
@@ -48,7 +48,7 @@ Change the [--error-format](https://doc.rust-lang.org/rustc/command-line-argumen
 | <a id="error_format-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#extra_rustc_flags"></a>
+<a id="extra_rustc_flags"></a>
 
 ## extra_rustc_flags
 
@@ -66,7 +66,7 @@ Add additional rustc_flags from the command line with `--@rules_rust//:extra_rus
 | <a id="extra_rustc_flags-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#rust_binary"></a>
+<a id="rust_binary"></a>
 
 ## rust_binary
 
@@ -189,7 +189,7 @@ is available under the key `dsym_folder` in `OutputGroupInfo`.
 | <a id="rust_binary-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_library"></a>
+<a id="rust_library"></a>
 
 ## rust_library
 
@@ -285,7 +285,7 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_proc_macro"></a>
+<a id="rust_proc_macro"></a>
 
 ## rust_proc_macro
 
@@ -321,7 +321,7 @@ Builds a Rust proc-macro crate.
 | <a id="rust_proc_macro-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_shared_library"></a>
+<a id="rust_shared_library"></a>
 
 ## rust_shared_library
 
@@ -365,7 +365,7 @@ When building the whole binary in Bazel, use `rust_library` instead.
 | <a id="rust_shared_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_static_library"></a>
+<a id="rust_static_library"></a>
 
 ## rust_static_library
 
@@ -409,7 +409,7 @@ When building the whole binary in Bazel, use `rust_library` instead.
 | <a id="rust_static_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_test"></a>
+<a id="rust_test"></a>
 
 ## rust_test
 
@@ -563,7 +563,7 @@ Run the test with `bazel test //hello_lib:greeting_test`.
 | <a id="rust_test-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_test_suite"></a>
+<a id="rust_test_suite"></a>
 
 ## rust_test_suite
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -49,7 +49,7 @@
 * [rustfmt_test](#rustfmt_test)
 
 
-<a id="#capture_clippy_output"></a>
+<a id="capture_clippy_output"></a>
 
 ## capture_clippy_output
 
@@ -67,7 +67,7 @@ Control whether to print clippy output or store it to a file, using the configur
 | <a id="capture_clippy_output-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#cargo_bootstrap_repository"></a>
+<a id="cargo_bootstrap_repository"></a>
 
 ## cargo_bootstrap_repository
 
@@ -102,7 +102,7 @@ A rule for bootstrapping a Rust binary using [Cargo](https://doc.rust-lang.org/c
 | <a id="cargo_bootstrap_repository-version"></a>version |  The version of cargo the resolver should use   | String | optional | "1.62.0" |
 
 
-<a id="#error_format"></a>
+<a id="error_format"></a>
 
 ## error_format
 
@@ -120,7 +120,7 @@ Change the [--error-format](https://doc.rust-lang.org/rustc/command-line-argumen
 | <a id="error_format-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#extra_rustc_flags"></a>
+<a id="extra_rustc_flags"></a>
 
 ## extra_rustc_flags
 
@@ -138,7 +138,7 @@ Add additional rustc_flags from the command line with `--@rules_rust//:extra_rus
 | <a id="extra_rustc_flags-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#incompatible_flag"></a>
+<a id="incompatible_flag"></a>
 
 ## incompatible_flag
 
@@ -157,7 +157,7 @@ A rule defining an incompatible flag.
 | <a id="incompatible_flag-issue"></a>issue |  The link to the github issue associated with this flag   | String | required |  |
 
 
-<a id="#rust_binary"></a>
+<a id="rust_binary"></a>
 
 ## rust_binary
 
@@ -280,7 +280,7 @@ is available under the key `dsym_folder` in `OutputGroupInfo`.
 | <a id="rust_binary-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_bindgen"></a>
+<a id="rust_bindgen"></a>
 
 ## rust_bindgen
 
@@ -303,7 +303,7 @@ Generates a rust source file from a cc_library and a header.
 | <a id="rust_bindgen-rustfmt"></a>rustfmt |  Enable or disable running rustfmt on the generated file.   | Boolean | optional | True |
 
 
-<a id="#rust_bindgen_toolchain"></a>
+<a id="rust_bindgen_toolchain"></a>
 
 ## rust_bindgen_toolchain
 
@@ -352,7 +352,7 @@ For additional information, see the [Bazel toolchains documentation](https://doc
 | <a id="rust_bindgen_toolchain-rustfmt"></a>rustfmt |  The label of a <code>rustfmt</code> executable. If this is not provided, falls back to the rust_toolchain rustfmt.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
-<a id="#rust_clippy"></a>
+<a id="rust_clippy"></a>
 
 ## rust_clippy
 
@@ -406,7 +406,7 @@ rust_clippy(
 | <a id="rust_clippy-deps"></a>deps |  Rust targets to run clippy on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rust_doc"></a>
+<a id="rust_doc"></a>
 
 ## rust_doc
 
@@ -464,7 +464,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | <a id="rust_doc-markdown_css"></a>markdown_css |  CSS files to include via <code>&lt;link&gt;</code> in a rendered Markdown file.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rust_doc_test"></a>
+<a id="rust_doc_test"></a>
 
 ## rust_doc_test
 
@@ -520,7 +520,7 @@ Running `bazel test //hello_lib:hello_lib_doc_test` will run all documentation t
 | <a id="rust_doc_test-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other <code>rust_library</code> targets or <code>cc_library</code> targets if linking a native library.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rust_grpc_library"></a>
+<a id="rust_grpc_library"></a>
 
 ## rust_grpc_library
 
@@ -563,7 +563,7 @@ rust_binary(
 | <a id="rust_grpc_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rust_library"></a>
+<a id="rust_library"></a>
 
 ## rust_library
 
@@ -659,7 +659,7 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_proc_macro"></a>
+<a id="rust_proc_macro"></a>
 
 ## rust_proc_macro
 
@@ -695,7 +695,7 @@ Builds a Rust proc-macro crate.
 | <a id="rust_proc_macro-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_proto_library"></a>
+<a id="rust_proto_library"></a>
 
 ## rust_proto_library
 
@@ -738,7 +738,7 @@ rust_binary(
 | <a id="rust_proto_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rust_proto_toolchain"></a>
+<a id="rust_proto_toolchain"></a>
 
 ## rust_proto_toolchain
 
@@ -795,7 +795,7 @@ See @rules_rust//proto:BUILD for examples of defining the toolchain.
 | <a id="rust_proto_toolchain-protoc"></a>protoc |  The location of the <code>protoc</code> binary. It should be an executable target.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @com_google_protobuf//:protoc |
 
 
-<a id="#rust_shared_library"></a>
+<a id="rust_shared_library"></a>
 
 ## rust_shared_library
 
@@ -839,7 +839,7 @@ When building the whole binary in Bazel, use `rust_library` instead.
 | <a id="rust_shared_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_static_library"></a>
+<a id="rust_static_library"></a>
 
 ## rust_static_library
 
@@ -883,7 +883,7 @@ When building the whole binary in Bazel, use `rust_library` instead.
 | <a id="rust_static_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_stdlib_filegroup"></a>
+<a id="rust_stdlib_filegroup"></a>
 
 ## rust_stdlib_filegroup
 
@@ -902,7 +902,7 @@ A dedicated filegroup-like rule for Rust stdlib artifacts.
 | <a id="rust_stdlib_filegroup-srcs"></a>srcs |  The list of targets/files that are components of the rust-stdlib file group   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 
-<a id="#rust_test"></a>
+<a id="rust_test"></a>
 
 ## rust_test
 
@@ -1056,7 +1056,7 @@ Run the test with `bazel test //hello_lib:greeting_test`.
 | <a id="rust_test-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
 
 
-<a id="#rust_toolchain"></a>
+<a id="rust_toolchain"></a>
 
 ## rust_toolchain
 
@@ -1141,7 +1141,7 @@ See @rules_rust//rust:repositories.bzl for examples of defining the @rust_cpuX r
 | <a id="rust_toolchain-target_triple"></a>target_triple |  The platform triple for the toolchains target environment. For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations   | String | optional | "" |
 
 
-<a id="#rust_toolchain_repository"></a>
+<a id="rust_toolchain_repository"></a>
 
 ## rust_toolchain_repository
 
@@ -1176,7 +1176,7 @@ A given instance of this rule should be accompanied by a rust_toolchain_reposito
 | <a id="rust_toolchain_repository-version"></a>version |  The version of the tool among "nightly", "beta", or an exact version.   | String | required |  |
 
 
-<a id="#rust_toolchain_repository_proxy"></a>
+<a id="rust_toolchain_repository_proxy"></a>
 
 ## rust_toolchain_repository_proxy
 
@@ -1200,7 +1200,7 @@ Generates a toolchain-bearing repository that declares the toolchains from some 
 | <a id="rust_toolchain_repository_proxy-toolchain_name_prefix"></a>toolchain_name_prefix |  The per-target prefix expected for the rust_toolchain declarations in the parent workspace.   | String | optional | "" |
 
 
-<a id="#rust_wasm_bindgen"></a>
+<a id="rust_wasm_bindgen"></a>
 
 ## rust_wasm_bindgen
 
@@ -1237,7 +1237,7 @@ An example of this rule in use can be seen at [@rules_rust//examples/wasm](../ex
 | <a id="rust_wasm_bindgen-wasm_file"></a>wasm_file |  The <code>.wasm</code> file or crate to generate bindings for.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
-<a id="#rust_wasm_bindgen_toolchain"></a>
+<a id="rust_wasm_bindgen_toolchain"></a>
 
 ## rust_wasm_bindgen_toolchain
 
@@ -1285,7 +1285,7 @@ For additional information, see the [Bazel toolchains documentation][toolchains]
 | <a id="rust_wasm_bindgen_toolchain-bindgen"></a>bindgen |  The label of a <code>wasm-bindgen-cli</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
-<a id="#rustfmt_test"></a>
+<a id="rustfmt_test"></a>
 
 ## rustfmt_test
 
@@ -1304,7 +1304,7 @@ A test rule for performing `rustfmt --check` on a set of targets
 | <a id="rustfmt_test-targets"></a>targets |  Rust targets to run <code>rustfmt --check</code> on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#CrateInfo"></a>
+<a id="CrateInfo"></a>
 
 ## CrateInfo
 
@@ -1336,7 +1336,7 @@ A provider containing general Crate information.
 | <a id="CrateInfo-wrapped_crate_type"></a>wrapped_crate_type |  str, optional: The original crate type for targets generated using a previously defined crate (typically tests using the <code>rust_test::crate</code> attribute)    |
 
 
-<a id="#DepInfo"></a>
+<a id="DepInfo"></a>
 
 ## DepInfo
 
@@ -1361,7 +1361,7 @@ A provider containing information about a Crate's dependencies.
 | <a id="DepInfo-transitive_noncrates"></a>transitive_noncrates |  depset[LinkerInput]: All transitive dependencies that aren't crates.    |
 
 
-<a id="#StdLibInfo"></a>
+<a id="StdLibInfo"></a>
 
 ## StdLibInfo
 
@@ -1389,7 +1389,7 @@ A collection of files either found within the `rust-stdlib` artifact or generate
 | <a id="StdLibInfo-std_rlibs"></a>std_rlibs |  List[File]: All <code>.rlib</code> files    |
 
 
-<a id="#cargo_build_script"></a>
+<a id="cargo_build_script"></a>
 
 ## cargo_build_script
 
@@ -1476,7 +1476,7 @@ The `hello_lib` target will be build with the flags and the environment variable
 | <a id="cargo_build_script-kwargs"></a>kwargs |  Forwards to the underlying <code>rust_binary</code> rule.   |  none |
 
 
-<a id="#cargo_env"></a>
+<a id="cargo_env"></a>
 
 ## cargo_env
 
@@ -1523,7 +1523,7 @@ cargo_bootstrap_repository(
 str: A json encoded string of the environment variables
 
 
-<a id="#rules_rust_dependencies"></a>
+<a id="rules_rust_dependencies"></a>
 
 ## rules_rust_dependencies
 
@@ -1535,7 +1535,7 @@ Dependencies used in the implementation of `rules_rust`.
 
 
 
-<a id="#rust_bindgen_dependencies"></a>
+<a id="rust_bindgen_dependencies"></a>
 
 ## rust_bindgen_dependencies
 
@@ -1547,7 +1547,7 @@ Declare dependencies needed for bindgen.
 
 
 
-<a id="#rust_bindgen_library"></a>
+<a id="rust_bindgen_library"></a>
 
 ## rust_bindgen_library
 
@@ -1574,7 +1574,7 @@ Arguments are the same as `rust_bindgen`, and `kwargs` are passed directly to ru
 | <a id="rust_bindgen_library-kwargs"></a>kwargs |  Arguments to forward to the underlying <code>rust_library</code> rule.   |  none |
 
 
-<a id="#rust_bindgen_register_toolchains"></a>
+<a id="rust_bindgen_register_toolchains"></a>
 
 ## rust_bindgen_register_toolchains
 
@@ -1595,7 +1595,7 @@ Registers the default toolchains for the `rules_rust` [bindgen][bg] rules.
 | <a id="rust_bindgen_register_toolchains-register_toolchains"></a>register_toolchains |  Whether or not to register toolchains.   |  <code>True</code> |
 
 
-<a id="#rust_proto_repositories"></a>
+<a id="rust_proto_repositories"></a>
 
 ## rust_proto_repositories
 
@@ -1613,7 +1613,7 @@ Declare dependencies needed for proto compilation.
 | <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain) (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
 
 
-<a id="#rust_proto_transitive_repositories"></a>
+<a id="rust_proto_transitive_repositories"></a>
 
 ## rust_proto_transitive_repositories
 
@@ -1627,7 +1627,7 @@ This macro should be called immediately after the `rust_proto_repositories` macr
 
 
 
-<a id="#rust_register_toolchains"></a>
+<a id="rust_register_toolchains"></a>
 
 ## rust_register_toolchains
 
@@ -1670,7 +1670,7 @@ See `load_arbitrary_tool` in `@rules_rust//rust:repositories.bzl` for more detai
 | <a id="rust_register_toolchains-version"></a>version |  The version of Rust. Either "nightly", "beta", or an exact version. Defaults to a modern version.   |  <code>"1.62.0"</code> |
 
 
-<a id="#rust_repositories"></a>
+<a id="rust_repositories"></a>
 
 ## rust_repositories
 
@@ -1688,7 +1688,7 @@ rust_repositories(<a href="#rust_repositories-kwargs">kwargs</a>)
 | <a id="rust_repositories-kwargs"></a>kwargs |  Keyword arguments for the <code>rust_register_toolchains</code> macro.   |  none |
 
 
-<a id="#rust_repository_set"></a>
+<a id="rust_repository_set"></a>
 
 ## rust_repository_set
 
@@ -1722,7 +1722,7 @@ N.B. A "proxy repository" is needed to allow for registering the toolchain (with
 | <a id="rust_repository_set-register_toolchain"></a>register_toolchain |  If True, the generated <code>rust_toolchain</code> target will become a registered toolchain.   |  <code>True</code> |
 
 
-<a id="#rust_test_suite"></a>
+<a id="rust_test_suite"></a>
 
 ## rust_test_suite
 
@@ -1786,7 +1786,7 @@ rust_test_suite(
 | <a id="rust_test_suite-kwargs"></a>kwargs |  Additional keyword arguments for the underyling [rust_test](#rust_test) targets. The <code>tags</code> argument is also passed to the generated <code>test_suite</code> target.   |  none |
 
 
-<a id="#rust_wasm_bindgen_dependencies"></a>
+<a id="rust_wasm_bindgen_dependencies"></a>
 
 ## rust_wasm_bindgen_dependencies
 
@@ -1800,7 +1800,7 @@ Declare dependencies needed for the `rules_rust` [wasm-bindgen][wb] rules.
 
 
 
-<a id="#rust_wasm_bindgen_register_toolchains"></a>
+<a id="rust_wasm_bindgen_register_toolchains"></a>
 
 ## rust_wasm_bindgen_register_toolchains
 
@@ -1821,7 +1821,7 @@ Registers the default toolchains for the `rules_rust` [wasm-bindgen][wb] rules.
 | <a id="rust_wasm_bindgen_register_toolchains-register_toolchains"></a>register_toolchains |  Whether or not to register toolchains.   |  <code>True</code> |
 
 
-<a id="#rust_analyzer_aspect"></a>
+<a id="rust_analyzer_aspect"></a>
 
 ## rust_analyzer_aspect
 
@@ -1850,7 +1850,7 @@ Annotates rust rules with RustAnalyzerInfo later used to build a rust-project.js
 | <a id="rust_analyzer_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
 
 
-<a id="#rust_clippy_aspect"></a>
+<a id="rust_clippy_aspect"></a>
 
 ## rust_clippy_aspect
 
@@ -1898,7 +1898,7 @@ $ bazel build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect           
 | <a id="rust_clippy_aspect-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |   |
 
 
-<a id="#rustfmt_aspect"></a>
+<a id="rustfmt_aspect"></a>
 
 ## rustfmt_aspect
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -5,7 +5,7 @@
 * [DepInfo](#DepInfo)
 * [StdLibInfo](#StdLibInfo)
 
-<a id="#CrateInfo"></a>
+<a id="CrateInfo"></a>
 
 ## CrateInfo
 
@@ -37,7 +37,7 @@ A provider containing general Crate information.
 | <a id="CrateInfo-wrapped_crate_type"></a>wrapped_crate_type |  str, optional: The original crate type for targets generated using a previously defined crate (typically tests using the <code>rust_test::crate</code> attribute)    |
 
 
-<a id="#DepInfo"></a>
+<a id="DepInfo"></a>
 
 ## DepInfo
 
@@ -62,7 +62,7 @@ A provider containing information about a Crate's dependencies.
 | <a id="DepInfo-transitive_noncrates"></a>transitive_noncrates |  depset[LinkerInput]: All transitive dependencies that aren't crates.    |
 
 
-<a id="#StdLibInfo"></a>
+<a id="StdLibInfo"></a>
 
 ## StdLibInfo
 

--- a/docs/rust_analyzer.md
+++ b/docs/rust_analyzer.md
@@ -70,7 +70,7 @@ to ensure a `rust-project.json` file is created and up to date when the editor i
 ```
 
 
-<a id="#rust_analyzer_aspect"></a>
+<a id="rust_analyzer_aspect"></a>
 
 ## rust_analyzer_aspect
 

--- a/docs/rust_bindgen.md
+++ b/docs/rust_bindgen.md
@@ -36,7 +36,7 @@ rust_bindgen_register_toolchains()
 
 
 
-<a id="#rust_bindgen"></a>
+<a id="rust_bindgen"></a>
 
 ## rust_bindgen
 
@@ -59,7 +59,7 @@ Generates a rust source file from a cc_library and a header.
 | <a id="rust_bindgen-rustfmt"></a>rustfmt |  Enable or disable running rustfmt on the generated file.   | Boolean | optional | True |
 
 
-<a id="#rust_bindgen_toolchain"></a>
+<a id="rust_bindgen_toolchain"></a>
 
 ## rust_bindgen_toolchain
 
@@ -108,7 +108,7 @@ For additional information, see the [Bazel toolchains documentation](https://doc
 | <a id="rust_bindgen_toolchain-rustfmt"></a>rustfmt |  The label of a <code>rustfmt</code> executable. If this is not provided, falls back to the rust_toolchain rustfmt.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
-<a id="#rust_bindgen_dependencies"></a>
+<a id="rust_bindgen_dependencies"></a>
 
 ## rust_bindgen_dependencies
 
@@ -120,7 +120,7 @@ Declare dependencies needed for bindgen.
 
 
 
-<a id="#rust_bindgen_library"></a>
+<a id="rust_bindgen_library"></a>
 
 ## rust_bindgen_library
 
@@ -147,7 +147,7 @@ Arguments are the same as `rust_bindgen`, and `kwargs` are passed directly to ru
 | <a id="rust_bindgen_library-kwargs"></a>kwargs |  Arguments to forward to the underlying <code>rust_library</code> rule.   |  none |
 
 
-<a id="#rust_bindgen_register_toolchains"></a>
+<a id="rust_bindgen_register_toolchains"></a>
 
 ## rust_bindgen_register_toolchains
 

--- a/docs/rust_clippy.md
+++ b/docs/rust_clippy.md
@@ -37,7 +37,7 @@ the upstream implementation of clippy, this file must be named either `.clippy.t
 build --@rules_rust//:clippy.toml=//:clippy.toml
 ```
 
-<a id="#rust_clippy"></a>
+<a id="rust_clippy"></a>
 
 ## rust_clippy
 
@@ -91,7 +91,7 @@ rust_clippy(
 | <a id="rust_clippy-deps"></a>deps |  Rust targets to run clippy on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rust_clippy_aspect"></a>
+<a id="rust_clippy_aspect"></a>
 
 ## rust_clippy_aspect
 

--- a/docs/rust_doc.md
+++ b/docs/rust_doc.md
@@ -4,7 +4,7 @@
 * [rust_doc](#rust_doc)
 * [rust_doc_test](#rust_doc_test)
 
-<a id="#rust_doc"></a>
+<a id="rust_doc"></a>
 
 ## rust_doc
 
@@ -62,7 +62,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | <a id="rust_doc-markdown_css"></a>markdown_css |  CSS files to include via <code>&lt;link&gt;</code> in a rendered Markdown file.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rust_doc_test"></a>
+<a id="rust_doc_test"></a>
 
 ## rust_doc_test
 

--- a/docs/rust_fmt.md
+++ b/docs/rust_fmt.md
@@ -46,7 +46,7 @@ build --@rules_rust//:rustfmt.toml=//:rustfmt.toml
 [rfcp]: https://github.com/rust-lang-nursery/fmt-rfcs
 [rgp]: https://rust-lang.github.io/rustfmt/
 
-<a id="#rustfmt_test"></a>
+<a id="rustfmt_test"></a>
 
 ## rustfmt_test
 
@@ -65,7 +65,7 @@ A test rule for performing `rustfmt --check` on a set of targets
 | <a id="rustfmt_test-targets"></a>targets |  Rust targets to run <code>rustfmt --check</code> on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rustfmt_aspect"></a>
+<a id="rustfmt_aspect"></a>
 
 ## rustfmt_aspect
 

--- a/docs/rust_proto.md
+++ b/docs/rust_proto.md
@@ -117,7 +117,7 @@ all dependencies added via the toolchain ends-up being in the wrong
 configuration.
 
 
-<a id="#rust_grpc_library"></a>
+<a id="rust_grpc_library"></a>
 
 ## rust_grpc_library
 
@@ -160,7 +160,7 @@ rust_binary(
 | <a id="rust_grpc_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rust_proto_library"></a>
+<a id="rust_proto_library"></a>
 
 ## rust_proto_library
 
@@ -203,7 +203,7 @@ rust_binary(
 | <a id="rust_proto_library-rust_deps"></a>rust_deps |  The crates the generated library depends on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
-<a id="#rust_proto_toolchain"></a>
+<a id="rust_proto_toolchain"></a>
 
 ## rust_proto_toolchain
 
@@ -260,7 +260,7 @@ See @rules_rust//proto:BUILD for examples of defining the toolchain.
 | <a id="rust_proto_toolchain-protoc"></a>protoc |  The location of the <code>protoc</code> binary. It should be an executable target.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @com_google_protobuf//:protoc |
 
 
-<a id="#rust_proto_repositories"></a>
+<a id="rust_proto_repositories"></a>
 
 ## rust_proto_repositories
 
@@ -278,7 +278,7 @@ Declare dependencies needed for proto compilation.
 | <a id="rust_proto_repositories-register_default_toolchain"></a>register_default_toolchain |  If True, the default [rust_proto_toolchain](#rust_proto_toolchain) (<code>@rules_rust//proto:default-proto-toolchain</code>) is registered. This toolchain requires a set of dependencies that were generated using [cargo raze](https://github.com/google/cargo-raze). These will also be loaded.   |  <code>True</code> |
 
 
-<a id="#rust_proto_transitive_repositories"></a>
+<a id="rust_proto_transitive_repositories"></a>
 
 ## rust_proto_transitive_repositories
 

--- a/docs/rust_repositories.md
+++ b/docs/rust_repositories.md
@@ -10,7 +10,7 @@
 * [rust_toolchain_repository](#rust_toolchain_repository)
 * [rust_toolchain](#rust_toolchain)
 
-<a id="#rust_stdlib_filegroup"></a>
+<a id="rust_stdlib_filegroup"></a>
 
 ## rust_stdlib_filegroup
 
@@ -29,7 +29,7 @@ A dedicated filegroup-like rule for Rust stdlib artifacts.
 | <a id="rust_stdlib_filegroup-srcs"></a>srcs |  The list of targets/files that are components of the rust-stdlib file group   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 
-<a id="#rust_toolchain"></a>
+<a id="rust_toolchain"></a>
 
 ## rust_toolchain
 
@@ -114,7 +114,7 @@ See @rules_rust//rust:repositories.bzl for examples of defining the @rust_cpuX r
 | <a id="rust_toolchain-target_triple"></a>target_triple |  The platform triple for the toolchains target environment. For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations   | String | optional | "" |
 
 
-<a id="#rust_toolchain_repository"></a>
+<a id="rust_toolchain_repository"></a>
 
 ## rust_toolchain_repository
 
@@ -149,7 +149,7 @@ A given instance of this rule should be accompanied by a rust_toolchain_reposito
 | <a id="rust_toolchain_repository-version"></a>version |  The version of the tool among "nightly", "beta", or an exact version.   | String | required |  |
 
 
-<a id="#rust_toolchain_repository_proxy"></a>
+<a id="rust_toolchain_repository_proxy"></a>
 
 ## rust_toolchain_repository_proxy
 
@@ -173,7 +173,7 @@ Generates a toolchain-bearing repository that declares the toolchains from some 
 | <a id="rust_toolchain_repository_proxy-toolchain_name_prefix"></a>toolchain_name_prefix |  The per-target prefix expected for the rust_toolchain declarations in the parent workspace.   | String | optional | "" |
 
 
-<a id="#rules_rust_dependencies"></a>
+<a id="rules_rust_dependencies"></a>
 
 ## rules_rust_dependencies
 
@@ -185,7 +185,7 @@ Dependencies used in the implementation of `rules_rust`.
 
 
 
-<a id="#rust_register_toolchains"></a>
+<a id="rust_register_toolchains"></a>
 
 ## rust_register_toolchains
 
@@ -228,7 +228,7 @@ See `load_arbitrary_tool` in `@rules_rust//rust:repositories.bzl` for more detai
 | <a id="rust_register_toolchains-version"></a>version |  The version of Rust. Either "nightly", "beta", or an exact version. Defaults to a modern version.   |  <code>"1.62.0"</code> |
 
 
-<a id="#rust_repositories"></a>
+<a id="rust_repositories"></a>
 
 ## rust_repositories
 
@@ -246,7 +246,7 @@ rust_repositories(<a href="#rust_repositories-kwargs">kwargs</a>)
 | <a id="rust_repositories-kwargs"></a>kwargs |  Keyword arguments for the <code>rust_register_toolchains</code> macro.   |  none |
 
 
-<a id="#rust_repository_set"></a>
+<a id="rust_repository_set"></a>
 
 ## rust_repository_set
 

--- a/docs/rust_wasm_bindgen.md
+++ b/docs/rust_wasm_bindgen.md
@@ -25,7 +25,7 @@ bazel build @examples//hello_world_wasm --platforms=@rules_rust//rust/platform:w
 building WebAssembly code for the host target.
 
 
-<a id="#rust_wasm_bindgen"></a>
+<a id="rust_wasm_bindgen"></a>
 
 ## rust_wasm_bindgen
 
@@ -62,7 +62,7 @@ An example of this rule in use can be seen at [@rules_rust//examples/wasm](../ex
 | <a id="rust_wasm_bindgen-wasm_file"></a>wasm_file |  The <code>.wasm</code> file or crate to generate bindings for.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
-<a id="#rust_wasm_bindgen_toolchain"></a>
+<a id="rust_wasm_bindgen_toolchain"></a>
 
 ## rust_wasm_bindgen_toolchain
 
@@ -110,7 +110,7 @@ For additional information, see the [Bazel toolchains documentation][toolchains]
 | <a id="rust_wasm_bindgen_toolchain-bindgen"></a>bindgen |  The label of a <code>wasm-bindgen-cli</code> executable.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
-<a id="#rust_wasm_bindgen_dependencies"></a>
+<a id="rust_wasm_bindgen_dependencies"></a>
 
 ## rust_wasm_bindgen_dependencies
 
@@ -124,7 +124,7 @@ Declare dependencies needed for the `rules_rust` [wasm-bindgen][wb] rules.
 
 
 
-<a id="#rust_wasm_bindgen_register_toolchains"></a>
+<a id="rust_wasm_bindgen_register_toolchains"></a>
 
 ## rust_wasm_bindgen_register_toolchains
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -4,7 +4,7 @@
 * [incompatible_flag](#incompatible_flag)
 * [fail_when_enabled](#fail_when_enabled)
 
-<a id="#incompatible_flag"></a>
+<a id="incompatible_flag"></a>
 
 ## incompatible_flag
 


### PR DESCRIPTION
I am eagerly awaiting https://github.com/bazelbuild/stardoc/pull/124 so
the anchor links work.

Looks like that's the only change to the generated files.