### PR TITLE
Fix regression in building zlib

### DIFF
--- a/crate_universe/3rdparty/BUILD.zlib.bazel
+++ b/crate_universe/3rdparty/BUILD.zlib.bazel
@@ -31,6 +31,12 @@ _ZLIB_PREFIXED_HEADERS = ["{}/{}".format(_ZLIB_HEADER_PREFIX, hdr) for hdr in _Z
     for hdr in _ZLIB_HEADERS
 ]
 
+_COMMON_COPTS = [
+    "-Wno-deprecated-non-prototype",
+    "-Wno-unused-variable",
+    "-Wno-implicit-function-declaration",
+]
+
 cc_library(
     name = "zlib",
     srcs = [
@@ -55,12 +61,15 @@ cc_library(
     ] + _ZLIB_HEADERS,
     hdrs = _ZLIB_PREFIXED_HEADERS,
     copts = select({
+        "@platforms//os:linux": [
+            # Required for opt builds to avoid
+            # `libzlib.a(crc32.o): requires unsupported dynamic reloc 11; recompile with -fPIC`
+            "-fPIC",
+            # Silence all warnings
+            "-w",
+        ] + _COMMON_COPTS,
         "@platforms//os:windows": [],
-        "//conditions:default": [
-            "-Wno-deprecated-non-prototype",
-            "-Wno-unused-variable",
-            "-Wno-implicit-function-declaration",
-        ],
+        "//conditions:default": _COMMON_COPTS,
     }),
     includes = ["zlib/include/"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
https://github.com/bazelbuild/rules_rust/pull/1931 introduced a regression for some folks on linux. Comments and flags in that PR are now restored.

For future readers, the BUILD file here is a combination of [@com_google_protobuf//third_party/zlib.BUILD](https://github.com/protocolbuffers/protobuf/blob/v22.3/third_party/zlib.BUILD) and [@bazel//third_party/zlib/BUILD](https://github.com/bazelbuild/bazel/blob/6.1.2/third_party/zlib/BUILD) and [@cargo_bazel//3rdparty/BUILD.zlib.bazel](https://github.com/abrisco/cargo-bazel/blob/0.0.29/3rdparty/BUILD.zlib.bazel). 