### PR TITLE
feat: Add `crate_features` attr to `rust_doc` rule

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -451,8 +451,8 @@ rust_clippy(
 ## rust_doc
 
 <pre>
-rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>, <a href="#rust_doc-markdown_css">markdown_css</a>,
-         <a href="#rust_doc-rustc_flags">rustc_flags</a>)
+rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-crate_features">crate_features</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>,
+         <a href="#rust_doc-markdown_css">markdown_css</a>, <a href="#rust_doc-rustc_flags">rustc_flags</a>)
 </pre>
 
 Generates code documentation.
@@ -499,6 +499,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_doc-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_doc-crate"></a>crate |  The label of the target to generate code documentation for.<br><br><code>rust_doc</code> can generate HTML code documentation for the source files of <code>rust_library</code> or <code>rust_binary</code> targets.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="rust_doc-crate_features"></a>crate_features |  The list of rust features that should be enabled when documenting the crate.   | List of strings | optional | [] |
 | <a id="rust_doc-html_after_content"></a>html_after_content |  File to add in <code>&lt;body&gt;</code>, after content.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_doc-html_before_content"></a>html_before_content |  File to add in <code>&lt;body&gt;</code>, before content.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_doc-html_in_header"></a>html_in_header |  File to add to <code>&lt;head&gt;</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |

--- a/docs/rust_doc.md
+++ b/docs/rust_doc.md
@@ -9,8 +9,8 @@
 ## rust_doc
 
 <pre>
-rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>, <a href="#rust_doc-markdown_css">markdown_css</a>,
-         <a href="#rust_doc-rustc_flags">rustc_flags</a>)
+rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-crate_features">crate_features</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>,
+         <a href="#rust_doc-markdown_css">markdown_css</a>, <a href="#rust_doc-rustc_flags">rustc_flags</a>)
 </pre>
 
 Generates code documentation.
@@ -57,6 +57,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_doc-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rust_doc-crate"></a>crate |  The label of the target to generate code documentation for.<br><br><code>rust_doc</code> can generate HTML code documentation for the source files of <code>rust_library</code> or <code>rust_binary</code> targets.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="rust_doc-crate_features"></a>crate_features |  The list of rust features that should be enabled when documenting the crate.   | List of strings | optional | [] |
 | <a id="rust_doc-html_after_content"></a>html_after_content |  File to add in <code>&lt;body&gt;</code>, after content.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_doc-html_before_content"></a>html_before_content |  File to add in <code>&lt;body&gt;</code>, before content.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="rust_doc-html_in_header"></a>html_in_header |  File to add to <code>&lt;head&gt;</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -265,6 +265,9 @@ rust_doc = rule(
             providers = [rust_common.crate_info],
             mandatory = True,
         ),
+        "crate_features": attr.string_list(
+            doc = "The list of rust features that should be enabled when documenting the crate.",
+        ),
         "html_after_content": attr.label(
             doc = "File to add in `<body>`, after content.",
             allow_single_file = [".html", ".md"],

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -90,6 +90,7 @@ def _target_maker(rule_fn, name, rustdoc_deps = [], **kwargs):
     rust_doc(
         name = "{}_doc".format(name),
         crate = ":{}".format(name),
+        crate_features = kwargs.get("crate_features", []),
     )
 
     rust_doc_test(


### PR DESCRIPTION
This PR adds the `crate_features` attr to the `rust_doc` rule, which allows you to specify what features should be enabled when building docs. Currently `rust_doc` doesn't enable any features (as far as I can tell, not even default features) which makes it impossible to build docs when a feature isn't available on the platform you're currently running on.