### PR TITLE
Upgraded cfg-expr dependency to 0.12.0.

### DIFF
--- a/crate_universe/3rdparty/crates/BUILD.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bazel
@@ -59,7 +59,7 @@ alias(
 
 alias(
     name = "cfg-expr",
-    actual = "@cui__cfg-expr-0.11.0//:cfg_expr",
+    actual = "@cui__cfg-expr-0.12.0//:cfg_expr",
     tags = ["manual"],
 )
 

--- a/crate_universe/3rdparty/crates/BUILD.cfg-expr-0.12.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cfg-expr-0.12.0.bazel
@@ -82,7 +82,7 @@ rust_library(
         "noclippy",
         "norustfmt",
     ],
-    version = "0.11.0",
+    version = "0.12.0",
     deps = [
     ] + select_with_or({
         "//conditions:default": [

--- a/crate_universe/3rdparty/crates/defs.bzl
+++ b/crate_universe/3rdparty/crates/defs.bzl
@@ -296,7 +296,7 @@ _NORMAL_DEPENDENCIES = {
             "cargo-platform": "@cui__cargo-platform-0.1.2//:cargo_platform",
             "cargo_metadata": "@cui__cargo_metadata-0.15.1//:cargo_metadata",
             "cargo_toml": "@cui__cargo_toml-0.13.0//:cargo_toml",
-            "cfg-expr": "@cui__cfg-expr-0.11.0//:cfg_expr",
+            "cfg-expr": "@cui__cfg-expr-0.12.0//:cfg_expr",
             "clap": "@cui__clap-4.0.18//:clap",
             "crates-index": "@cui__crates-index-0.18.10//:crates_index",
             "hex": "@cui__hex-0.4.3//:hex",
@@ -634,12 +634,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "cui__cfg-expr-0.11.0",
-        sha256 = "b0357a6402b295ca3a86bc148e84df46c02e41f41fef186bda662557ef6328aa",
+        name = "cui__cfg-expr-0.12.0",
+        sha256 = "0bbc13bf6290a6b202cc3efb36f7ec2b739a80634215630c8053a313edf6abef",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/cfg-expr/0.11.0/download"],
-        strip_prefix = "cfg-expr-0.11.0",
-        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.cfg-expr-0.11.0.bazel"),
+        urls = ["https://crates.io/api/v1/crates/cfg-expr/0.12.0/download"],
+        strip_prefix = "cfg-expr-0.12.0",
+        build_file = Label("@rules_rust//crate_universe/3rdparty/crates:BUILD.cfg-expr-0.12.0.bazel"),
     )
 
     maybe(

--- a/crate_universe/Cargo.lock
+++ b/crate_universe/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0357a6402b295ca3a86bc148e84df46c02e41f41fef186bda662557ef6328aa"
+checksum = "0bbc13bf6290a6b202cc3efb36f7ec2b739a80634215630c8053a313edf6abef"
 dependencies = [
  "smallvec",
 ]

--- a/crate_universe/Cargo.toml
+++ b/crate_universe/Cargo.toml
@@ -24,7 +24,7 @@ cargo_metadata = "0.15.1"
 cargo_toml = "0.13.0"
 cargo-lock = "8.0.2"
 cargo-platform = "0.1.2"
-cfg-expr = "0.11.0"
+cfg-expr = "0.12.0"
 clap = { version = "4.0.13", features = ["derive", "env"] }
 crates-index = { version = "0.18.10", default-features = false }
 hex = "0.4.3"


### PR DESCRIPTION
Upgrades [cfg-expr](https://crates.io/crates/cfg-expr) to version 0.12.0, which now supports `target_abi` in cfg expressions. Without it, if your project depends on a crate that uses it (one example of such crate is `getrandom`) the `crago-bazel` tool fails parsing generated metadata.json.