### PR TITLE
Limit coverage to requested files

### DIFF
--- a/util/collect_coverage.sh
+++ b/util/collect_coverage.sh
@@ -19,6 +19,7 @@ readonly profdata_file=$COVERAGE_DIR/coverage.profdata
   -instr-profile "$profdata_file" \
   -ignore-filename-regex='.*external/.+' \
   -ignore-filename-regex='/tmp/.+' \
-  -path-equivalence="$ROOT",. \
+  -path-equivalence=.,"$ROOT" \
   "$RUNFILES_DIR/$TEST_WORKSPACE/$TEST_BINARY" \
+  @"$COVERAGE_MANIFEST" \
   | sed 's#/proc/self/cwd/##' > "$COVERAGE_OUTPUT_FILE"


### PR DESCRIPTION
Bazel provides COVERAGE_MANIFEST which is a file we can pass through to
llvm-cov to limit the files that we produce coverage for. Using this
revealed the path-equivalence was backwards because we're using the
coverage prefix map to disable absolute paths in code coverage info,
but llvm-cov operates on absolute paths, so we have to remap the `.` in
the coverage data to the full path so that llvm-cov understands the
relative paths (which it absolutizes internal) from the manifest file.
This feels a bit weird and ideally it could operate entirely on these
relative paths instead.

This has the side effect of excluding files that aren't part of bazel
sources, which fixes https://github.com/bazelbuild/rules_rust/issues/1466

This should also improve interaction with `--instrumentation_filter`.