### PR TITLE
Update lockfile checksums

### DIFF
--- a/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "22324143593ee8f6bd791d836d132583b37f45a3d6dd2b2965541a888c421f98",
+  "checksum": "1abebc0b516ea71f61b73a4b929d15908034c774c7e364dfb511221aee8c0bbc",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",

--- a/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7d58a2569ecff202c9bf834d2bba05d02a1270dac40630c0e408216b07b2eb4f",
+  "checksum": "1aa8ae3a3d3c6d658bbc9eae7de85d46e2867654a66e325cb6b972a4d2926c88",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",

--- a/examples/crate_universe/multi_package/cargo-bazel-lock.json
+++ b/examples/crate_universe/multi_package/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7fef42b6d782782940cbe4dacc27788a16488864c5b44c03e2f2f0fc9b27ee40",
+  "checksum": "7bb6861ca56ccb4146c02101f5011774d6629c4775f8e2ce855e1b70be435ca4",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",


### PR DESCRIPTION
After https://github.com/bazelbuild/rules_rust/commit/cb9ca1b817febcaf8edc28d160866be759825c31 went in, I'm getting errors when I run tests in `examples/crate_universe` with [`--incompatible_unambiguous_label_stringification`](https://github.com/bazelbuild/bazel/issues/16196):

```
DEBUG: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/cae3acec4b4a3c8e715b5a1706a73dbf/external/rules_rust/crate_universe/private/generate_utils.bzl:364:14: Digests do not match: Digest("22324143593ee8f6bd791d836d132583b37f45a3d6dd2b2965541a888c421f98") != Digest("1abebc0b516ea71f61b73a4b929d15908034c774c7e364dfb511221aee8c0bbc")
--
  | ERROR: An error occurred during the fetch of repository 'cargo_aliases':
  | Traceback (most recent call last):
  | File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/cae3acec4b4a3c8e715b5a1706a73dbf/external/rules_rust/crate_universe/private/crates_repository.bzl", line 45, column 28, in _crates_repository_impl
  | repin = determine_repin(
  | File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/cae3acec4b4a3c8e715b5a1706a73dbf/external/rules_rust/crate_universe/private/generate_utils.bzl", line 365, column 13, in determine_repin
  | fail((
  | Error in fail: The current `lockfile` is out of date for 'cargo_aliases'. Please re-run bazel using `CARGO_BAZEL_REPIN=true` if this is expected and the lockfile should be updated.
```

This PR is the result of running the same tests with `CARGO_BAZEL_REPIN=workspace`. However, if I were to submit this PR, running those tests without `--incompatible_unambiguous_label_stringification` would fail. As I'm planning to flip this flag for Bazel 6.0, is there a way to make those tests work with both values of the flag? Particularly, I need some help determining what exactly is causing the digests to be different.