### PR TITLE
Eliminate all use of hash-based collections from crate_universe

### DIFF
--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -15,7 +15,7 @@ use serde::de::Visitor;
 use serde::{Deserialize, Serialize, Serializer};
 
 /// Representations of different kinds of crate vendoring into workspaces.
-#[derive(Debug, Serialize, Deserialize, Hash, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum VendorMode {
     /// Crates having full source being vendored into a workspace
@@ -37,7 +37,7 @@ impl std::fmt::Display for VendorMode {
     }
 }
 
-#[derive(Debug, Default, Hash, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct RenderConfig {
     /// The name of the repository being rendered
@@ -141,7 +141,7 @@ pub enum Checksumish {
     },
 }
 
-#[derive(Debug, Default, Hash, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct CrateAnnotations {
     /// Determins whether or not Cargo build scripts should be generated for the current package
     pub gen_build_script: Option<bool>,
@@ -328,7 +328,7 @@ impl Sum for CrateAnnotations {
 }
 
 /// A unique identifier for Crates
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct CrateId {
     /// The name of the crate
     pub name: String,

--- a/crate_universe/src/context/platforms.rs
+++ b/crate_universe/src/context/platforms.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{anyhow, Context, Result};
 use cfg_expr::targets::{get_builtin_target_by_triple, TargetInfo};
@@ -57,7 +57,7 @@ pub fn resolve_cfg_platforms(
     // in order to parse configurations, the text is renamed for the check but the
     // original is retained for comaptibility with the manifest.
     let rename = |cfg: &str| -> String { format!("cfg(target = \"{cfg}\")") };
-    let original_cfgs: HashMap<String, String> = configurations
+    let original_cfgs: BTreeMap<String, String> = configurations
         .iter()
         .filter(|cfg| !cfg.starts_with("cfg("))
         .map(|cfg| (rename(cfg), cfg.clone()))
@@ -190,7 +190,7 @@ mod test {
 
     #[test]
     fn resolve_targeted() {
-        let data = HashMap::from([
+        let data = BTreeMap::from([
             (
                 r#"cfg(target = "x86_64-unknown-linux-gnu")"#.to_owned(),
                 BTreeSet::from(["x86_64-unknown-linux-gnu".to_owned()]),

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -1,6 +1,6 @@
 //! Utility module for interracting with different kinds of lock files
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::ffi::OsStr;
 use std::fs;
@@ -152,7 +152,7 @@ impl Digest {
         // computed consistently. If a new binary is released then this
         // condition should be removed
         // https://github.com/rust-lang/cargo/issues/10547
-        let corrections = HashMap::from([
+        let corrections = BTreeMap::from([
             (
                 "cargo 1.60.0 (d1fd9fe 2022-03-01)",
                 "cargo 1.60.0 (d1fd9fe2c 2022-03-01)",

--- a/crate_universe/src/rendering/template_engine.rs
+++ b/crate_universe/src/rendering/template_engine.rs
@@ -235,7 +235,7 @@ impl TemplateEngine {
     pub fn render_crate_build_files<'a>(
         &self,
         ctx: &'a Context,
-    ) -> Result<HashMap<&'a CrateId, String>> {
+    ) -> Result<BTreeMap<&'a CrateId, String>> {
         // Create the render context with the global planned context to be
         // reused when rendering crates.
         let mut context = self.new_tera_ctx();

--- a/crate_universe/src/splicing.rs
+++ b/crate_universe/src/splicing.rs
@@ -3,7 +3,7 @@
 pub(crate) mod cargo_config;
 mod splicer;
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -193,7 +193,7 @@ impl TryFrom<serde_json::Value> for WorkspaceMetadata {
 impl WorkspaceMetadata {
     fn new(
         splicing_manifest: &SplicingManifest,
-        member_manifests: HashMap<&PathBuf, String>,
+        member_manifests: BTreeMap<&PathBuf, String>,
     ) -> Result<Self> {
         let mut package_prefixes: BTreeMap<String, String> = member_manifests
             .iter()

--- a/crate_universe/tools/urls_generator/src/main.rs
+++ b/crate_universe/tools/urls_generator/src/main.rs
@@ -1,6 +1,6 @@
 //! A helper tool for generating urls and sha256 checksums of cargo-bazel binaries and writing them to a module.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -120,12 +120,12 @@ CARGO_BAZEL_LABEL = Label("@cargo_bazel_bootstrap//:binary")
 "#;
 
 fn render_module(artifacts: &[Artifact]) -> String {
-    let urls: HashMap<&String, &String> = artifacts
+    let urls: BTreeMap<&String, &String> = artifacts
         .iter()
         .map(|artifact| (&artifact.triple, &artifact.url))
         .collect();
 
-    let sha256s: HashMap<&String, &String> = artifacts
+    let sha256s: BTreeMap<&String, &String> = artifacts
         .iter()
         .map(|artifact| (&artifact.triple, &artifact.sha256))
         .collect();


### PR DESCRIPTION
This is necessary together with #1736 to keep the generated BUILD files deterministic. Iterating a hashmap or hashset in hash order is a common source of nondeterminism in code generators (based on my experience with proc macros).

I haven't looked into which of the hashmaps changed in this diff are correctly used. It's *possible* to use a hashmap correctly, if all we do with them is lookups, not iteration. But it's simple enough to just not use hash-based containers entirely and never have hash order nondeterminism problems.