### PR TITLE
Added CI for single toolchain channel workspaces

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,6 +4,12 @@ aspects_flags: &aspects_flags
   - "--config=clippy"
 min_rust_version_shell_commands: &min_rust_version_shell_commands
   - sed -i 's|^rust_register_toolchains(|rust_register_toolchains(versions = ["1.59.0"],\n|' WORKSPACE.bazel
+nightly_flags: &nightly_flags
+  - "--//rust/toolchain/channel=nightly"
+nightly_aspects_flags: &nightly_aspects_flags
+  - "--//rust/toolchain/channel=nightly"
+  - "--config=rustfmt"
+  - "--config=clippy"
 single_rust_channel_targets: &single_rust_channel_targets
   - "--"
   - "//..."
@@ -219,9 +225,48 @@ tasks:
     name: "Min Rust Version With Aspects"
     platform: ubuntu2004
     shell_commands: *min_rust_version_shell_commands
+    build_flags: *aspects_flags
+    build_targets: *single_rust_channel_targets
+    test_flags: *aspects_flags
+    test_targets: *single_rust_channel_targets
+  ubuntu2004_stable_toolchain:
+    name: "Only Stable Toolchain"
+    platform: ubuntu2004
+    # Test rules while only registering a nightly toolchain
+    shell_commands:
+      - sed -i 's|^rust_register_toolchains(|load("//rust/private:common.bzl", "DEFAULT_RUST_VERSION")\nrust_register_toolchains(versions = [DEFAULT_RUST_VERSION],\n|' WORKSPACE.bazel
     build_targets: *single_rust_channel_targets
     test_targets: *single_rust_channel_targets
+  ubuntu2004_stable_with_aspects:
+    name: "Only Stable Toolchain With Aspects"
+    platform: ubuntu2004
+    # Test rules while only registering a nightly toolchain
+    shell_commands:
+      - sed -i 's|^rust_register_toolchains(|load("//rust/private:common.bzl", "DEFAULT_RUST_VERSION")\nrust_register_toolchains(versions = [DEFAULT_RUST_VERSION],\n|' WORKSPACE.bazel
     build_flags: *aspects_flags
+    build_targets: *single_rust_channel_targets
+    test_flags: *aspects_flags
+    test_targets: *single_rust_channel_targets
+  ubuntu2004_nightly_toolchain:
+    name: "Only Nightly Toolchain"
+    platform: ubuntu2004
+    # Test rules while only registering a nightly toolchain
+    shell_commands:
+      - sed -i 's|^rust_register_toolchains(|load("//rust/private:common.bzl", "DEFAULT_NIGHTLY_ISO_DATE")\nrust_register_toolchains(versions = ["nightly/" + DEFAULT_NIGHTLY_ISO_DATE],\n|' WORKSPACE.bazel
+    build_flags: *nightly_flags
+    build_targets: *single_rust_channel_targets
+    test_flags: *nightly_flags
+    test_targets: *single_rust_channel_targets
+  ubuntu2004_nightly_with_aspects:
+    name: "Only Nightly Toolchain With Aspects"
+    platform: ubuntu2004
+    # Test rules while only registering a nightly toolchain
+    shell_commands:
+      - sed -i 's|^rust_register_toolchains(|load("//rust/private:common.bzl", "DEFAULT_NIGHTLY_ISO_DATE")\nrust_register_toolchains(versions = ["nightly/" + DEFAULT_NIGHTLY_ISO_DATE],\n|' WORKSPACE.bazel
+    build_flags: *nightly_aspects_flags
+    build_targets: *single_rust_channel_targets
+    test_flags: *nightly_aspects_flags
+    test_targets: *single_rust_channel_targets
   ubuntu2004_rolling_with_aspects:
     name: "Rolling Bazel Version With Aspects"
     bazel: "rolling"

--- a/test/cargo_build_script/tools_exec.rs
+++ b/test/cargo_build_script/tools_exec.rs
@@ -3,7 +3,6 @@ pub fn test_tool_exec() {
     let tool_path = env!("TOOL_PATH");
     assert!(
         tool_path.contains("-exec-"),
-        "tool_path did not contain '-exec-': {}",
-        tool_path
+        "tool_path did not contain '-exec-'",
     );
 }

--- a/test/process_wrapper/rustc_quit_on_rmeta.rs
+++ b/test/process_wrapper/rustc_quit_on_rmeta.rs
@@ -68,8 +68,7 @@ mod test {
         ]);
         assert!(
             !out_content.contains("should not be in output"),
-            "output should not contain 'should not be in output' but did: {}",
-            out_content
+            "output should not contain 'should not be in output' but did",
         );
     }
 

--- a/test/rustfmt/rustfmt_failure_test.sh
+++ b/test/rustfmt/rustfmt_failure_test.sh
@@ -23,7 +23,7 @@ cd "${BUILD_WORKSPACE_DIRECTORY}"
 function check_build_result() {
   local ret=0
   echo -n "Testing ${2}... "
-  (bazel test //test/rustfmt:"${2}" &> /dev/null) || ret="$?" && true
+  (bazel test //test/rustfmt:"${2}") || ret="$?" && true
   if [[ "${ret}" -ne "${1}" ]]; then
     echo "FAIL: Unexpected return code [saw: ${ret}, want: ${1}] building target //test/rustfmt:${2}"
     echo "  Run \"bazel test //test/rustfmt:${2}\" to see the output"


### PR DESCRIPTION
This provides regression testing for cases where users have only registered one toolchain in their workspace (meaning they only have a toolchain of a single [channel](https://rust-lang.github.io/rustup/concepts/channels.html) type).