### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/github.bazelrc
+++ b/.github/github.bazelrc
@@ -16,5 +16,4 @@ build --verbose_failures
 # UI for cleaner CI output
 common --color=no
 common --curses=no
-common --show_task_finish
 common --show_timestamps


### PR DESCRIPTION
The ability to create releases seems to have broken with Bazel 6.0.0
https://github.com/bazelbuild/rules_rust/actions/runs/3847636156/jobs/6554345446#step:6:20
```
Run # Build binaries
2023/01/05 14:35:23 Downloading https://releases.bazel.build/6.0.0/release/bazel-6.0.0-linux-x86_64...
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: Reading rc options for 'run' from /home/runner/work/rules_rust/rules_rust/.github/github.bazelrc:
  Inherited 'common' options: --announce_rc --color=no --curses=no --show_task_finish --show_timestamps
ERROR: --show_task_finish :: Unrecognized option: --show_task_finish
Error: Process completed with exit code 2.
```
This should fix the issue as it seems by https://github.com/bazelbuild/bazel/issues/14052 this flag was removed (and did nothing before).