### PR TITLE
Fix tests for new Apple toolchain

### DIFF
--- a/examples/ios/.bazelrc
+++ b/examples/ios/.bazelrc
@@ -1,0 +1,4 @@
+# Enable CC toolchain that supports iOS from https://github.com/bazelbuild/apple_support
+build --apple_crosstool_top=@local_config_apple_cc//:toolchain
+build --crosstool_top=@local_config_apple_cc//:toolchain
+build --host_crosstool_top=@local_config_apple_cc//:toolchain

--- a/examples/ios/WORKSPACE.bazel
+++ b/examples/ios/WORKSPACE.bazel
@@ -1,5 +1,25 @@
 workspace(name = "ios_examples")
 
+# Users of `rules_rust` will commonly be unable to load it
+# using a `local_repository`. Instead, to setup the rules,
+# please see https://bazelbuild.github.io/rules_rust/#setup
+local_repository(
+    name = "rules_rust",
+    path = "../..",
+)
+
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
+
+rules_rust_dependencies()
+
+rust_register_toolchains(
+    edition = "2018",
+    extra_target_triples = [
+        "aarch64-apple-ios-sim",
+        "x86_64-apple-ios",
+    ],
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -28,23 +48,3 @@ load(
 )
 
 apple_support_dependencies()
-
-# Users of `rules_rust` will commonly be unable to load it
-# using a `local_repository`. Instead, to setup the rules,
-# please see https://bazelbuild.github.io/rules_rust/#setup
-local_repository(
-    name = "rules_rust",
-    path = "../..",
-)
-
-load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
-
-rules_rust_dependencies()
-
-rust_register_toolchains(
-    edition = "2018",
-    extra_target_triples = [
-        "aarch64-apple-ios-sim",
-        "x86_64-apple-ios",
-    ],
-)

--- a/examples/ios_build/.bazelrc
+++ b/examples/ios_build/.bazelrc
@@ -1,0 +1,4 @@
+# Enable CC toolchain that supports iOS from https://github.com/bazelbuild/apple_support
+build --apple_crosstool_top=@local_config_apple_cc//:toolchain
+build --crosstool_top=@local_config_apple_cc//:toolchain
+build --host_crosstool_top=@local_config_apple_cc//:toolchain

--- a/examples/ios_build/WORKSPACE.bazel
+++ b/examples/ios_build/WORKSPACE.bazel
@@ -47,3 +47,10 @@ rbe_preconfig(
     name = "buildkite_config",
     toolchain = "ubuntu1804-bazel-java11",
 )
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -75,8 +75,8 @@ def rules_rust_dependencies():
     maybe(
         http_archive,
         name = "build_bazel_apple_support",
-        sha256 = "d94b7a0f49d735f196e1f36d2e6ef79c4e8e8b82132848dd8cd93cd82d9b12a8",
-        url = "https://github.com/bazelbuild/apple_support/releases/download/1.3.0/apple_support.1.3.0.tar.gz",
+        sha256 = "77a121a0f5d4cd88824429464ad2bfb54bdc8a3bccdb4d31a6c846003a3f5e44",
+        url = "https://github.com/bazelbuild/apple_support/releases/download/1.4.1/apple_support.1.4.1.tar.gz",
     )
 
     # process_wrapper needs a low-dependency way to process json.


### PR DESCRIPTION
The Apple toolchain that is used to build iOS targets is moving out of bazel and into the apple_support repo. This switches tests to that toolchain so that this repo continues to work once it is removed from bazel.

https://github.com/bazelbuild/bazel/pull/16619