### PR TITLE
Addressed clippy warnings from `clippy 0.1.67 (ec56537c 2022-12-15)`

### DIFF
--- a/cargo/bootstrap/bootstrap_installer.rs
+++ b/cargo/bootstrap/bootstrap_installer.rs
@@ -29,7 +29,7 @@ fn install() -> std::io::Result<u64> {
 
 fn main() {
     if let Err(err) = install() {
-        eprintln!("{:?}", err);
+        eprintln!("{err:?}");
         std::process::exit(1);
     };
 }

--- a/cargo/cargo_build_script_runner/bin.rs
+++ b/cargo/cargo_build_script_runner/bin.rs
@@ -127,7 +127,7 @@ fn run_buildrs() -> Result<(), String> {
         format!(
             "Build script process failed{}\n--stdout:\n{}\n--stderr:\n{}",
             if let Some(exit_code) = process_output.status.code() {
-                format!(" with exit code {}", exit_code)
+                format!(" with exit code {exit_code}")
             } else {
                 String::new()
             },
@@ -236,15 +236,14 @@ fn get_target_env_vars<P: AsRef<Path>>(rustc: &P) -> Result<BTreeMap<String, Str
             env::var("TARGET").expect("missing TARGET")
         ))
         .output()
-        .map_err(|err| format!("Error running rustc to get target information: {}", err))?;
+        .map_err(|err| format!("Error running rustc to get target information: {err}"))?;
     if !output.status.success() {
         return Err(format!(
-            "Error running rustc to get target information: {:?}",
-            output
+            "Error running rustc to get target information: {output:?}",
         ));
     }
     let stdout = std::str::from_utf8(&output.stdout)
-        .map_err(|err| format!("Non-UTF8 stdout from rustc: {:?}", err))?;
+        .map_err(|err| format!("Non-UTF8 stdout from rustc: {err:?}"))?;
 
     Ok(parse_rustc_cfg_output(stdout))
 }
@@ -280,7 +279,7 @@ fn main() {
         Ok(_) => 0,
         Err(err) => {
             // Neatly print errors
-            eprintln!("{}", err);
+            eprintln!("{err}");
             1
         }
     });

--- a/cargo/cargo_build_script_runner/lib.rs
+++ b/cargo/cargo_build_script_runner/lib.rs
@@ -183,11 +183,11 @@ impl BuildScriptOutput {
 
         for flag in outputs {
             match flag {
-                BuildScriptOutput::Cfg(e) => compile_flags.push(format!("--cfg={}", e)),
+                BuildScriptOutput::Cfg(e) => compile_flags.push(format!("--cfg={e}")),
                 BuildScriptOutput::Flags(e) => compile_flags.push(e.to_owned()),
-                BuildScriptOutput::LinkArg(e) => compile_flags.push(format!("-Clink-arg={}", e)),
-                BuildScriptOutput::LinkLib(e) => link_flags.push(format!("-l{}", e)),
-                BuildScriptOutput::LinkSearch(e) => link_search_paths.push(format!("-L{}", e)),
+                BuildScriptOutput::LinkArg(e) => compile_flags.push(format!("-Clink-arg={e}")),
+                BuildScriptOutput::LinkLib(e) => link_flags.push(format!("-l{e}")),
+                BuildScriptOutput::LinkSearch(e) => link_search_paths.push(format!("-L{e}")),
                 _ => {}
             }
         }

--- a/crate_universe/src/cli/query.rs
+++ b/crate_universe/src/cli/query.rs
@@ -70,10 +70,7 @@ pub fn query(opt: QueryOptions) -> Result<()> {
         &opt.rustc,
     )?;
     if digest != expected {
-        return announce_repin(&format!(
-            "Digests do not match: {:?} != {:?}",
-            digest, expected
-        ));
+        return announce_repin(&format!("Digests do not match: {digest:?} != {expected:?}",));
     }
 
     // There is no need to repin
@@ -81,7 +78,7 @@ pub fn query(opt: QueryOptions) -> Result<()> {
 }
 
 fn announce_repin(reason: &str) -> Result<()> {
-    eprintln!("{}", reason);
+    eprintln!("{reason}");
     println!("repin");
     Ok(())
 }

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -286,7 +286,7 @@ impl Add for CrateAnnotations {
         };
 
         let concat_string = |lhs: &mut String, rhs: String| {
-            *lhs = format!("{}{}", lhs, rhs);
+            *lhs = format!("{lhs}{rhs}");
         };
 
         #[rustfmt::skip]
@@ -405,8 +405,7 @@ impl<'de> Visitor<'de> for CrateIdVisitor {
             })
             .ok_or_else(|| {
                 E::custom(format!(
-                    "Expected string value of `{{name}} {{version}}`. Got '{}'",
-                    v
+                    "Expected string value of `{{name}} {{version}}`. Got '{v}'"
                 ))
             })
     }

