### PR TITLE
Don't propagate `compatible_with` to the underlying `cargo_build_script` `rust_binary` target

### DIFF
--- a/cargo/private/cargo_build_script_wrapper.bzl
+++ b/cargo/private/cargo_build_script_wrapper.bzl
@@ -94,7 +94,10 @@ def cargo_build_script(
         rustc_flags (list, optional): List of compiler flags passed to `rustc`.
         visibility (list of label, optional): Visibility to apply to the generated build script output.
         tags: (list of str, optional): Tags to apply to the generated build script output.
-        **kwargs: Forwards to the underlying `rust_binary` rule.
+        **kwargs: Forwards to the underlying `rust_binary` rule. An exception is the `compatible_with`
+            attribute, which shouldn't be forwarded to the `rust_binary`, as the `rust_binary` is only
+            built and used in `exec` mode. We propagate the `compatible_with` attribute to the `_build_scirpt_run`
+            target.
     """
 
     # This duplicates the code in _cargo_build_script_impl because we need to make these
@@ -111,8 +114,10 @@ def cargo_build_script(
     if "manual" not in binary_tags:
         binary_tags.append("manual")
     build_script_kwargs = {}
+    binary_kwargs = kwargs
     if "compatible_with" in kwargs:
-        build_script_kwargs["compatible_with"] = kwargs.pop("compatible_with")
+        build_script_kwargs["compatible_with"] = kwargs["compatible_with"]
+        binary_kwargs.pop("compatible_with")
 
     rust_binary(
         name = name + "_",
@@ -123,7 +128,7 @@ def cargo_build_script(
         rustc_env = rustc_env,
         rustc_flags = rustc_flags,
         tags = binary_tags,
-        **kwargs
+        **binary_kwargs
     )
     _build_script_run(
         name = name,

--- a/cargo/private/cargo_build_script_wrapper.bzl
+++ b/cargo/private/cargo_build_script_wrapper.bzl
@@ -112,7 +112,7 @@ def cargo_build_script(
         binary_tags.append("manual")
     build_script_kwargs = {}
     if "compatible_with" in kwargs:
-        build_script_kwargs["compatible_with"] = kwargs["compatible_with"]
+        build_script_kwargs["compatible_with"] = kwargs.pop("compatible_with")
 
     rust_binary(
         name = name + "_",

--- a/docs/cargo.md
+++ b/docs/cargo.md
@@ -143,7 +143,7 @@ The `hello_lib` target will be build with the flags and the environment variable
 | <a id="cargo_build_script-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   |  `[]` |
 | <a id="cargo_build_script-visibility"></a>visibility |  Visibility to apply to the generated build script output.   |  `None` |
 | <a id="cargo_build_script-tags"></a>tags |  (list of str, optional): Tags to apply to the generated build script output.   |  `None` |
-| <a id="cargo_build_script-kwargs"></a>kwargs |  Forwards to the underlying <code>rust_binary</code> rule.   |  none |
+| <a id="cargo_build_script-kwargs"></a>kwargs |  Forwards to the underlying <code>rust_binary</code> rule. An exception is the <code>compatible_with</code> attribute, which shouldn't be forwarded to the <code>rust_binary</code>, as the <code>rust_binary</code> is only built and used in <code>exec</code> mode. We propagate the <code>compatible_with</code> attribute to the <code>_build_scirpt_run</code> target.   |  none |
 
 
 <a id="cargo_env"></a>

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -1570,7 +1570,7 @@ The `hello_lib` target will be build with the flags and the environment variable
 | <a id="cargo_build_script-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.   |  `[]` |
 | <a id="cargo_build_script-visibility"></a>visibility |  Visibility to apply to the generated build script output.   |  `None` |
 | <a id="cargo_build_script-tags"></a>tags |  (list of str, optional): Tags to apply to the generated build script output.   |  `None` |
-| <a id="cargo_build_script-kwargs"></a>kwargs |  Forwards to the underlying <code>rust_binary</code> rule.   |  none |
+| <a id="cargo_build_script-kwargs"></a>kwargs |  Forwards to the underlying <code>rust_binary</code> rule. An exception is the <code>compatible_with</code> attribute, which shouldn't be forwarded to the <code>rust_binary</code>, as the <code>rust_binary</code> is only built and used in <code>exec</code> mode. We propagate the <code>compatible_with</code> attribute to the <code>_build_scirpt_run</code> target.   |  none |
 
 
 <a id="cargo_env"></a>

--- a/test/cargo_build_script/BUILD.bazel
+++ b/test/cargo_build_script/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//cargo:defs.bzl", "cargo_build_script")
-load("//rust:defs.bzl", "rust_test")
+load("//rust:defs.bzl", "rust_library", "rust_test")
 
 # Test that tools are built in the exec configuration.
 cargo_build_script(
@@ -45,11 +45,18 @@ environment(
     name = "bar",
 )
 
+rust_library(
+    name = "build_script_dep_without_compatible_with",
+    srcs = ["lib.rs"],
+    edition = "2018",
+)
+
 cargo_build_script(
     name = "empty_build_script",
     srcs = ["do_nothing.rs"],
     compatible_with = [":bar"],
     edition = "2018",
+    deps = [":build_script_dep_without_compatible_with"],
 )
 
 rust_test(


### PR DESCRIPTION
I mostly fixed the interaction between `compatible_with` and `cargo_build_script` in https://github.com/bazelbuild/rules_rust/pull/1745, however I forgot to remove the `compatible_with` attribute from the underlying `rust_binary` target. This target shouldn't have the `compatible_with` specification as we only depend on it in `exec` mode.