### PR TITLE
Updated all toolchain_type definitions to be named `toolchain_type`.

### DIFF
--- a/bindgen/BUILD.bazel
+++ b/bindgen/BUILD.bazel
@@ -10,6 +10,7 @@ toolchain_type(
 alias(
     name = "bindgen_toolchain",
     actual = "toolchain_type",
+    deprecation = "instead use `@rules_rust//bindgen:toolchain_type`",
     tags = ["manual"],
 )
 

--- a/bindgen/BUILD.bazel
+++ b/bindgen/BUILD.bazel
@@ -3,7 +3,15 @@ load("//bindgen:bindgen.bzl", "rust_bindgen_toolchain")
 
 package(default_visibility = ["//visibility:public"])
 
-toolchain_type(name = "bindgen_toolchain")
+toolchain_type(
+    name = "toolchain_type",
+)
+
+alias(
+    name = "bindgen_toolchain",
+    actual = "toolchain_type",
+    tags = ["manual"],
+)
 
 bzl_library(
     name = "bzl_lib",
@@ -43,5 +51,5 @@ rust_bindgen_toolchain(
 toolchain(
     name = "default_bindgen_toolchain",
     toolchain = "default_bindgen_toolchain_impl",
-    toolchain_type = "//bindgen:bindgen_toolchain",
+    toolchain_type = "//bindgen:toolchain_type",
 )

--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -92,7 +92,7 @@ def _rust_bindgen_impl(ctx):
     if header not in cc_header_list:
         fail("Header {} is not in {}'s transitive headers.".format(ctx.attr.header, cc_lib), "header")
 
-    toolchain = ctx.toolchains[Label("//bindgen:bindgen_toolchain")]
+    toolchain = ctx.toolchains[Label("//bindgen:toolchain_type")]
     bindgen_bin = toolchain.bindgen
     rustfmt_bin = toolchain.rustfmt or rust_toolchain.rustfmt
     clang_bin = toolchain.clang
@@ -214,8 +214,8 @@ rust_bindgen = rule(
     outputs = {"out": "%{name}.rs"},
     fragments = ["cpp"],
     toolchains = [
-        str(Label("//bindgen:bindgen_toolchain")),
-        str(Label("//rust:toolchain")),
+        str(Label("//bindgen:toolchain_type")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
@@ -253,7 +253,7 @@ rust_bindgen_toolchain(
 toolchain(
     name = "bindgen_toolchain",
     toolchain = "bindgen_toolchain_impl",
-    toolchain_type = "@rules_rust//bindgen:bindgen_toolchain",
+    toolchain_type = "@rules_rust//bindgen:toolchain_type",
 )
 ```
 

--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -302,7 +302,7 @@ _build_script_run = rule(
     },
     fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -36,7 +36,7 @@ def _runfiles_path(path, is_windows):
     return "{}/{}".format(runtime_pwd_var, path)
 
 def _is_windows(ctx):
-    toolchain = ctx.toolchains[Label("@rules_rust//rust:toolchain")]
+    toolchain = ctx.toolchains[Label("@rules_rust//rust:toolchain_type")]
     return "windows" in toolchain.target_triple
 
 def _get_output_package(ctx):
@@ -175,7 +175,7 @@ def _write_config_file(ctx):
     return args, runfiles
 
 def _crates_vendor_impl(ctx):
-    toolchain = ctx.toolchains[Label("@rules_rust//rust:toolchain")]
+    toolchain = ctx.toolchains[Label("@rules_rust//rust:toolchain_type")]
     is_windows = _is_windows(ctx)
 
     environ = {
@@ -400,7 +400,7 @@ call against the generated workspace. The following table describes how to contr
         ),
     },
     executable = True,
-    toolchains = ["@rules_rust//rust:toolchain"],
+    toolchains = ["@rules_rust//rust:toolchain_type"],
 )
 
 def _crates_vendor_remote_repository_impl(repository_ctx):

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -371,7 +371,7 @@ rust_bindgen_toolchain(
 toolchain(
     name = "bindgen_toolchain",
     toolchain = "bindgen_toolchain_impl",
-    toolchain_type = "@rules_rust//bindgen:bindgen_toolchain",
+    toolchain_type = "@rules_rust//bindgen:toolchain_type",
 )
 ```
 
@@ -1301,7 +1301,7 @@ rust_bindgen_toolchain(
 toolchain(
     name = "wasm_bindgen_toolchain",
     toolchain = "wasm_bindgen_toolchain_impl",
-    toolchain_type = "@rules_rust//wasm_bindgen:wasm_bindgen_toolchain",
+    toolchain_type = "@rules_rust//wasm_bindgen:toolchain_type",
 )
 ```
 

--- a/docs/rust_bindgen.md
+++ b/docs/rust_bindgen.md
@@ -87,7 +87,7 @@ rust_bindgen_toolchain(
 toolchain(
     name = "bindgen_toolchain",
     toolchain = "bindgen_toolchain_impl",
-    toolchain_type = "@rules_rust//bindgen:bindgen_toolchain",
+    toolchain_type = "@rules_rust//bindgen:toolchain_type",
 )
 ```
 

--- a/docs/rust_proto.md
+++ b/docs/rust_proto.md
@@ -77,7 +77,7 @@ rust_proto_toolchain(
 toolchain(
     name = "proto-toolchain",
     toolchain = ":proto-toolchain-impl",
-    toolchain_type = "@rules_rust//proto:toolchain",
+    toolchain_type = "@rules_rust//proto:toolchain_type",
 )
 ```
 

--- a/docs/rust_proto.vm
+++ b/docs/rust_proto.vm
@@ -68,7 +68,7 @@ rust_proto_toolchain(
 toolchain(
     name = "proto-toolchain",
     toolchain = ":proto-toolchain-impl",
-    toolchain_type = "@rules_rust//proto:toolchain",
+    toolchain_type = "@rules_rust//proto:toolchain_type",
 )
 ```
 

--- a/docs/rust_wasm_bindgen.md
+++ b/docs/rust_wasm_bindgen.md
@@ -85,7 +85,7 @@ rust_bindgen_toolchain(
 toolchain(
     name = "wasm_bindgen_toolchain",
     toolchain = "wasm_bindgen_toolchain_impl",
-    toolchain_type = "@rules_rust//wasm_bindgen:wasm_bindgen_toolchain",
+    toolchain_type = "@rules_rust//wasm_bindgen:toolchain_type",
 )
 ```
 

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -36,6 +36,7 @@ toolchain_type(
 alias(
     name = "toolchain",
     actual = "toolchain_type",
+    deprecation = "instead use `@rules_rust//proto:toolchain_type`",
     tags = ["manual"],
 )
 

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -29,7 +29,15 @@ filegroup(
     visibility = ["//:__subpackages__"],
 )
 
-toolchain_type(name = "toolchain")
+toolchain_type(
+    name = "toolchain_type",
+)
+
+alias(
+    name = "toolchain",
+    actual = "toolchain_type",
+    tags = ["manual"],
+)
 
 rust_binary(
     name = "optional_output_wrapper",
@@ -41,7 +49,7 @@ rust_binary(
 toolchain(
     name = "default-proto-toolchain",
     toolchain = ":default-proto-toolchain-impl",
-    toolchain_type = "@rules_rust//proto:toolchain",
+    toolchain_type = "@rules_rust//proto:toolchain_type",
 )
 
 rust_proto_toolchain(

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -186,7 +186,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
     """
 
     # Create all the source in a specific folder
-    proto_toolchain = ctx.toolchains[Label("//proto:toolchain")]
+    proto_toolchain = ctx.toolchains[Label("//proto:toolchain_type")]
     output_dir = "%s.%s.rust" % (crate_name, "grpc" if is_grpc else "proto")
 
     # Generate the proto stubs
@@ -319,8 +319,8 @@ rust_proto_library = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//proto:toolchain")),
-        str(Label("//rust:toolchain")),
+        str(Label("//proto:toolchain_type")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     # TODO: Remove once (bazelbuild/bazel#11584) is closed and the rules use
@@ -397,8 +397,8 @@ rust_grpc_library = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//proto:toolchain")),
-        str(Label("//rust:toolchain")),
+        str(Label("//proto:toolchain_type")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     # TODO: Remove once (bazelbuild/bazel#11584) is closed and the rules use

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -16,6 +16,7 @@ toolchain_type(
 alias(
     name = "toolchain",
     actual = "toolchain_type",
+    deprecation = "instead use `@rules_rust//rust:toolchain_type`",
     tags = ["manual"],
 )
 

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -10,7 +10,13 @@ exports_files([
 ])
 
 toolchain_type(
+    name = "toolchain_type",
+)
+
+alias(
     name = "toolchain",
+    actual = "toolchain_type",
+    tags = ["manual"],
 )
 
 bzl_library(

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -226,7 +226,7 @@ rust_clippy_aspect = aspect(
     },
     provides = [ClippyInfo],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -759,7 +759,7 @@ rust_library = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
@@ -835,7 +835,7 @@ rust_static_library = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
@@ -858,7 +858,7 @@ rust_shared_library = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
@@ -910,7 +910,7 @@ rust_proc_macro = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
@@ -961,7 +961,7 @@ rust_binary = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
@@ -1089,7 +1089,7 @@ rust_binary_without_process_wrapper = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
@@ -1102,7 +1102,7 @@ rust_library_without_process_wrapper = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,
@@ -1118,7 +1118,7 @@ rust_test = rule(
     host_fragments = ["cpp"],
     test = True,
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -117,7 +117,7 @@ def find_proc_macro_dylib_path(toolchain, target):
 rust_analyzer_aspect = aspect(
     attr_aspects = ["deps", "proc_macro_deps", "crate", "actual"],
     implementation = _rust_analyzer_aspect_impl,
-    toolchains = [str(Label("//rust:toolchain"))],
+    toolchains = [str(Label("//rust:toolchain_type"))],
     incompatible_use_toolchain_transition = True,
     doc = "Annotates rust rules with RustAnalyzerInfo later used to build a rust-project.json",
 )
@@ -236,7 +236,7 @@ def _rust_analyzer_detect_sysroot_impl(ctx):
 rust_analyzer_detect_sysroot = rule(
     implementation = _rust_analyzer_detect_sysroot_impl,
     toolchains = [
-        "@rules_rust//rust:toolchain",
+        "@rules_rust//rust:toolchain_type",
         "@rules_rust//rust/rust_analyzer:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -321,7 +321,7 @@ rust_doc = rule(
         "rust_doc_zip": "%{name}.zip",
     },
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -206,7 +206,7 @@ rust_doc_test = rule(
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,

--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -138,7 +138,7 @@ generated source files are also ignored by this aspect.
     fragments = ["cpp"],
     host_fragments = ["cpp"],
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
     ],
 )
 

--- a/rust/private/toolchain_utils.bzl
+++ b/rust/private/toolchain_utils.bzl
@@ -1,7 +1,7 @@
 """A module defining toolchain utilities"""
 
 def _toolchain_files_impl(ctx):
-    toolchain = ctx.toolchains[str(Label("//rust:toolchain"))]
+    toolchain = ctx.toolchains[str(Label("//rust:toolchain_type"))]
 
     runfiles = None
     if ctx.attr.tool == "cargo":
@@ -73,13 +73,13 @@ toolchain_files = rule(
         ),
     },
     toolchains = [
-        str(Label("//rust:toolchain")),
+        str(Label("//rust:toolchain_type")),
     ],
     incompatible_use_toolchain_transition = True,
 )
 
 def _current_rust_toolchain_impl(ctx):
-    toolchain = ctx.toolchains[str(Label("@rules_rust//rust:toolchain"))]
+    toolchain = ctx.toolchains[str(Label("@rules_rust//rust:toolchain_type"))]
 
     return [
         toolchain,
@@ -98,7 +98,7 @@ current_rust_toolchain = rule(
     doc = "A rule for exposing the current registered `rust_toolchain`.",
     implementation = _current_rust_toolchain_impl,
     toolchains = [
-        str(Label("@rules_rust//rust:toolchain")),
+        str(Label("@rules_rust//rust:toolchain_type")),
     ],
     incompatible_use_toolchain_transition = True,
 )

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -34,7 +34,7 @@ def find_toolchain(ctx):
     Returns:
         rust_toolchain: A Rust toolchain context.
     """
-    return ctx.toolchains[Label("//rust:toolchain")]
+    return ctx.toolchains[Label("//rust:toolchain_type")]
 
 def find_cc_toolchain(ctx):
     """Extracts a CcToolchain from the current target's context

--- a/test/unit/consistent_crate_name/with_modified_crate_name.bzl
+++ b/test/unit/consistent_crate_name/with_modified_crate_name.bzl
@@ -9,7 +9,7 @@ load("//rust/private:providers.bzl", "BuildInfo", "CrateInfo", "DepInfo", "DepVa
 load("//rust/private:rustc.bzl", "rustc_compile_action")
 
 def _with_modified_crate_name_impl(ctx):
-    toolchain = ctx.toolchains[Label("//rust:toolchain")]
+    toolchain = ctx.toolchains[Label("//rust:toolchain_type")]
 
     crate_root = ctx.attr.src.files.to_list()[0]
     output_hash = repr(hash(crate_root.path))
@@ -73,7 +73,10 @@ with_modified_crate_name = rule(
             cfg = "exec",
         ),
     },
-    toolchains = ["@rules_rust//rust:toolchain", "@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = [
+        "@rules_rust//rust:toolchain_type",
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
     incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )

--- a/test/unit/force_all_deps_direct/generator.bzl
+++ b/test/unit/force_all_deps_direct/generator.bzl
@@ -26,7 +26,7 @@ EOF
         mnemonic = "WriteRsFile",
     )
 
-    toolchain = ctx.toolchains[Label("//rust:toolchain")]
+    toolchain = ctx.toolchains[Label("//rust:toolchain_type")]
 
     # Determine unique hash for this rlib
     output_hash = repr(hash(rs_file.path))
@@ -88,7 +88,10 @@ generator = rule(
             cfg = "exec",
         ),
     },
-    toolchains = ["@rules_rust//rust:toolchain", "@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = [
+        "@rules_rust//rust:toolchain_type",
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
     incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )

--- a/test/unit/toolchain_make_variables/toolchain_make_variables_test.bzl
+++ b/test/unit/toolchain_make_variables/toolchain_make_variables_test.bzl
@@ -124,7 +124,7 @@ rust_toolchain_consumer = rule(
         ),
     },
     toolchains = [
-        "@rules_rust//rust:toolchain",
+        "@rules_rust//rust:toolchain_type",
     ],
 )
 

--- a/wasm_bindgen/BUILD.bazel
+++ b/wasm_bindgen/BUILD.bazel
@@ -10,6 +10,7 @@ toolchain_type(
 alias(
     name = "wasm_bindgen_toolchain",
     actual = "toolchain_type",
+    deprecation = "instead use `@rules_rust//wasm_bindgen:toolchain_type`",
     tags = ["manual"],
 )
 

--- a/wasm_bindgen/BUILD.bazel
+++ b/wasm_bindgen/BUILD.bazel
@@ -3,7 +3,15 @@ load("//wasm_bindgen:wasm_bindgen.bzl", "rust_wasm_bindgen_toolchain")
 
 package(default_visibility = ["//visibility:public"])
 
-toolchain_type(name = "wasm_bindgen_toolchain")
+toolchain_type(
+    name = "toolchain_type",
+)
+
+alias(
+    name = "wasm_bindgen_toolchain",
+    actual = "toolchain_type",
+    tags = ["manual"],
+)
 
 bzl_library(
     name = "bzl_lib",
@@ -32,5 +40,5 @@ rust_wasm_bindgen_toolchain(
 toolchain(
     name = "default_wasm_bindgen_toolchain",
     toolchain = "default_wasm_bindgen_toolchain_impl",
-    toolchain_type = "//wasm_bindgen:wasm_bindgen_toolchain",
+    toolchain_type = "//wasm_bindgen:toolchain_type",
 )

--- a/wasm_bindgen/wasm_bindgen.bzl
+++ b/wasm_bindgen/wasm_bindgen.bzl
@@ -58,7 +58,7 @@ rust_bindgen_toolchain(
 toolchain(
     name = "wasm_bindgen_toolchain",
     toolchain = "wasm_bindgen_toolchain_impl",
-    toolchain_type = "@rules_rust//wasm_bindgen:wasm_bindgen_toolchain",
+    toolchain_type = "@rules_rust//wasm_bindgen:toolchain_type",
 )
 ```
 


### PR DESCRIPTION
Upstream Bazel rules seem to consistently define [toolchain_type](https://docs.bazel.build/versions/main/toolchains.html#writing-rules-that-use-toolchains) names as `toolchain_type` ([rules_cc](https://github.com/bazelbuild/rules_cc/blob/0.0.2/cc/BUILD#L33-L36), [rules_python](https://github.com/bazelbuild/rules_python/blob/0.10.2/python/BUILD)). The changes here move `rules_rust` to be consistent with upstream Bazel.

This will be a breaking change for any users who index toolchains via the string of the label of the toolchain type in their rules.