### PR TITLE
Remove -lgcc from Android builds

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -137,7 +137,7 @@ _SYSTEM_TO_DYLIB_EXT = {
 _SYSTEM_TO_STDLIB_LINKFLAGS = {
     # NOTE: Rust stdlib `build.rs` treats android as a subset of linux, rust rules treat android
     # as its own system.
-    "android": ["-ldl", "-llog", "-lgcc"],
+    "android": ["-ldl", "-llog"],
     "bitrig": [],
     # TODO(gregbowyer): If rust stdlib is compiled for cloudabi with the backtrace feature it
     # includes `-lunwind` but this might not actually be required.


### PR DESCRIPTION
Newer NDKs no longer have this library, if it's still needed for folks
using older NDKs I think they'll have to manually link it.