### PR TITLE
Update apple_support

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -72,8 +72,8 @@ def rules_rust_dependencies():
     maybe(
         http_archive,
         name = "build_bazel_apple_support",
-        sha256 = "5bbce1b2b9a3d4b03c0697687023ef5471578e76f994363c641c5f50ff0c7268",
-        url = "https://github.com/bazelbuild/apple_support/releases/download/0.13.0/apple_support.0.13.0.tar.gz",
+        sha256 = "d94b7a0f49d735f196e1f36d2e6ef79c4e8e8b82132848dd8cd93cd82d9b12a8",
+        url = "https://github.com/bazelbuild/apple_support/releases/download/1.3.0/apple_support.1.3.0.tar.gz",
     )
 
     # process_wrapper needs a low-dependency way to process json.


### PR DESCRIPTION
Nothing in this for rules_rust specifically, but for users using rules_rust + rules_apple, this makes sure they get a version that's compatible with both regardless of WORKSPACE load order.