### PR TITLE
Common glob excludes

### DIFF
--- a/crate_universe/src/rendering/template_engine.rs
+++ b/crate_universe/src/rendering/template_engine.rs
@@ -23,6 +23,14 @@ pub struct TemplateEngine {
     context: tera::Context,
 }
 
+const COMMON_GLOB_EXCLUDES: &'static [&str] = &[
+    "**/* *",
+    "BUILD.bazel",
+    "BUILD",
+    "WORKSPACE.bazel",
+    "WORKSPACE",
+];
+
 impl TemplateEngine {
     pub fn new(render_config: &RenderConfig) -> Self {
         let mut tera = Tera::default();
@@ -202,6 +210,7 @@ impl TemplateEngine {
         context.insert("vendor_mode", &render_config.vendor_mode);
         context.insert("regen_command", &render_config.regen_command);
         context.insert("Null", &tera::Value::Null);
+        context.insert("common_glob_excludes", &COMMON_GLOB_EXCLUDES);
         context.insert(
             "default_package_name",
             &match render_config.default_package_name.as_ref() {

--- a/crate_universe/src/rendering/template_engine.rs
+++ b/crate_universe/src/rendering/template_engine.rs
@@ -23,7 +23,7 @@ pub struct TemplateEngine {
     context: tera::Context,
 }
 
-const COMMON_GLOB_EXCLUDES: &'static [&str] = &[
+const COMMON_GLOB_EXCLUDES: &[&str] = &[
     "**/* *",
     "BUILD.bazel",
     "BUILD",

--- a/crate_universe/src/rendering/templates/partials/crate/build_script.j2
+++ b/crate_universe/src/rendering/templates/partials/crate/build_script.j2
@@ -3,7 +3,7 @@ cargo_build_script(
     name = "{{ crate.name }}_build_script",
     aliases = {% set selectable = build_aliases %}{% include "partials/crate/aliases.j2" -%},
     build_script_env = {% set selectable = crate.build_script_attrs | get(key="build_script_env", default=Null) %}{% include "partials/starlark/selectable_dict.j2" -%},
-    compile_data = {% if crate.build_script_attrs | get(key="compile_data_glob") %}glob({{ crate.build_script_attrs.compile_data_glob | json_encode | safe }}) + {% endif %}{% set selectable = crate.build_script_attrs | get(key="compile_data", default=Null) %}{% include "partials/starlark/selectable_list.j2" %},
+    compile_data = {% if crate.build_script_attrs | get(key="compile_data_glob") %}glob(include = {{ crate.build_script_attrs.compile_data_glob | json_encode | safe }}, exclude = {{ common_glob_excludes | json_encode() | safe }}) + {% endif %}{% set selectable = crate.build_script_attrs | get(key="compile_data", default=Null) %}{% include "partials/starlark/selectable_list.j2" %},
     crate_name = "{{ sanitize_module_name(crate_name=target.crate_name) }}",
     crate_root = "{{ target.crate_root }}",
     crate_features = [
@@ -13,7 +13,7 @@ cargo_build_script(
         {%- endfor %}
         {%- endif %}
     ],
-    data = {% if crate.build_script_attrs | get(key="data_glob") %}glob({{ crate.build_script_attrs.data_glob | json_encode | safe }}) + {% endif %}{% set selectable = crate.build_script_attrs | get(key="data", default=Null) %}{% include "partials/starlark/selectable_list.j2" %},
+    data = {% if crate.build_script_attrs | get(key="data_glob") %}glob(include = {{ crate.build_script_attrs.data_glob | json_encode | safe }}, exclude = {{ common_glob_excludes | json_encode() | safe }}) + {% endif %}{% set selectable = crate.build_script_attrs | get(key="data", default=Null) %}{% include "partials/starlark/selectable_list.j2" %},
     deps = [
         {%- for dep in crate.build_script_attrs | get(key="extra_deps", default=[]) %}
         "{{ dep }}",

--- a/crate_universe/src/rendering/templates/partials/crate/common_attrs.j2
+++ b/crate_universe/src/rendering/templates/partials/crate/common_attrs.j2
@@ -1,11 +1,11 @@
-    compile_data = {% if crate.common_attrs | get(key="compile_data_glob") %}glob(include = {{ crate.common_attrs.compile_data_glob | json_encode | safe }}, exclude = ["BUILD", "BUILD.bazel", "WORKSPACE", "WORKSPACE.bazel"]) + {% endif %}{% set selectable = crate.common_attrs | get(key="compile_data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
+    compile_data = {% if crate.common_attrs | get(key="compile_data_glob") %}glob(include = {{ crate.common_attrs.compile_data_glob | json_encode | safe }}, exclude = {{ common_glob_excludes | json_encode() | safe }}) + {% endif %}{% set selectable = crate.common_attrs | get(key="compile_data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
     crate_root = "{{ target.crate_root }}",
     crate_features = [
         {%- for feature in crate.common_attrs | get(key="crate_features", default=[]) %}
         "{{ feature }}",
         {%- endfor %}
     ],
-    data = {% if crate.common_attrs | get(key="data_glob") %}glob(include = {{ crate.common_attrs.data_glob | json_encode | safe }}, exclude = ["BUILD", "BUILD.bazel", "WORKSPACE", "WORKSPACE.bazel", "**/* *"]) + {% endif %}{% set selectable = crate.common_attrs | get(key="data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
+    data = {% if crate.common_attrs | get(key="data_glob") %}glob(include = {{ crate.common_attrs.data_glob | json_encode | safe }}, exclude = {{ common_glob_excludes | json_encode() | safe }}) + {% endif %}{% set selectable = crate.common_attrs | get(key="data", default=default_select_list) %}{% include "partials/starlark/selectable_list.j2" -%},
     edition = "{{ crate.common_attrs.edition }}",
     {%- if crate.common_attrs | get(key="linker_script", default=Null) %}
     linker_script = "{{ crate.common_attrs.linker_script }}",


### PR DESCRIPTION
PR #1665, unfortunately, missed updating the exclude attribute from the glob helper function everywhere it was used. This PR fixes that and also makes it now consistent everywhere it is needed by creating a centralized list.

I created a repro in [bazaglia/rules_rust_apollo_router](https://github.com/bazaglia/rules_rust_apollo_router) and verify a build that was previously failing because of the inconsistency in the exclude globs works with the changes in that PR. Thanks for sharing the diff @UebelAndre. 😃 