### PR TITLE
feat: make source path prefix configurable

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//rust:defs.bzl", "capture_clippy_output", "clippy_flags", "error_format", "extra_exec_rustc_flag", "extra_exec_rustc_flags", "extra_rustc_flag", "extra_rustc_flags", "is_proc_macro_dep", "is_proc_macro_dep_enabled")
+load("//rust:defs.bzl", "capture_clippy_output", "clippy_flags", "error_format", "extra_exec_rustc_flag", "extra_exec_rustc_flags", "extra_rustc_flag", "extra_rustc_flags", "is_proc_macro_dep", "is_proc_macro_dep_enabled", "source_path_prefix")
 
 exports_files(["LICENSE"])
 
@@ -73,6 +73,15 @@ extra_exec_rustc_flags(
 extra_exec_rustc_flag(
     name = "extra_exec_rustc_flag",
     build_setting_default = "",
+    visibility = ["//visibility:public"],
+)
+
+# This setting may be used to override the prefix for source paths rustc embeds into build artifacts.
+# Setting this setting to a fixed value (e.g., "/source/") can help achieve reproducible builds and
+# improve cache utilization.
+source_path_prefix(
+    name = "source_path_prefix",
+    build_setting_default = ".",
     visibility = ["//visibility:public"],
 )
 

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -56,6 +56,7 @@ PAGES = dict([
             "error_format",
             "extra_rustc_flag",
             "extra_rustc_flags",
+            "source_path_prefix",
             "capture_clippy_output",
         ],
     ),

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -595,7 +595,7 @@ Run the test with `bazel test //hello_lib:greeting_test`.
 source_path_prefix(<a href="#source_path_prefix-name">name</a>)
 </pre>
 
-Specify the path for the compiler to remap the source path prefix in all output, including compiler diagnostics,debug information, and macro expansions with `--@rules_rust//:static_path_prefix`.Setting the prefix a fixed value enables reproducible builds that do not depend on the location of the source directory.
+Specify the path for the compiler to remap the source path prefix in all output, including compiler diagnostics,debug information, and macro expansions with `--@rules_rust//:source_path_prefix`.Setting the prefix a fixed value enables reproducible builds that do not depend on the location of the source directory.
 
 **ATTRIBUTES**
 

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -11,6 +11,7 @@
 * [error_format](#error_format)
 * [extra_rustc_flag](#extra_rustc_flag)
 * [extra_rustc_flags](#extra_rustc_flags)
+* [source_path_prefix](#source_path_prefix)
 * [capture_clippy_output](#capture_clippy_output)
 
 <a id="capture_clippy_output"></a>
@@ -584,6 +585,24 @@ Run the test with `bazel test //hello_lib:greeting_test`.
 | <a id="rust_test-stamp"></a>stamp |  Whether to encode build information into the <code>Rustc</code> action. Possible values:<br><br>- <code>stamp = 1</code>: Always stamp the build information into the <code>Rustc</code> action, even in             [--nostamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) builds.             This setting should be avoided, since it potentially kills remote caching for the target and             any downstream actions that depend on it.<br><br>- <code>stamp = 0</code>: Always replace build information by constant values. This gives good build result caching.<br><br>- <code>stamp = -1</code>: Embedding of build information is controlled by the             [--[no]stamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) flag.<br><br>Stamped targets are not rebuilt unless their dependencies change.<br><br>For example if a <code>rust_library</code> is stamped, and a <code>rust_binary</code> depends on that library, the stamped library won't be rebuilt when we change sources of the <code>rust_binary</code>. This is different from how [<code>cc_library.linkstamps</code>](https://docs.bazel.build/versions/main/be/c-cpp.html#cc_library.linkstamp) behaves.   | Integer | optional | 0 |
 | <a id="rust_test-use_libtest_harness"></a>use_libtest_harness |  Whether to use <code>libtest</code>. For targets using this flag, individual tests can be run by using the [--test_arg](https://docs.bazel.build/versions/4.0.0/command-line-reference.html#flag--test_arg) flag. E.g. <code>bazel test //src:rust_test --test_arg=foo::test::test_fn</code>.   | Boolean | optional | True |
 | <a id="rust_test-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | "0.0.0" |
+
+
+<a id="source_path_prefix"></a>
+
+## source_path_prefix
+
+<pre>
+source_path_prefix(<a href="#source_path_prefix-name">name</a>)
+</pre>
+
+Specify the path for the compiler to remap the source path prefix in all output, including compiler diagnostics,debug information, and macro expansions with `--@rules_rust//:static_path_prefix`.Setting the prefix a fixed value enables reproducible builds that do not depend on the location of the source directory.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="source_path_prefix-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
 <a id="rust_test_suite"></a>

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1361,7 +1361,7 @@ A test rule for performing `rustfmt --check` on a set of targets
 source_path_prefix(<a href="#source_path_prefix-name">name</a>)
 </pre>
 
-Specify the path for the compiler to remap the source path prefix in all output, including compiler diagnostics,debug information, and macro expansions with `--@rules_rust//:static_path_prefix`.Setting the prefix a fixed value enables reproducible builds that do not depend on the location of the source directory.
+Specify the path for the compiler to remap the source path prefix in all output, including compiler diagnostics,debug information, and macro expansions with `--@rules_rust//:source_path_prefix`.Setting the prefix a fixed value enables reproducible builds that do not depend on the location of the source directory.
 
 **ATTRIBUTES**
 

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -50,6 +50,7 @@
 * [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)
 * [rustfmt_aspect](#rustfmt_aspect)
 * [rustfmt_test](#rustfmt_test)
+* [source_path_prefix](#source_path_prefix)
 
 
 <a id="capture_clippy_output"></a>
@@ -1350,6 +1351,24 @@ A test rule for performing `rustfmt --check` on a set of targets
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rustfmt_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="rustfmt_test-targets"></a>targets |  Rust targets to run <code>rustfmt --check</code> on.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+
+
+<a id="source_path_prefix"></a>
+
+## source_path_prefix
+
+<pre>
+source_path_prefix(<a href="#source_path_prefix-name">name</a>)
+</pre>
+
+Specify the path for the compiler to remap the source path prefix in all output, including compiler diagnostics,debug information, and macro expansions with `--@rules_rust//:static_path_prefix`.Setting the prefix a fixed value enables reproducible builds that do not depend on the location of the source directory.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="source_path_prefix-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
 <a id="CrateInfo"></a>

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -64,6 +64,7 @@ load(
     _rust_test_suite = "rust_test_suite",
     _rustfmt_aspect = "rustfmt_aspect",
     _rustfmt_test = "rustfmt_test",
+    _source_path_prefix = "source_path_prefix",
 )
 load(
     "@rules_rust//rust:repositories.bzl",
@@ -163,6 +164,7 @@ rustfmt_test = _rustfmt_test
 error_format = _error_format
 extra_rustc_flag = _extra_rustc_flag
 extra_rustc_flags = _extra_rustc_flags
+source_path_prefix = _source_path_prefix
 incompatible_flag = _incompatible_flag
 capture_clippy_output = _capture_clippy_output
 

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -49,6 +49,7 @@ load(
     _extra_rustc_flags = "extra_rustc_flags",
     _is_proc_macro_dep = "is_proc_macro_dep",
     _is_proc_macro_dep_enabled = "is_proc_macro_dep_enabled",
+    _source_path_prefix = "source_path_prefix",
 )
 load(
     "//rust/private:rustdoc.bzl",
@@ -122,6 +123,9 @@ is_proc_macro_dep = _is_proc_macro_dep
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 is_proc_macro_dep_enabled = _is_proc_macro_dep_enabled
+# See @rules_rust//rust/private:rustc.bzl for a complete description.
+
+source_path_prefix = _source_path_prefix
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 rust_common = _rust_common

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -701,6 +701,9 @@ _common_attrs = {
     "_extra_rustc_flags": attr.label(
         default = Label("//:extra_rustc_flags"),
     ),
+    "_source_path_prefix": attr.label(
+        default = Label("//:source_path_prefix"),
+    ),
     "_import_macro_dep": attr.label(
         default = Label("//util/import"),
         cfg = "exec",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -90,6 +90,11 @@ is_proc_macro_dep_enabled = rule(
     build_setting = config.bool(flag = True),
 )
 
+SourcePathPrefixInfo = provider(
+    doc = "Remap source path prefixes in all output, including compiler diagnostics, debug information, macro expansions to a path",
+    fields = {"source_path_prefix": "string The path to substitute ${pwd} for"},
+)
+
 def _get_rustc_env(attr, toolchain, crate_name):
     """Gathers rustc environment variables
 
@@ -708,7 +713,6 @@ def construct_arguments(
         force_all_deps_direct = False,
         force_link = False,
         stamp = False,
-        remap_path_prefix = ".",
         use_json_output = False,
         build_metadata = False,
         force_depend_on_objects = False):
@@ -737,7 +741,6 @@ def construct_arguments(
         force_link (bool, optional): Whether to add link flags to the command regardless of `emit`.
         stamp (bool, optional): Whether or not workspace status stamping is enabled. For more details see
             https://docs.bazel.build/versions/main/user-manual.html#flag--stamp
-        remap_path_prefix (str, optional): A value used to remap `${pwd}` to. If set to a falsey value, no prefix will be set.
         use_json_output (bool): Have rustc emit json and process_wrapper parse json messages to output rendered output.
         build_metadata (bool): Generate CLI arguments for building *only* .rmeta files. This requires use_json_output.
         force_depend_on_objects (bool): Force using `.rlib` object files instead of metadata (`.rmeta`) files even if they are available.
@@ -874,8 +877,8 @@ def construct_arguments(
     rustc_flags.add("--codegen=debuginfo=" + compilation_mode.debug_info)
 
     # For determinism to help with build distribution and such
-    if remap_path_prefix:
-        rustc_flags.add("--remap-path-prefix=${{pwd}}={}".format(remap_path_prefix))
+    if hasattr(ctx.attr, "_source_path_prefix"):
+        rustc_flags.add("--remap-path-prefix=${{pwd}}={}".format(ctx.attr._source_path_prefix[SourcePathPrefixInfo].source_path_prefix))
 
     if emit:
         rustc_flags.add("--emit=" + ",".join(emit_with_paths))
@@ -1836,6 +1839,19 @@ extra_rustc_flag = rule(
     ),
     implementation = _extra_rustc_flag_impl,
     build_setting = config.string(flag = True, allow_multiple = True),
+)
+
+def _source_path_prefix_impl(ctx):
+    return SourcePathPrefixInfo(source_path_prefix = ctx.build_setting_value)
+
+source_path_prefix = rule(
+    doc = (
+        "Specify the path for the compiler to remap the source path prefix in all output, including compiler diagnostics," +
+        "debug information, and macro expansions with `--@rules_rust//:static_path_prefix`." +
+        "Setting the prefix a fixed value enables reproducible builds that do not depend on the location of the source directory."
+    ),
+    implementation = _source_path_prefix_impl,
+    build_setting = config.string(flag = True),
 )
 
 def _extra_exec_rustc_flags_impl(ctx):

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -713,6 +713,7 @@ def construct_arguments(
         force_all_deps_direct = False,
         force_link = False,
         stamp = False,
+        remap_path_prefix = True,
         use_json_output = False,
         build_metadata = False,
         force_depend_on_objects = False):
@@ -877,7 +878,7 @@ def construct_arguments(
     rustc_flags.add("--codegen=debuginfo=" + compilation_mode.debug_info)
 
     # For determinism to help with build distribution and such
-    if hasattr(ctx.attr, "_source_path_prefix"):
+    if remap_path_prefix and hasattr(ctx.attr, "_source_path_prefix"):
         rustc_flags.add("--remap-path-prefix=${{pwd}}={}".format(ctx.attr._source_path_prefix[SourcePathPrefixInfo].source_path_prefix))
 
     if emit:

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1848,7 +1848,7 @@ def _source_path_prefix_impl(ctx):
 source_path_prefix = rule(
     doc = (
         "Specify the path for the compiler to remap the source path prefix in all output, including compiler diagnostics," +
-        "debug information, and macro expansions with `--@rules_rust//:static_path_prefix`." +
+        "debug information, and macro expansions with `--@rules_rust//:source_path_prefix`." +
         "Setting the prefix a fixed value enables reproducible builds that do not depend on the location of the source directory."
     ),
     implementation = _source_path_prefix_impl,

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -120,7 +120,7 @@ def rustdoc_compile_action(
         build_env_files = build_env_files,
         build_flags_files = build_flags_files,
         emit = [],
-        remap_path_prefix = None,
+        remap_path_prefix = False,
         force_link = True,
         force_depend_on_objects = is_test,
     )


### PR DESCRIPTION
Currently, the rules apply the `--remap-path-prefix=${pwd}=.` substitution when building inside a sandbox.
Sometimes this substitution causes non-determinism in our CI setup.
Specifying a fixed path prefix, such as `/source/`, resolves the non-determinism issue (at least on Linux).
This change allows configuring the prefix via the `@rules_rust//:source_path_prefex` option, leaving the current behavior as default.