### PR TITLE
Upgrade crate_universe's dependency on cargo_toml.

### DIFF
--- a/crate_universe/Cargo.lock
+++ b/crate_universe/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497049e9477329f8f6a559972ee42e117487d01d1e8c2cc9f836ea6fa23a9e1a"
+checksum = "0f1204fe51a1e56042b8ec31d6407547ecd18f596b66f470dadb9abd9be9c843"
 dependencies = [
  "serde",
  "toml",

--- a/crate_universe/Cargo.toml
+++ b/crate_universe/Cargo.toml
@@ -21,7 +21,7 @@ default = ["cargo"]
 [dependencies]
 anyhow = "1.0.66"
 cargo_metadata = "0.15.2"
-cargo_toml = "0.13.0"
+cargo_toml = "0.14.0"
 cargo-lock = "8.0.3"
 cargo-platform = "0.1.2"
 cfg-expr = "0.12.0"


### PR DESCRIPTION
Because `cargo_toml` 0.13 did not support automatic resolution of workspace inheritance, attempts to use the Cargo `workspace.dependencies` feature resulted in an error.  In `cargo_toml` 0.14, this automatic resolution support was added.

Fixes #1771.