### PR TITLE
Update current_toolchain_files tests to use a dedicated test rule

### DIFF
--- a/test/current_toolchain_files/BUILD.bazel
+++ b/test/current_toolchain_files/BUILD.bazel
@@ -1,43 +1,36 @@
+load(":current_toolchain_files_test.bzl", "current_toolchain_files_test")
+
+exports_files([
+    "current_toolchain_files_test.sh",
+])
+
 # Executable targets will output a pattern similar to the following
 # cargo 1.53.0 (4369396ce 2021-04-27)
 # Also Note, rustc_srcs is too big for this test
 _FILES = {
-    "cargo": ("--executable", r"^cargo [0-9\.]\+ ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
-    "clippy": ("--executable", r"^clippy [0-9\.]\+ ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
-    "rust_stdlib": ("--files", r"\.rlib"),
-    "rustc": ("--executable", r"^rustc [0-9\.]\+ ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
-    "rustc_lib": ("--files", r"rustc_driver"),
-    "rustdoc": ("--executable", r"^rustdoc [0-9\.]\+ ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
-    "rustfmt": ("--executable", r"^rustfmt [0-9\.]\+\-stable ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
+    "cargo": ("executable", r"^cargo [0-9\.]\+\(-nightly\)\? ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
+    "clippy": ("executable", r"^clippy [0-9\.]\+ ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
+    "rust_stdlib": ("files", r"\.rlib"),
+    "rustc": ("executable", r"^rustc [0-9\.]\+\(-nightly\)\? ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
+    "rustc_lib": ("files", r"rustc_driver"),
+    "rustdoc": ("executable", r"^rustdoc [0-9\.]\+\(\-nightly\)\? ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
+    "rustfmt": ("executable", r"^rustfmt [0-9\.]\+\-\(stable\|nightly\) ([0-9a-z]\+ [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\})"),
 }
 
-# Generate a list manifest for all files in the filegroup
+# Test that all toolchain tools consumable (executables are executable and filegroups contain expected sources)
 [
-    genrule(
-        name = "{}_manifest_genrule".format(files),
-        srcs = ["//rust/toolchain:current_{}_files".format(files)],
-        outs = ["{}_manifest".format(files)],
-        cmd = "for file in $(rootpaths //rust/toolchain:current_{}_files); do echo $$file >> $@; done".format(files),
-    )
-    for files in _FILES
-    if "--files" in _FILES[files]
-]
-
-# Test that all toolchain tools are executable targets
-[
-    sh_test(
+    current_toolchain_files_test(
         name = tool + "_test",
-        srcs = ["current_exec_files_test.sh"],
-        args = [
-            "$(rootpath //rust/toolchain:current_{}_files)".format(tool) if "--executable" == arg else "$(rootpath {}_manifest)".format(tool),
-            arg,
-            "'{}'".format(pattern),
-        ],
-        data = [
-            "//rust/toolchain:current_{}_files".format(tool),
-        ] + (
-            ["{}_manifest".format(tool)] if "--files" == arg else []
-        ),
+        kind = kind,
+        pattern = pattern,
+        # TOOO: Windows requires use of bash which is not guaranteed to be available.
+        # The test runner should ideally be rewritten in rust so that windows could
+        # be tested.
+        target_compatible_with = select({
+            "@platforms//os:windows": ["@platforms//:incompatible"],
+            "//conditions:default": [],
+        }),
+        tool = "//rust/toolchain:current_{}_files".format(tool),
     )
-    for tool, (arg, pattern) in _FILES.items()
+    for tool, (kind, pattern) in _FILES.items()
 ]

--- a/test/current_toolchain_files/current_toolchain_files_test.bzl
+++ b/test/current_toolchain_files/current_toolchain_files_test.bzl
@@ -1,0 +1,81 @@
+"""Test rules for `current_*_files` targets"""
+
+def _current_toolchain_files_test_impl(ctx):
+    runfiles_files = []
+    if ctx.attr.kind == "files":
+        manifest = ctx.actions.declare_file("{}.files.manifest".format(
+            ctx.label.name,
+        ))
+        ctx.actions.write(
+            output = manifest,
+            content = "\n".join([file.short_path for file in ctx.files.tool]),
+        )
+        runfiles_files.append(manifest)
+        runfiles_files.extend(ctx.files.tool)
+        input = manifest
+    elif ctx.attr.kind == "executable":
+        tool_files = ctx.files.tool
+        if len(tool_files) != 1:
+            fail("Unexpected number of files provided by tool for {}: {}".format(
+                ctx.label,
+                tool_files,
+            ))
+        input = tool_files[0]
+        runfiles_files.append(input)
+    else:
+        fail("Unexpected kind: {}".format(ctx.attr.kind))
+
+    extension = ".{}".format(ctx.executable._test_runner.extension) if ctx.executable._test_runner.extension else ""
+    test_runner = ctx.actions.declare_file("{}{}".format(ctx.label.name, extension))
+    ctx.actions.symlink(
+        output = test_runner,
+        target_file = ctx.executable._test_runner,
+    )
+
+    runfiles = ctx.runfiles(files = runfiles_files)
+    runfiles = runfiles.merge(ctx.attr._test_runner[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge(ctx.attr.tool[DefaultInfo].default_runfiles)
+
+    return [
+        DefaultInfo(
+            runfiles = runfiles,
+            executable = test_runner,
+        ),
+        testing.TestEnvironment({
+            "CURRENT_TOOLCHAIN_FILES_TEST_INPUT": input.short_path,
+            "CURRENT_TOOLCHAIN_FILES_TEST_KIND": ctx.attr.kind,
+            "CURRENT_TOOLCHAIN_FILES_TEST_PATTERN": ctx.attr.pattern,
+        }),
+    ]
+
+current_toolchain_files_test = rule(
+    doc = "Test that `current_*_toolchain` tools consumable (executables are executable and filegroups contain expected sources)",
+    implementation = _current_toolchain_files_test_impl,
+    attrs = {
+        "kind": attr.string(
+            doc = "The kind of the component.",
+            values = ["executable", "files"],
+            mandatory = True,
+        ),
+        "pattern": attr.string(
+            doc = (
+                "A pattern used to confirm either executables produce an expected " +
+                "value or lists of files contain expected contents."
+            ),
+            mandatory = True,
+        ),
+        "tool": attr.label(
+            doc = "The current toolchain component.",
+            allow_files = True,
+            mandatory = True,
+        ),
+        "_test_runner": attr.label(
+            doc = "A shared test runner for validating targets.",
+            cfg = "exec",
+            allow_files = True,
+            executable = True,
+            default = Label("//test/current_toolchain_files:current_toolchain_files_test_runner.sh"),
+        ),
+    },
+    test = True,
+)

--- a/test/current_toolchain_files/current_toolchain_files_test_runner.sh
+++ b/test/current_toolchain_files/current_toolchain_files_test_runner.sh
@@ -2,14 +2,14 @@
 
 set -euo pipefail
 
-TARGET="$1"
-OPTION="$2"
+TARGET="${CURRENT_TOOLCHAIN_FILES_TEST_INPUT}"
+OPTION="${CURRENT_TOOLCHAIN_FILES_TEST_KIND}"
 
 # To parse this argument on windows it must be wrapped in quotes but
 # these quotes should not be passed to grep. Remove them here.
-PATTERN="$(echo -n "$3" | sed "s/'//g")"
+PATTERN="$(echo -n "${CURRENT_TOOLCHAIN_FILES_TEST_PATTERN}" | sed "s/'//g")"
 
-if [[ "${OPTION}" == "--executable" ]]; then
+if [[ "${OPTION}" == "executable" ]]; then
     # Clippy requires this environment variable is set
     export SYSROOT=""
 
@@ -18,7 +18,7 @@ if [[ "${OPTION}" == "--executable" ]]; then
     exit 0
 fi
 
-if [[ "${OPTION}" == "--files" ]]; then
+if [[ "${OPTION}" == "files" ]]; then
     cat "${TARGET}"
     grep "${PATTERN}" "${TARGET}"
     exit 0


### PR DESCRIPTION
While working on other changes, I had to read through these tests again to understand a failure and felt the use of `genrule` with `sh_test` was more confusing than it was "convenient" to use over writing a dedicated rule. I feel this was the wrong decision and a rule should have always been written so I've done that now.