### PR TITLE
Update `//util/label` to support `+` in packages

### DIFF
--- a/util/label/label.rs
+++ b/util/label/label.rs
@@ -153,7 +153,7 @@ fn consume_package_name<'s>(input: &'s str, label: &'s str) -> Result<(&'s str, 
         return Err(LabelError(err(
             label,
             "package names may contain only A-Z, \
-        a-z, 0-9, '/', '-', '.', ' ', '$', '(', ')' and '_'.",
+        a-z, 0-9, '/', '-', '.', ' ', '$', '(', ')', '_', and '+'.",
         )));
     }
     if package_name.ends_with('/') {
@@ -339,7 +339,7 @@ mod tests {
             analyze("//bar#:baz"),
             Err(LabelError(
                 "//bar#:baz must be a legal label; package names may contain only A-Z, \
-                a-z, 0-9, '/', '-', '.', ' ', '$', '(', ')' and '_'."
+                a-z, 0-9, '/', '-', '.', ' ', '$', '(', ')', '_', and '+'."
                     .to_string()
             ))
         );

--- a/util/label/label.rs
+++ b/util/label/label.rs
@@ -148,6 +148,7 @@ fn consume_package_name<'s>(input: &'s str, label: &'s str) -> Result<(&'s str, 
             || c == '('
             || c == ')'
             || c == '_'
+            || c == '+'
     }) {
         return Err(LabelError(err(
             label,
@@ -419,6 +420,12 @@ mod tests {
         assert_eq!(
             analyze("@repo//foo/bar:baz")?.packages(),
             vec!["foo", "bar"]
+        );
+
+        // Plus (+) is valid in packages
+        assert_eq!(
+            analyze("@repo//foo/bar+baz:qaz")?.packages(),
+            vec!["foo", "bar+baz"]
         );
 
         Ok(())


### PR DESCRIPTION
This is apparently valid which I confirmed with an `sh_test` in a `baz/foo+bar` package.
```
rules_rust % bazel test //baz/...
INFO: Analyzed target //baz/foo+bar:test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //baz/foo+bar:test up-to-date:
  bazel-bin/baz/foo+bar/test
INFO: Elapsed time: 0.216s, Critical Path: 0.09s
INFO: 3 processes: 1 internal, 2 darwin-sandbox.
INFO: Build completed successfully, 3 total actions
//baz/foo+bar:test                                                       PASSED in 0.1s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 3 total actions
```