--- a/crate_universe/src/context/platforms.rs
+++ b/crate_universe/src/context/platforms.rs
@@ -56,7 +56,7 @@ pub fn resolve_cfg_platforms(
     // (`x86_64-unknown-linux-gun` vs `cfg(target = "x86_64-unkonwn-linux-gnu")`). So
     // in order to parse configurations, the text is renamed for the check but the
     // original is retained for comaptibility with the manifest.
-    let rename = |cfg: &str| -> String { format!("cfg(target = \"{}\")", cfg) };
+    let rename = |cfg: &str| -> String { format!("cfg(target = \"{cfg}\")") };
     let original_cfgs: HashMap<String, String> = configurations
         .iter()
         .filter(|cfg| !cfg.starts_with("cfg("))
@@ -73,8 +73,8 @@ pub fn resolve_cfg_platforms(
         })
         // Check the current configuration with against each supported triple
         .map(|cfg| {
-            let expression = Expression::parse(&cfg)
-                .context(format!("Failed to parse expression: '{}'", cfg))?;
+            let expression =
+                Expression::parse(&cfg).context(format!("Failed to parse expression: '{cfg}'"))?;
 
             let triples = target_infos
                 .iter()

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -40,7 +40,7 @@ pub fn write_lockfile(lockfile: Context, path: &Path, dry_run: bool) -> Result<(
     let content = serde_json::to_string_pretty(&lockfile)?;
 
     if dry_run {
-        println!("{:#?}", content);
+        println!("{content:#?}");
     } else {
         // Ensure the parent directory exists
         if let Some(parent) = path.parent() {

--- a/crate_universe/src/metadata/metadata_annotation.rs
+++ b/crate_universe/src/metadata/metadata_annotation.rs
@@ -549,7 +549,7 @@ mod test {
         let result = Annotations::new(test::metadata::no_deps(), test::lockfile::no_deps(), config);
         assert!(result.is_err());
 
-        let result_str = format!("{:?}", result);
+        let result_str = format!("{result:?}");
         assert!(result_str.contains("Unused annotations were provided. Please remove them"));
         assert!(result_str.contains("mock-crate"));
     }

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -134,7 +134,7 @@ pub fn write_outputs(
             println!(
                 "==============================================================================="
             );
-            println!("{}\n", content);
+            println!("{content}\n");
         }
     } else {
         for (path, content) in outputs {
@@ -513,7 +513,7 @@ mod test {
         assert!(build_file_content.replace(' ', "").contains(
             &rustc_flags
                 .iter()
-                .map(|s| format!("\"{}\",", s))
+                .map(|s| format!("\"{s}\","))
                 .collect::<Vec<String>>()
                 .join("\n")
         ));

--- a/crate_universe/src/rendering/template_engine.rs
+++ b/crate_universe/src/rendering/template_engine.rs
@@ -214,7 +214,7 @@ impl TemplateEngine {
         context.insert(
             "default_package_name",
             &match render_config.default_package_name.as_ref() {
-                Some(pkg_name) => format!("\"{}\"", pkg_name),
+                Some(pkg_name) => format!("\"{pkg_name}\""),
                 None => "None".to_owned(),
             },
         );

--- a/crate_universe/src/splicing.rs
+++ b/crate_universe/src/splicing.rs
@@ -310,11 +310,11 @@ impl WorkspaceMetadata {
 
                     // Load the index for the current url
                     let index = crates_index::Index::from_url(index_url)
-                        .with_context(|| format!("Failed to load index for url: {}", index_url))?;
+                        .with_context(|| format!("Failed to load index for url: {index_url}"))?;
 
                     // Ensure each index has a valid index config
                     index.index_config().with_context(|| {
-                        format!("`config.json` not found in index: {}", index_url)
+                        format!("`config.json` not found in index: {index_url}")
                     })?;
 
                     index

--- a/crate_universe/src/splicing/splicer.rs
+++ b/crate_universe/src/splicing/splicer.rs
@@ -118,7 +118,7 @@ impl<'a> SplicerKind<'a> {
                     .keys()
                     .map(|p| {
                         p.normalize()
-                            .with_context(|| format!("Failed to normalize path {:?}", p))
+                            .with_context(|| format!("Failed to normalize path {p:?}"))
                     })
                     .collect::<Result<_, _>>()?,
             )
@@ -165,7 +165,7 @@ impl<'a> SplicerKind<'a> {
             .map(|member| {
                 let path = root_manifest_dir.join(member).join("Cargo.toml");
                 path.normalize()
-                    .with_context(|| format!("Failed to normalize path {:?}", path))
+                    .with_context(|| format!("Failed to normalize path {path:?}"))
             })
             .collect::<Result<BTreeSet<normpath::BasePathBuf>, _>>()?;
 
@@ -178,10 +178,7 @@ impl<'a> SplicerKind<'a> {
             .map(|workspace_manifest_path| {
                 let label = Label::from_absolute_path(workspace_manifest_path.as_path())
                     .with_context(|| {
-                        format!(
-                            "Failed to identify label for path {:?}",
-                            workspace_manifest_path
-                        )
+                        format!("Failed to identify label for path {workspace_manifest_path:?}")
                     })?;
                 Ok(label.to_string())
             })
@@ -548,9 +545,8 @@ pub fn default_cargo_workspace_manifest(
     let mut manifest = cargo_toml::Manifest::from_str(&textwrap::dedent(&format!(
         r#"
             [workspace]
-            resolver = "{}"
+            resolver = "{resolver_version}"
         "#,
-        resolver_version,
     )))
     .unwrap();
 
@@ -867,7 +863,7 @@ mod test {
 
             splicing_manifest.manifests.insert(
                 manifest_path,
-                Label::from_str(&format!("//{}:Cargo.toml", pkg)).unwrap(),
+                Label::from_str(&format!("//{pkg}:Cargo.toml")).unwrap(),
             );
         }
 
@@ -925,7 +921,7 @@ mod test {
 
             splicing_manifest.manifests.insert(
                 manifest_path,
-                Label::from_str(&format!("//{}:Cargo.toml", pkg)).unwrap(),
+                Label::from_str(&format!("//{pkg}:Cargo.toml")).unwrap(),
             );
         }
 
@@ -1008,11 +1004,11 @@ mod test {
 
         if is_root {
             PackageId {
-                repr: format!("{} 0.0.1 (path+file://{})", name, workspace_root),
+                repr: format!("{name} 0.0.1 (path+file://{workspace_root})"),
             }
         } else {
             PackageId {
-                repr: format!("{} 0.0.1 (path+file://{}/{})", name, workspace_root, name,),
+                repr: format!("{name} 0.0.1 (path+file://{workspace_root}/{name})"),
             }
         }
     }

--- a/crate_universe/src/utils/starlark/label.rs
+++ b/crate_universe/src/utils/starlark/label.rs
@@ -23,7 +23,7 @@ impl FromStr for Label {
         let re = Regex::new(r"^(@@?[\w\d\-_\.]*)?/{0,2}([\w\d\-_\./+]+)?(:([\+\w\d\-_\./]+))?$")?;
         let cap = re
             .captures(s)
-            .with_context(|| format!("Failed to parse label from string: {}", s))?;
+            .with_context(|| format!("Failed to parse label from string: {s}"))?;
 
         let repository = cap
             .get(1)
@@ -57,14 +57,14 @@ impl Display for Label {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Add the repository
         if let Some(repo) = &self.repository {
-            write!(f, "@{}", repo)?;
+            write!(f, "@{repo}")?;
         }
 
         write!(f, "//")?;
 
         // Add the package
         if let Some(pkg) = &self.package {
-            write!(f, "{}", pkg)?;
+            write!(f, "{pkg}")?;
         }
 
         write!(f, ":{}", self.target)?;

--- a/crate_universe/src/utils/starlark/select.rs
+++ b/crate_universe/src/utils/starlark/select.rs
@@ -55,7 +55,7 @@ impl<T: Ord> SelectList<T> {
     }
 
     // TODO: This should probably be added to the [Select] trait
-    pub fn get_iter<'a>(&'a self, config: Option<&String>) -> Option<btree_set::Iter<T>> {
+    pub fn get_iter(&self, config: Option<&String>) -> Option<btree_set::Iter<T>> {
         match config {
             Some(conf) => self.selects.get(conf).map(|set| set.iter()),
             None => Some(self.common.iter()),

--- a/crate_universe/tools/cross_installer/src/main.rs
+++ b/crate_universe/tools/cross_installer/src/main.rs
@@ -23,7 +23,7 @@ struct Options {
 fn prepare_workspace(workspace_root: &Path) {
     let src = PathBuf::from(env!("CROSS_CONFIG"));
     let dest = workspace_root.join("Cross.toml");
-    println!("{:?} -> {:?}", src, dest);
+    println!("{src:?} -> {dest:?}");
     fs::copy(src, dest).unwrap();
 
     // Unfortunately, cross runs into issues when cross compiling incramentally.
@@ -46,7 +46,7 @@ fn execute_cross(working_dir: &Path, target_triple: &str) {
         .arg("--locked")
         .arg("--bin")
         .arg("cargo-bazel")
-        .arg(format!("--target={}", target_triple))
+        .arg(format!("--target={target_triple}"))
         .status()
         .unwrap();
 

--- a/crate_universe/tools/urls_generator/src/main.rs
+++ b/crate_universe/tools/urls_generator/src/main.rs
@@ -78,7 +78,7 @@ fn locate_artifacts(artifacts_dir: &Path, url_prefix: &str) -> Vec<Artifact> {
                         .map(|ext| format!(".{}", ext.to_string_lossy()))
                         .unwrap_or_default();
                     Artifact {
-                        url: format!("{}/{}-{}{}", url_prefix, stem, triple, extension),
+                        url: format!("{url_prefix}/{stem}-{triple}{extension}"),
                         triple: triple.to_string(),
                         sha256: calculate_sha256(&f_entry.path()),
                     }

--- a/proto/optional_output_wrapper.rs
+++ b/proto/optional_output_wrapper.rs
@@ -50,7 +50,7 @@ fn main() {
         Err(e) => {
             println!("Usage: [optional_output1...optional_outputN] -- program [arg1...argn]");
             println!("{:?}", args());
-            println!("{:?}", e);
+            println!("{e:?}");
             -1
         }
     });

--- a/test/cargo_build_script/tools_exec.rs
+++ b/test/cargo_build_script/tools_exec.rs
@@ -1,6 +1,3 @@
-// TODO: Remove this exception after https://github.com/rust-lang/rust-clippy/pull/10055 is released
-#![allow(clippy::uninlined_format_args)]
-
 #[test]
 pub fn test_tool_exec() {
     let tool_path = env!("TOOL_PATH");

--- a/test/cargo_build_script/tools_exec.rs
+++ b/test/cargo_build_script/tools_exec.rs
@@ -1,3 +1,6 @@
+// TODO: Remove this exception after https://github.com/rust-lang/rust-clippy/pull/10055 is released
+#![allow(clippy::uninlined_format_args)]
+
 #[test]
 pub fn test_tool_exec() {
     let tool_path = env!("TOOL_PATH");

--- a/test/chained_direct_deps/mod2.rs
+++ b/test/chained_direct_deps/mod2.rs
@@ -1,7 +1,7 @@
 extern crate mod1;
 
 pub fn greeter(name: &str) -> String {
-    format!("Hello, {}!", name)
+    format!("Hello, {name}!")
 }
 
 pub fn default_greeter() -> String {

--- a/test/process_wrapper/rustc_quit_on_rmeta.rs
+++ b/test/process_wrapper/rustc_quit_on_rmeta.rs
@@ -1,3 +1,6 @@
+// TODO: Remove this exception after https://github.com/rust-lang/rust-clippy/pull/10055 is released
+#![allow(clippy::uninlined_format_args)]
+
 #[cfg(test)]
 mod test {
     use std::path::PathBuf;
@@ -8,6 +11,7 @@ mod test {
 
     /// fake_rustc runs the fake_rustc binary under process_wrapper with the specified
     /// process wrapper arguments. No arguments are passed to fake_rustc itself.
+    ///
     fn fake_rustc(process_wrapper_args: &[&'static str]) -> String {
         let r = Runfiles::create().unwrap();
         let fake_rustc = r.rlocation(

--- a/test/process_wrapper/rustc_quit_on_rmeta.rs
+++ b/test/process_wrapper/rustc_quit_on_rmeta.rs
@@ -1,6 +1,3 @@
-// TODO: Remove this exception after https://github.com/rust-lang/rust-clippy/pull/10055 is released
-#![allow(clippy::uninlined_format_args)]
-
 #[cfg(test)]
 mod test {
     use std::path::PathBuf;

--- a/test/renamed_deps/mod2.rs
+++ b/test/renamed_deps/mod2.rs
@@ -1,7 +1,7 @@
 extern crate mod1;
 
 pub fn greeter(name: &str) -> String {
-    format!("Hello, {}!", name)
+    format!("Hello, {name}!")
 }
 
 pub fn default_greeter() -> String {

--- a/test/unit/exports/lib_a/src/lib.rs
+++ b/test/unit/exports/lib_a/src/lib.rs
@@ -1,5 +1,5 @@
 pub fn greeting_from(from: &str) -> String {
-    format!("Hello from {}!", from)
+    format!("Hello from {from}!")
 }
 
 pub fn greeting_a() -> String {

--- a/test/unit/is_proc_macro_dep/proc_macro_crate.rs
+++ b/test/unit/is_proc_macro_dep/proc_macro_crate.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 #[proc_macro]
 pub fn make_answer(_item: TokenStream) -> TokenStream {
     let answer = proc_macro_dep::proc_macro_dep();
-    format!("fn answer() -> u32 {{ {} }}", answer)
+    format!("fn answer() -> u32 {{ {answer} }}")
         .parse()
         .unwrap()
 }

--- a/test/versioned_dylib/src/main.rs
+++ b/test/versioned_dylib/src/main.rs
@@ -20,7 +20,7 @@ extern "C" {
 
 fn main() {
     let zero = unsafe { return_zero() };
-    println!("Got {} from our shared lib", zero);
+    println!("Got {zero} from our shared lib");
 }
 
 #[cfg(test)]

--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -71,7 +71,7 @@ pub fn get_crate_specs(
     log::debug!("Get crate specs with targets: {:?}", targets);
     let target_pattern = targets
         .iter()
-        .map(|t| format!("deps({})", t))
+        .map(|t| format!("deps({t})"))
         .collect::<Vec<_>>()
         .join("+");
 
@@ -80,13 +80,11 @@ pub fn get_crate_specs(
         .arg("aquery")
         .arg("--include_aspects")
         .arg(format!(
-            "--aspects={}//rust:defs.bzl%rust_analyzer_aspect",
-            rules_rust_name
+            "--aspects={rules_rust_name}//rust:defs.bzl%rust_analyzer_aspect"
         ))
         .arg("--output_groups=rust_analyzer_crate_spec")
         .arg(format!(
-            r#"outputs(".*[.]rust_analyzer_crate_spec",{})"#,
-            target_pattern
+            r#"outputs(".*[.]rust_analyzer_crate_spec",{target_pattern})"#
         ))
         .arg("--output=jsonproto")
         .output()?;

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -62,8 +62,7 @@ pub fn write_rust_project(
         s => s,
     };
     let toolchain_info_path = format!(
-        "{}/rust/private/rust_analyzer_detect_sysroot.rust_analyzer_toolchain.json",
-        workspace_name
+        "{workspace_name}/rust/private/rust_analyzer_detect_sysroot.rust_analyzer_toolchain.json"
     );
     let r = Runfiles::create()?;
     let path = r.rlocation(toolchain_info_path);

--- a/tools/rustdoc/rustdoc_test_writer.rs
+++ b/tools/rustdoc/rustdoc_test_writer.rs
@@ -177,7 +177,7 @@ fn write_test_runner_unix(
         "exec env - \\".to_owned(),
     ];
 
-    content.extend(env.iter().map(|(key, val)| format!("{}='{}' \\", key, val)));
+    content.extend(env.iter().map(|(key, val)| format!("{key}='{val}' \\")));
 
     let argv_str = argv
         .iter()
@@ -189,7 +189,7 @@ fn write_test_runner_unix(
                 .for_each(|substring| stripped_arg = stripped_arg.replace(substring, ""));
             stripped_arg
         })
-        .map(|arg| format!("'{}'", arg))
+        .map(|arg| format!("'{arg}'"))
         .collect::<Vec<String>>()
         .join(" ");
 
@@ -207,7 +207,7 @@ fn write_test_runner_windows(
 ) {
     let env_str = env
         .iter()
-        .map(|(key, val)| format!("$env:{}='{}'", key, val))
+        .map(|(key, val)| format!("$env:{key}='{val}'"))
         .collect::<Vec<String>>()
         .join(" ; ");
 
@@ -221,14 +221,14 @@ fn write_test_runner_windows(
                 .for_each(|substring| stripped_arg = stripped_arg.replace(substring, ""));
             stripped_arg
         })
-        .map(|arg| format!("'{}'", arg))
+        .map(|arg| format!("'{arg}'"))
         .collect::<Vec<String>>()
         .join(" ");
 
     let content = vec![
         "@ECHO OFF".to_owned(),
         "".to_owned(),
-        format!("powershell.exe -c \"{} ; & {}\"", env_str, argv_str),
+        format!("powershell.exe -c \"{env_str} ; & {argv_str}\""),
         "".to_owned(),
     ];
 

--- a/tools/rustfmt/src/main.rs
+++ b/tools/rustfmt/src/main.rs
@@ -79,8 +79,6 @@ fn edition_query(bazel_bin: &Path, edition: &str, scope: &str, current_dir: &Pat
         //             And except for targets with a populated `crate` attribute since `crate` defines edition for this target
         format!(
             r#"let scope = set({scope}) in filter("^//.*\.rs$", kind("source file", deps(attr(edition, "{edition}", $scope) except attr(tags, "(^\[|, )(no-format|no-rustfmt|norustfmt)(, |\]$)", $scope) except attr(crate, ".*", $scope), 1)))"#,
-            edition = edition,
-            scope = scope,
         ),
         "--keep_going".to_owned(),
         "--noimplicit_deps".to_owned(),

--- a/util/process_wrapper/flags.rs
+++ b/util/process_wrapper/flags.rs
@@ -30,10 +30,10 @@ pub(crate) enum FlagParseError {
 impl fmt::Display for FlagParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::UnknownFlag(ref flag) => write!(f, "unknown flag \"{}\"", flag),
-            Self::ValueMissing(ref flag) => write!(f, "flag \"{}\" missing parameter(s)", flag),
+            Self::UnknownFlag(ref flag) => write!(f, "unknown flag \"{flag}\""),
+            Self::ValueMissing(ref flag) => write!(f, "flag \"{flag}\" missing parameter(s)"),
             Self::ProvidedMultipleTimes(ref flag) => {
-                write!(f, "flag \"{}\" can only appear once", flag)
+                write!(f, "flag \"{flag}\" can only appear once")
             }
             Self::ProgramNameMissing => {
                 write!(f, "program name (argv[0]) missing")
@@ -133,12 +133,11 @@ impl<'a> Flags<'a> {
         let mut help_text = String::new();
         writeln!(
             &mut help_text,
-            "Help for {}: [options] -- [extra arguments]",
-            program_name
+            "Help for {program_name}: [options] -- [extra arguments]"
         )
         .unwrap();
         for line in all {
-            writeln!(&mut help_text, "\t{}", line).unwrap();
+            writeln!(&mut help_text, "\t{line}").unwrap();
         }
         help_text
     }

--- a/util/process_wrapper/util.rs
+++ b/util/process_wrapper/util.rs
@@ -72,7 +72,7 @@ fn stamp_status_to_array(reader: impl Read) -> Result<Vec<(String, String)>, Str
         .map(|l| {
             let (s1, s2) = l
                 .split_once(' ')
-                .ok_or_else(|| format!("wrong workspace status file format for \"{}\"", l))?;
+                .ok_or_else(|| format!("wrong workspace status file format for \"{l}\""))?;
             Ok((s1.to_owned(), s2.to_owned()))
         })
         .collect()


### PR DESCRIPTION
This PR addresses newer clippy warnings that exist in nightly toolchains. https://github.com/bazelbuild/rules_rust/pull/1712 introduces regression testing for this change but since it's larger change I thought it made sense to review separately.