### PR TITLE
Deduplicate expand_location targets in rust-project.json crate creation to avoid a bazel crash

### DIFF
--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -23,7 +23,13 @@ to Cargo.toml files.
 load("//rust/platform:triple_mappings.bzl", "system_to_dylib_ext", "triple_to_system")
 load("//rust/private:common.bzl", "rust_common")
 load("//rust/private:rustc.bzl", "BuildInfo")
-load("//rust/private:utils.bzl", "dedent", "find_toolchain")
+load(
+    "//rust/private:utils.bzl",
+    "concat",
+    "dedent",
+    "dedup_expand_location",
+    "find_toolchain",
+)
 
 RustAnalyzerInfo = provider(
     doc = "RustAnalyzerInfo holds rust crate metadata for targets",
@@ -182,14 +188,11 @@ def _create_single_crate(ctx, info):
             "include_dirs": [crate_root, _EXEC_ROOT_TEMPLATE + out_dir_path],
         }
 
-    # We deduplicate the entries from each of the additional targets to work around
-    # https://github.com/bazelbuild/bazel/issues/16664
-    #
     # TODO: The only imagined use case is an env var holding a filename in the workspace passed to a
     # macro like include_bytes!. Other use cases might exist that require more complex logic.
-    expand_targets = _deduplicate(_concat([getattr(ctx.rule.attr, attr, []) for attr in ["data", "compile_data"]]))
+    expand_targets = concat([getattr(ctx.rule.attr, attr, []) for attr in ["data", "compile_data"]])
 
-    crate["env"].update({k: ctx.expand_location(v, expand_targets) for k, v in info.env.items()})
+    crate["env"].update({k: dedup_expand_location(ctx, v, expand_targets) for k, v in info.env.items()})
 
     # Omit when a crate appears to depend on itself (e.g. foo_test crates).
     # It can happen a single source file is present in multiple crates - there can
@@ -207,12 +210,6 @@ def _create_single_crate(ctx, info):
     if info.proc_macro_dylib_path != None:
         crate["proc_macro_dylib_path"] = _EXEC_ROOT_TEMPLATE + info.proc_macro_dylib_path
     return crate
-
-def _deduplicate(xs):
-    return {x: True for x in xs}.keys()
-
-def _concat(xss):
-    return [x for xs in xss for x in xs]
 
 def _rust_analyzer_toolchain_impl(ctx):
     toolchain = platform_common.ToolchainInfo(

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -223,7 +223,7 @@ def get_preferred_artifact(library_to_link, use_pic):
             library_to_link.dynamic_library
         )
 
-def _expand_location(ctx, env, data):
+def _expand_location_for_build_script_runner(ctx, env, data):
     """A trivial helper for `expand_dict_value_locations` and `expand_list_element_locations`
 
     Args:
@@ -273,7 +273,7 @@ def expand_dict_value_locations(ctx, env, data):
     Returns:
         dict: A dict of environment variables with expanded location macros
     """
-    return dict([(k, _expand_location(ctx, v, data)) for (k, v) in env.items()])
+    return dict([(k, _expand_location_for_build_script_runner(ctx, v, data)) for (k, v) in env.items()])
 
 def expand_list_element_locations(ctx, args, data):
     """Performs location-macro expansion on a list of string values.
@@ -296,7 +296,7 @@ def expand_list_element_locations(ctx, args, data):
     Returns:
         list: A list of arguments with expanded location macros
     """
-    return [_expand_location(ctx, arg, data) for arg in args]
+    return [_expand_location_for_build_script_runner(ctx, arg, data) for arg in args]
 
 def name_to_crate_name(name):
     """Converts a build target's name into the name of its associated crate.

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -3,7 +3,13 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//rust/private:common.bzl", "rust_common")
 load("//rust/private:rust_analyzer.bzl", _rust_analyzer_toolchain = "rust_analyzer_toolchain")
-load("//rust/private:utils.bzl", "dedent", "find_cc_toolchain", "make_static_lib_symlink")
+load(
+    "//rust/private:utils.bzl",
+    "dedent",
+    "dedup_expand_location",
+    "find_cc_toolchain",
+    "make_static_lib_symlink",
+)
 
 rust_analyzer_toolchain = _rust_analyzer_toolchain
 
@@ -456,7 +462,8 @@ def _rust_toolchain_impl(ctx):
     expanded_stdlib_linkflags = []
     for flag in ctx.attr.stdlib_linkflags:
         expanded_stdlib_linkflags.append(
-            ctx.expand_location(
+            dedup_expand_location(
+                ctx,
                 flag,
                 targets = rust_std[rust_common.stdlib_info].srcs,
             ),


### PR DESCRIPTION
There's a bug in bazel where the server crashes if it encounters duplicate entries in expand_location's targets field.

See https://github.com/bazelbuild/bazel/issues/16664.