### PR TITLE
Added `rustdoc_flags` attribute to rust_doc rule

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -529,7 +529,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | <a id="rust_doc-html_in_header"></a>html_in_header |  File to add to <code>&lt;head&gt;</code>.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="rust_doc-markdown_css"></a>markdown_css |  CSS files to include via <code>&lt;link&gt;</code> in a rendered Markdown file.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="rust_doc-rustc_flags"></a>rustc_flags |  **Deprecated**: use <code>rustdoc_flags</code> instead   | List of strings | optional | <code>[]</code> |
-| <a id="rust_doc-rustdoc_flags"></a>rustdoc_flags |  List of compiler flags passed to <code>rustdock</code>.<br><br>These strings are subject to Make variable expansion for predefined source/output path variables like <code>$location</code>, <code>$execpath</code>, and <code>$rootpath</code>. This expansion is useful if you wish to pass a generated file of arguments to rustc: <code>@$(location //package:target)</code>.   | List of strings | optional | <code>[]</code> |
+| <a id="rust_doc-rustdoc_flags"></a>rustdoc_flags |  List of flags passed to <code>rustdoc</code>.<br><br>These strings are subject to Make variable expansion for predefined source/output path variables like <code>$location</code>, <code>$execpath</code>, and <code>$rootpath</code>. This expansion is useful if you wish to pass a generated file of arguments to rustc: <code>@$(location //package:target)</code>.   | List of strings | optional | <code>[]</code> |
 
 
 <a id="rust_doc_test"></a>

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -477,7 +477,7 @@ rust_clippy(
 
 <pre>
 rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>, <a href="#rust_doc-markdown_css">markdown_css</a>,
-         <a href="#rust_doc-rustc_flags">rustc_flags</a>)
+         <a href="#rust_doc-rustc_flags">rustc_flags</a>, <a href="#rust_doc-rustdoc_flags">rustdoc_flags</a>)
 </pre>
 
 Generates code documentation.
@@ -528,7 +528,8 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | <a id="rust_doc-html_before_content"></a>html_before_content |  File to add in <code>&lt;body&gt;</code>, before content.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="rust_doc-html_in_header"></a>html_in_header |  File to add to <code>&lt;head&gt;</code>.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="rust_doc-markdown_css"></a>markdown_css |  CSS files to include via <code>&lt;link&gt;</code> in a rendered Markdown file.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="rust_doc-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.<br><br>These strings are subject to Make variable expansion for predefined source/output path variables like <code>$location</code>, <code>$execpath</code>, and <code>$rootpath</code>. This expansion is useful if you wish to pass a generated file of arguments to rustc: <code>@$(location //package:target)</code>.   | List of strings | optional | <code>[]</code> |
+| <a id="rust_doc-rustc_flags"></a>rustc_flags |  **Deprecated**: use <code>rustdoc_flags</code> instead   | List of strings | optional | <code>[]</code> |
+| <a id="rust_doc-rustdoc_flags"></a>rustdoc_flags |  List of compiler flags passed to <code>rustdock</code>.<br><br>These strings are subject to Make variable expansion for predefined source/output path variables like <code>$location</code>, <code>$execpath</code>, and <code>$rootpath</code>. This expansion is useful if you wish to pass a generated file of arguments to rustc: <code>@$(location //package:target)</code>.   | List of strings | optional | <code>[]</code> |
 
 
 <a id="rust_doc_test"></a>

--- a/docs/rust_doc.md
+++ b/docs/rust_doc.md
@@ -10,7 +10,7 @@
 
 <pre>
 rust_doc(<a href="#rust_doc-name">name</a>, <a href="#rust_doc-crate">crate</a>, <a href="#rust_doc-html_after_content">html_after_content</a>, <a href="#rust_doc-html_before_content">html_before_content</a>, <a href="#rust_doc-html_in_header">html_in_header</a>, <a href="#rust_doc-markdown_css">markdown_css</a>,
-         <a href="#rust_doc-rustc_flags">rustc_flags</a>)
+         <a href="#rust_doc-rustc_flags">rustc_flags</a>, <a href="#rust_doc-rustdoc_flags">rustdoc_flags</a>)
 </pre>
 
 Generates code documentation.
@@ -61,7 +61,8 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | <a id="rust_doc-html_before_content"></a>html_before_content |  File to add in <code>&lt;body&gt;</code>, before content.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="rust_doc-html_in_header"></a>html_in_header |  File to add to <code>&lt;head&gt;</code>.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="rust_doc-markdown_css"></a>markdown_css |  CSS files to include via <code>&lt;link&gt;</code> in a rendered Markdown file.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="rust_doc-rustc_flags"></a>rustc_flags |  List of compiler flags passed to <code>rustc</code>.<br><br>These strings are subject to Make variable expansion for predefined source/output path variables like <code>$location</code>, <code>$execpath</code>, and <code>$rootpath</code>. This expansion is useful if you wish to pass a generated file of arguments to rustc: <code>@$(location //package:target)</code>.   | List of strings | optional | <code>[]</code> |
+| <a id="rust_doc-rustc_flags"></a>rustc_flags |  **Deprecated**: use <code>rustdoc_flags</code> instead   | List of strings | optional | <code>[]</code> |
+| <a id="rust_doc-rustdoc_flags"></a>rustdoc_flags |  List of compiler flags passed to <code>rustdock</code>.<br><br>These strings are subject to Make variable expansion for predefined source/output path variables like <code>$location</code>, <code>$execpath</code>, and <code>$rootpath</code>. This expansion is useful if you wish to pass a generated file of arguments to rustc: <code>@$(location //package:target)</code>.   | List of strings | optional | <code>[]</code> |
 
 
 <a id="rust_doc_test"></a>

--- a/docs/rust_doc.md
+++ b/docs/rust_doc.md
@@ -62,7 +62,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 | <a id="rust_doc-html_in_header"></a>html_in_header |  File to add to <code>&lt;head&gt;</code>.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="rust_doc-markdown_css"></a>markdown_css |  CSS files to include via <code>&lt;link&gt;</code> in a rendered Markdown file.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="rust_doc-rustc_flags"></a>rustc_flags |  **Deprecated**: use <code>rustdoc_flags</code> instead   | List of strings | optional | <code>[]</code> |
-| <a id="rust_doc-rustdoc_flags"></a>rustdoc_flags |  List of compiler flags passed to <code>rustdock</code>.<br><br>These strings are subject to Make variable expansion for predefined source/output path variables like <code>$location</code>, <code>$execpath</code>, and <code>$rootpath</code>. This expansion is useful if you wish to pass a generated file of arguments to rustc: <code>@$(location //package:target)</code>.   | List of strings | optional | <code>[]</code> |
+| <a id="rust_doc-rustdoc_flags"></a>rustdoc_flags |  List of flags passed to <code>rustdoc</code>.<br><br>These strings are subject to Make variable expansion for predefined source/output path variables like <code>$location</code>, <code>$execpath</code>, and <code>$rootpath</code>. This expansion is useful if you wish to pass a generated file of arguments to rustc: <code>@$(location //package:target)</code>.   | List of strings | optional | <code>[]</code> |
 
 
 <a id="rust_doc_test"></a>

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -178,6 +178,12 @@ def _rust_doc_impl(ctx):
         ctx (ctx): The rule's context object
     """
 
+    if ctx.attr.rustc_flags:
+        # buildifier: disable=print
+        print("rustc_flags is deprecated in favor of `rustdoc_flags` for rustdoc targets. Please update {}".format(
+            ctx.label,
+        ))
+
     crate = ctx.attr.crate
     crate_info = crate[rust_common.crate_info]
 
@@ -188,6 +194,8 @@ def _rust_doc_impl(ctx):
         "--extern",
         "{}={}".format(crate_info.name, crate_info.output.path),
     ]
+
+    rustdoc_flags.extend(ctx.attr.rustdoc_flags)
 
     action = rustdoc_compile_action(
         ctx = ctx,
@@ -290,8 +298,11 @@ rust_doc = rule(
             allow_files = [".css"],
         ),
         "rustc_flags": attr.string_list(
+            doc = "**Deprecated**: use `rustdoc_flags` instead",
+        ),
+        "rustdoc_flags": attr.string_list(
             doc = dedent("""\
-                List of compiler flags passed to `rustc`.
+                List of flags passed to `rustdoc`.
 
                 These strings are subject to Make variable expansion for predefined
                 source/output path variables like `$location`, `$execpath`, and

--- a/test/unit/rustdoc/rustdoc_requires_args.rs
+++ b/test/unit/rustdoc/rustdoc_requires_args.rs
@@ -1,0 +1,2 @@
+/// I want to link to [`Nonexistent`] but it doesn't exist!
+pub fn foo() {}


### PR DESCRIPTION
Add support for `rustdoc_flags` on Rustdoc rules. This avoids some confusion around how to pass args to `rustdoc` as `rustc_flags` is misleading.