### PR TITLE
Pipe stderr from cargo tree processes

### DIFF
--- a/crate_universe/src/metadata.rs
+++ b/crate_universe/src/metadata.rs
@@ -425,6 +425,7 @@ impl FeatureGenerator {
                 .arg(target)
                 .env("RUSTC", &self.rustc_bin)
                 .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
                 .spawn()
                 .with_context(|| {
                     format!(


### PR DESCRIPTION
Now that we're racing a bunch of them in parallel, they occasionally print:
> Blocking waiting for file lock on package cache
to stderr.

We print stderr if the process failed, but now swallow this benign output if the process succeeded.