### PR TITLE
Add `Runfiles::current_repository` to runfiles library

### DIFF
--- a/rust/private/BUILD.bazel
+++ b/rust/private/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//rust/private:rust_analyzer.bzl", "rust_analyzer_detect_sysroot")
-load("//rust/private:rustfmt.bzl", "rustfmt_workspace_name")
 load("//rust/private:stamp.bzl", "stamp_build_setting")
 
 bzl_library(
@@ -14,10 +13,5 @@ stamp_build_setting(name = "stamp")
 
 rust_analyzer_detect_sysroot(
     name = "rust_analyzer_detect_sysroot",
-    visibility = ["//visibility:public"],
-)
-
-rustfmt_workspace_name(
-    name = "rustfmt_workspace_name",
     visibility = ["//visibility:public"],
 )

--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -204,22 +204,3 @@ rustfmt_test = rule(
     },
     test = True,
 )
-
-def _rustfmt_workspace_name_impl(ctx):
-    output = ctx.actions.declare_file(ctx.label.name)
-
-    ctx.actions.write(
-        output = output,
-        content = "RUSTFMT_WORKSPACE={}".format(
-            ctx.workspace_name,
-        ),
-    )
-
-    return [DefaultInfo(
-        files = depset([output]),
-    )]
-
-rustfmt_workspace_name = rule(
-    implementation = _rustfmt_workspace_name_impl,
-    doc = "A rule for detecting the workspace name for Rustfmt runfiles.",
-)

--- a/tools/runfiles/BUILD.bazel
+++ b/tools/runfiles/BUILD.bazel
@@ -1,14 +1,22 @@
 load(
     "//rust:defs.bzl",
-    "rust_doc_test",
+    "rust_doc",
     "rust_library",
     "rust_test",
+)
+load("//tools/runfiles/private:runfiles_utils.bzl", "workspace_name")
+
+workspace_name(
+    name = "workspace_name.env",
 )
 
 rust_library(
     name = "runfiles",
     srcs = ["runfiles.rs"],
     edition = "2018",
+    rustc_env_files = [
+        ":workspace_name.env",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -18,7 +26,7 @@ rust_test(
     data = ["data/sample.txt"],
 )
 
-rust_doc_test(
-    name = "runfiles_doc_test",
+rust_doc(
+    name = "runfiles_doc",
     crate = ":runfiles",
 )

--- a/tools/runfiles/private/BUILD.bazel
+++ b/tools/runfiles/private/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility = ["//tools/runfiles:__pkg__"])
+
+filegroup(
+    name = "distro",
+    srcs = glob([
+        "**/*.bzl",
+    ]) + [
+        "BUILD.bazel",
+    ],
+)

--- a/tools/runfiles/private/runfiles_utils.bzl
+++ b/tools/runfiles/private/runfiles_utils.bzl
@@ -1,0 +1,26 @@
+"""Utilities for the `@rules_rust//tools/runfiles` library"""
+
+_RULES_RUST_RUNFILES_WORKSPACE_NAME = "RULES_RUST_RUNFILES_WORKSPACE_NAME"
+
+def _workspace_name_impl(ctx):
+    output = ctx.actions.declare_file(ctx.label.name)
+
+    ctx.actions.write(
+        output = output,
+        content = "{}={}\n".format(
+            _RULES_RUST_RUNFILES_WORKSPACE_NAME,
+            ctx.workspace_name,
+        ),
+    )
+
+    return [DefaultInfo(
+        files = depset([output]),
+    )]
+
+workspace_name = rule(
+    implementation = _workspace_name_impl,
+    doc = """\
+A rule for detecting the current workspace name and writing it to a file for
+for use with `rustc_env_files` attributes on `rust_*` rules. The workspace
+name is exposed by the variable `{}`.""".format(_RULES_RUST_RUNFILES_WORKSPACE_NAME),
+)

--- a/tools/runfiles/runfiles.rs
+++ b/tools/runfiles/runfiles.rs
@@ -105,6 +105,13 @@ impl Runfiles {
                 .clone(),
         }
     }
+
+    /// Returns the canonical name of the caller's Bazel repository.
+    pub fn current_repository(&self) -> &str {
+        // This value must match the value of `_RULES_RUST_RUNFILES_WORKSPACE_NAME`
+        // which can be found in `@rules_rust//tools/runfiles/private:workspace_name.bzl`
+        env!("RULES_RUST_RUNFILES_WORKSPACE_NAME")
+    }
 }
 
 /// Returns the .runfiles directory for the currently executing binary.
