### PR TITLE
draft: fix data and compile_data for rust_doc

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1401,8 +1401,9 @@ A toolchain for [rustfmt](https://rust-lang.github.io/rustfmt/)
 ## CrateInfo
 
 <pre>
-CrateInfo(<a href="#CrateInfo-aliases">aliases</a>, <a href="#CrateInfo-compile_data">compile_data</a>, <a href="#CrateInfo-deps">deps</a>, <a href="#CrateInfo-edition">edition</a>, <a href="#CrateInfo-is_test">is_test</a>, <a href="#CrateInfo-metadata">metadata</a>, <a href="#CrateInfo-name">name</a>, <a href="#CrateInfo-output">output</a>, <a href="#CrateInfo-owner">owner</a>,
-          <a href="#CrateInfo-proc_macro_deps">proc_macro_deps</a>, <a href="#CrateInfo-root">root</a>, <a href="#CrateInfo-rustc_env">rustc_env</a>, <a href="#CrateInfo-rustc_env_files">rustc_env_files</a>, <a href="#CrateInfo-srcs">srcs</a>, <a href="#CrateInfo-type">type</a>, <a href="#CrateInfo-wrapped_crate_type">wrapped_crate_type</a>)
+CrateInfo(<a href="#CrateInfo-aliases">aliases</a>, <a href="#CrateInfo-compile_data">compile_data</a>, <a href="#CrateInfo-compile_data_targets">compile_data_targets</a>, <a href="#CrateInfo-deps">deps</a>, <a href="#CrateInfo-edition">edition</a>, <a href="#CrateInfo-is_test">is_test</a>, <a href="#CrateInfo-metadata">metadata</a>, <a href="#CrateInfo-name">name</a>,
+          <a href="#CrateInfo-output">output</a>, <a href="#CrateInfo-owner">owner</a>, <a href="#CrateInfo-proc_macro_deps">proc_macro_deps</a>, <a href="#CrateInfo-root">root</a>, <a href="#CrateInfo-rustc_env">rustc_env</a>, <a href="#CrateInfo-rustc_env_files">rustc_env_files</a>, <a href="#CrateInfo-srcs">srcs</a>, <a href="#CrateInfo-type">type</a>,
+          <a href="#CrateInfo-wrapped_crate_type">wrapped_crate_type</a>)
 </pre>
 
 A provider containing general Crate information.
@@ -1414,6 +1415,7 @@ A provider containing general Crate information.
 | :------------- | :------------- |
 | <a id="CrateInfo-aliases"></a>aliases |  Dict[Label, String]: Renamed and aliased crates    |
 | <a id="CrateInfo-compile_data"></a>compile_data |  depset[File]: Compile data required by this crate.    |
+| <a id="CrateInfo-compile_data_targets"></a>compile_data_targets |  depset[Label]: Compile data targets required by this crate.    |
 | <a id="CrateInfo-deps"></a>deps |  depset[DepVariantInfo]: This crate's (rust or cc) dependencies' providers.    |
 | <a id="CrateInfo-edition"></a>edition |  str: The edition of this crate.    |
 | <a id="CrateInfo-is_test"></a>is_test |  bool: If the crate is being compiled in a test context    |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,8 +10,9 @@
 ## CrateInfo
 
 <pre>
-CrateInfo(<a href="#CrateInfo-aliases">aliases</a>, <a href="#CrateInfo-compile_data">compile_data</a>, <a href="#CrateInfo-deps">deps</a>, <a href="#CrateInfo-edition">edition</a>, <a href="#CrateInfo-is_test">is_test</a>, <a href="#CrateInfo-metadata">metadata</a>, <a href="#CrateInfo-name">name</a>, <a href="#CrateInfo-output">output</a>, <a href="#CrateInfo-owner">owner</a>,
-          <a href="#CrateInfo-proc_macro_deps">proc_macro_deps</a>, <a href="#CrateInfo-root">root</a>, <a href="#CrateInfo-rustc_env">rustc_env</a>, <a href="#CrateInfo-rustc_env_files">rustc_env_files</a>, <a href="#CrateInfo-srcs">srcs</a>, <a href="#CrateInfo-type">type</a>, <a href="#CrateInfo-wrapped_crate_type">wrapped_crate_type</a>)
+CrateInfo(<a href="#CrateInfo-aliases">aliases</a>, <a href="#CrateInfo-compile_data">compile_data</a>, <a href="#CrateInfo-compile_data_targets">compile_data_targets</a>, <a href="#CrateInfo-deps">deps</a>, <a href="#CrateInfo-edition">edition</a>, <a href="#CrateInfo-is_test">is_test</a>, <a href="#CrateInfo-metadata">metadata</a>, <a href="#CrateInfo-name">name</a>,
+          <a href="#CrateInfo-output">output</a>, <a href="#CrateInfo-owner">owner</a>, <a href="#CrateInfo-proc_macro_deps">proc_macro_deps</a>, <a href="#CrateInfo-root">root</a>, <a href="#CrateInfo-rustc_env">rustc_env</a>, <a href="#CrateInfo-rustc_env_files">rustc_env_files</a>, <a href="#CrateInfo-srcs">srcs</a>, <a href="#CrateInfo-type">type</a>,
+          <a href="#CrateInfo-wrapped_crate_type">wrapped_crate_type</a>)
 </pre>
 
 A provider containing general Crate information.
@@ -23,6 +24,7 @@ A provider containing general Crate information.
 | :------------- | :------------- |
 | <a id="CrateInfo-aliases"></a>aliases |  Dict[Label, String]: Renamed and aliased crates    |
 | <a id="CrateInfo-compile_data"></a>compile_data |  depset[File]: Compile data required by this crate.    |
+| <a id="CrateInfo-compile_data_targets"></a>compile_data_targets |  depset[Label]: Compile data targets required by this crate.    |
 | <a id="CrateInfo-deps"></a>deps |  depset[DepVariantInfo]: This crate's (rust or cc) dependencies' providers.    |
 | <a id="CrateInfo-edition"></a>edition |  str: The edition of this crate.    |
 | <a id="CrateInfo-is_test"></a>is_test |  bool: If the crate is being compiled in a test context    |

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -246,7 +246,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
             rustc_env = {},
             is_test = False,
             compile_data = depset([target.files for target in getattr(ctx.attr, "compile_data", [])]),
-            compile_data_targets = getattr(ctx.attr, "compile_data", depset([])),
+            compile_data_targets = depset(getattr(ctx.attr, "compile_data", [])),
             wrapped_crate_type = None,
             owner = ctx.label,
         ),

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -246,6 +246,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
             rustc_env = {},
             is_test = False,
             compile_data = depset([target.files for target in getattr(ctx.attr, "compile_data", [])]),
