### PR TITLE
Support crate_features and proc macros in doctests

### DIFF
--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -67,6 +67,10 @@ def _construct_writer_arguments(ctx, test_runner, opt_test_params, action, crate
     root = crate_info.output.root.path
     if not root in roots:
         roots.append(root)
+    for proc_macro_dep in crate_info.proc_macro_deps.to_list():
+        root = proc_macro_dep.crate_info.output.root.path
+        if not root in roots:
+            roots.append(root)
     for dep in crate_info.deps.to_list():
         dep_crate_info = getattr(dep, "crate_info", None)
         dep_dep_info = getattr(dep, "dep_info", None)
@@ -197,6 +201,15 @@ rust_doc_test = rule(
             ),
             providers = [rust_common.crate_info],
             mandatory = True,
+        ),
+        "crate_features": attr.string_list(
+            doc = dedent("""\
+                List of features to enable for this crate.
+
+                Features are defined in the code using the `#[cfg(feature = "foo")]`
+                configuration option. The features listed here will be passed to `rustc`
+                with `--cfg feature="${feature_name}"` flags.
+            """),
         ),
         "deps": attr.label_list(
             doc = dedent("""\

--- a/test/unit/rustdoc/rustdoc_lib.rs
+++ b/test/unit/rustdoc/rustdoc_lib.rs
@@ -1,3 +1,8 @@
+//! ```
+//! #[cfg(feature = "with_proc_macro")]
+//! rustdoc_proc_macro::make_answer!();
+//! ```
+
 #[cfg(feature = "with_proc_macro")]
 use rustdoc_proc_macro::make_answer;
 

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -75,10 +75,11 @@ rustdoc_for_lib_with_proc_macro_test = analysistest.make(_rustdoc_for_lib_with_p
 rustdoc_for_bin_with_transitive_proc_macro_test = analysistest.make(_rustdoc_for_bin_with_transitive_proc_macro_test_impl)
 rustdoc_for_lib_with_cc_lib_test = analysistest.make(_rustdoc_for_lib_with_cc_lib_test_impl)
 
-def _target_maker(rule_fn, name, rustdoc_deps = [], **kwargs):
+def _target_maker(rule_fn, name, rustdoc_deps = [], crate_features = [], **kwargs):
     rule_fn(
         name = name,
         edition = "2018",
+        crate_features = crate_features,
         **kwargs
     )
 
@@ -97,6 +98,7 @@ def _target_maker(rule_fn, name, rustdoc_deps = [], **kwargs):
         name = "{}_doctest".format(name),
         crate = ":{}".format(name),
         deps = rustdoc_deps,
+        crate_features = crate_features,
     )
 
 def _define_targets():


### PR DESCRIPTION
Previously setting features for the doctests themselves wasn't supported at all, and attempting to use a proc macro would fail. I needed both of these together to write a test.

This is the last of my changes to get rust_doc_test working for all of my crates at work.