### PR TITLE
Add "crate-name={}" tag to Crate Universe targets

### DIFF
--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -514,6 +514,7 @@ impl Renderer {
                 tags.insert("manual".to_owned());
                 tags.insert("noclippy".to_owned());
                 tags.insert("norustfmt".to_owned());
+                tags.insert(format!("crate-name={}", krate.name));
                 tags
             },
             version: krate.common_attrs.version.clone(),


### PR DESCRIPTION
When interoperating with Cargo, it's useful to have knowledge of the original crate name for a crate downloaded via Crate Universe (e.g: for distributing a crate compiled via Bazel on crates.io).

Unfortunately this name is not currently exposed anywhere, besides (incidentally) via the auto-generated repository name: `@crates__async-trait-0.36.0` (for the target `@crates__async-trait-0.36.0//:async_trait`) and via the `alias`, `@crates//:async-trait`, which (to the best of my knowledge) is not generally visible to a Bazel aspect, as the `target` field in an aspect implementation refers to the original target being aliased - in this case `@crates__async-trait-0.36.0//:async_trait`

As a workaround it is possible to retrieve the crate name through string parsing, but this feels like a hack. In this PR we add a tag to each Crate Universe target: for example `"crate-name=async-trait"`.

Fixes #1783 .

