### PR TITLE
Add `rust_dylib_library` rule

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -50,6 +50,7 @@ PAGES = dict([
             "rust_binary",
             "rust_library",
             "rust_static_library",
+            "rust_dylib_library",
             "rust_shared_library",
             "rust_proc_macro",
             "rust_test",

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -4,6 +4,7 @@
 * [rust_binary](#rust_binary)
 * [rust_library](#rust_library)
 * [rust_static_library](#rust_static_library)
+* [rust_dylib_library](#rust_dylib_library)
 * [rust_shared_library](#rust_shared_library)
 * [rust_proc_macro](#rust_proc_macro)
 * [rust_test](#rust_test)

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -27,6 +27,7 @@
 * [rust_clippy_aspect](#rust_clippy_aspect)
 * [rust_doc](#rust_doc)
 * [rust_doc_test](#rust_doc_test)
+* [rust_dylib_library](#rust_dylib_library)
 * [rust_grpc_library](#rust_grpc_library)
 * [rust_library](#rust_library)
 * [rust_proc_macro](#rust_proc_macro)

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -29,10 +29,10 @@ load("//rust/private:common.bzl", _rust_common = "rust_common")
 load(
     "//rust/private:rust.bzl",
     _rust_binary = "rust_binary",
+    _rust_dylib_library = "rust_dylib_library",
     _rust_library = "rust_library",
     _rust_proc_macro = "rust_proc_macro",
     _rust_shared_library = "rust_shared_library",
-    _rust_dylib_library = "rust_dylib_library",
     _rust_static_library = "rust_static_library",
     _rust_test = "rust_test",
     _rust_test_suite = "rust_test_suite",

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -32,6 +32,7 @@ load(
     _rust_library = "rust_library",
     _rust_proc_macro = "rust_proc_macro",
     _rust_shared_library = "rust_shared_library",
+    _rust_dylib_library = "rust_dylib_library",
     _rust_static_library = "rust_static_library",
     _rust_test = "rust_test",
     _rust_test_suite = "rust_test_suite",
@@ -67,6 +68,8 @@ load(
 
 rust_library = _rust_library
 # See @rules_rust//rust/private:rust.bzl for a complete description.
+
+rust_dylib_library = _rust_dylib_library
 
 rust_static_library = _rust_static_library
 # See @rules_rust//rust/private:rust.bzl for a complete description.

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -197,6 +197,24 @@ def _rust_library_impl(ctx):
     """
     return _rust_library_common(ctx, "rlib")
 
+def _rust_dylib_library_impl(ctx):
+    """The implementation of the `rust_dylib_library` rule.
+
+    This rule provides CcInfo, so it can be used everywhere Bazel
+    expects rules_cc.
+
+    On Windows, a PDB file containing debugging information is available under
+    the key `pdb_file` in `OutputGroupInfo`. Similarly on macOS, a dSYM folder
+    is available under the key `dsym_folder` in `OutputGroupInfo`.
+
+    Args:
+        ctx (ctx): The rule's context object
+
+    Returns:
+        list: A list of providers.
+    """
+    return _rust_library_common(ctx, "dylib")
+
 def _rust_static_library_impl(ctx):
     """The implementation of the `rust_static_library` rule.
 
@@ -837,6 +855,29 @@ rust_library = rule(
         bazel-bin/examples/rust/hello_lib/libhello_lib.rlib
         INFO: Elapsed time: 1.245s, Critical Path: 1.01s
         ```
+        """),
+)
+
+rust_dylib_library = rule(
+    implementation = _rust_dylib_library_impl,
+    attrs = dict(_common_attrs.items()),
+    fragments = ["cpp"],
+    host_fragments = ["cpp"],
+    toolchains = [
+        str(Label("//rust:toolchain_type")),
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
+    incompatible_use_toolchain_transition = True,
+    doc = dedent("""\
+        Builds a Rust dynamic library.
+
+        This dynamic library will contain all transitively reachable crates and native objects.
+        It is meant to be used when producing an artifact that is then consumed by some other build system
+        (for example to produce a shared library that Python program links against).
+
+        This rule provides CcInfo, so it can be used everywhere Bazel expects `rules_cc`.
+
+        When building the whole binary in Bazel, use `rust_library` instead.
         """),
 )
 


### PR DESCRIPTION
add dylib option support for building a rust library.

To use it, we will have to specify a rust_dylib_library rule.