### PR TITLE
Add a build setting to disable the hash prefix on `rust_test` outputs.

### DIFF
--- a/docs/rust_test_output_path_uniqueness.md
+++ b/docs/rust_test_output_path_uniqueness.md
@@ -1,0 +1,34 @@
+# rust_test Output Path Uniqueness
+
+## Overview of the problem
+
+On some platforms, including Windows, Bazel runs local actions in a shared
+execroot without sandboxing (`--spawn_strategy=standalone`). If two actions
+generate intermediate files with the same path, then executing them concurrently
+may cause non-deterministic failures due to one action overwriting the files
+created by another.
+
+This is known to affect `rust_test` and `rust_binary` targets when built from
+the same crate. A representative error message that may occur is:
+
+```
+= note: bin_with_transitive_proc_macro.bin_with_transitive_proc_macro.573369dc-cgu.3.rcgu.o :
+  error LNK2019:
+  unresolved external symbol _ZN4test16test_main_static17h3f2f4fbff47df3a8E
+  referenced in function _ZN30bin_with_transitive_proc_macro4main17h28726504dc060f8dE
+```
+
+## The hash prefix workaround
+
+PR [rules_rust#1434](https://github.com/bazelbuild/rules_rust/pull/1434) added
+a workaround by configuring `rust_test` targets to write their output files to
+a hash prefix computed from the crate info and Bazel label. This workaround is
+transparent to most users, as it does not affect the behavior or output of
+`bazel test //path/to:my_rust_test`.
+
+## Disabling
+
+In some cases the path of the `rust_test` binary must be made predictable, for
+example when they need to be located in the runfiles of a wrapper test. To
+disable the `rust_test` hash prefix workaround, set the Bazel build setting
+`@rules_rust//rust/settings:rust_test_prefix_output_files` to `false`.

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -362,6 +362,9 @@ def _rust_binary_impl(ctx):
 def _rust_test_output_name(ctx, toolchain, crate_root):
     """Generate the output name for a rust_test target.
 
+    See `docs/rust_test_output_path_uniqueness.md` for details on why a
+    `rust_test` output path needs special handling.
+
     Args:
         ctx (ctx): The ctx object for the current target.
         toolchain (rust_toolchain): The current `rust_toolchain`

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -52,6 +52,15 @@ bool_flag(
     build_setting_default = False,
 )
 
+# If true (the default), rust_test output files will be prefixed with
+# a hash derived from the crate root and build target. This prefix
+# avoids possible filename collisions in non-sandboxed builds.
+bool_flag(
+    name = "rust_test_prefix_output_files",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "bzl_lib",
     srcs = glob(["**/*.bzl"]),

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -55,6 +55,8 @@ bool_flag(
 # If true (the default), rust_test output files will be prefixed with
 # a hash derived from the crate root and build target. This prefix
 # avoids possible filename collisions in non-sandboxed builds.
+#
+# See `docs/rust_test_output_path_uniqueness.md` for more details.
 bool_flag(
     name = "rust_test_prefix_output_files",
     build_setting_default = True,

--- a/test/test_prefix_setting/BUILD.bazel
+++ b/test/test_prefix_setting/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":prefix_setting_tests.bzl", "prefix_setting_tests")
+
+prefix_setting_tests(name = "prefix_setting_tests")

--- a/test/test_prefix_setting/lib.rs
+++ b/test/test_prefix_setting/lib.rs
@@ -1,0 +1,1 @@
+pub fn test() {}

--- a/test/test_prefix_setting/prefix_setting_tests.bzl
+++ b/test/test_prefix_setting/prefix_setting_tests.bzl
@@ -1,0 +1,109 @@
+"""Tests for the @rules_rust//rust/settings:rust_test_prefix_output_files flag."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//rust:defs.bzl", "rust_test")
+
+def _rust_test_prefix_output_files_transition_impl(_settings, attr):
+    return {
+        "//rust/settings:rust_test_prefix_output_files": attr.rust_test_prefix_output_files,
+    }
+
+_rust_test_prefix_output_files_transition = transition(
+    implementation = _rust_test_prefix_output_files_transition_impl,
+    inputs = [],
+    outputs = ["//rust/settings:rust_test_prefix_output_files"],
+)
+
+def _with_rust_test_prefix_output_files_cfg_impl(ctx):
+    return [DefaultInfo(files = depset(ctx.files.srcs))]
+
+with_rust_test_prefix_output_files_cfg = rule(
+    implementation = _with_rust_test_prefix_output_files_cfg_impl,
+    attrs = {
+        "rust_test_prefix_output_files": attr.bool(
+            mandatory = True,
+        ),
+        "srcs": attr.label_list(
+            allow_files = True,
+            cfg = _rust_test_prefix_output_files_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = Label("//tools/allowlists/function_transition_allowlist"),
+        ),
+    },
+)
+
+def _output_paths_test(ctx):
+    env = analysistest.begin(ctx)
+
+    files = ctx.attr.target_under_test.files.to_list()
+    asserts.equals(env, 1, len(files))
+
+    test_binary = files[0]
+    if ctx.attr.expect_output_hash:
+        # The output hash is injected between the rule's directory path and
+        # the rust_test binary name.
+        asserts.false(env, "test_prefix_setting/test_binary" in test_binary.short_path)
+    else:
+        # With no output hash, the rust_test binary is placed directly under
+        # the rule's directory path.
+        asserts.true(env, "test_prefix_setting/test_binary" in test_binary.short_path)
+
+    return analysistest.end(env)
+
+output_paths_test = analysistest.make(
+    _output_paths_test,
+    attrs = {
+        "expect_output_hash": attr.bool(mandatory = True),
+    },
+)
+
+def prefix_setting_tests(name, **kwargs):
+    """Macro for declaring test_prefix_setting test targets.
+
+    Args:
+        name (str): The name of the test suite
+        **kwargs (dict): Additional keyword arguments for the underlying test_suite.
+    """
+
+    rust_test(
+        name = "test_binary",
+        srcs = ["lib.rs"],
+        edition = "2018",
+        tags = ["manual"],
+    )
+
+    with_rust_test_prefix_output_files_cfg(
+        name = "test_binary_with_output_hash",
+        testonly = True,
+        srcs = [":test_binary"],
+        rust_test_prefix_output_files = True,
+    )
+
+    with_rust_test_prefix_output_files_cfg(
+        name = "test_binary_without_output_hash",
+        testonly = True,
+        srcs = [":test_binary"],
+        rust_test_prefix_output_files = False,
+    )
+
+    output_paths_test(
+        name = "with_output_hash_test",
+        expect_output_hash = True,
+        target_under_test = ":test_binary_with_output_hash",
+    )
+
+    output_paths_test(
+        name = "without_output_hash_test",
+        expect_output_hash = False,
+        target_under_test = ":test_binary_without_output_hash",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":with_output_hash_test",
+            ":without_output_hash_test",
+        ],
+        **kwargs
+    )


### PR DESCRIPTION
The hash prefix for test outputs was originally added to work around potential filename conflicts between `rust_test` and `rust_binary` on platforms without sandboxed builds (Windows).

However, on platforms that *do* have sandboxed builds, the prefix can be unwanted because it makes path of Rust test binaries different from what would be produced using other language rules such as `cc_test`.

This commit adds a Bazel build setting so that the output prefix can be disabled in cases where it's unwanted.

```
$ bazel build //test/rust:hello_lib_test
Target //test/rust:hello_lib_test up-to-date:
  bazel-bin/test/rust/test-365930506/hello_lib_test
$ bazel build --@rules_rust//rust/settings:rust_test_prefix_output_files=false //test/rust:hello_lib_test
Target //test/rust:hello_lib_test up-to-date:
  bazel-bin/test/rust/hello_lib_test
```