+            compile_data_targets = getattr(ctx.attr, "compile_data", depset([])),
             wrapped_crate_type = None,
             owner = ctx.label,
         ),

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -19,6 +19,7 @@ CrateInfo = provider(
     fields = {
         "aliases": "Dict[Label, String]: Renamed and aliased crates",
         "compile_data": "depset[File]: Compile data required by this crate.",
+        "compile_data_targets": "depset[Label]: Compile data targets required by this crate.",
         "deps": "depset[DepVariantInfo]: This crate's (rust or cc) dependencies' providers.",
         "edition": "str: The edition of this crate.",
         "is_test": "bool: If the crate is being compiled in a test context",

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -306,6 +306,7 @@ def _rust_library_common(ctx, crate_type):
             rustc_env_files = ctx.files.rustc_env_files,
             is_test = False,
             compile_data = depset(ctx.files.compile_data),
+            compile_data_targets = depset(ctx.attr.compile_data),
             owner = ctx.label,
         ),
         output_hash = output_hash,
@@ -351,6 +352,7 @@ def _rust_binary_impl(ctx):
             rustc_env_files = ctx.files.rustc_env_files,
             is_test = False,
             compile_data = depset(ctx.files.compile_data),
+            compile_data_targets = depset(ctx.attr.compile_data),
             owner = ctx.label,
         ),
     )
