### PR TITLE
crate_universe re-pinning now defaults to "workspace"

### DIFF
--- a/crate_universe/private/crates_repository.bzl
+++ b/crate_universe/private/crates_repository.bzl
@@ -180,8 +180,8 @@ that is called behind the scenes to update dependencies.
 
 | Value | Cargo command |
 | --- | --- |
-| Any of [`true`, `1`, `yes`, `on`] | `cargo update` |
-| `workspace` | `cargo update --workspace` |
+| Any of [`true`, `1`, `yes`, `on`, `workspace`] | `cargo update --workspace` |
+| Any of [`full`, `eager`, `all`] | `cargo update` |
 | `package_name` | `cargo upgrade --package package_name` |
 | `package_name@1.2.3` | `cargo upgrade --package package_name --precise 1.2.3` |
 

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -329,8 +329,8 @@ call against the generated workspace. The following table describes how to contr
 
 | Value | Cargo command |
 | --- | --- |
-| Any of [`true`, `1`, `yes`, `on`] | `cargo update` |
-| `workspace` | `cargo update --workspace` |
+| Any of [`true`, `1`, `yes`, `on`, `workspace`] | `cargo update --workspace` |
+| Any of [`full`, `eager`, `all`] | `cargo update` |
 | `package_name` | `cargo upgrade --package package_name` |
 | `package_name@1.2.3` | `cargo upgrade --package package_name --precise 1.2.3` |
 

--- a/crate_universe/src/metadata.rs
+++ b/crate_universe/src/metadata.rs
@@ -100,11 +100,11 @@ impl FromStr for CargoUpdateRequest {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let lower = s.to_lowercase();
 
-        if ["1", "yes", "true", "on"].contains(&lower.as_str()) {
+        if ["eager", "full", "all"].contains(&lower.as_str()) {
             return Ok(Self::Eager);
         }
 
-        if ["workspace", "minimal"].contains(&lower.as_str()) {
+        if ["1", "yes", "true", "on", "workspace", "minimal"].contains(&lower.as_str()) {
             return Ok(Self::Workspace);
         }
 
@@ -361,7 +361,7 @@ mod test {
 
     #[test]
     fn deserialize_cargo_update_request_for_eager() {
-        for value in ["1", "yes", "true", "on"] {
+        for value in ["all", "full", "eager"] {
             let request = CargoUpdateRequest::from_str(value).unwrap();
 
             assert_eq!(request, CargoUpdateRequest::Eager);
@@ -370,7 +370,7 @@ mod test {
 
     #[test]
     fn deserialize_cargo_update_request_for_workspace() {
-        for value in ["workspace", "minimal"] {
+        for value in ["1", "true", "yes", "on", "workspace", "minimal"] {
             let request = CargoUpdateRequest::from_str(value).unwrap();
 
             assert_eq!(request, CargoUpdateRequest::Workspace);

--- a/crate_universe/version.bzl
+++ b/crate_universe/version.bzl
@@ -1,3 +1,3 @@
 """ Version info for the `cargo-bazel` repository """
 
-VERSION = "0.6.0"
+VERSION = "0.7.0"

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -263,8 +263,8 @@ that is called behind the scenes to update dependencies.
 
 | Value | Cargo command |
 | --- | --- |
-| Any of [`true`, `1`, `yes`, `on`] | `cargo update` |
-| `workspace` | `cargo update --workspace` |
+| Any of [`true`, `1`, `yes`, `on`, `workspace`] | `cargo update --workspace` |
+| Any of [`full`, `eager`, `all`] | `cargo update` |
 | `package_name` | `cargo upgrade --package package_name` |
 | `package_name@1.2.3` | `cargo upgrade --package package_name --precise 1.2.3` |
 
@@ -372,8 +372,8 @@ call against the generated workspace. The following table describes how to contr
 
 | Value | Cargo command |
 | --- | --- |
-| Any of [`true`, `1`, `yes`, `on`] | `cargo update` |
-| `workspace` | `cargo update --workspace` |
+| Any of [`true`, `1`, `yes`, `on`, `workspace`] | `cargo update --workspace` |
+| Any of [`full`, `eager`, `all`] | `cargo update` |
 | `package_name` | `cargo upgrade --package package_name` |
 | `package_name@1.2.3` | `cargo upgrade --package package_name --precise 1.2.3` |
 


### PR DESCRIPTION
This change updates the default behavior of re-pinning with `crates_vendor` and `crates_repository` to re-pin workspace dependencies, not all transitive ones. Users who wish to do a full re-pin of all their dependencies should can pass the following values:
- `eager`
- `full`
- `all`

closes https://github.com/bazelbuild/rules_rust/issues/1522