### PR TITLE
Add `stdlib_deps` to `rust_toolchain`

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -33,6 +33,7 @@ load(
     "is_exec_configuration",
     "make_static_lib_symlink",
     "relativize",
+    "transform_deps",
 )
 
 BuildInfo = _BuildInfo
@@ -1030,7 +1031,7 @@ def rustc_compile_action(
             experimental_use_cc_common_link = toolchain._experimental_use_cc_common_link
 
     dep_info, build_info, linkstamps = collect_deps(
-        deps = crate_info.deps,
+        deps = depset(transform_deps(toolchain.stdlib_deps.to_list()), transitive = [crate_info.deps]),
         proc_macro_deps = crate_info.proc_macro_deps,
         aliases = crate_info.aliases,
         are_linkstamps_supported = _are_linkstamps_supported(

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -531,6 +531,7 @@ def _rust_toolchain_impl(ctx):
         rustfmt = sysroot.rustfmt,
         staticlib_ext = ctx.attr.staticlib_ext,
         stdlib_linkflags = stdlib_linkflags_cc_info,
+        stdlib_deps = depset(ctx.attr.stdlib_deps),
         sysroot = sysroot_path,
         sysroot_short_path = sysroot_short_path,
         target_arch = ctx.attr.target_triple.split("-")[0],
@@ -669,6 +670,9 @@ rust_toolchain = rule(
                 "to the srcs of the `rust_std` attribute."
             ),
             mandatory = True,
+        ),
+        "stdlib_deps": attr.label_list(
+            doc = "Extra deps needed for any targets that link to the standard library",
         ),
         "target_json": attr.label(
             doc = ("Override the target_triple with a custom target specification. " +


### PR DESCRIPTION
Currently it's possible to use `stdlib_linkflags` to add things like `-lpthread` when linking against std. However this relies on the toolchain implicitly adding the search dir for that library (iiuc it works because pthread is part of the sysroot). For the [*-fuchsia targets](https://doc.rust-lang.org/nightly/rustc/platform-support/fuchsia.html) the stdlib also depends on the library `fdio` which is _not_ part of the sysroot.

Today to get compilation for fuchsia working you have to add this dependency on fdio manually on _every_ rust target (`deps = if_fuchsia(["@fuchsia_sdk//pkg/fdio"])`), otherwise you'll get `ld.lld: error: unable to find library -lfdio`. To accommodate for this we propose adding a `stdlib_deps` field on the toolchain definition. Its contents will be added as a dep for all rust targets built with that toolchain.