### PR TITLE
Adjusting `rust_test` example

### DIFF
--- a/docs/defs.md
+++ b/docs/defs.md
@@ -501,7 +501,8 @@ rust_test(
     name = "hello_lib_test",
     crate = ":hello_lib",
     # You may add other deps that are specific to the test configuration
-    deps = ["//some/dev/dep"],
+    # deps = ["//some/dev/dep"],
+)
 ```
 
 Run the test with `bazel test //hello_lib:hello_lib_test`. The crate

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1017,7 +1017,8 @@ rust_test(
     name = "hello_lib_test",
     crate = ":hello_lib",
     # You may add other deps that are specific to the test configuration
-    deps = ["//some/dev/dep"],
+    # deps = ["//some/dev/dep"],
+)
 ```
 
 Run the test with `bazel test //hello_lib:hello_lib_test`. The crate


### PR DESCRIPTION
* Added missing parenthesis.
* Commented out `//some/dev/dep`. Examples I've ran into in the rules_rust docs follow a "compile successfully by default" style, so this brings that to be consistent.

Ref: #1594