### PR TITLE
Encapsulate running cargo into a struct

### DIFF
--- a/crate_universe/src/cli/generate.rs
+++ b/crate_universe/src/cli/generate.rs
@@ -9,8 +9,7 @@ use clap::Parser;
 use crate::config::Config;
 use crate::context::Context;
 use crate::lockfile::{lock_context, write_lockfile};
-use crate::metadata::load_metadata;
-use crate::metadata::Annotations;
+use crate::metadata::{load_metadata, Annotations, Cargo};
 use crate::rendering::{write_outputs, Renderer};
 use crate::splicing::SplicingManifest;
 
@@ -84,10 +83,10 @@ pub fn generate(opt: GenerateOptions) -> Result<()> {
     }
 
     // Ensure Cargo and Rustc are available for use during generation.
-    let cargo_bin = match &opt.cargo {
+    let cargo_bin = Cargo::new(match opt.cargo {
         Some(bin) => bin,
         None => bail!("The `--cargo` argument is required when generating unpinned content"),
-    };
+    });
     let rustc_bin = match &opt.rustc {
         Some(bin) => bin,
         None => bail!("The `--rustc` argument is required when generating unpinned content"),
@@ -108,7 +107,7 @@ pub fn generate(opt: GenerateOptions) -> Result<()> {
     // Annotate metadata
     let annotations = Annotations::new(cargo_metadata, cargo_lockfile.clone(), config.clone())?;
 
-    // Generate renderable contexts for earch package
+    // Generate renderable contexts for each package
     let context = Context::new(annotations)?;
 
     // Render build files
@@ -117,12 +116,12 @@ pub fn generate(opt: GenerateOptions) -> Result<()> {
     // Write outputs
     write_outputs(outputs, &opt.repository_dir, opt.dry_run)?;
 
-    // Ensure Bazel lockfiles are written to disk so future generations can be short-circuted.
+    // Ensure Bazel lockfiles are written to disk so future generations can be short-circuited.
     if let Some(lockfile) = opt.lockfile {
         let splicing_manifest = SplicingManifest::try_from_path(&opt.splicing_manifest)?;
 
         let lock_content =
-            lock_context(context, &config, &splicing_manifest, cargo_bin, rustc_bin)?;
+            lock_context(context, &config, &splicing_manifest, &cargo_bin, rustc_bin)?;
 
         write_lockfile(lock_content, &lockfile, opt.dry_run)?;
     }

--- a/crate_universe/src/cli/query.rs
+++ b/crate_universe/src/cli/query.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 use crate::config::Config;
 use crate::context::Context;
 use crate::lockfile::Digest;
+use crate::metadata::Cargo;
 use crate::splicing::SplicingManifest;
 
 /// Command line options for the `query` subcommand
@@ -66,7 +67,7 @@ pub fn query(opt: QueryOptions) -> Result<()> {
         &lockfile,
         &config,
         &splicing_manifest,
-        &opt.cargo,
+        &Cargo::new(opt.cargo),
         &opt.rustc,
     )?;
     if digest != expected {

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -14,13 +14,14 @@ use sha2::{Digest as Sha2Digest, Sha256};
 
 use crate::config::Config;
 use crate::context::Context;
+use crate::metadata::Cargo;
 use crate::splicing::{SplicingManifest, SplicingMetadata};
 
 pub fn lock_context(
     mut context: Context,
     config: &Config,
     splicing_manifest: &SplicingManifest,
-    cargo_bin: &Path,
+    cargo_bin: &Cargo,
     rustc_bin: &Path,
 ) -> Result<Context> {
     // Ensure there is no existing checksum which could impact the lockfile results
@@ -61,11 +62,11 @@ impl Digest {
         context: &Context,
         config: &Config,
         splicing_manifest: &SplicingManifest,
-        cargo_bin: &Path,
+        cargo_bin: &Cargo,
         rustc_bin: &Path,
     ) -> Result<Self> {
         let splicing_metadata = SplicingMetadata::try_from((*splicing_manifest).clone())?;
-        let cargo_version = Self::bin_version(cargo_bin)?;
+        let cargo_version = cargo_bin.full_version()?;
         let rustc_version = Self::bin_version(rustc_bin)?;
         let cargo_bazel_version = env!("CARGO_PKG_VERSION");
 
@@ -129,7 +130,7 @@ impl Digest {
         Self(hasher.finalize().encode_hex::<String>())
     }
 
-    fn bin_version(binary: &Path) -> Result<String> {
+    pub fn bin_version(binary: &Path) -> Result<String> {
         let safe_vars = [OsStr::new("HOMEDRIVE"), OsStr::new("PATHEXT")];
         let env = std::env::vars_os().filter(|(var, _)| safe_vars.contains(&var.as_os_str()));
 

--- a/crate_universe/src/splicing.rs
+++ b/crate_universe/src/splicing.rs
@@ -15,7 +15,7 @@ use hex::ToHex;
 use serde::{Deserialize, Serialize};
 
 use crate::config::CrateId;
-use crate::metadata::{CargoUpdateRequest, LockGenerator};
+use crate::metadata::{Cargo, CargoUpdateRequest, LockGenerator};
 use crate::utils::starlark::{Label, SelectList};
 
 use self::cargo_config::CargoConfig;
@@ -421,7 +421,7 @@ pub fn read_manifest(manifest: &Path) -> Result<Manifest> {
 pub fn generate_lockfile(
     manifest_path: &SplicedManifest,
     existing_lock: &Option<PathBuf>,
-    cargo_bin: &Path,
+    cargo_bin: Cargo,
     rustc_bin: &Path,
     update_request: &Option<CargoUpdateRequest>,
 ) -> Result<cargo_lock::Lockfile> {
@@ -438,8 +438,11 @@ pub fn generate_lockfile(
     }
 
     // Generate the new lockfile
-    let lockfile = LockGenerator::new(PathBuf::from(cargo_bin), PathBuf::from(rustc_bin))
-        .generate(manifest_path.as_path_buf(), existing_lock, update_request)?;
+    let lockfile = LockGenerator::new(cargo_bin, PathBuf::from(rustc_bin)).generate(
+        manifest_path.as_path_buf(),
+        existing_lock,
+        update_request,
+    )?;
 
     // Write the lockfile to disk
     if !root_lockfile_path.exists() {


### PR DESCRIPTION
I'm about to add conditionally setting environment variables depending on the cargo version in-use, so it's useful to route all calls to cargo through controlled methods.