### PR TITLE
Restore support for old `cargo_build_script` load statements

### DIFF
--- a/cargo/cargo_build_script.bzl
+++ b/cargo/cargo_build_script.bzl
@@ -1,0 +1,16 @@
+"""Legacy load locations for Cargo build script rules
+
+Instead, `defs.bzl` should be used.
+"""
+
+load(
+    "//cargo/private:cargo_build_script.bzl",
+    _cargo_dep_env = "cargo_dep_env",
+)
+load(
+    "//cargo/private:cargo_build_script_wrapper.bzl",
+    _cargo_build_script = "cargo_build_script",
+)
+
+cargo_build_script = _cargo_build_script
+cargo_dep_env = _cargo_dep_env


### PR DESCRIPTION
This is a follow up to https://github.com/bazelbuild/rules_rust/pull/1612. To ensure the git history for `cargo_build_script.bzl` is cleanly migrated, backwards compatibility is handled in this PR.