### PR TITLE
Remap $PWD to empty string instead of "."

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -708,7 +708,7 @@ def construct_arguments(
         force_all_deps_direct = False,
         force_link = False,
         stamp = False,
-        remap_path_prefix = ".",
+        remap_path_prefix = "",
         use_json_output = False,
         build_metadata = False,
         force_depend_on_objects = False):
@@ -737,7 +737,7 @@ def construct_arguments(
         force_link (bool, optional): Whether to add link flags to the command regardless of `emit`.
         stamp (bool, optional): Whether or not workspace status stamping is enabled. For more details see
             https://docs.bazel.build/versions/main/user-manual.html#flag--stamp
-        remap_path_prefix (str, optional): A value used to remap `${pwd}` to. If set to a falsey value, no prefix will be set.
+        remap_path_prefix (str, optional): A value used to remap `${pwd}` to. If set to None, no prefix will be set.
         use_json_output (bool): Have rustc emit json and process_wrapper parse json messages to output rendered output.
         build_metadata (bool): Generate CLI arguments for building *only* .rmeta files. This requires use_json_output.
         force_depend_on_objects (bool): Force using `.rlib` object files instead of metadata (`.rmeta`) files even if they are available.
@@ -874,7 +874,7 @@ def construct_arguments(
     rustc_flags.add("--codegen=debuginfo=" + compilation_mode.debug_info)
 
     # For determinism to help with build distribution and such
-    if remap_path_prefix:
+    if remap_path_prefix != None:
         rustc_flags.add("--remap-path-prefix=${{pwd}}={}".format(remap_path_prefix))
 
     if emit:

--- a/test/unit/remap_path_prefix/BUILD.bazel
+++ b/test/unit/remap_path_prefix/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_library(
+    name = "dep",
+    srcs = ["dep.rs"],
+    edition = "2018",
+)
+
+rust_test(
+    name = "remap_path_prefix",
+    srcs = ["test.rs"],
+    edition = "2018",
+    deps = [":dep"],
+)

--- a/test/unit/remap_path_prefix/dep.rs
+++ b/test/unit/remap_path_prefix/dep.rs
@@ -1,0 +1,4 @@
+// Without --remap-path-prefix, Location::caller() in this generic function will return an absolute path
+pub fn get_file_name<T>() -> &'static str {
+    std::panic::Location::caller().file()
+}

--- a/test/unit/remap_path_prefix/test.rs
+++ b/test/unit/remap_path_prefix/test.rs
@@ -1,0 +1,7 @@
+#[test]
+fn test_dep_file_name() {
+    assert_eq!(
+        dep::get_file_name::<()>(),
+        "test/unit/remap_path_prefix/dep.rs"
+    );
+}


### PR DESCRIPTION
This fixes an inconsistency in file paths (included in e.g. panic info), wherein some paths would have a leading `./` and some would not.

I believe specifically generic code that is instantiated across a crate boundary would end up with an absolute path, then have it remapped to `.`, whereas other code would use the literal path passed on the command line to `rustc`, which is generally a relative path with no `./` prefix.