### PR TITLE
Handle $(locations) and $(execpaths) expansions

### DIFF
--- a/examples/env_locations/BUILD.bazel
+++ b/examples/env_locations/BUILD.bazel
@@ -16,6 +16,7 @@ _data = [
     # we should also be able to access external binaries
     # such as protoc.
     "@com_google_protobuf//:protoc",
+    "@com_google_protobuf//:well_known_protos",
 ]
 
 cargo_build_script(
@@ -26,6 +27,8 @@ cargo_build_script(
         "SOME_TOOL": "$(execpath @com_google_protobuf//:protoc)",
         # both execpath and location should work
         "SOURCE_FILE": "$(execpath source.file)",
+        "SOME_TOOL_PLURAL_SINGLE": "$(execpaths @com_google_protobuf//:protoc)",
+        "SOME_FILES_PLURAL": "$(execpaths @com_google_protobuf//:well_known_protos)",
     },
     data = _data,
 )
@@ -42,6 +45,8 @@ rust_test(
         "GENERATED_DATA_ROOT": "$(rootpath generated.data)",
         "SOME_TOOL": "$(rootpath @com_google_protobuf//:protoc)",
         "SOURCE_FILE": "$(rootpath source.file)",
+        "SOME_TOOL_PLURAL_SINGLE": "$(execpaths @com_google_protobuf//:protoc)",
+        "SOME_FILES_PLURAL": "$(execpaths @com_google_protobuf//:well_known_protos)",
     },
     deps = [
         ":build",

--- a/examples/env_locations/build.rs
+++ b/examples/env_locations/build.rs
@@ -14,4 +14,10 @@ fn main() {
     // and we should be able to read (and thus execute) our tool
     let path = env::var("SOME_TOOL").unwrap();
     assert!(!fs::read(&path).unwrap().is_empty());
+    let path = env::var("SOME_TOOL_PLURAL_SINGLE").unwrap();
+    assert!(!fs::read(&path).unwrap().is_empty());
+
+    for path in env::var("SOME_FILES_PLURAL").unwrap().split(' ') {
+        assert!(!fs::read(path).unwrap().is_empty());
+    }
 }

--- a/examples/env_locations/main.rs
+++ b/examples/env_locations/main.rs
@@ -9,4 +9,11 @@ fn test() {
     assert_eq!(generated_data, generated_data2);
     // and we should be able to read (and thus execute) our tool
     assert!(!std::fs::read(env!("SOME_TOOL")).unwrap().is_empty());
+    assert!(!std::fs::read(env!("SOME_TOOL_PLURAL_SINGLE"))
+        .unwrap()
+        .is_empty());
+    // multiple source files at once should also be readable
+    for source_file in env!("SOME_FILES_PLURAL").split(' ') {
+        assert!(!std::fs::read_to_string(source_file).unwrap().is_empty());
+    }
 }

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -781,6 +781,7 @@ def construct_arguments(
     # Since we cannot get the `exec_root` from starlark, we cheat a little and
     # use `${pwd}` which resolves the `exec_root` at action execution time.
     process_wrapper_flags.add("--subst", "pwd=${pwd}")
+    process_wrapper_flags.add("--subst-multipwd", "true")
 
     # If stamping is enabled, enable the functionality in the process wrapper
     if stamp:


### PR DESCRIPTION
Same idea as $(location) and $(execpath), but it's a bit trickier because we don't have the paths until later.