### PR TITLE
Support `-Cpanic=abort`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//rust:defs.bzl", "capture_clippy_output", "clippy_flags", "error_format", "extra_exec_rustc_flag", "extra_exec_rustc_flags", "extra_rustc_flag", "extra_rustc_flags", "is_proc_macro_dep", "is_proc_macro_dep_enabled")
+load("//rust:defs.bzl", "capture_clippy_output", "clippy_flags", "error_format", "extra_exec_rustc_flag", "extra_exec_rustc_flags", "extra_rustc_flag", "extra_rustc_flags", "is_proc_macro_dep", "is_proc_macro_dep_enabled", "panic_style")
 
 exports_files(["LICENSE"])
 
@@ -15,6 +15,13 @@ bzl_library(
 error_format(
     name = "error_format",
     build_setting_default = "human",
+    visibility = ["//visibility:public"],
+)
+
+# This setting may be changed from the command line to panic immediately upon abort.
+panic_style(
+    name = "panic_style",
+    build_setting_default = "unwind",
     visibility = ["//visibility:public"],
 )
 

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -55,6 +55,7 @@ PAGES = dict([
             "rust_test",
             "rust_test_suite",
             "error_format",
+            "panic_style",
             "extra_rustc_flag",
             "extra_rustc_flags",
             "capture_clippy_output",

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -9,6 +9,7 @@
 * [rust_test](#rust_test)
 * [rust_test_suite](#rust_test_suite)
 * [error_format](#error_format)
+* [panic_style](#panic_style)
 * [extra_rustc_flag](#extra_rustc_flag)
 * [extra_rustc_flags](#extra_rustc_flags)
 * [capture_clippy_output](#capture_clippy_output)
@@ -83,6 +84,24 @@ Add additional rustc_flags from the command line with `--@rules_rust//:extra_rus
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="extra_rustc_flags-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+
+
+<a id="panic_style"></a>
+
+## panic_style
+
+<pre>
+panic_style(<a href="#panic_style-name">name</a>)
+</pre>
+
+Change the [-Cpanic](https://doc.rust-lang.org/rustc/codegen-options/index.html#panic) flag from the command line with `--@rules_rust//:panic_style`. See rustc documentation for valid values. Automatically reset to `unwind` for proc macros and tests.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="panic_style-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 
 
 <a id="rust_binary"></a>

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -13,6 +13,7 @@
 * [extra_rustc_flags](#extra_rustc_flags)
 * [fail_when_enabled](#fail_when_enabled)
 * [incompatible_flag](#incompatible_flag)
+* [panic_style](#panic_style)
 * [rules_rust_dependencies](#rules_rust_dependencies)
 * [rust_analyzer_aspect](#rust_analyzer_aspect)
 * [rust_analyzer_toolchain](#rust_analyzer_toolchain)
@@ -197,6 +198,24 @@ A rule defining an incompatible flag.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="incompatible_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="incompatible_flag-issue"></a>issue |  The link to the github issue associated with this flag   | String | required |  |
+
+
+<a id="panic_style"></a>
+
+## panic_style
+
+<pre>
+panic_style(<a href="#panic_style-name">name</a>)
+</pre>
+
+Change the [-Cpanic](https://doc.rust-lang.org/rustc/codegen-options/index.html#panic) flag from the command line with `--@rules_rust//:panic_style`. See rustc documentation for valid values. Automatically reset to `unwind` for proc macros and tests.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="panic_style-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 
 
 <a id="rust_analyzer_toolchain"></a>

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -51,6 +51,7 @@ load(
     _error_format = "error_format",
     _extra_rustc_flag = "extra_rustc_flag",
     _extra_rustc_flags = "extra_rustc_flags",
+    _panic_style = "panic_style",
     _rust_analyzer_aspect = "rust_analyzer_aspect",
     _rust_binary = "rust_binary",
     _rust_clippy = "rust_clippy",
@@ -175,6 +176,7 @@ rustfmt_test = _rustfmt_test
 rustfmt_toolchain = _rustfmt_toolchain
 
 error_format = _error_format
+panic_style = _panic_style
 extra_rustc_flag = _extra_rustc_flag
 extra_rustc_flags = _extra_rustc_flags
 incompatible_flag = _incompatible_flag

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -49,6 +49,7 @@ load(
     _extra_rustc_flags = "extra_rustc_flags",
     _is_proc_macro_dep = "is_proc_macro_dep",
     _is_proc_macro_dep_enabled = "is_proc_macro_dep_enabled",
+    _panic_style = "panic_style",
 )
 load(
     "//rust/private:rustdoc.bzl",
@@ -104,6 +105,9 @@ capture_clippy_output = _capture_clippy_output
 # See @rules_rust//rust/private:clippy.bzl for a complete description.
 
 error_format = _error_format
+# See @rules_rust//rust/private:rustc.bzl for a complete description.
+
+panic_style = _panic_style
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 extra_rustc_flag = _extra_rustc_flag

--- a/test/panic_style/BUILD.bazel
+++ b/test/panic_style/BUILD.bazel
@@ -1,0 +1,53 @@
+load("//rust:defs.bzl", "rust_binary", "rust_test")
+load(":defs.bzl", "with_panic_style_cfg")
+
+rust_binary(
+    name = "try_catch_panic",
+    srcs = ["src/try_catch_panic.rs"],
+    edition = "2018",
+)
+
+# This should always succeed, independent of the flag, because tests should
+# always have -Cpanic=unwind.
+rust_test(
+    name = "test_catch_panic",
+    srcs = ["tests/catch_panic.rs"],
+    edition = "2018",
+)
+
+with_panic_style_cfg(
+    name = "try_catch_panic_with_unwind",
+    srcs = [":try_catch_panic"],
+    panic_style = "unwind",
+)
+
+with_panic_style_cfg(
+    name = "try_catch_panic_with_abort",
+    srcs = [":try_catch_panic"],
+    panic_style = "abort",
+)
+
+rust_test(
+    name = "verify_abort",
+    srcs = ["src/verify_abort.rs"],
+    data = [
+        ":try_catch_panic_with_abort",
+    ],
+    edition = "2018",
+    deps = [
+        "//tools/runfiles",
+        "@libc",
+    ],
+)
+
+rust_test(
+    name = "verify_unwind",
+    srcs = ["src/verify_unwind.rs"],
+    data = [
+        ":try_catch_panic_with_unwind",
+    ],
+    edition = "2018",
+    deps = [
+        "//tools/runfiles",
+    ],
+)

--- a/test/panic_style/defs.bzl
+++ b/test/panic_style/defs.bzl
@@ -1,0 +1,29 @@
+"""Test transitions to test panic_style."""
+
+def _panic_style_transition_impl(_settings, attr):
+    return {
+        "//:panic_style": attr.panic_style,
+    }
+
+_panic_style_transition = transition(
+    implementation = _panic_style_transition_impl,
+    inputs = [],
+    outputs = ["//:panic_style"],
+)
+
+def _with_panic_style_cfg_impl(ctx):
+    return [DefaultInfo(files = depset(ctx.files.srcs))]
+
+with_panic_style_cfg = rule(
+    implementation = _with_panic_style_cfg_impl,
+    attrs = {
+        "panic_style": attr.string(mandatory = True),
+        "srcs": attr.label_list(
+            allow_files = True,
+            cfg = _panic_style_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = Label("//tools/allowlists/function_transition_allowlist"),
+        ),
+    },
+)

--- a/test/panic_style/src/try_catch_panic.rs
+++ b/test/panic_style/src/try_catch_panic.rs
@@ -1,0 +1,11 @@
+//! This binary attempts to catch a panic. Depending on how it is built, this may fail. Exit codes
+//! are:
+//!   0 if successfully caught
+//!   101 if catch_unwind returns Ok somehow
+//!   Exited with SIGABRT if the panic is not caught
+
+use std::panic::catch_unwind;
+
+fn main() {
+    assert!(catch_unwind(|| panic!("Test panic")).is_err());
+}

--- a/test/panic_style/src/verify_abort.rs
+++ b/test/panic_style/src/verify_abort.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use libc::SIGABRT;
+
+use runfiles::Runfiles;
+
+#[test]
+fn test() {
+    let r = Runfiles::create().unwrap();
+    let try_catch_panic = r.rlocation(
+        [
+            "rules_rust",
+            "test",
+            "panic_style",
+            if cfg!(unix) {
+                "try_catch_panic"
+            } else {
+                "try_catch_panic.exe"
+            },
+        ]
+        .iter()
+        .collect::<PathBuf>(),
+    );
+    let status = Command::new(try_catch_panic)
+        .status()
+        .expect("Failed to spawn test process");
+    assert!(!status.success(), "Test process should have failed");
+    if cfg!(unix) {
+        use std::os::unix::process::ExitStatusExt;
+        if status.signal() != Some(SIGABRT) {
+            panic!("Test process failed in an unexpected way: {:?}", status);
+        }
+    } else {
+        // The Windows API doesn't let us validate anything else.
+    }
+}

--- a/test/panic_style/src/verify_unwind.rs
+++ b/test/panic_style/src/verify_unwind.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use runfiles::Runfiles;
+
+#[test]
+fn test() {
+    let r = Runfiles::create().unwrap();
+    let try_catch_panic = r.rlocation(
+        [
+            "rules_rust",
+            "test",
+            "panic_style",
+            if cfg!(unix) {
+                "try_catch_panic"
+            } else {
+                "try_catch_panic.exe"
+            },
+        ]
+        .iter()
+        .collect::<PathBuf>(),
+    );
+    let status = Command::new(try_catch_panic)
+        .status()
+        .expect("Failed to spawn test process");
+    assert!(
+        status.success(),
+        "Test process should have exited with success"
+    );
+}

--- a/test/panic_style/tests/catch_panic.rs
+++ b/test/panic_style/tests/catch_panic.rs
@@ -1,0 +1,6 @@
+use std::panic::catch_unwind;
+
+#[test]
+fn catch_panic() {
+    assert!(catch_unwind(|| panic!("Test panic")).is_err());
+}

--- a/test/unit/stdlib/stdlib.bzl
+++ b/test/unit/stdlib/stdlib.bzl
@@ -48,14 +48,13 @@ libstd_ordering_test = analysistest.make(_libstd_ordering_test_impl)
 
 def _libstd_panic_test_impl(ctx):
     # The libraries panic_unwind and panic_abort are alternatives.
-    # Check that they don't occur together.
+    # Check that we have one or the other.
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
     stdlibs = _stdlibs(tut)
     has_panic_unwind = [lib for lib in stdlibs if "panic_unwind" in lib.basename]
-    if has_panic_unwind:
-        has_panic_abort = [lib for lib in stdlibs if "panic_abort" in lib.basename]
-        asserts.false(env, has_panic_abort)
+    has_panic_abort = [lib for lib in stdlibs if "panic_abort" in lib.basename]
+    asserts.false(env, has_panic_unwind == has_panic_abort)
 
     return analysistest.end(env)
 

--- a/test/unit/toolchain_make_variables/toolchain_make_variables_test.bzl
+++ b/test/unit/toolchain_make_variables/toolchain_make_variables_test.bzl
@@ -1,8 +1,8 @@
 """Tests for make variables provided by `rust_toolchain`"""
 
-load("@bazel_skylib//lib:unittest.bzl", "analysistest")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
-load("//test/unit:common.bzl", "assert_action_mnemonic", "assert_env_value")
+load("//test/unit:common.bzl", "assert_action_mnemonic")
 
 _RUST_TOOLCHAIN_ENV = {
     "ENV_VAR_CARGO": "$(CARGO)",
@@ -15,6 +15,13 @@ _RUST_TOOLCHAIN_ENV = {
 _RUSTFMT_TOOLCHAIN_ENV = {
     "ENV_VAR_RUSTFMT": "$(RUSTFMT)",
 }
+
+def _mangle_path(path):
+    if not path:
+        return path
+    components = path.split("/")
+    components[1] = "<OUTDIR>"
+    "/".join(components)
 
 def _rust_toolchain_make_variable_expansion_test_common_impl(ctx, mnemonic):
     env = analysistest.begin(ctx)
@@ -45,12 +52,7 @@ def _rust_toolchain_make_variable_expansion_test_common_impl(ctx, mnemonic):
         }
 
     for key in env_vars:
-        assert_env_value(
-            env = env,
-            action = action,
-            key = key,
-            value = expected_values[key],
-        )
+        asserts.equals(env, _mangle_path(action.env[key]), _mangle_path(expected_values[key]))
 
     return analysistest.end(env)
 


### PR DESCRIPTION
This takes some effort to switch back to `-Cpanic=unwind` for tests and
proc macros, which are incompatible with it.