### PR TITLE
feat: Add `capture_output` attr to `rust_doc` rule

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -451,8 +451,8 @@ rust_clippy(
 ## rust_doc
 
 <pre>
-rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>, <a href="#rust_doc-markdown_css">markdown_css</a>,
-         <a href="#rust_doc-rustc_flags">rustc_flags</a>)
+rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-capture_output">capture_output</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>,
+         <a href="#rust_doc-markdown_css">markdown_css</a>, <a href="#rust_doc-rustc_flags">rustc_flags</a>)
 </pre>
 
 Generates code documentation.
@@ -498,6 +498,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_doc-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_doc-capture_output"></a>capture_output |  Enable or disable capturing the output of rustdoc to a file.   | Boolean | optional | False |
 | <a id="rust_doc-crate"></a>crate |  The label of the target to generate code documentation for.<br><br><code>rust_doc</code> can generate HTML code documentation for the source files of <code>rust_library</code> or <code>rust_binary</code> targets.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="rust_doc-html_after_content"></a>html_after_content |  File to add in <code>&lt;body&gt;</code>, after content.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_doc-html_before_content"></a>html_before_content |  File to add in <code>&lt;body&gt;</code>, before content.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |

--- a/docs/rust_doc.md
+++ b/docs/rust_doc.md
@@ -9,8 +9,8 @@
 ## rust_doc
 
 <pre>
-rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>, <a href="#rust_doc-markdown_css">markdown_css</a>,
-         <a href="#rust_doc-rustc_flags">rustc_flags</a>)
+rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-capture_output">capture_output</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>,
+         <a href="#rust_doc-markdown_css">markdown_css</a>, <a href="#rust_doc-rustc_flags">rustc_flags</a>)
 </pre>
 
 Generates code documentation.
@@ -56,6 +56,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_doc-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="rust_doc-capture_output"></a>capture_output |  Enable or disable capturing the output of rustdoc to a file.   | Boolean | optional | False |
 | <a id="rust_doc-crate"></a>crate |  The label of the target to generate code documentation for.<br><br><code>rust_doc</code> can generate HTML code documentation for the source files of <code>rust_library</code> or <code>rust_binary</code> targets.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="rust_doc-html_after_content"></a>html_after_content |  File to add in <code>&lt;body&gt;</code>, after content.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_doc-html_before_content"></a>html_before_content |  File to add in <code>&lt;body&gt;</code>, before content.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -131,7 +131,6 @@ def rustdoc_compile_action(
         # for this, the flag must be explicitly passed to the `rustdoc` binary.
         args.rustc_flags.add("--sysroot=${{pwd}}/{}".format(toolchain.sysroot_short_path))
 
-
     return struct(
         executable = ctx.executable._process_wrapper,
         inputs = depset([crate_info.output], transitive = [compile_inputs]),

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -131,12 +131,6 @@ def rustdoc_compile_action(
         # for this, the flag must be explicitly passed to the `rustdoc` binary.
         args.rustc_flags.add("--sysroot=${{pwd}}/{}".format(toolchain.sysroot_short_path))
 
-    if ctx.attr.capture_output:
-        rustdoc_out = ctx.actions.declare_file(ctx.label.name + ".rustdoc.out", sibling = ctx.outputs.rust_doc_zip)
-        args.process_wrapper_flags.add("--stderr-file", rustdoc_out.path)
-    else:
-        rustdoc_out = ctx.actions.declare_file(ctx.label.name + ".rustdoc.ok", sibling = ctx.outputs.rust_doc_zip)
-        args.process_wrapper_flags.add("--touch-file", rustdoc_out.path)
 
     return struct(
         executable = ctx.executable._process_wrapper,
@@ -144,7 +138,7 @@ def rustdoc_compile_action(
         env = env,
         arguments = args.all,
         tools = [toolchain.rust_doc],
-        rustdoc_output = rustdoc_out,
+        process_wrapper_flags = args.process_wrapper_flags,
     )
 
 def _zip_action(ctx, input_dir, output_zip, crate_label):
@@ -197,10 +191,17 @@ def _rust_doc_impl(ctx):
         rustdoc_flags = rustdoc_flags,
     )
 
+    if ctx.attr.capture_output:
+        rustdoc_out = ctx.actions.declare_file(ctx.label.name + ".rustdoc.out", sibling = ctx.outputs.rust_doc_zip)
+        action.process_wrapper_flags.add("--stderr-file", rustdoc_out.path)
+    else:
+        rustdoc_out = ctx.actions.declare_file(ctx.label.name + ".rustdoc.ok", sibling = ctx.outputs.rust_doc_zip)
+        action.process_wrapper_flags.add("--touch-file", rustdoc_out.path)
+
     ctx.actions.run(
         mnemonic = "Rustdoc",
         progress_message = "Generating Rustdoc for {}".format(crate.label),
-        outputs = [output_dir, action.rustdoc_output],
+        outputs = [output_dir, rustdoc_out],
         executable = action.executable,
         inputs = action.inputs,
         env = action.env,
@@ -217,7 +218,7 @@ def _rust_doc_impl(ctx):
         ),
         OutputGroupInfo(
             rustdoc_dir = depset([output_dir]),
-            rustdoc_output = depset([action.rustdoc_output]),
+            rustdoc_output = depset([rustdoc_out]),
             rustdoc_zip = depset([ctx.outputs.rust_doc_zip]),
         ),
     ]

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -151,7 +151,7 @@ def _rust_doc_test_impl(ctx):
         tools = tools,
         arguments = [writer_args] + action.arguments,
         env = action.env,
-        outputs = [test_runner, action.rustdoc_output],
+        outputs = [test_runner],
     )
 
     return [DefaultInfo(

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -151,7 +151,7 @@ def _rust_doc_test_impl(ctx):
         tools = tools,
         arguments = [writer_args] + action.arguments,
         env = action.env,
-        outputs = [test_runner],
+        outputs = [test_runner, action.rustdoc_output],
     )
 
     return [DefaultInfo(


### PR DESCRIPTION
This PR adds a `capture_output` attr to the `rust_doc` rule, which if set to `True` will redirect the output of `stderr` into a file with the suffix of `.rustdoc.out`.

Adding this unlocks the ability for users to define a bazel test rule that asserts their docs build without warnings. This is useful because it allows you to semi-automate the process of making sure your docs are up to date.