@@ -393,6 +395,10 @@ def _rust_test_impl(ctx):
             compile_data = depset(ctx.files.compile_data, transitive = [crate.compile_data])
         else:
             compile_data = depset(ctx.files.compile_data)
+        if crate.compile_data_targets:
+            compile_data_targets = depset(ctx.attr.compile_data, transitive = [crate.compile_data_targets])
+        else:
+            compile_data_targets = depset(ctx.attr.compile_data)
         rustc_env_files = ctx.files.rustc_env_files + crate.rustc_env_files
         rustc_env = dict(crate.rustc_env)
         rustc_env.update(**ctx.attr.rustc_env)
@@ -412,6 +418,7 @@ def _rust_test_impl(ctx):
             rustc_env_files = rustc_env_files,
             is_test = True,
             compile_data = compile_data,
+            compile_data_targets = compile_data_targets,
             wrapped_crate_type = crate.type,
             owner = ctx.label,
         )
@@ -444,6 +451,7 @@ def _rust_test_impl(ctx):
             rustc_env_files = ctx.files.rustc_env_files,
             is_test = True,
             compile_data = depset(ctx.files.compile_data),
+            compile_data_targets = depset(ctx.attr.compile_data),
             owner = ctx.label,
         )
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -906,10 +906,10 @@ def construct_arguments(
     rustc_flags.add_all(rust_flags)
 
     # Gather data path from crate_info since it is inherited from real crate for rust_doc and rust_test
-    data_paths = getattr(attr, "data", []) + crate_info.compile_data_targets.to_list()
+    data_paths = depset(direct = getattr(attr, "data", []), transitive = [crate_info.compile_data_targets])
 
     # Deduplicate data paths due to https://github.com/bazelbuild/bazel/issues/14681
-    data_paths = depset(direct = data_paths).to_list()
+    data_paths = data_paths.to_list()
 
     rustc_flags.add_all(
         expand_list_element_locations(

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -906,16 +906,14 @@ def construct_arguments(
     rustc_flags.add_all(rust_flags)
 
     # Gather data path from crate_info since it is inherited from real crate for rust_doc and rust_test
-    data_paths = depset(direct = getattr(attr, "data", []), transitive = [crate_info.compile_data_targets])
-
     # Deduplicate data paths due to https://github.com/bazelbuild/bazel/issues/14681
-    data_paths = data_paths.to_list()
+    data_paths = depset(direct = getattr(attr, "data", []), transitive = [crate_info.compile_data_targets])
 
     rustc_flags.add_all(
         expand_list_element_locations(
             ctx,
             getattr(attr, "rustc_flags", []),
-            data_paths,
+            data_paths.to_list(),
         ),
     )
     add_edition_flags(rustc_flags, crate_info)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -907,13 +907,13 @@ def construct_arguments(
 
     # Gather data path from crate_info since it is inherited from real crate for rust_doc and rust_test
     # Deduplicate data paths due to https://github.com/bazelbuild/bazel/issues/14681
-    data_paths = depset(direct = getattr(attr, "data", []), transitive = [crate_info.compile_data_targets])
+    data_paths = depset(direct = getattr(attr, "data", []), transitive = [crate_info.compile_data_targets]).to_list()
 
     rustc_flags.add_all(
         expand_list_element_locations(
             ctx,
             getattr(attr, "rustc_flags", []),
-            data_paths.to_list(),
+            data_paths,
         ),
     )
     add_edition_flags(rustc_flags, crate_info)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -905,8 +905,11 @@ def construct_arguments(
     rustc_flags.add_all(rust_std_paths, before_each = "-L", format_each = "%s")
     rustc_flags.add_all(rust_flags)
 
+    # Gather data path from crate_info since it is inherited from real crate for rust_doc and rust_test
+    data_paths = getattr(attr, "data", []) + crate_info.compile_data_targets.to_list()
+
     # Deduplicate data paths due to https://github.com/bazelbuild/bazel/issues/14681
-    data_paths = depset(direct = getattr(attr, "data", []) + getattr(attr, "compile_data", [])).to_list()
+    data_paths = depset(direct = data_paths).to_list()
 
     rustc_flags.add_all(
         expand_list_element_locations(

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -43,6 +43,7 @@ def _strip_crate_info_output(crate_info):
         rustc_env_files = crate_info.rustc_env_files,
         is_test = crate_info.is_test,
         compile_data = crate_info.compile_data,
+        compile_data_targets = crate_info.compile_data_targets,
     )
 
 def rustdoc_compile_action(

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -122,6 +122,7 @@ def _rust_doc_test_impl(ctx):
         rustc_env_files = crate.rustc_env_files,
         is_test = True,
         compile_data = crate.compile_data,
+        compile_data_targets = crate.compile_data_targets,
         wrapped_crate_type = crate.type,
         owner = ctx.label,
     )

--- a/test/unit/compile_data/compile_data_env.rs
+++ b/test/unit/compile_data/compile_data_env.rs
@@ -1,0 +1,26 @@
+/// Data loaded from compile data
+pub const COMPILE_DATA: &str = include_str!(env!("COMPILE_DATA_PATH"));
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// A test that is expected to be compiled from a target that does not
+    /// directly populate the `compile_data` attribute
+    #[test]
+    fn test_compile_data_contents() {
+        assert_eq!(COMPILE_DATA.trim_end(), "compile data contents");
+    }
+
+    /// An extra module that tests the `rust_test` rule wrapping the
+    /// `rust_library` is able to provide it's own compile data.
+    #[cfg(test_compile_data)]
+    mod test_compile_data {
+        const TEST_COMPILE_DATA: &str = include_str!("test_compile_data.txt");
+
+        #[test]
+        fn test_compile_data_contents() {
+            assert_eq!(TEST_COMPILE_DATA.trim_end(), "test compile data contents");
+        }
+    }
+}

--- a/test/unit/compile_data/compile_data_test.bzl
+++ b/test/unit/compile_data/compile_data_test.bzl
@@ -1,7 +1,7 @@
 """Unittest to verify compile_data (attribute) propagation"""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("//rust:defs.bzl", "rust_common", "rust_library", "rust_test")
+load("//rust:defs.bzl", "rust_common", "rust_library", "rust_test", "rust_doc")
 
 def _target_has_compile_data(ctx, expected):
     env = analysistest.begin(ctx)
@@ -41,9 +41,16 @@ def _wrapper_rule_propagates_and_joins_compile_data_test_impl(ctx):
         ],
     )
 
+def _compile_data_propagates_to_rust_doc_test_impl(ctx):
+    return _target_has_compile_data(
+        ctx,
+        ["test/unit/compile_data/compile_data.txt"],
+    )
+
 compile_data_propagates_to_crate_info_test = analysistest.make(_compile_data_propagates_to_crate_info_test_impl)
 wrapper_rule_propagates_to_crate_info_test = analysistest.make(_wrapper_rule_propagates_to_crate_info_test_impl)
 wrapper_rule_propagates_and_joins_compile_data_test = analysistest.make(_wrapper_rule_propagates_and_joins_compile_data_test_impl)
+compile_data_propagates_to_rust_doc_test = analysistest.make(_compile_data_propagates_to_rust_doc_test_impl)
 
 def _define_test_targets():
     rust_library(
@@ -63,6 +70,11 @@ def _define_test_targets():
         compile_data = ["test_compile_data.txt"],
         crate = ":compile_data",
         rustc_flags = ["--cfg=test_compile_data"],
+    )
+
+    rust_doc(
+        name = "compile_data_rust_doc",
+        crate = ":compile_data",
     )
 
 def compile_data_test_suite(name):
@@ -89,11 +101,18 @@ def compile_data_test_suite(name):
         target_under_test = ":test_compile_data_unit_test",
     )
 
+    compile_data_propagates_to_rust_doc_test(
+        name = "compile_data_propagates_to_rust_doc_test",
+        target_under_test = ":compile_data",
+    )
+
+
     native.test_suite(
         name = name,
         tests = [
             ":compile_data_propagates_to_crate_info_test",
             ":wrapper_rule_propagates_to_crate_info_test",
             ":wrapper_rule_propagates_and_joins_compile_data_test",
+            ":compile_data_propagates_to_rust_doc_test",
         ],
     )

--- a/test/unit/compile_data/compile_data_test.bzl
+++ b/test/unit/compile_data/compile_data_test.bzl
@@ -1,7 +1,7 @@
 """Unittest to verify compile_data (attribute) propagation"""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("//rust:defs.bzl", "rust_common", "rust_library", "rust_test", "rust_doc")
+load("//rust:defs.bzl", "rust_common", "rust_doc", "rust_library", "rust_test")
 load(
     "//test/unit:common.bzl",
     "assert_action_mnemonic",
@@ -123,7 +123,6 @@ def compile_data_test_suite(name):
         name = "compile_data_propagates_to_rust_doc_test",
         target_under_test = ":compile_data_env_rust_doc",
     )
-
 
     native.test_suite(
         name = name,

--- a/test/unit/compile_data/compile_data_test.bzl
+++ b/test/unit/compile_data/compile_data_test.bzl
@@ -85,7 +85,7 @@ def _define_test_targets():
         srcs = ["compile_data_env.rs"],
         compile_data = ["compile_data.txt"],
         rustc_env = {
-            "COMPILE_DATA_PATH": "$(location :compile_data.txt)",
+            "COMPILE_DATA_PATH": "$(execpath :compile_data.txt)",
         },
         edition = "2018",
     )

--- a/test/unit/consistent_crate_name/with_modified_crate_name.bzl
+++ b/test/unit/consistent_crate_name/with_modified_crate_name.bzl
@@ -47,6 +47,7 @@ def _with_modified_crate_name_impl(ctx):
             owner = ctx.label,
             edition = "2018",
             compile_data = depset([]),
+            compile_data_targets = depset([]),
             rustc_env = {},
             is_test = False,
         ),

--- a/test/unit/force_all_deps_direct/generator.bzl
+++ b/test/unit/force_all_deps_direct/generator.bzl
@@ -64,6 +64,7 @@ EOF
             owner = ctx.label,
             edition = "2018",
             compile_data = depset([]),
+            compile_data_targets = depset([]),
             rustc_env = {},
             is_test = False,
         ),

--- a/test/unit/pipelined_compilation/wrap.bzl
+++ b/test/unit/pipelined_compilation/wrap.bzl
@@ -74,6 +74,7 @@ EOF
             owner = ctx.label,
             edition = "2018",
             compile_data = depset([]),
+            compile_data_targets = depset([]),
             rustc_env = {},
             is_test = False,
         ),


