### PR TITLE
Use `_make_link_flags_darwin` when target os is `ios`.

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1786,7 +1786,7 @@ def _add_native_link_flags(args, dep_info, linkstamp_outs, ambiguous_libs, crate
     if toolchain.os == "windows":
         make_link_flags = _make_link_flags_windows
         get_lib_name = get_lib_name_for_windows
-    elif toolchain.os.startswith("mac") or toolchain.os.startswith("darwin"):
+    elif toolchain.os.startswith("mac") or toolchain.os.startswith("darwin") or toolchain.os.startswith("ios"):
         make_link_flags = _make_link_flags_darwin
         get_lib_name = get_lib_name_default
     else:


### PR DESCRIPTION
Right now, `_make_link_flags_default` is used when the target os is `ios`. However, it makes use of `--whole-archive` and `--no-whole-archive` flags, which are not supported by `dyld`.

As it is done for the `macos` target, we should use `-force_load` instead. `_make_link_flags_darwin` does that, therefore we should use it when linking for iOS.