### PR TITLE
Fix `rust_binary_without_process_wrapper` build with `--stamp` past https://github.com/bazelbuild/rules_rust/pull/1452

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1056,7 +1056,7 @@ rust_binary = rule(
 )
 
 def _common_attrs_for_binary_without_process_wrapper(attrs):
-    new_attr = dict(attrs.items())
+    new_attr = dict(attrs)
 
     # use a fake process wrapper
     new_attr["_process_wrapper"] = attr.label(
@@ -1084,7 +1084,7 @@ def _common_attrs_for_binary_without_process_wrapper(attrs):
 rust_binary_without_process_wrapper = rule(
     implementation = _rust_binary_impl,
     provides = _common_providers,
-    attrs = dict(_common_attrs_for_binary_without_process_wrapper(_common_attrs).items() + _rust_binary_attrs.items()),
+    attrs = _common_attrs_for_binary_without_process_wrapper(_common_attrs.items() + _rust_binary_attrs.items()),
     executable = True,
     fragments = ["cpp"],
     host_fragments = ["cpp"],

--- a/test/unit/stamp/stamp_test.bzl
+++ b/test/unit/stamp/stamp_test.bzl
@@ -277,13 +277,39 @@ def _stamp_attribute_tests():
             ])
     return tests
 
+def _process_wrapper_with_stamp_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    action = target.actions[0]
+    assert_action_mnemonic(env, action, "Rustc")
+
+    _assert_not_stamped(env, action)
+
+    return analysistest.end(env)
+
+process_wrapper_with_stamp_test = analysistest.make(
+    _process_wrapper_with_stamp_test_impl,
+    config_settings = {
+        "//command_line_option:stamp": True,
+    },
+)
+
+def _process_wrapper_tests():
+    process_wrapper_with_stamp_test(
+        name = "test_process_wrapper_with_stamp_test",
+        target_under_test = "//util/process_wrapper:process_wrapper",
+    )
+
+    return ["test_process_wrapper_with_stamp_test"]
+
 def stamp_test_suite(name):
     """Entry-point macro called from the BUILD file.
 
     Args:
         name (str): Name of the macro.
     """
-    tests = _build_flag_tests() + _stamp_attribute_tests()
+    tests = _build_flag_tests() + _stamp_attribute_tests() + _process_wrapper_tests()
 
     native.test_suite(
         name = name,


### PR DESCRIPTION
https://github.com/bazelbuild/rules_rust/pull/1452 set `rust_*.stamp=0` as a default for all rules except `rust_binary`, which has -1 as a default.

The `rust_binary_without_process_wrapper` rule is used to build the process wrapper itself. It needs to override the `stamp` attribute back to 0, as we do not support stamping without the process wrapper. https://github.com/bazelbuild/rules_rust/pull/1452 introduced a bug where the default value for this rule became `-1`, thus building `//util/process_wrapper` with `--stamp` is now broken.

This PR fixes the issue by routing all the attributes through the [_common_attrs_for_binary_without_process_wrapper](https://source.corp.google.com/piper///depot/google3/third_party/bazel_rules/rules_rust/rust/private/rust.bzl;rcl=461281665;l=1069?q=rust_binary_without_process_wrapper&ct=os&sq=package:piper%20file:%2F%2Fdepot%2Fgoogle3%20-file:google3%2Fexperimental) function, thus ensuring that the `stamp` attribute is once again set to 0.