### PR TITLE
Fix issue #1417 - Group deps by platform triple rather than cfg(...) string.

### DIFF
--- a/crate_universe/src/rendering/templates/partials/crate/aliases.j2
+++ b/crate_universe/src/rendering/templates/partials/crate/aliases.j2
@@ -1,32 +1,23 @@
-selects.with_or({
-    {%- for cfg, values in selectable.selects %}
-    {%- if context.conditions | get(key=cfg, default="") | length%}
-        # {{ cfg }}
-        (
-            {%- for triple in context.conditions | get(key=cfg) %}
-            "{{ platform_label(triple = triple) }}",
-            {%- endfor %}
-        ): {
-            {%- for dep in values %}
-            {%- set dep_crate = context.crates | get(key=dep.id) %}
-            "{{ crate_label(name = dep_crate.name, version = dep_crate.version, target = dep.target) }}": "{{ dep.alias }}",
-            {%- endfor %}
-            {%- for dep in selectable.common %}
-            {%- set dep_crate = context.crates | get(key=dep.id) %}
-            "{{ crate_label(name = dep_crate.name, version = dep_crate.version, target = dep.target) }}": "{{ dep.alias }}",
+select({
+    {%- set selectable_and_unmapped = selectable | remap_deps_configurations(mapping=context.conditions) %}
+    {%- set selectable = selectable_and_unmapped.0 %}
+    {%- set unmapped = selectable_and_unmapped.1 %}
+    {%- for triple, deps in selectable.selects %}
+        "{{ platform_label(triple = triple) }}": {
+            {%- for dep in deps %}
+            {%- set_global orig_confg_list = [] %}
+            {%- for orig_config in dep.original_configurations %}
+            {%- set_global orig_confg_list = orig_confg_list | concat(with=orig_config | default(value="common dependency")) %}
+            {%- endfor -%}
+            {%- set dep_crate = context.crates | get(key=dep.value.id) %}
+            "{{ crate_label(name = dep_crate.name, version = dep_crate.version, target = dep.value.target) }}": "{{ dep.value.alias }}",  # {{ orig_confg_list | join(sep=", ") }}
             {%- endfor %}
         },
-    {%- else %}
-        # {
-        # No supported platform triples for cfg: '{{ cfg }}'
-        # Skipped dependencies: {{ values | json_encode | safe }}
-        # }
-    {%- endif %}
     {%- endfor %}
         "//conditions:default": {
             {%- for dep in selectable.common %}
-            {%- set dep_crate = context.crates | get(key=dep.id) %}
-            "{{ crate_label(name = dep_crate.name, version = dep_crate.version, target = dep.target) }}": "{{ dep.alias }}",
+            {%- set dep_crate = context.crates | get(key=dep.value.id) %}
+            "{{ crate_label(name = dep_crate.name, version = dep_crate.version, target = dep.value.target) }}": "{{ dep.value.alias }}",
             {%- endfor %}
         },
     })

--- a/crate_universe/src/rendering/templates/partials/crate/deps.j2
+++ b/crate_universe/src/rendering/templates/partials/crate/deps.j2
@@ -1,36 +1,29 @@
-select_with_or({
-    {%- set selectable = deps | default(value=default_select_list) %}
-    {%- for cfg, values in selectable.selects %}
-        # {{ cfg }}
-    {%- if context.conditions | get(key=cfg, default="") | length %}
-        (
-            {%- for triple in context.conditions | get(key=cfg) %}
-            "{{ platform_label(triple = triple) }}",
-            {%- endfor %}
-        ): [
-            # Target Deps
-            {%- for dep in values %}
-            {%- set dep_crate = context.crates | get(key=dep.id) %}
-            "{{ crate_label(name = dep_crate.name, version = dep_crate.version, target = dep.target) }}",
-            {%- endfor %}
-
-            # Common Deps
-            {%- for common_dep in selectable.common %}
-            {%- set common_dep_crate = context.crates | get(key=common_dep.id) %}
-            "{{ crate_label(name = common_dep_crate.name, version = common_dep_crate.version, target = common_dep.target) }}",
+select({
+    {%- set selectable_and_unmapped = deps | default(value=default_select_list) | remap_deps_configurations(mapping=context.conditions) %}
+    {%- set selectable = selectable_and_unmapped.0 %}
+    {%- set unmapped = selectable_and_unmapped.1 %}
+    {%- for triple, deps in selectable.selects %}
+        "{{ platform_label(triple = triple) }}": [
+            {%- for dep in deps %}
+            {%- set_global orig_confg_list = [] %}
+            {%- for orig_config in dep.original_configurations %}
+            {%- set_global orig_confg_list = orig_confg_list | concat(with=orig_config | default(value="common dependency")) %}
+            {%- endfor -%}
+            {%- set dep_crate = context.crates | get(key=dep.value.id) %}
+            "{{ crate_label(name = dep_crate.name, version = dep_crate.version, target = dep.value.target) }}",  # {{ orig_confg_list | join(sep=", ") }}
             {%- endfor %}
         ],
-    {%- else %}
-            #
-            # No supported platform triples for cfg: '{{ cfg }}'
-            # Skipped dependencies: {{ values | json_encode | safe }}
-            #
-    {%- endif %}
     {%- endfor %}
         "//conditions:default": [
             {%- for common_dep in selectable.common %}
-            {%- set common_dep_crate = context.crates | get(key=common_dep.id) %}
-            "{{ crate_label(name = common_dep_crate.name, version = common_dep_crate.version, target = common_dep.target) }}",
+            {%- set common_dep_crate = context.crates | get(key=common_dep.value.id) %}
+            "{{ crate_label(name = common_dep_crate.name, version = common_dep_crate.version, target = common_dep.value.target) }}",
             {%- endfor %}
         ],
+    {%- for cfg, deps in unmapped %}
+        #
+        # No supported platform triples for cfg: '{{ cfg }}'
+        # Skipped dependencies: {{ deps | json_encode | safe }}
+        #
+    {%- endfor %}
     })

--- a/crate_universe/src/test.rs
+++ b/crate_universe/src/test.rs
@@ -127,6 +127,14 @@ pub mod lockfile {
         .unwrap()
     }
 
+    pub fn multi_cfg_dep() -> cargo_lock::Lockfile {
+        cargo_lock::Lockfile::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_data/metadata/multi_cfg_dep/Cargo.lock"
+        )))
+        .unwrap()
+    }
+
     pub fn no_deps() -> cargo_lock::Lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),


### PR DESCRIPTION
Group deps and aliases by platform triple rather than by cfg string when generating BUILD files. This avoid Bazel errors due to duplicate keys/deps. See https://github.com/bazelbuild/rules_rust/issues/1417.

This is done purely at render time by adding a new Tera filter which will remap the conditions in the deps SelectList from "cfg(...)" strings to platform triple strings.

This is my first PR here, so please bear with me if I'm doing things wrong!