### PR TITLE
Skip supplying rpaths on Fuchsia

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1403,7 +1403,8 @@ def _compute_rpaths(toolchain, output_dir, dep_info, use_pic):
     """
 
     # Windows has no rpath equivalent, so always return an empty depset.
-    if toolchain.os == "windows":
+    # Fuchsia assembles shared libraries during packaging.
+    if toolchain.os == "windows" or toolchain.os == "fuchsia":
         return depset([])
 
     dylibs = [


### PR DESCRIPTION
Fuchsia rules assemble shared libraries during packaging, so rpaths are not needed.