### PR TITLE
Handle corner case for windows architecture detection

### DIFF
--- a/rust/platform/triple.bzl
+++ b/rust/platform/triple.bzl
@@ -3,7 +3,7 @@ a way to convert a triple string into a well structured object to avoid constant
 parsing in starlark code, and a way for a repository_rule to extract the target triple
 of the host platform.
 
-Triples can be described at the following link: 
+Triples can be described at the following link:
 https://clang.llvm.org/docs/CrossCompilation.html#target-triple
 """
 
@@ -100,12 +100,16 @@ def _query_cpu_architecture(repository_ctx, expected_archs, is_windows = False):
         # Example output:
         # OSArchitecture
         # 64-bit
+        #
+        # In some cases windows can return the same but with an uppercase b
+        # OSArchitecture
+        # 64-Bit
         lines = result.stdout.split("\n")
-        arch = lines[1].strip()
+        arch = lines[1].strip().lower()
 
         # Translate 64-bit to a compatible rust platform
         # https://doc.rust-lang.org/nightly/rustc/platform-support.html
-        if arch.startswith("ARM 64-bit"):
+        if arch.startswith("arm 64-bit"):
             arch = "aarch64"
         elif arch == "64-bit":
             arch = "x86_64"


### PR DESCRIPTION
It appears that `wmic os get osarchitecture` can also return

```
OSArchitecture
64-Bit
```

Note the capital `B`!

This fails for the string comparison and therefore fails to detect the existing architecture for windows.

Unfortunately i could not find any documentation on why or when this happens, but a simple `lower()` handles both cases just fine

Closes: https://github.com/bazelbuild/rules_rust/issues/1916