### PR TITLE
Allow dotted target names.

### DIFF
--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -330,7 +330,7 @@ def name_to_crate_name(name):
     Returns:
         str: The name of the crate for this target.
     """
-    for illegal in ("-", "/"):
+    for illegal in ("-", "/", "."):
         name = name.replace(illegal, "_")
     return name
 


### PR DESCRIPTION
Targets like `foo.bar` are often used for generated targets in my experience. For example, `my_macro(name="foo")` might generate a target named `foo.something`.

`name_to_crate_name` claims to convert "all illegal characters" to underscores, but dots are the most notable exception so far.