### PR TITLE
Generate only the needed subset of binaries for bindgen and proto

### DIFF
--- a/bindgen/3rdparty/BUILD.bazel
+++ b/bindgen/3rdparty/BUILD.bazel
@@ -5,6 +5,7 @@ crates_vendor(
     name = "crates_vendor",
     annotations = {
         "bindgen": [crate.annotation(
+            gen_binaries = ["bindgen"],
             gen_build_script = True,
         )],
         "clang-sys": [crate.annotation(
@@ -21,7 +22,6 @@ crates_vendor(
         )],
     },
     cargo_lockfile = "Cargo.Bazel.lock",
-    generate_binaries = True,
     generate_build_scripts = False,
     mode = "remote",
     packages = {

--- a/bindgen/3rdparty/crates/BUILD.bazel
+++ b/bindgen/3rdparty/crates/BUILD.bazel
@@ -43,9 +43,3 @@ alias(
     actual = "@rules_rust_bindgen__bindgen-0.60.1//:bindgen__bin",
     tags = ["manual"],
 )
-
-alias(
-    name = "clap__stdio-fixture",
-    actual = "@rules_rust_bindgen__clap-3.2.23//:stdio-fixture__bin",
-    tags = ["manual"],
-)

--- a/bindgen/3rdparty/crates/BUILD.clap-3.2.23.bazel
+++ b/bindgen/3rdparty/crates/BUILD.clap-3.2.23.bazel
@@ -8,7 +8,6 @@
 
 load(
     "@rules_rust//rust:defs.bzl",
-    "rust_binary",
     "rust_library",
 )
 
@@ -51,50 +50,6 @@ rust_library(
     ],
     version = "3.2.23",
     deps = [
-        "@rules_rust_bindgen__atty-0.2.14//:atty",
-        "@rules_rust_bindgen__bitflags-1.3.2//:bitflags",
-        "@rules_rust_bindgen__clap_lex-0.2.4//:clap_lex",
-        "@rules_rust_bindgen__indexmap-1.9.2//:indexmap",
-        "@rules_rust_bindgen__strsim-0.10.0//:strsim",
-        "@rules_rust_bindgen__termcolor-1.1.3//:termcolor",
-        "@rules_rust_bindgen__textwrap-0.16.0//:textwrap",
-    ],
-)
-
-rust_binary(
-    name = "stdio-fixture__bin",
-    srcs = glob(["**/*.rs"]),
-    compile_data = glob(
-        include = ["**"],
-        exclude = [
-            "**/* *",
-            "BUILD",
-            "BUILD.bazel",
-            "WORKSPACE",
-            "WORKSPACE.bazel",
-        ],
-    ),
-    crate_features = [
-        "atty",
-        "color",
-        "default",
-        "std",
-        "strsim",
-        "suggestions",
-        "termcolor",
-    ],
-    crate_root = "src/bin/stdio-fixture.rs",
-    edition = "2021",
-    rustc_flags = ["--cap-lints=allow"],
-    tags = [
-        "cargo-bazel",
-        "manual",
-        "noclippy",
-        "norustfmt",
-    ],
-    version = "3.2.23",
-    deps = [
-        ":clap",
         "@rules_rust_bindgen__atty-0.2.14//:atty",
         "@rules_rust_bindgen__bitflags-1.3.2//:bitflags",
         "@rules_rust_bindgen__clap_lex-0.2.4//:clap_lex",

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -265,49 +265,14 @@ impl Add for CrateAnnotations {
     type Output = CrateAnnotations;
 
     fn add(self, rhs: Self) -> Self::Output {
-        let shallow_since = if self.shallow_since.is_some() {
-            self.shallow_since
-        } else if rhs.shallow_since.is_some() {
-            rhs.shallow_since
-        } else {
-            None
-        };
-
-        let patch_tool = if self.patch_tool.is_some() {
-            self.patch_tool
-        } else if rhs.patch_tool.is_some() {
-            rhs.patch_tool
-        } else {
-            None
-        };
-
-        let gen_binaries =
-            self.gen_binaries
-                .zip(rhs.gen_binaries)
-                .map(|(lhs, rhs)| match (lhs, rhs) {
-                    (GenBinaries::All, _) | (_, GenBinaries::All) => GenBinaries::All,
-                    (GenBinaries::Some(mut lhs), GenBinaries::Some(rhs)) => {
-                        lhs.extend(rhs);
-                        GenBinaries::Some(lhs)
-                    }
-                });
-
-        let gen_build_script = if self.gen_build_script.is_some() {
-            self.gen_build_script
-        } else if rhs.gen_build_script.is_some() {
-            rhs.gen_build_script
-        } else {
-            None
-        };
-
         let concat_string = |lhs: &mut String, rhs: String| {
             *lhs = format!("{lhs}{rhs}");
         };
 
         #[rustfmt::skip]
         let output = CrateAnnotations {
-            gen_binaries,
-            gen_build_script,
+            gen_binaries: self.gen_binaries.or(rhs.gen_binaries),
+            gen_build_script: self.gen_build_script.or(rhs.gen_build_script),
             deps: joined_extra_member!(self.deps, rhs.deps, BTreeSet::new, BTreeSet::extend),
             proc_macro_deps: joined_extra_member!(self.proc_macro_deps, rhs.proc_macro_deps, BTreeSet::new, BTreeSet::extend),
             crate_features: joined_extra_member!(self.crate_features, rhs.crate_features, BTreeSet::new, BTreeSet::extend),
@@ -327,9 +292,9 @@ impl Add for CrateAnnotations {
             build_script_rustc_env: joined_extra_member!(self.build_script_rustc_env, rhs.build_script_rustc_env, BTreeMap::new, BTreeMap::extend),
             build_script_toolchains: joined_extra_member!(self.build_script_toolchains, rhs.build_script_toolchains, BTreeSet::new, BTreeSet::extend),
             additive_build_file_content: joined_extra_member!(self.additive_build_file_content, rhs.additive_build_file_content, String::new, concat_string),
-            shallow_since,
+            shallow_since: self.shallow_since.or(rhs.shallow_since),
             patch_args: joined_extra_member!(self.patch_args, rhs.patch_args, Vec::new, Vec::extend),
-            patch_tool,
+            patch_tool: self.patch_tool.or(rhs.patch_tool),
             patches: joined_extra_member!(self.patches, rhs.patches, BTreeSet::new, BTreeSet::extend),
         };
 

--- a/proto/3rdparty/BUILD.bazel
+++ b/proto/3rdparty/BUILD.bazel
@@ -4,6 +4,9 @@ load("//crate_universe:defs.bzl", "crate", "crates_vendor")
 crates_vendor(
     name = "crates_vendor",
     annotations = {
+        "grpc-compiler": [crate.annotation(
+            gen_binaries = ["protoc-gen-rust-grpc"],
+        )],
         "lazy_static": [crate.annotation(
             rustc_flags = [
                 "--cfg=lazy_static_heap_impl",
@@ -13,9 +16,11 @@ crates_vendor(
             patch_args = ["-p1"],
             patches = ["@rules_rust//proto/3rdparty/patches:protobuf-2.8.2.patch"],
         )],
+        "protobuf-codegen": [crate.annotation(
+            gen_binaries = ["protoc-gen-rust"],
+        )],
     },
     cargo_lockfile = "Cargo.Bazel.lock",
-    generate_binaries = True,
     mode = "remote",
     packages = {
         "grpc": crate.spec(

--- a/proto/3rdparty/crates/BUILD.bazel
+++ b/proto/3rdparty/crates/BUILD.bazel
@@ -75,12 +75,6 @@ alias(
 )
 
 alias(
-    name = "protobuf-codegen__protobuf-bin-gen-rust-do-not-use",
-    actual = "@rules_rust_proto__protobuf-codegen-2.8.2//:protobuf-bin-gen-rust-do-not-use__bin",
-    tags = ["manual"],
-)
-
-alias(
     name = "protobuf-codegen__protoc-gen-rust",
     actual = "@rules_rust_proto__protobuf-codegen-2.8.2//:protoc-gen-rust__bin",
     tags = ["manual"],

--- a/proto/3rdparty/crates/BUILD.protobuf-codegen-2.8.2.bazel
+++ b/proto/3rdparty/crates/BUILD.protobuf-codegen-2.8.2.bazel
@@ -47,35 +47,6 @@ rust_library(
 )
 
 rust_binary(
-    name = "protobuf-bin-gen-rust-do-not-use__bin",
-    srcs = glob(["**/*.rs"]),
-    compile_data = glob(
-        include = ["**"],
-        exclude = [
-            "**/* *",
-            "BUILD",
-            "BUILD.bazel",
-            "WORKSPACE",
-            "WORKSPACE.bazel",
-        ],
-    ),
-    crate_root = "src/bin/protobuf-bin-gen-rust-do-not-use.rs",
-    edition = "2015",
-    rustc_flags = ["--cap-lints=allow"],
-    tags = [
-        "cargo-bazel",
-        "manual",
-        "noclippy",
-        "norustfmt",
-    ],
-    version = "2.8.2",
-    deps = [
-        ":protobuf_codegen",
-        "@rules_rust_proto__protobuf-2.8.2//:protobuf",
-    ],
-)
-
-rust_binary(
     name = "protoc-gen-rust__bin",
     srcs = glob(["**/*.rs"]),
     compile_data = glob(


### PR DESCRIPTION
This removes, for example, the `protobuf-bin-gen-rust-do-not-use` binary that was previously getting exposed.

https://github.com/bazelbuild/rules_rust/blob/d6e3003594713ba00d03a354cbf7a7c2c65e22d2/proto/3rdparty/crates/BUILD.bazel#L77-L81

I had to change `impl Add for CrateAnnotations` to make crate-level `gen_binaries` work. It turns out in #1718 I didn't fully understand what this `Add` impl was supposed to do, and I had only tested `gen_binaries` _before_ adding the global-level `generate_binaries` argument (https://github.com/bazelbuild/rules_rust/pull/1718#discussion_r1055669481). (I'm still not sure that I understand what this `Add` is supposed to do exactly, but at least now it appears to work in practice.)

The behavior I observed before the change in this PR was that global-level `generate_binaries = True` would do the right thing but crate-level `gen_binaries` would seem to get ignored whether or not global-level `generate_binaries` was set. 