### PR TITLE
Fix typo in an example of crates_repository rule

### DIFF
--- a/crate_universe/private/crates_repository.bzl
+++ b/crate_universe/private/crates_repository.bzl
@@ -138,7 +138,7 @@ load("@rules_rust//crate_universe:defs.bzl", "crates_repository", "crate")
 
 crates_repository(
     name = "crate_index",
-    annotations = annotations = {
+    annotations = {
         "rand": [crate.annotation(
             default_features = False,
             features = ["small_rng"],

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -219,7 +219,7 @@ load("@rules_rust//crate_universe:defs.bzl", "crates_repository", "crate")
 
 crates_repository(
     name = "crate_index",
-    annotations = annotations = {
+    annotations = {
         "rand": [crate.annotation(
             default_features = False,
             features = ["small_rng"],

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -219,7 +219,7 @@ load("@rules_rust//crate_universe:defs.bzl", "crates_repository", "crate")
 
 crates_repository(
     name = "crate_index",
-    annotations = {
+    annotations = annotations = {
         "rand": [crate.annotation(
             default_features = False,
             features = ["small_rng"],


### PR DESCRIPTION
This fixes a typo in an example of crates_repository rule.