### PR TITLE
Add an output group for the .rmeta

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1303,6 +1303,8 @@ def rustc_compile_action(
         providers.append(OutputGroupInfo(pdb_file = depset([pdb_file])))
     if dsym_folder:
         providers.append(OutputGroupInfo(dsym_folder = depset([dsym_folder])))
+    if build_metadata:
+        providers.append(OutputGroupInfo(build_metadata = depset([build_metadata])))
 
     return providers
 


### PR DESCRIPTION
This is similar to the other output groups. It's helpful for debugging. For example, I used it to build the .rmeta multiple times to chase down the root cause of #1584.