### PR TITLE
fix: add space to crate data exclude list

### DIFF
--- a/crate_universe/src/rendering/templates/partials/crate/common_attrs.j2
+++ b/crate_universe/src/rendering/templates/partials/crate/common_attrs.j2
@@ -5,7 +5,7 @@
         "{{ feature }}",
         {%- endfor %}
     ],
-    data = {% if crate.common_attrs | get(key="data_glob") %}glob(include = {{ crate.common_attrs.data_glob | json_encode | safe }}, exclude = ["BUILD", "BUILD.bazel", "WORKSPACE", "WORKSPACE.bazel"]) + {% endif %}{% set selectable = crate.common_attrs | get(key="data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
+    data = {% if crate.common_attrs | get(key="data_glob") %}glob(include = {{ crate.common_attrs.data_glob | json_encode | safe }}, exclude = ["BUILD", "BUILD.bazel", "WORKSPACE", "WORKSPACE.bazel", "**/* *"]) + {% endif %}{% set selectable = crate.common_attrs | get(key="data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
     edition = "{{ crate.common_attrs.edition }}",
     {%- if crate.common_attrs | get(key="linker_script", default=Null) %}
     linker_script = "{{ crate.common_attrs.linker_script }}",


### PR DESCRIPTION
Add files with spaces to the exclude list. [Original discussion raised on Slack](https://bazelbuild.slack.com/archives/CSV56UT0F/p1669140022100749?thread_ts=1669139179.947319&cid=CSV56UT0F): 

> Hey! I'm trying to setup my Rust project for the first time following the example from rules_rust/examples/crate_universe but I get the following error. My rust binary compiles and run just fine when running outside Bazel. It seems to be related with one of the deps having a space in its name? How can I address that?
> ```
> INFO: Analyzed target //backend/router:router (1 packages loaded, 5 targets configured).
> INFO: Found 1 target...
> ERROR: /private/var/tmp/_bazel_andre.bazaglia/d99a96be6823e596c135c9df87021555/external/crate_index__v8-0.44.3/BUILD.bazel:98:19: Creating runfiles tree bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/crate_index__v8-0.44.3/v8_build_script_.runfiles [for tool] failed: build-runfiles failed: error executing command
>   (cd /private/var/tmp/_bazel_andre.bazaglia/d99a96be6823e596c135c9df87021555/execroot/energy_services && \
>   exec env - \
>     PATH=/bin:/usr/bin:/usr/local/bin \
>   /var/tmp/_bazel_andre.bazaglia/install/796da0a89b8d87ba0127fbf18aa5085d/build-runfiles --allow_relative bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/crate_index__v8-0.44.3/v8_build_script_.runfiles_manifest bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/crate_index__v8-0.44.3/v8_build_script_.runfiles): Process exited with status 1: Process exited with status 1
> /var/tmp/_bazel_andre.bazaglia/install/796da0a89b8d87ba0127fbf18aa5085d/build-runfiles (args bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/crate_index__v8-0.44.3/v8_build_script_.runfiles_manifest bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/crate_index__v8-0.44.3/v8_build_script_.runfiles): link or target filename contains space on line 1835: 'crate_index__v8-0.44.3/third_party/zlib/google/test/data/Different Encryptions.zip /private/var/tmp/_bazel_andre.bazaglia/d99a96be6823e596c135c9df87021555/external/crate_index__v8-0.44.3/third_party/zlib/google/test/data/Different Encryptions.zip'
> ```