### PR TITLE
Added support for `--nolegacy_external_runfiles` to `rust_doc_test`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,9 @@ build:clippy --output_groups=+clippy_checks
 # https://github.com/bazelbuild/bazel/issues/8195
 build --incompatible_disallow_empty_glob=true
 
+# https://github.com/bazelbuild/bazel/issues/12821
+build --nolegacy_external_runfiles
+
 ###############################################################################
 ## Custom user flags
 ##

--- a/tools/rustdoc/rustdoc_test_writer.rs
+++ b/tools/rustdoc/rustdoc_test_writer.rs
@@ -174,6 +174,11 @@ fn write_test_runner_unix(
     let mut content = vec![
         "#!/usr/bin/env bash".to_owned(),
         "".to_owned(),
+        // TODO: Instead of creating a symlink to mimic the behavior of
+        // --legacy_external_runfiles, this rule should be able to correcrtly
+        // sanitize the action args to run in a runfiles without this link.
+        "if [[ ! -e 'external' ]]; then ln -s ../ external ; fi".to_owned(),
+        "".to_owned(),
         "exec env - \\".to_owned(),
     ];
 
@@ -227,6 +232,12 @@ fn write_test_runner_windows(
 
     let content = vec![
         "@ECHO OFF".to_owned(),
+        "".to_owned(),
+        // TODO: Instead of creating a symlink to mimic the behavior of
+        // --legacy_external_runfiles, this rule should be able to correcrtly
+        // sanitize the action args to run in a runfiles without this link.
+        "powershell.exe -c \"if (!(Test-Path .\\external)) { New-Item -Path .\\external -ItemType SymbolicLink -Value ..\\ }\""
+            .to_owned(),
         "".to_owned(),
         format!("powershell.exe -c \"{env_str} ; & {argv_str}\""),
         "".to_owned(),


### PR DESCRIPTION
This solution is pretty hacky but should get the job done. I think a hacky solution is acceptable though since the way this rule works is already less than desirable. https://github.com/bazelbuild/rules_rust/issues/1431 tracks the ideal implementation.

closes https://github.com/bazelbuild/rules_rust/issues/1681