### PR TITLE
Deduplicate CARGO_MANIFEST_DIR logic

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -11,7 +11,7 @@ load("//rust/private:providers.bzl", _DepInfo = "DepInfo")
 load("//rust/private:rustc.bzl", "BuildInfo", "get_compilation_mode_opts", "get_linker_and_args")
 
 # buildifier: disable=bzl-visibility
-load("//rust/private:utils.bzl", "dedent", "expand_dict_value_locations", "find_cc_toolchain", "find_toolchain", "name_to_crate_name")
+load("//rust/private:utils.bzl", "cargo_manifest_dir", "dedent", "expand_dict_value_locations", "find_cc_toolchain", "find_toolchain", "name_to_crate_name")
 
 def get_cc_compile_args_and_env(cc_toolchain, feature_configuration):
     """Gather cc environment variables from the given `cc_toolchain`
@@ -82,7 +82,7 @@ def _build_script_impl(ctx):
     flags_out = ctx.actions.declare_file(ctx.label.name + ".flags")
     link_flags = ctx.actions.declare_file(ctx.label.name + ".linkflags")
     link_search_paths = ctx.actions.declare_file(ctx.label.name + ".linksearchpaths")  # rustc-link-search, propagated from transitive dependencies
-    manifest_dir = "%s.runfiles/%s/%s" % (script.path, ctx.label.workspace_name or ctx.workspace_name, ctx.label.package)
+    manifest_dir = cargo_manifest_dir(ctx, runfiles_dir = "%s.runfiles" % script.path)
     compilation_mode_opt_level = get_compilation_mode_opts(ctx, toolchain).opt_level
 
     streams = struct(

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -19,6 +19,7 @@ load("//rust/private:rustc.bzl", "rustc_compile_action")
 load(
     "//rust/private:utils.bzl",
     "can_build_metadata",
+    "cargo_manifest_dir",
     "compute_crate_name",
     "crate_root_src",
     "dedent",
@@ -467,8 +468,7 @@ def _rust_test_impl(ctx):
 
         env["RUST_LLVM_COV"] = toolchain.llvm_cov.path
         env["RUST_LLVM_PROFDATA"] = toolchain.llvm_profdata.path
-    components = "{}/{}".format(ctx.label.workspace_root, ctx.label.package).split("/")
-    env["CARGO_MANIFEST_DIR"] = "/".join([c for c in components if c])
+    env["CARGO_MANIFEST_DIR"] = cargo_manifest_dir(ctx)
     providers.append(testing.TestEnvironment(env))
 
     return providers

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -712,3 +712,14 @@ def _shortest_src_with_basename(srcs, basename):
             if not shortest or len(f.dirname) < len(shortest.dirname):
                 shortest = f
     return shortest
+
+def cargo_manifest_dir(ctx, runfiles_dir = None):
+    manifest_dir_parts = []
+    if runfiles_dir:
+        manifest_dir_parts.append(runfiles_dir)
+    workspace = ctx.label.workspace_name or ctx.workspace_name
+    if workspace:
+        manifest_dir_parts.append(workspace)
+    if ctx.label.package:
+        manifest_dir_parts.append(ctx.label.package)
+    return "/".join(manifest_dir_parts)


### PR DESCRIPTION
We currently compute this the same in two places - let's have one block of code do so.