### PR DESCRIPTION
Try to fix #1572 

Main issue is that data_paths do not inherit from original crate when building rust_doc (and probably rust_test).
The main idea is to rely on crate_info which inherit correctly from original crate.

Issue with this draft is that compile_data is filed with File instead of Target when building 3rd party crate.

```
ERROR: <redacted>__base64-0.13.1/BUILD.bazel:34:13: in rust_library rule @<redacted>__base64-0.13.1//:base64:
Traceback (most recent call last):
	File "external/rules_rust/rust/private/rust.bzl", line 197, column 32, in _rust_library_impl
		return _rust_library_common(ctx, "rlib")
	File "external/rules_rust/rust/private/rust.bzl", line 292, column 32, in _rust_library_common
		return rustc_compile_action(
	File "external/rules_rust/rust/private/rustc.bzl", line 1093, column 46, in rustc_compile_action
		args, env_from_args = construct_arguments(
	File "external/rules_rust/rust/private/rustc.bzl", line 915, column 38, in construct_arguments
		expand_list_element_locations(
	File "external/rules_rust/rust/private/utils.bzl", line 311, column 53, in expand_list_element_locations
		return [_expand_location_for_build_script_runner(ctx, arg, data) for arg in args]
	File "external/rules_rust/rust/private/utils.bzl", line 255, column 30, in _expand_location_for_build_script_runner
		dedup_expand_location(ctx, env, data),
	File "external/rules_rust/rust/private/utils.bzl", line 230, column 31, in dedup_expand_location
		return ctx.expand_location(input, _deduplicate(targets))
Error in expand_location: at index 0 of targets, got element of type File, want Target
```