### PR TITLE
Arm Thumb Embedded Targets.

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -66,7 +66,7 @@ _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX = {
     "riscv64gc": "riscv64",
     "s390": None,
     "s390x": "s390x",
-    "thumbv7m": "armv7",
+    "thumbv7m": "armv7-m",
     "wasm32": None,
     "x86_64": "x86_64",
 }

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -66,6 +66,7 @@ _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX = {
     "riscv64gc": "riscv64",
     "s390": None,
     "s390x": "s390x",
+    "thumbv6m": "armv6-m",
     "thumbv7m": "armv7-m",
     "wasm32": None,
     "x86_64": "x86_64",


### PR DESCRIPTION
Corrects `thumbv7m` cpu definition and adds `thumbv6m`.