### PR TITLE
Release rules_rust and cargo-bazel

### DIFF
--- a/crate_universe/Cargo.lock
+++ b/crate_universe/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bazel"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cargo-lock",

--- a/crate_universe/Cargo.toml
+++ b/crate_universe/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "cargo-bazel"
-version = "0.6.0"
+version = "0.8.0"
 authors = [
     "Andre Brisco - andre.brisco@protonmail.com",
 ]

--- a/crate_universe/version.bzl
+++ b/crate_universe/version.bzl
@@ -1,3 +1,3 @@
 """ Version info for the `cargo-bazel` repository """
 
-VERSION = "0.7.0"
+VERSION = "0.8.0"

--- a/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e00b3994f2484b9b7953bfca735dc00dd778be331629f6a94b24dbb5b024bc4f",
+  "checksum": "593aa0154cac24e9307f79df850d379f1d0114e0e47aa8e0571fd678ee370726",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",

--- a/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1af5d7a4f9c14ecb1dd8479573534bd450b2bfbdcbfb9abfac21f40b8ef315da",
+  "checksum": "82ea315f26690f40d58731d754b5a4c4d12185b98bccaeb7264831c1fe1153f0",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",

--- a/examples/crate_universe/multi_package/cargo-bazel-lock.json
+++ b/examples/crate_universe/multi_package/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e378165a3aa9e8b87356e8e488820aac72ad38a33cce537f71e444ac03caafb9",
+  "checksum": "406141a4b7e7f4f175213fd66a5ae3a793048ae96a9f7298ff04af8c6c5a43e6",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",

--- a/examples/crate_universe/no_cargo_manifests/cargo-bazel-lock.json
+++ b/examples/crate_universe/no_cargo_manifests/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "805e0185ed5f33132b011110c542b69cf3dedae8ad628c9245957675d35c7243",
+  "checksum": "f905299ba854bb49b2880b3d856ff4bc8edcf359f13bfb343c2f3330af8edb12",
   "crates": {
     "async-trait 0.1.64": {
       "name": "async-trait",

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.18.0"
+VERSION = "0.19.0"


### PR DESCRIPTION
I'd like to get a release out soon containing a bunch of recent perf improvements for cargo-bazel - is there anything pending which people want to block the release on?