### PR TITLE
Give useful error on missing workspace manifest

### DIFF
--- a/crate_universe/src/cli/splice.rs
+++ b/crate_universe/src/cli/splice.rs
@@ -70,7 +70,7 @@ pub fn splice(opt: SpliceOptions) -> Result<()> {
     let splicer = Splicer::new(splicing_dir, splicing_manifest)?;
 
     // Splice together the manifest
-    let manifest_path = splicer.splice_workspace()?;
+    let manifest_path = splicer.splice_workspace(&opt.cargo)?;
 
     // Generate a lockfile
     let cargo_lockfile = generate_lockfile(

--- a/crate_universe/src/cli/vendor.rs
+++ b/crate_universe/src/cli/vendor.rs
@@ -127,7 +127,7 @@ pub fn vendor(opt: VendorOptions) -> Result<()> {
 
     // Splice together the manifest
     let manifest_path = splicer
-        .splice_workspace()
+        .splice_workspace(&opt.cargo)
         .context("Failed to splice workspace")?;
 
     // Gather a cargo lockfile


### PR DESCRIPTION
Previously if the workspace root manifest was missing, a panic would be
triggered due to unwrapping a `None` option.

Now, we suggest the missing manifest if possible, or direct you to work
it out yourself if we can't.