### PR TITLE
Remove Google mirror from Starlark snippet in release notes

### DIFF
--- a/.github/release_notes.template
+++ b/.github/release_notes.template
@@ -5,10 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_rust",
     sha256 = "{sha256}",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/{version}/rules_rust-v{version}.tar.gz",
-        "https://github.com/bazelbuild/rules_rust/releases/download/{version}/rules_rust-v{version}.tar.gz",
-    ],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/{version}/rules_rust-v{version}.tar.gz"],
 )
 ```
 


### PR DESCRIPTION
Given the response in https://github.com/bazelbuild/continuous-integration/issues/1347, it doesn't sound like Googlers are interested in adding release to the Google mirror. If anyone else has a desire for this functionality I'd suggest reaching out to someone at Google and reverting this change.

closes https://github.com/bazelbuild/rules_rust/issues/1502