@@ -246,5 +253,14 @@ mod test {
         };
 
         assert_eq!(r.rlocation("a/b"), PathBuf::from("c/d"));
+    }
+
+    #[test]
+    fn test_current_repository() {
+        let r = Runfiles::create().unwrap();
+
+        // This check is unique to the rules_rust repository. The name
+        // here is expected to be different in consumers of this library
+        assert_eq!(r.current_repository(), "rules_rust")
     }
 }

--- a/tools/rustfmt/BUILD.bazel
+++ b/tools/rustfmt/BUILD.bazel
@@ -26,9 +26,6 @@ rust_library(
         "RUSTFMT": "$(rootpath //rust/toolchain:current_rustfmt_files)",
         "RUSTFMT_CONFIG": "$(rootpath //:rustfmt.toml)",
     },
-    rustc_env_files = [
-        "@rules_rust//rust/private:rustfmt_workspace_name",
-    ],
     deps = [
         "//tools/runfiles",
     ],

--- a/tools/rustfmt/src/lib.rs
+++ b/tools/rustfmt/src/lib.rs
@@ -21,14 +21,18 @@ pub struct RustfmtConfig {
 pub fn parse_rustfmt_config() -> RustfmtConfig {
     let runfiles = runfiles::Runfiles::create().unwrap();
 
-    let rustfmt = runfiles.rlocation(concat!(env!("RUSTFMT_WORKSPACE"), "/", env!("RUSTFMT")));
+    let rustfmt = runfiles.rlocation(format!(
+        "{}/{}",
+        runfiles.current_repository(),
+        env!("RUSTFMT")
+    ));
     if !rustfmt.exists() {
         panic!("rustfmt does not exist at: {}", rustfmt.display());
     }
 
-    let config = runfiles.rlocation(concat!(
-        env!("RUSTFMT_WORKSPACE"),
-        "/",
+    let config = runfiles.rlocation(format!(
+        "{}/{}",
+        runfiles.current_repository(),
         env!("RUSTFMT_CONFIG")
     ));
     if !config.exists() {
@@ -76,7 +80,7 @@ pub fn parse_rustfmt_manifest(manifest: &Path) -> RustfmtManifest {
         edition,
         sources: lines
             .into_iter()
-            .map(|src| runfiles.rlocation(format!("{}/{}", env!("RUSTFMT_WORKSPACE"), src)))
+            .map(|src| runfiles.rlocation(format!("{}/{}", runfiles.current_repository(), src)))
             .collect(),
     }
 }
@@ -95,7 +99,9 @@ pub fn find_manifests() -> Vec<PathBuf> {
     std::env::var("RUSTFMT_MANIFESTS")
         .map(|var| {
             var.split(PATH_ENV_SEP)
-                .map(|path| runfiles.rlocation(format!("{}/{}", env!("RUSTFMT_WORKSPACE"), path)))
+                .map(|path| {
+                    runfiles.rlocation(format!("{}/{}", runfiles.current_repository(), path,))
+                })
                 .collect()
         })
         .unwrap_or_default()


### PR DESCRIPTION
This allows users of the Rust runfiles library to construct runfiles paths using a combination of [File.short_path](https://bazel.build/rules/lib/File#short_path) and the new `Runfiles::current_repository` which returns the current workspace name.

Inspired by https://github.com/bazelbuild/bazel/pull/16341