### PR TITLE
Fix BAZEL_RUST_STDLIB_LINKFLAGS

### DIFF
--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -282,7 +282,8 @@ def BUILD_for_rust_toolchain(
     """
     system = triple_to_system(target_triple)
     if stdlib_linkflags == None:
-        stdlib_linkflags = ", ".join(['"%s"' % x for x in system_to_stdlib_linkflags(system)])
+        stdlib_linkflags = system_to_stdlib_linkflags(system)
+    stdlib_linkflags = ", ".join(['"%s"' % x for x in stdlib_linkflags])
 
     rustc_srcs = "None"
     if include_rustc_srcs:


### PR DESCRIPTION
The expected behavior for BUILD_for_rust_toolchain() is for it to receive a list of flags, and if None are specified, a default set of link flags are selected dependent upon the target system.

The logic here was broken as any list specified would get silently passed through, breaking further on in the code where it is expecting stdlib_linkflags to be in string form.