### PR TITLE
Add runfiles support to rust_stdlib_filegroup

### DIFF
--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -72,6 +72,7 @@ def _rust_stdlib_filegroup_impl(ctx):
     return [
         DefaultInfo(
             files = depset(ctx.files.srcs),
+            runfiles = ctx.runfiles(ctx.files.srcs),
         ),
         rust_common.stdlib_info(
             std_rlibs = std_rlibs,

--- a/test/toolchain/toolchain_test.bzl
+++ b/test/toolchain/toolchain_test.bzl
@@ -142,6 +142,18 @@ def _define_targets():
         dep = ":lib",
     )
 
+def _rust_stdlib_filegroup_provides_runfiles_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    runfiles = target[DefaultInfo].default_runfiles
+    asserts.true(env, len(runfiles.files.to_list()) > 0)
+
+    return analysistest.end(env)
+
+rust_stdlib_filegroup_provides_runfiles_test = analysistest.make(
+    _rust_stdlib_filegroup_provides_runfiles_test_impl,
+)
+
 def toolchain_test_suite(name):
     _define_targets()
 
@@ -150,9 +162,15 @@ def toolchain_test_suite(name):
         target_under_test = ":lib_with_extra_toolchain",
     )
 
+    rust_stdlib_filegroup_provides_runfiles_test(
+        name = "rust_stdlib_filegroup_provides_runfiles_test",
+        target_under_test = ":std_libs",
+    )
+
     native.test_suite(
         name = name,
         tests = [
             ":toolchain_adds_rustc_flags_test",
+            ":rust_stdlib_filegroup_provides_runfiles_test",
         ],
     )


### PR DESCRIPTION
Currently `rust_stdlib_filegroup` doesn't provide runfiles, therefore it cannot be easily used to pass all the stdlib artifacts to rules that expect runfiles (for example, passing stdlibs to `sh_test` so the `sh_test` can invoke rustc). This PR fixes that.