### PR TITLE
Fix vendoring when not in a package

### DIFF
--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -48,7 +48,7 @@ def _get_output_package(ctx):
             ctx.label.package,
             ctx.attr.vendor_path,
         )
-    return output
+    return output.lstrip("/")
 
 def _write_data_file(ctx, name, data):
     file = ctx.actions.declare_file("{}.{}".format(ctx.label.name, name))


### PR DESCRIPTION
When vendoring from a label that is not in a package, the output directory would be incorrectly set to `/vendor_path` and be treated as an absolute path.