### PR TITLE
Reenable windows job

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -65,17 +65,17 @@ tasks:
     test_targets: *default_macos_targets
     build_flags:
       - "--compilation_mode=opt"
-   windows_opt:
-     name: Opt Mode
-     platform: windows
-     build_flags:
-       - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts
-       - "--compilation_mode=opt"
-     test_flags:
-       - "--enable_runfiles"
-       - "--compilation_mode=opt"
-     build_targets: *default_windows_targets
-     test_targets: *default_windows_targets
+  windows_opt:
+    name: Opt Mode
+    platform: windows
+    build_flags:
+      - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts
+      - "--compilation_mode=opt"
+    test_flags:
+      - "--enable_runfiles"
+      - "--compilation_mode=opt"
+    build_targets: *default_windows_targets
+    test_targets: *default_windows_targets
   ubuntu2004_with_aspects:
     name: With Aspects
     platform: ubuntu2004
@@ -135,6 +135,8 @@ tasks:
       - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts
       - "--config=rustfmt"
       - "--config=clippy"
+    test_flags:
+      - "--enable_runfiles"
     build_targets: *default_windows_targets
     test_targets: *default_windows_targets
   windows_rolling_with_aspects:
@@ -145,7 +147,7 @@ tasks:
       - "--config=rustfmt"
       - "--config=clippy"
     test_flags:
-      - "--compilation_mode=opt"
+      - "--enable_runfiles"
     build_targets: *default_windows_targets
     test_targets: *default_windows_targets
     soft_fail: yes


### PR DESCRIPTION
Previously we were not passing `--enable_runfiles` to the CI tests. This PR fixes all the windows jobs to pass `--enable_runfiles`