### PR TITLE
Preserve directory structure of source files when some are generated

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -151,9 +151,10 @@ def _transform_sources(ctx, srcs, crate_root):
     generated_sources = []
 
     generated_root = crate_root
+    package_root = paths.dirname(ctx.build_file_path)
 
     if crate_root and (crate_root.is_source or crate_root.root.path != ctx.bin_dir.path):
-        generated_root = ctx.actions.declare_file(crate_root.basename)
+        generated_root = ctx.actions.declare_file(paths.relativize(crate_root.short_path, package_root))
         ctx.actions.symlink(
             output = generated_root,
             target_file = crate_root,
@@ -167,7 +168,7 @@ def _transform_sources(ctx, srcs, crate_root):
         if src == crate_root:
             continue
         if src.is_source or src.root.path != ctx.bin_dir.path:
-            src_symlink = ctx.actions.declare_file(src.basename)
+            src_symlink = ctx.actions.declare_file(paths.relativize(src.short_path, package_root))
             ctx.actions.symlink(
                 output = src_symlink,
                 target_file = src,

--- a/test/generated_inputs/BUILD.bazel
+++ b/test/generated_inputs/BUILD.bazel
@@ -21,10 +21,26 @@ pub fn get_forty_two_as_string() -> String {
     newline = "unix",
 )
 
+write_file(
+    name = "generate_src_generated",
+    out = "src/generated.rs",
+    content = """
+mod submodule;
+
+#[cfg(test)]
+#[test]
+fn test_foo() {
+    assert_eq!(submodule::foo(), "foo");
+}
+""".splitlines(),
+    newline = "unix",
+)
+
 rust_library(
     name = "use_generated_src",
     srcs = [
         "lib.rs",
+        "submodule/mod.rs",
         ":src.rs",
     ],
     edition = "2018",
@@ -35,6 +51,7 @@ rust_library(
     name = "use_generated_src_with_crate_root_defined",
     srcs = [
         "lib.rs",
+        "submodule/mod.rs",
         ":src.rs",
     ],
     crate_root = "lib.rs",
@@ -52,6 +69,25 @@ rust_library(
     crate_root = ":src.rs",
     edition = "2018",
     rustc_flags = ["--cfg=generated_file_as_root"],
+    tags = ["norustfmt"],
+)
+
+rust_library(
+    name = "use_generated_src_with_crate_root_in_subdir",
+    srcs = [
+        "src/generated.rs",
+        "src/generated/submodule.rs",
+        "src/lib.rs",
+    ],
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    tags = ["norustfmt"],
+)
+
+rust_test(
+    name = "use_generated_src_with_crate_root_in_subdir_test",
+    crate = "use_generated_src_with_crate_root_in_subdir",
+    edition = "2018",
     tags = ["norustfmt"],
 )
 

--- a/test/generated_inputs/lib.rs
+++ b/test/generated_inputs/lib.rs
@@ -1,4 +1,5 @@
 mod src;
+mod submodule;
 
 pub fn forty_two_as_string() -> String {
     format!("{}", src::forty_two())

--- a/test/generated_inputs/src/generated/submodule.rs
+++ b/test/generated_inputs/src/generated/submodule.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+pub fn foo() -> &'static str {
+    "foo"
+}

--- a/test/generated_inputs/src/lib.rs
+++ b/test/generated_inputs/src/lib.rs
@@ -1,0 +1,1 @@
+mod generated;

--- a/test/generated_inputs/submodule/mod.rs
+++ b/test/generated_inputs/submodule/mod.rs
@@ -1,0 +1,1 @@
+//! This is to test that the folder structure is properly preserved


### PR DESCRIPTION
When some input files are generated, the source files get symlinked to `bazel-out` so the generated and source files are in the same directory. This was implemented in #1340. However, the directory structure would get flattened since only the basename was used for the symlink location. Now the package-relative path is used.

Fixes #1510.