### PR TITLE
Added tests for build script dependencies to crate_universe

### DIFF
--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -836,7 +836,7 @@ mod test {
         let annotations = build_script_annotations();
 
         let package_id = PackageId {
-            repr: "openssl-sys 0.9.72 (registry+https://github.com/rust-lang/crates.io-index)"
+            repr: "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
                 .to_owned(),
         };
 
@@ -881,7 +881,7 @@ mod test {
         let annotations = build_script_annotations();
 
         let package_id = PackageId {
-            repr: "openssl-sys 0.9.72 (registry+https://github.com/rust-lang/crates.io-index)"
+            repr: "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
                 .to_owned(),
         };
 

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -1100,7 +1100,7 @@ mod test {
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
-            .get(&PathBuf::from("BUILD.cpufeatures-0.2.1.bazel"))
+            .get(&PathBuf::from("BUILD.cpufeatures-0.2.7.bazel"))
             .unwrap();
 
         // This is unfortunately somewhat brittle. Alas. Ultimately we wish to demonstrate that the
@@ -1108,7 +1108,7 @@ mod test {
         let expected = indoc! {r#"
             deps = select({
                 "@rules_rust//rust/platform:aarch64-apple-darwin": [
-                    "@multi_cfg_dep__libc-0.2.117//:libc",  # aarch64-apple-darwin
+                    "@multi_cfg_dep__libc-0.2.117//:libc",  # cfg(all(target_arch = "aarch64", target_vendor = "apple"))
                 ],
                 "@rules_rust//rust/platform:aarch64-unknown-linux-gnu": [
                     "@multi_cfg_dep__libc-0.2.117//:libc",  # cfg(all(target_arch = "aarch64", target_os = "linux"))

--- a/crate_universe/test_data/metadata/aliases/metadata.json
+++ b/crate_universe/test_data/metadata/aliases/metadata.json
@@ -476,6 +476,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "default": [],
                 "example_generated": [],
                 "rustc-dep-of-std": [
@@ -580,6 +586,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "rustc-dep-of-std": [
                     "core",
                     "compiler_builtins"
@@ -1734,8 +1746,17 @@
                 }
             ],
             "features": {
+                "atty": [
+                    "dep:atty"
+                ],
+                "backtrace": [
+                    "dep:backtrace"
+                ],
                 "cargo": [
                     "lazy_static"
+                ],
+                "clap_derive": [
+                    "dep:clap_derive"
                 ],
                 "color": [
                     "atty",
@@ -1755,11 +1776,29 @@
                     "lazy_static"
                 ],
                 "env": [],
+                "lazy_static": [
+                    "dep:lazy_static"
+                ],
+                "regex": [
+                    "dep:regex"
+                ],
                 "std": [
                     "indexmap/std"
                 ],
+                "strsim": [
+                    "dep:strsim"
+                ],
                 "suggestions": [
                     "strsim"
+                ],
+                "termcolor": [
+                    "dep:termcolor"
+                ],
+                "terminal_size": [
+                    "dep:terminal_size"
+                ],
+                "unicase": [
+                    "dep:unicase"
                 ],
                 "unicode": [
                     "textwrap/unicode-width",
@@ -1787,6 +1826,9 @@
                 ],
                 "yaml": [
                     "yaml-rust"
+                ],
+                "yaml-rust": [
+                    "dep:yaml-rust"
                 ]
             },
             "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-3.1.5/Cargo.toml",
@@ -2306,10 +2348,19 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "custom": [],
                 "js": [
                     "wasm-bindgen",
                     "js-sys"
+                ],
+                "js-sys": [
+                    "dep:js-sys"
                 ],
                 "rdrand": [],
                 "rustc-dep-of-std": [
@@ -2319,7 +2370,10 @@
                     "wasi/rustc-dep-of-std"
                 ],
                 "std": [],
-                "test-in-browser": []
+                "test-in-browser": [],
+                "wasm-bindgen": [
+                    "dep:wasm-bindgen"
+                ]
             },
             "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.5/Cargo.toml",
             "metadata": {
@@ -2609,8 +2663,23 @@
                 }
             ],
             "features": {
+                "ahash": [
+                    "dep:ahash"
+                ],
                 "ahash-compile-time-rng": [
                     "ahash/compile-time-rng"
+                ],
+                "alloc": [
+                    "dep:alloc"
+                ],
+                "bumpalo": [
+                    "dep:bumpalo"
+                ],
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
                 ],
                 "default": [
                     "ahash",
@@ -2619,6 +2688,9 @@
                 "inline-more": [],
                 "nightly": [],
                 "raw": [],
+                "rayon": [
+                    "dep:rayon"
+                ],
                 "rustc-dep-of-std": [
                     "nightly",
                     "core",
@@ -2626,7 +2698,10 @@
                     "alloc",
                     "rustc-internal-api"
                 ],
-                "rustc-internal-api": []
+                "rustc-internal-api": [],
+                "serde": [
+                    "dep:serde"
+                ]
             },
             "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.11.2/Cargo.toml",
             "metadata": {
@@ -2706,6 +2781,9 @@
                 "default": [],
                 "unicode": [
                     "unicode-segmentation"
+                ],
+                "unicode-segmentation": [
+                    "dep:unicode-segmentation"
                 ]
             },
             "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/heck-0.4.0/Cargo.toml",
@@ -2794,6 +2872,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "default": [],
                 "docs": [],
                 "rustc-dep-of-std": [
@@ -3106,6 +3190,15 @@
                 }
             ],
             "features": {
+                "rayon": [
+                    "dep:rayon"
+                ],
+                "rustc-rayon": [
+                    "dep:rustc-rayon"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
                 "serde-1": [
                     "serde"
                 ],
@@ -3229,6 +3322,9 @@
                 }
             ],
             "features": {
+                "spin": [
+                    "dep:spin"
+                ],
                 "spin_no_std": [
                     "spin"
                 ]
@@ -3334,6 +3430,9 @@
                 "rustc-dep-of-std": [
                     "align",
                     "rustc-std-workspace-core"
+                ],
+                "rustc-std-workspace-core": [
+                    "dep:rustc-std-workspace-core"
                 ],
                 "std": [],
                 "use_std": [
@@ -3693,7 +3792,16 @@
                 "release_max_level_off": [],
                 "release_max_level_trace": [],
                 "release_max_level_warn": [],
-                "std": []
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "sval": [
+                    "dep:sval"
+                ],
+                "value-bag": [
+                    "dep:value-bag"
+                ]
             },
             "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/Cargo.toml",
             "metadata": {
@@ -3817,8 +3925,17 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "default": [
                     "std"
+                ],
+                "libc": [
+                    "dep:libc"
                 ],
                 "rustc-dep-of-std": [
                     "core",
@@ -3963,6 +4080,9 @@
                 "application": [
                     "clap"
                 ],
+                "clap": [
+                    "dep:clap"
+                ],
                 "default": [
                     "application"
                 ]
@@ -4105,6 +4225,9 @@
                 "application": [
                     "clap"
                 ],
+                "clap": [
+                    "dep:clap"
+                ],
                 "default": [
                     "application"
                 ]
@@ -4216,7 +4339,16 @@
                     "memchr",
                     "raw_os_str"
                 ],
-                "raw_os_str": []
+                "memchr": [
+                    "dep:memchr"
+                ],
+                "print_bytes": [
+                    "dep:print_bytes"
+                ],
+                "raw_os_str": [],
+                "uniquote": [
+                    "dep:uniquote"
+                ]
             },
             "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/os_str_bytes-6.0.0/Cargo.toml",
             "metadata": {
@@ -4501,6 +4633,9 @@
             "features": {
                 "default": [
                     "syn-error"
+                ],
+                "syn": [
+                    "dep:syn"
                 ],
                 "syn-error": [
                     "syn"
@@ -5092,8 +5227,23 @@
                 "getrandom": [
                     "rand_core/getrandom"
                 ],
+                "libc": [
+                    "dep:libc"
+                ],
+                "log": [
+                    "dep:log"
+                ],
                 "min_const_gen": [],
                 "nightly": [],
+                "packed_simd": [
+                    "dep:packed_simd"
+                ],
+                "rand_chacha": [
+                    "dep:rand_chacha"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
                 "serde1": [
                     "serde",
                     "rand_core/serde1"
@@ -5235,6 +5385,9 @@
                 "default": [
                     "std"
                 ],
+                "serde": [
+                    "dep:serde"
+                ],
                 "serde1": [
                     "serde"
                 ],
@@ -5323,6 +5476,12 @@
             ],
             "features": {
                 "alloc": [],
+                "getrandom": [
+                    "dep:getrandom"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
                 "serde1": [
                     "serde"
                 ],
@@ -6103,6 +6262,9 @@
                     "proc-macro2/proc-macro",
                     "quote/proc-macro"
                 ],
+                "quote": [
+                    "dep:quote"
+                ],
                 "test": [
                     "syn-test-suite/all-features"
                 ],
@@ -6455,6 +6617,21 @@
                     "unicode-linebreak",
                     "unicode-width",
                     "smawk"
+                ],
+                "hyphenation": [
+                    "dep:hyphenation"
+                ],
+                "smawk": [
+                    "dep:smawk"
+                ],
+                "terminal_size": [
+                    "dep:terminal_size"
+                ],
+                "unicode-linebreak": [
+                    "dep:unicode-linebreak"
+                ],
+                "unicode-width": [
+                    "dep:unicode-width"
                 ]
             },
             "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/textwrap-0.15.0/Cargo.toml",
@@ -6774,6 +6951,9 @@
                 }
             ],
             "features": {
+                "erased-serde1": [
+                    "dep:erased-serde1"
+                ],
                 "error": [
                     "std",
                     "sval1_lib/std"
@@ -6788,12 +6968,21 @@
                     "erased-serde1/alloc",
                     "serde1_fmt"
                 ],
+                "serde1_fmt": [
+                    "dep:serde1_fmt"
+                ],
+                "serde1_lib": [
+                    "dep:serde1_lib"
+                ],
                 "std": [],
                 "sval": [
                     "sval1"
                 ],
                 "sval1": [
                     "sval1_lib"
+                ],
+                "sval1_lib": [
+                    "dep:sval1_lib"
                 ],
                 "test": [
                     "std"
@@ -6945,6 +7134,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "default": [
                     "std"
                 ],
@@ -6952,6 +7147,9 @@
                     "compiler_builtins",
                     "core",
                     "rustc-std-workspace-alloc"
+                ],
+                "rustc-std-workspace-alloc": [
+                    "dep:rustc-std-workspace-alloc"
                 ],
                 "std": []
             },

--- a/crate_universe/test_data/metadata/build_scripts/Cargo.lock
+++ b/crate_universe/test_data/metadata/build_scripts/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +12,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "build-scripts"
 version = "0.1.0"
 dependencies = [
+ "git2",
  "openssl",
 ]
 
@@ -26,6 +21,9 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -49,10 +47,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "git2"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.15.1+1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "once_cell"
@@ -62,25 +152,42 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
 ]
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.72"
+name = "openssl-macros"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "autocfg",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+dependencies = [
  "cc",
  "libc",
  "pkg-config",
@@ -88,10 +195,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vcpkg"

--- a/crate_universe/test_data/metadata/build_scripts/Cargo.toml
+++ b/crate_universe/test_data/metadata/build_scripts/Cargo.toml
@@ -11,4 +11,5 @@ path = "lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openssl = "=0.10.36"
+openssl = "=0.10.52"
+git2 = "=0.17.1"

--- a/crate_universe/test_data/metadata/build_scripts/metadata.json
+++ b/crate_universe/test_data/metadata/build_scripts/metadata.json
@@ -1,125 +1,6 @@
 {
     "packages": [
         {
-            "name": "autocfg",
-            "version": "1.0.1",
-            "id": "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-            "license": "Apache-2.0 OR MIT",
-            "license_file": null,
-            "description": "Automatic cfg for Rust compiler features",
-            "source": "registry+https://github.com/rust-lang/crates.io-index",
-            "dependencies": [],
-            "targets": [
-                {
-                    "kind": [
-                        "lib"
-                    ],
-                    "crate_types": [
-                        "lib"
-                    ],
-                    "name": "autocfg",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.0.1/src/lib.rs",
-                    "edition": "2015",
-                    "doc": true,
-                    "doctest": true,
-                    "test": true
-                },
-                {
-                    "kind": [
-                        "example"
-                    ],
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "name": "integers",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.0.1/examples/integers.rs",
-                    "edition": "2015",
-                    "doc": false,
-                    "doctest": false,
-                    "test": false
-                },
-                {
-                    "kind": [
-                        "example"
-                    ],
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "name": "paths",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.0.1/examples/paths.rs",
-                    "edition": "2015",
-                    "doc": false,
-                    "doctest": false,
-                    "test": false
-                },
-                {
-                    "kind": [
-                        "example"
-                    ],
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "name": "versions",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.0.1/examples/versions.rs",
-                    "edition": "2015",
-                    "doc": false,
-                    "doctest": false,
-                    "test": false
-                },
-                {
-                    "kind": [
-                        "example"
-                    ],
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "name": "traits",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.0.1/examples/traits.rs",
-                    "edition": "2015",
-                    "doc": false,
-                    "doctest": false,
-                    "test": false
-                },
-                {
-                    "kind": [
-                        "test"
-                    ],
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "name": "rustflags",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.0.1/tests/rustflags.rs",
-                    "edition": "2015",
-                    "doc": false,
-                    "doctest": false,
-                    "test": true
-                }
-            ],
-            "features": {},
-            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.0.1/Cargo.toml",
-            "metadata": null,
-            "publish": null,
-            "authors": [
-                "Josh Stone <cuviper@gmail.com>"
-            ],
-            "categories": [
-                "development-tools::build-utils"
-            ],
-            "keywords": [
-                "rustc",
-                "build",
-                "autoconf"
-            ],
-            "readme": "README.md",
-            "repository": "https://github.com/cuviper/autocfg",
-            "homepage": null,
-            "documentation": null,
-            "edition": "2015",
-            "links": null,
-            "default_run": null,
-            "rust_version": null
-        },
-        {
             "name": "bitflags",
             "version": "1.3.2",
             "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -270,6 +151,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "default": [],
                 "example_generated": [],
                 "rustc-dep-of-std": [
@@ -319,9 +206,21 @@
             "source": null,
             "dependencies": [
                 {
+                    "name": "git2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.17.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
                     "name": "openssl",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "req": "=0.10.36",
+                    "req": "=0.10.52",
                     "kind": null,
                     "rename": null,
                     "optional": false,
@@ -484,6 +383,9 @@
                 }
             ],
             "features": {
+                "jobserver": [
+                    "dep:jobserver"
+                ],
                 "parallel": [
                     "jobserver"
                 ]
@@ -574,6 +476,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "rustc-dep-of-std": [
                     "core",
                     "compiler_builtins"
@@ -696,6 +604,861 @@
             "rust_version": null
         },
         {
+            "name": "form_urlencoded",
+            "version": "1.1.0",
+            "id": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "percent-encoding",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "form_urlencoded",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/form_urlencoded-1.1.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/form_urlencoded-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The rust-url developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/rust-url",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.51"
+        },
+        {
+            "name": "git2",
+            "version": "0.17.1",
+            "id": "git2 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Bindings to libgit2 for interoperating with git repositories. This library is\nboth threadsafe and memory safe and allows both reading and writing git\nrepositories.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libgit2-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.15.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "url",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "structopt",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "time",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.39",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "openssl-probe",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(unix, not(target_os = \"macos\")))",
+                    "registry": null
+                },
+                {
+                    "name": "openssl-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(unix, not(target_os = \"macos\")))",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "git2",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "ls-remote",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/ls-remote.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "add",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/add.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "pull",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/pull.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "log",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/log.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rev-parse",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/rev-parse.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cat-file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/cat-file.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fetch",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/fetch.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "clone",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/clone.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "status",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/status.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tag",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/tag.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "init",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/init.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rev-list",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/rev-list.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "blame",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/blame.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "diff",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/examples/diff.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "add_extensions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/tests/add_extensions.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "remove_extensions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/tests/remove_extensions.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "get_extensions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/tests/get_extensions.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "global_state",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/tests/global_state.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "ssh",
+                    "https",
+                    "ssh_key_from_memory"
+                ],
+                "https": [
+                    "libgit2-sys/https",
+                    "openssl-sys",
+                    "openssl-probe"
+                ],
+                "openssl-probe": [
+                    "dep:openssl-probe"
+                ],
+                "openssl-sys": [
+                    "dep:openssl-sys"
+                ],
+                "ssh": [
+                    "libgit2-sys/ssh"
+                ],
+                "ssh_key_from_memory": [
+                    "libgit2-sys/ssh_key_from_memory"
+                ],
+                "unstable": [],
+                "vendored-libgit2": [
+                    "libgit2-sys/vendored"
+                ],
+                "vendored-openssl": [
+                    "openssl-sys/vendored",
+                    "libgit2-sys/vendored-openssl"
+                ],
+                "zlib-ng-compat": [
+                    "libgit2-sys/zlib-ng-compat"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/git2-0.17.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Josh Triplett <josh@joshtriplett.org>",
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "api-bindings"
+            ],
+            "keywords": [
+                "git"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/git2-rs",
+            "homepage": null,
+            "documentation": "https://docs.rs/git2",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "idna",
+            "version": "0.3.0",
+            "id": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "IDNA (Internationalizing Domain Names in Applications) and Punycode.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "unicode-bidi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-normalization",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.17",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "assert_matches",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bencher",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tester",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "idna",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/tests/tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "unit",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/tests/unit.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "all",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/benches/all.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The rust-url developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/rust-url/",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.51"
+        },
+        {
+            "name": "jobserver",
+            "version": "0.1.26",
+            "id": "jobserver 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "An implementation of the GNU make jobserver for Rust\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "num_cpus",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tokio-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tokio-process",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.50",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "jobserver",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/jobserver-0.1.26/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "client",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/jobserver-0.1.26/tests/client.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "server",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/jobserver-0.1.26/tests/server.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "client-of-myself",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/jobserver-0.1.26/tests/client-of-myself.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "make-as-a-client",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/jobserver-0.1.26/tests/make-as-a-client.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "helper",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/jobserver-0.1.26/tests/helper.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/jobserver-0.1.26/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/alexcrichton/jobserver-rs",
+            "homepage": "https://github.com/alexcrichton/jobserver-rs",
+            "documentation": "https://docs.rs/jobserver",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "libc",
             "version": "0.2.112",
             "id": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -772,6 +1535,9 @@
                     "align",
                     "rustc-std-workspace-core"
                 ],
+                "rustc-std-workspace-core": [
+                    "dep:rustc-std-workspace-core"
+                ],
                 "std": [],
                 "use_std": [
                     "std"
@@ -808,6 +1574,736 @@
             "repository": "https://github.com/rust-lang/libc",
             "homepage": "https://github.com/rust-lang/libc",
             "documentation": "https://docs.rs/libc/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "libgit2-sys",
+            "version": "0.15.1+1.6.4",
+            "id": "libgit2-sys 0.15.1+1.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Native bindings to the libgit2 library",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libssh2-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libz-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "libc"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.43",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "parallel"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pkg-config",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.7",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "openssl-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "libgit2_sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libgit2-sys-0.15.1+1.6.4/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libgit2-sys-0.15.1+1.6.4/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "https": [
+                    "openssl-sys"
+                ],
+                "libssh2-sys": [
+                    "dep:libssh2-sys"
+                ],
+                "openssl-sys": [
+                    "dep:openssl-sys"
+                ],
+                "ssh": [
+                    "libssh2-sys"
+                ],
+                "ssh_key_from_memory": [],
+                "vendored": [],
+                "vendored-openssl": [
+                    "openssl-sys/vendored"
+                ],
+                "zlib-ng-compat": [
+                    "libz-sys/zlib-ng",
+                    "libssh2-sys?/zlib-ng-compat"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libgit2-sys-0.15.1+1.6.4/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Josh Triplett <josh@joshtriplett.org>",
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/rust-lang/git2-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": "git2",
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "libssh2-sys",
+            "version": "0.3.0",
+            "id": "libssh2-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Native bindings to the libssh2 library",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libz-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "libc"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.25",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pkg-config",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.11",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "vcpkg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_env = \"msvc\")",
+                    "registry": null
+                },
+                {
+                    "name": "openssl-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.35",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "openssl-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.35",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "libssh2_sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libssh2-sys-0.3.0/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libssh2-sys-0.3.0/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "openssl-on-win32": [
+                    "openssl-sys"
+                ],
+                "openssl-sys": [
+                    "dep:openssl-sys"
+                ],
+                "vendored-openssl": [
+                    "openssl-sys/vendored"
+                ],
+                "zlib-ng-compat": [
+                    "libz-sys/zlib-ng"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libssh2-sys-0.3.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>",
+                "Wez Furlong <wez@wezfurlong.org>",
+                "Matteo Bigoi <bigo@crisidev.org>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/alexcrichton/ssh2-rs",
+            "homepage": null,
+            "documentation": "https://docs.rs/libssh2-sys",
+            "edition": "2015",
+            "links": "ssh2",
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "libz-sys",
+            "version": "1.1.8",
+            "id": "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Low-level bindings to the system libz library (also known as zlib).",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.43",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.18",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cmake",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.44",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pkg-config",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.9",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "vcpkg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_env = \"msvc\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "libz-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libz-sys-1.1.8/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libz-sys-1.1.8/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "asm": [],
+                "cmake": [
+                    "dep:cmake"
+                ],
+                "default": [
+                    "libc",
+                    "stock-zlib"
+                ],
+                "libc": [
+                    "dep:libc"
+                ],
+                "static": [],
+                "stock-zlib": [],
+                "zlib-ng": [
+                    "libc",
+                    "cmake"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libz-sys-1.1.8/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>",
+                "Josh Triplett <josh@joshtriplett.org>"
+            ],
+            "categories": [
+                "compression",
+                "external-ffi-bindings"
+            ],
+            "keywords": [
+                "zlib",
+                "zlib-ng"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/libz-sys",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": "z",
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "log",
+            "version": "0.4.17",
+            "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A lightweight logging facade for Rust\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sval",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "value-bag",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sval",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "value-bag",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "test"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "log",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "filters",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/filters.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/macros.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "value",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/benches/value.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "kv_unstable": [
+                    "value-bag"
+                ],
+                "kv_unstable_serde": [
+                    "kv_unstable_std",
+                    "value-bag/serde",
+                    "serde"
+                ],
+                "kv_unstable_std": [
+                    "std",
+                    "kv_unstable",
+                    "value-bag/error"
+                ],
+                "kv_unstable_sval": [
+                    "kv_unstable",
+                    "value-bag/sval",
+                    "sval"
+                ],
+                "max_level_debug": [],
+                "max_level_error": [],
+                "max_level_info": [],
+                "max_level_off": [],
+                "max_level_trace": [],
+                "max_level_warn": [],
+                "release_max_level_debug": [],
+                "release_max_level_error": [],
+                "release_max_level_info": [],
+                "release_max_level_off": [],
+                "release_max_level_trace": [],
+                "release_max_level_warn": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "sval": [
+                    "dep:sval"
+                ],
+                "value-bag": [
+                    "dep:value-bag"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std",
+                            "serde",
+                            "kv_unstable_std",
+                            "kv_unstable_sval",
+                            "kv_unstable_serde"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "development-tools::debugging"
+            ],
+            "keywords": [
+                "logging"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/log",
+            "homepage": null,
+            "documentation": "https://docs.rs/log",
             "edition": "2015",
             "links": null,
             "default_run": null,
@@ -1036,8 +2532,14 @@
                 "alloc": [
                     "race"
                 ],
+                "atomic-polyfill": [
+                    "dep:atomic-polyfill"
+                ],
                 "default": [
                     "std"
+                ],
+                "parking_lot": [
+                    "dep:parking_lot"
                 ],
                 "race": [],
                 "std": [
@@ -1076,8 +2578,8 @@
         },
         {
             "name": "openssl",
-            "version": "0.10.36",
-            "id": "openssl 0.10.36 (registry+https://github.com/rust-lang/crates.io-index)",
+            "version": "0.10.52",
+            "id": "openssl 0.10.52 (registry+https://github.com/rust-lang/crates.io-index)",
             "license": "Apache-2.0",
             "license_file": null,
             "description": "OpenSSL bindings",
@@ -1110,7 +2612,7 @@
                 {
                     "name": "openssl-sys",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "req": "^0.9.66",
+                    "req": "^0.9.87",
                     "kind": null,
                     "rename": "ffi",
                     "optional": false,
@@ -1156,10 +2658,10 @@
                     "registry": null
                 },
                 {
-                    "name": "hex",
+                    "name": "openssl-macros",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "req": "^0.3",
-                    "kind": "dev",
+                    "req": "^0.1.0",
+                    "kind": null,
                     "rename": null,
                     "optional": false,
                     "uses_default_features": true,
@@ -1168,7 +2670,7 @@
                     "registry": null
                 },
                 {
-                    "name": "tempdir",
+                    "name": "hex",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "req": "^0.3",
                     "kind": "dev",
@@ -1189,7 +2691,7 @@
                         "lib"
                     ],
                     "name": "openssl",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.36/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.52/src/lib.rs",
                     "edition": "2018",
                     "doc": true,
                     "doctest": true,
@@ -1203,7 +2705,7 @@
                         "bin"
                     ],
                     "name": "mk_certs",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.36/examples/mk_certs.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.52/examples/mk_certs.rs",
                     "edition": "2018",
                     "doc": false,
                     "doctest": false,
@@ -1217,7 +2719,7 @@
                         "bin"
                     ],
                     "name": "build-script-build",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.36/build.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.52/build.rs",
                     "edition": "2018",
                     "doc": false,
                     "doctest": false,
@@ -1225,6 +2727,13 @@
                 }
             ],
             "features": {
+                "bindgen": [
+                    "ffi/bindgen"
+                ],
+                "default": [],
+                "unstable_boringssl": [
+                    "ffi/unstable_boringssl"
+                ],
                 "v101": [],
                 "v102": [],
                 "v110": [],
@@ -1233,7 +2742,7 @@
                     "ffi/vendored"
                 ]
             },
-            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.36/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.52/Cargo.toml",
             "metadata": null,
             "publish": null,
             "authors": [
@@ -1259,14 +2768,163 @@
             "rust_version": null
         },
         {
+            "name": "openssl-macros",
+            "version": "0.1.1",
+            "id": "openssl-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Internal macros used by the openssl crate.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "full"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "name": "openssl-macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-macros-0.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-macros-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "openssl-probe",
+            "version": "0.1.5",
+            "id": "openssl-probe 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Tool for helping to find SSL certificate locations on the system for OpenSSL\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "openssl-probe",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-probe-0.1.5/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "probe",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-probe-0.1.5/examples/probe.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-probe-0.1.5/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/alexcrichton/openssl-probe",
+            "homepage": "https://github.com/alexcrichton/openssl-probe",
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "openssl-sys",
-            "version": "0.9.72",
-            "id": "openssl-sys 0.9.72 (registry+https://github.com/rust-lang/crates.io-index)",
+            "version": "0.9.87",
+            "id": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
             "license": "MIT",
             "license_file": null,
             "description": "FFI bindings to OpenSSL",
             "source": "registry+https://github.com/rust-lang/crates.io-index",
             "dependencies": [
+                {
+                    "name": "bssl-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
                 {
                     "name": "libc",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
@@ -1280,21 +2938,23 @@
                     "registry": null
                 },
                 {
-                    "name": "autocfg",
+                    "name": "bindgen",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "req": "^1.0",
+                    "req": "^0.64.0",
                     "kind": "build",
                     "rename": null,
-                    "optional": false,
+                    "optional": true,
                     "uses_default_features": true,
-                    "features": [],
+                    "features": [
+                        "experimental"
+                    ],
                     "target": null,
                     "registry": null
                 },
                 {
                     "name": "cc",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "req": "^1.0",
+                    "req": "^1.0.61",
                     "kind": "build",
                     "rename": null,
                     "optional": false,
@@ -1349,8 +3009,8 @@
                         "lib"
                     ],
                     "name": "openssl-sys",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.72/src/lib.rs",
-                    "edition": "2015",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.87/src/lib.rs",
+                    "edition": "2018",
                     "doc": true,
                     "doctest": true,
                     "test": true
@@ -1363,19 +3023,31 @@
                         "bin"
                     ],
                     "name": "build-script-main",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.72/build/main.rs",
-                    "edition": "2015",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.87/build/main.rs",
+                    "edition": "2018",
                     "doc": false,
                     "doctest": false,
                     "test": false
                 }
             ],
             "features": {
+                "bindgen": [
+                    "dep:bindgen"
+                ],
+                "bssl-sys": [
+                    "dep:bssl-sys"
+                ],
+                "openssl-src": [
+                    "dep:openssl-src"
+                ],
+                "unstable_boringssl": [
+                    "bssl-sys"
+                ],
                 "vendored": [
                     "openssl-src"
                 ]
             },
-            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.72/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.87/Cargo.toml",
             "metadata": {
                 "pkg-config": {
                     "openssl": "1.0.1"
@@ -1395,10 +3067,58 @@
             "repository": "https://github.com/sfackler/rust-openssl",
             "homepage": null,
             "documentation": null,
-            "edition": "2015",
+            "edition": "2018",
             "links": "openssl",
             "default_run": null,
             "rust_version": null
+        },
+        {
+            "name": "percent-encoding",
+            "version": "2.2.0",
+            "id": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Percent encoding and decoding",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "percent-encoding",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/percent-encoding-2.2.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "alloc": [],
+                "default": [
+                    "alloc"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/percent-encoding-2.2.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The rust-url developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/rust-url/",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.51"
         },
         {
             "name": "pkg-config",
@@ -1471,6 +3191,1982 @@
             "links": null,
             "default_run": null,
             "rust_version": null
+        },
+        {
+            "name": "proc-macro2",
+            "version": "1.0.56",
+            "id": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "unicode-ident",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "proc-macro2",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "features",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/tests/features.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/tests/test_size.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_fmt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/tests/test_fmt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "comments",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/tests/comments.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "marker",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/tests/marker.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "nightly": [],
+                "proc-macro": [],
+                "span-locations": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.56/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt",
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "span-locations"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>",
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/proc-macro2",
+            "homepage": null,
+            "documentation": "https://docs.rs/proc-macro2",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "quote",
+            "version": "1.0.26",
+            "id": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Quasi-quoting macro quote!(...)",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.52",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.66",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "diff"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "quote",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/quote",
+            "homepage": null,
+            "documentation": "https://docs.rs/quote/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "syn",
+            "version": "2.0.15",
+            "id": "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Parser for Rust source code",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.55",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.25",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-ident",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "automod",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "flate2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "insta",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ref-cast",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "regex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "reqwest",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "blocking"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn-test-suite",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tar",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.16",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "walkdir",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.3.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "syn",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_should_parse",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_should_parse.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_visibility",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_visibility.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_stmt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_stmt.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_round_trip",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_round_trip.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_size.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_shebang",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_shebang.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_pat",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_pat.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_receiver",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_receiver.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_precedence",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_precedence.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_lit",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_lit.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "regression",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/regression.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_parse_stream.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_grouping",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_grouping.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ident",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_ident.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_iterators",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_iterators.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_parse_buffer.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_asyncness",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_asyncness.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_token_trees",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_token_trees.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ty",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_ty.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "zzz_stable",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/zzz_stable.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_meta",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_meta.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_expr.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_item",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_item.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_path.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_derive_input",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_derive_input.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_generics.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_attribute",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/tests/test_attribute.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rust",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/benches/rust.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/benches/file.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "clone-impls": [],
+                "default": [
+                    "derive",
+                    "parsing",
+                    "printing",
+                    "clone-impls",
+                    "proc-macro"
+                ],
+                "derive": [],
+                "extra-traits": [],
+                "fold": [],
+                "full": [],
+                "parsing": [],
+                "printing": [
+                    "quote"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro",
+                    "quote/proc-macro"
+                ],
+                "quote": [
+                    "dep:quote"
+                ],
+                "test": [
+                    "syn-test-suite/all-features"
+                ],
+                "visit": [],
+                "visit-mut": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.15/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "full",
+                        "visit",
+                        "visit-mut",
+                        "fold",
+                        "extra-traits"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "parser-implementations"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/syn",
+            "homepage": null,
+            "documentation": "https://docs.rs/syn",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "tinyvec",
+            "version": "1.6.0",
+            "id": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Zlib OR Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "`tinyvec` provides 100% safe vec-like data structures.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arbitrary",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tinyvec_macros",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "tinyvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tinyvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/tests/tinyvec.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "alloc",
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "arrayvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/tests/arrayvec.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/benches/macros.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "alloc"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "smallvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/benches/smallvec.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "alloc",
+                        "real_blackbox"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "alloc": [
+                    "tinyvec_macros"
+                ],
+                "arbitrary": [
+                    "dep:arbitrary"
+                ],
+                "default": [],
+                "experimental_write_impl": [],
+                "grab_spare_slice": [],
+                "nightly_slice_partition_dedup": [],
+                "real_blackbox": [
+                    "criterion/real_blackbox"
+                ],
+                "rustc_1_40": [],
+                "rustc_1_55": [
+                    "rustc_1_40"
+                ],
+                "rustc_1_57": [
+                    "rustc_1_55"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [
+                    "alloc"
+                ],
+                "tinyvec_macros": [
+                    "dep:tinyvec_macros"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "alloc",
+                            "std",
+                            "grab_spare_slice",
+                            "rustc_1_40",
+                            "rustc_1_55",
+                            "serde"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docs_rs"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "alloc",
+                        "std",
+                        "grab_spare_slice",
+                        "rustc_1_40",
+                        "rustc_1_55",
+                        "serde"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Lokathor <zefria@gmail.com>"
+            ],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "vec",
+                "no_std",
+                "no-std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/Lokathor/tinyvec",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "tinyvec_macros",
+            "version": "0.1.1",
+            "id": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0 OR Zlib",
+            "license_file": null,
+            "description": "Some macros for tiny containers",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "tinyvec_macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec_macros-0.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec_macros-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Soveu <marx.tomasz@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/Soveu/tinyvec_macros",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "unicode-bidi",
+            "version": "0.3.13",
+            "id": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Implementation of the Unicode Bidirectional Algorithm",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "flame",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "flamer",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.8, <2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.8, <2.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode_bidi",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-bidi-0.3.13/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "conformance_tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-bidi-0.3.13/tests/conformance_tests.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "hardcoded-data"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "bench_it": [],
+                "default": [
+                    "std",
+                    "hardcoded-data"
+                ],
+                "flame": [
+                    "dep:flame"
+                ],
+                "flame_it": [
+                    "flame",
+                    "flamer"
+                ],
+                "flamer": [
+                    "dep:flamer"
+                ],
+                "hardcoded-data": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "unstable": [],
+                "with_serde": [
+                    "serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-bidi-0.3.13/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [
+                "no-std",
+                "encoding",
+                "text-processing"
+            ],
+            "keywords": [
+                "rtl",
+                "unicode",
+                "text",
+                "layout",
+                "bidi"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/servo/unicode-bidi",
+            "homepage": null,
+            "documentation": "https://docs.rs/unicode-bidi/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "unicode-ident",
+            "version": "1.0.8",
+            "id": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
+            "license_file": null,
+            "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fst",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "roaring",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ucd-trie",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-xid",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-ident",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "static_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/tests/static_size.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compare",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/tests/compare.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xid",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/benches/xid.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "no-std"
+            ],
+            "keywords": [
+                "unicode",
+                "xid"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/unicode-ident",
+            "homepage": null,
+            "documentation": "https://docs.rs/unicode-ident",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "unicode-normalization",
+            "version": "0.1.22",
+            "id": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "This crate provides functions for normalization of\nUnicode strings, including Canonical and Compatible\nDecomposition and Recomposition, as described in\nUnicode Standard Annex #15.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "tinyvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "alloc"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-normalization",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-normalization-0.1.22/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-normalization-0.1.22/benches/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-normalization-0.1.22/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "kwantam <kwantam@gmail.com>",
+                "Manish Goregaokar <manishsmail@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "text",
+                "unicode",
+                "normalization",
+                "decomposition",
+                "recomposition"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/unicode-rs/unicode-normalization",
+            "homepage": "https://github.com/unicode-rs/unicode-normalization",
+            "documentation": "https://docs.rs/unicode-normalization/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "url",
+            "version": "2.3.1",
+            "id": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "URL library for Rust, based on the WHATWG URL Standard",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "form_urlencoded",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "idna",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "percent-encoding",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bencher",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "debugger_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "debugger_test_parser",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "url",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "debugger_visualizer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/tests/debugger_visualizer.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "debugger_visualizer"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "data",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/tests/data.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "unit",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/tests/unit.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "parse_url",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/benches/parse_url.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "debugger_visualizer": [],
+                "default": [],
+                "expose_internals": [],
+                "serde": [
+                    "dep:serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The rust-url developers"
+            ],
+            "categories": [
+                "parser-implementations",
+                "web-programming",
+                "encoding"
+            ],
+            "keywords": [
+                "url",
+                "parser"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/servo/rust-url",
+            "homepage": null,
+            "documentation": "https://docs.rs/url",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.51"
         },
         {
             "name": "vcpkg",
@@ -1554,12 +5250,6 @@
     "resolve": {
         "nodes": [
             {
-                "id": "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                "dependencies": [],
-                "deps": [],
-                "features": []
-            },
-            {
                 "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
                 "dependencies": [],
                 "deps": [],
@@ -1570,12 +5260,23 @@
             {
                 "id": "build-scripts 0.1.0 (path+file://{TEMP_DIR}/build_scripts)",
                 "dependencies": [
-                    "openssl 0.10.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "git2 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "openssl 0.10.52 (registry+https://github.com/rust-lang/crates.io-index)"
                 ],
                 "deps": [
                     {
+                        "name": "git2",
+                        "pkg": "git2 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
                         "name": "openssl",
-                        "pkg": "openssl 0.10.36 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "pkg": "openssl 0.10.52 (registry+https://github.com/rust-lang/crates.io-index)",
                         "dep_kinds": [
                             {
                                 "kind": null,
@@ -1588,9 +5289,25 @@
             },
             {
                 "id": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
-                "dependencies": [],
-                "deps": [],
-                "features": []
+                "dependencies": [
+                    "jobserver 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "jobserver",
+                        "pkg": "jobserver 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "jobserver",
+                    "parallel"
+                ]
             },
             {
                 "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1624,6 +5341,166 @@
                 "features": []
             },
             {
+                "id": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "percent_encoding",
+                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "git2 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libgit2-sys 0.15.1+1.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "openssl-probe 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libgit2_sys",
+                        "pkg": "libgit2-sys 0.15.1+1.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "openssl_probe",
+                        "pkg": "openssl-probe 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(unix, not(target_os = \"macos\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "openssl_sys",
+                        "pkg": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(unix, not(target_os = \"macos\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "url",
+                        "pkg": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "https",
+                    "openssl-probe",
+                    "openssl-sys",
+                    "ssh",
+                    "ssh_key_from_memory"
+                ]
+            },
+            {
+                "id": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "unicode_bidi",
+                        "pkg": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_normalization",
+                        "pkg": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "jobserver 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
                 "id": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
                 "dependencies": [],
                 "deps": [],
@@ -1631,6 +5508,233 @@
                     "default",
                     "std"
                 ]
+            },
+            {
+                "id": "libgit2-sys 0.15.1+1.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libssh2-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cc",
+                        "pkg": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libssh2_sys",
+                        "pkg": "libssh2-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libz_sys",
+                        "pkg": "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "openssl_sys",
+                        "pkg": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "pkg_config",
+                        "pkg": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "https",
+                    "libssh2-sys",
+                    "openssl-sys",
+                    "ssh",
+                    "ssh_key_from_memory"
+                ]
+            },
+            {
+                "id": "libssh2-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cc",
+                        "pkg": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libz_sys",
+                        "pkg": "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "openssl_sys",
+                        "pkg": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "pkg_config",
+                        "pkg": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "vcpkg",
+                        "pkg": "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": "cfg(target_env = \"msvc\")"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cc",
+                        "pkg": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "pkg_config",
+                        "pkg": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "vcpkg",
+                        "pkg": "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": "cfg(target_env = \"msvc\")"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "libc"
+                ]
+            },
+            {
+                "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
             },
             {
                 "id": "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1644,14 +5748,15 @@
                 ]
             },
             {
-                "id": "openssl 0.10.36 (registry+https://github.com/rust-lang/crates.io-index)",
+                "id": "openssl 0.10.52 (registry+https://github.com/rust-lang/crates.io-index)",
                 "dependencies": [
                     "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
                     "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
                     "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
                     "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
                     "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "openssl-sys 0.9.72 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "openssl-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
                 ],
                 "deps": [
                     {
@@ -1705,8 +5810,61 @@
                         ]
                     },
                     {
+                        "name": "openssl_macros",
+                        "pkg": "openssl-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
                         "name": "ffi",
-                        "pkg": "openssl-sys 0.9.72 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "pkg": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "openssl-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
                         "dep_kinds": [
                             {
                                 "kind": null,
@@ -1718,25 +5876,20 @@
                 "features": []
             },
             {
-                "id": "openssl-sys 0.9.72 (registry+https://github.com/rust-lang/crates.io-index)",
+                "id": "openssl-probe 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
                 "dependencies": [
-                    "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
                     "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
                     "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
                     "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
                     "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
                 ],
                 "deps": [
-                    {
-                        "name": "autocfg",
-                        "pkg": "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                        "dep_kinds": [
-                            {
-                                "kind": "build",
-                                "target": null
-                            }
-                        ]
-                    },
                     {
                         "name": "cc",
                         "pkg": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1781,10 +5934,223 @@
                 "features": []
             },
             {
+                "id": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "alloc",
+                    "default"
+                ]
+            },
+            {
                 "id": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
                 "dependencies": [],
                 "deps": [],
                 "features": []
+            },
+            {
+                "id": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "unicode_ident",
+                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ]
+            },
+            {
+                "id": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ]
+            },
+            {
+                "id": "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_ident",
+                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "clone-impls",
+                    "default",
+                    "derive",
+                    "full",
+                    "parsing",
+                    "printing",
+                    "proc-macro",
+                    "quote"
+                ]
+            },
+            {
+                "id": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "tinyvec_macros",
+                        "pkg": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "alloc",
+                    "default",
+                    "tinyvec_macros"
+                ]
+            },
+            {
+                "id": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "hardcoded-data",
+                    "std"
+                ]
+            },
+            {
+                "id": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "tinyvec",
+                        "pkg": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "form_urlencoded",
+                        "pkg": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "idna",
+                        "pkg": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "percent_encoding",
+                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
             },
             {
                 "id": "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crate_universe/test_data/metadata/common/metadata.json
+++ b/crate_universe/test_data/metadata/common/metadata.json
@@ -151,6 +151,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "default": [],
                 "example_generated": [],
                 "rustc-dep-of-std": [
@@ -255,6 +261,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "rustc-dep-of-std": [
                     "core",
                     "compiler_builtins"

--- a/crate_universe/test_data/metadata/crate_combined_features/metadata.json
+++ b/crate_universe/test_data/metadata/crate_combined_features/metadata.json
@@ -1,0 +1,10404 @@
+{
+    "packages": [
+        {
+            "name": "assign",
+            "version": "1.1.1",
+            "id": "assign 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": "LICENSE",
+            "description": "Simple macro to allow mutating instance with declarative flavor",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "assign",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/assign-1.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/assign-1.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alan Darmasaputra <kelerchian@gmail.com>",
+                "Jonas Platte <jplatte@posteo.de>"
+            ],
+            "categories": [
+                "no-std"
+            ],
+            "keywords": [
+                "macro"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/Kelerchian/assign",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "autocfg",
+            "version": "1.1.0",
+            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "Automatic cfg for Rust compiler features",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "autocfg",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "integers",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/integers.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "paths",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/paths.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "versions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/versions.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "traits",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/traits.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rustflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/tests/rustflags.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Josh Stone <cuviper@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::build-utils"
+            ],
+            "keywords": [
+                "rustc",
+                "build",
+                "autoconf"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/cuviper/autocfg",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "base64",
+            "version": "0.13.1",
+            "id": "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "encodes and decodes base64 as bytes or utf8",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.3.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "structopt",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "base64",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/base64-0.13.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "base64",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/base64-0.13.1/examples/base64.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "make_tables",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/base64-0.13.1/examples/make_tables.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "encode",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/base64-0.13.1/tests/encode.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "helpers",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/base64-0.13.1/tests/helpers.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "decode",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/base64-0.13.1/tests/decode.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/base64-0.13.1/tests/tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "benchmarks",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/base64-0.13.1/benches/benchmarks.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "alloc": [],
+                "default": [
+                    "std"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/base64-0.13.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alice Maz <alice@alicemaz.com>",
+                "Marshall Pierce <marshall@mpierce.org>"
+            ],
+            "categories": [
+                "encoding"
+            ],
+            "keywords": [
+                "base64",
+                "utf8",
+                "encode",
+                "decode",
+                "no_std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/marshallpierce/rust-base64",
+            "homepage": null,
+            "documentation": "https://docs.rs/base64",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "bytes",
+            "version": "1.4.0",
+            "id": "bytes 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Types and traits for working with bytes",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "alloc"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "loom",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(loom)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bytes",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_buf",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_buf.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_bytes_odd_alloc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_bytes_odd_alloc.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_bytes",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_bytes.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_debug",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_debug.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_iter",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_iter.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_reader",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_reader.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_bytes_vec_alloc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_bytes_vec_alloc.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_chain",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_chain.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_serde",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_serde.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_buf_mut",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_buf_mut.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_take",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/tests/test_take.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "buf",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/benches/buf.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bytes_mut",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/benches/bytes_mut.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bytes",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/benches/bytes.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bytes-1.4.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Carl Lerche <me@carllerche.com>",
+                "Sean McArthur <sean@seanmonstar.com>"
+            ],
+            "categories": [
+                "network-programming",
+                "data-structures"
+            ],
+            "keywords": [
+                "buffers",
+                "zero-copy",
+                "io"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/tokio-rs/bytes",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cfg-if",
+            "version": "1.0.0",
+            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A macro to ergonomically define an item depending on a large number of #[cfg]\nparameters. Structured like an if-else chain, the first matching branch is the\nitem that gets emitted.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cfg-if",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xcrate",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/tests/xcrate.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "rustc-dep-of-std": [
+                    "core",
+                    "compiler_builtins"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/alexcrichton/cfg-if",
+            "homepage": "https://github.com/alexcrichton/cfg-if",
+            "documentation": "https://docs.rs/cfg-if",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "crate-combined-features",
+            "version": "0.1.0",
+            "id": "crate-combined-features 0.1.0 (path+file://{TEMP_DIR}/crate_combined_features)",
+            "license": null,
+            "license_file": null,
+            "description": null,
+            "source": null,
+            "dependencies": [
+                {
+                    "name": "ruma",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "crate-combined-features",
+                    "src_path": "{TEMP_DIR}/crate_combined_features/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{TEMP_DIR}/crate_combined_features/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "form_urlencoded",
+            "version": "1.1.0",
+            "id": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Parser and serializer for the application/x-www-form-urlencoded syntax, as used by HTML forms.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "percent-encoding",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "form_urlencoded",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/form_urlencoded-1.1.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/form_urlencoded-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The rust-url developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/rust-url",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.51"
+        },
+        {
+            "name": "hashbrown",
+            "version": "0.12.3",
+            "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A Rust port of Google's SwissTable hash map",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "ahash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "alloc",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bumpalo",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.5.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.25",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "doc-comment",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "hashbrown",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "serde",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/serde.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rayon",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/rayon.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "set",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/set.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hasher",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/hasher.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "insert_unique_unchecked",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/benches/insert_unique_unchecked.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/benches/bench.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "ahash": [
+                    "dep:ahash"
+                ],
+                "ahash-compile-time-rng": [
+                    "ahash/compile-time-rng"
+                ],
+                "alloc": [
+                    "dep:alloc"
+                ],
+                "bumpalo": [
+                    "dep:bumpalo"
+                ],
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [
+                    "ahash",
+                    "inline-more"
+                ],
+                "inline-more": [],
+                "nightly": [],
+                "raw": [],
+                "rayon": [
+                    "dep:rayon"
+                ],
+                "rustc-dep-of-std": [
+                    "nightly",
+                    "core",
+                    "compiler_builtins",
+                    "alloc",
+                    "rustc-internal-api"
+                ],
+                "rustc-internal-api": [],
+                "serde": [
+                    "dep:serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "nightly",
+                            "rayon",
+                            "serde",
+                            "raw"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Amanieu d'Antras <amanieu@gmail.com>"
+            ],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "hash",
+                "no_std",
+                "hashmap",
+                "swisstable"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/hashbrown",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56.0"
+        },
+        {
+            "name": "idna",
+            "version": "0.3.0",
+            "id": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "IDNA (Internationalizing Domain Names in Applications) and Punycode.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "unicode-bidi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-normalization",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.17",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "assert_matches",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bencher",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tester",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "idna",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/tests/tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "unit",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/tests/unit.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "all",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/benches/all.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/idna-0.3.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The rust-url developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/rust-url/",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.51"
+        },
+        {
+            "name": "indexmap",
+            "version": "1.9.2",
+            "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "A hash table with consistent order and fast iteration.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arbitrary",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "hashbrown",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "raw"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "itertools",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "autocfg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "indexmap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "quick",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/quick.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_full_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/macros_full_path.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "equivalent_trait",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/equivalent_trait.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/tests.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "faststring",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/benches/faststring.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/benches/bench.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/build.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "arbitrary": [
+                    "dep:arbitrary"
+                ],
+                "quickcheck": [
+                    "dep:quickcheck"
+                ],
+                "rayon": [
+                    "dep:rayon"
+                ],
+                "rustc-rayon": [
+                    "dep:rustc-rayon"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serde-1": [
+                    "serde"
+                ],
+                "std": [],
+                "test_debug": [],
+                "test_low_transition_point": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "arbitrary",
+                            "quickcheck",
+                            "serde-1",
+                            "rayon"
+                        ]
+                    }
+                },
+                "release": {
+                    "no-dev-version": true,
+                    "tag-name": "{{version}}"
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "hashmap",
+                "no_std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bluss/indexmap",
+            "homepage": null,
+            "documentation": "https://docs.rs/indexmap/",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "itoa",
+            "version": "1.0.6",
+            "id": "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Fast integer primitive to string conversion",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "no-panic",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "itoa",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/itoa-1.0.6/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/itoa-1.0.6/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/itoa-1.0.6/benches/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "no-panic": [
+                    "dep:no-panic"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/itoa-1.0.6/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "value-formatting",
+                "no-std"
+            ],
+            "keywords": [
+                "integer"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/itoa",
+            "homepage": null,
+            "documentation": "https://docs.rs/itoa",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.36"
+        },
+        {
+            "name": "js_int",
+            "version": "0.2.2",
+            "id": "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "JavaScript-interoperable integer types",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "js_int",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js_int-0.2.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "int",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js_int-0.2.2/tests/int.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "uint",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js_int-0.2.2/tests/uint.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "float_deserialize": [
+                    "serde"
+                ],
+                "lax_deserialize": [
+                    "float_deserialize"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js_int-0.2.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Jonas Platte <jplatte+git@posteo.de>"
+            ],
+            "categories": [
+                "no-std"
+            ],
+            "keywords": [
+                "integer",
+                "no_std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/ruma/js_int",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "js_option",
+            "version": "0.1.1",
+            "id": "js_option 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "An Option-like type with separate null and undefined variants",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.125",
+                    "kind": null,
+                    "rename": "serde_crate",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.125",
+                    "kind": "dev",
+                    "rename": "serde_crate",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.64",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "js_option",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js_option-0.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "serde"
+                ],
+                "serde": [
+                    "serde_crate"
+                ],
+                "serde_crate": [
+                    "dep:serde_crate"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js_option-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/ruma/js_option",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "once_cell",
+            "version": "1.17.1",
+            "id": "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Single assignment cells and lazy values.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "atomic-polyfill",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": "atomic_polyfill",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "critical-section",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": "critical_section",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot_core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "critical-section",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.1",
+                    "kind": "dev",
+                    "rename": "critical_section",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "std"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "crossbeam-utils",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "regex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "once_cell",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/examples/bench.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench_acquire",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/examples/bench_acquire.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench_vs_lazy_static",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/examples/bench_vs_lazy_static.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "lazy_static",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/examples/lazy_static.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "reentrant_init_deadlocks",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/examples/reentrant_init_deadlocks.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "regex",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/examples/regex.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_synchronization",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/examples/test_synchronization.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "it",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/tests/it.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "alloc": [
+                    "race"
+                ],
+                "atomic-polyfill": [
+                    "critical-section"
+                ],
+                "atomic_polyfill": [
+                    "dep:atomic_polyfill"
+                ],
+                "critical-section": [
+                    "critical_section",
+                    "atomic_polyfill"
+                ],
+                "critical_section": [
+                    "dep:critical_section"
+                ],
+                "default": [
+                    "std"
+                ],
+                "parking_lot": [
+                    "parking_lot_core"
+                ],
+                "parking_lot_core": [
+                    "dep:parking_lot_core"
+                ],
+                "race": [],
+                "std": [
+                    "alloc"
+                ],
+                "unstable": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.17.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Aleksey Kladov <aleksey.kladov@gmail.com>"
+            ],
+            "categories": [
+                "rust-patterns",
+                "memory-management"
+            ],
+            "keywords": [
+                "lazy",
+                "static"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/matklad/once_cell",
+            "homepage": null,
+            "documentation": "https://docs.rs/once_cell",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "percent-encoding",
+            "version": "2.2.0",
+            "id": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Percent encoding and decoding",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "percent-encoding",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/percent-encoding-2.2.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "alloc": [],
+                "default": [
+                    "alloc"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/percent-encoding-2.2.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The rust-url developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/rust-url/",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.51"
+        },
+        {
+            "name": "pin-project-lite",
+            "version": "0.2.9",
+            "id": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "A lightweight version of pin-project written with declarative macros.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "static_assertions",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.49",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "pin-project-lite",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "proper_unpin",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/proper_unpin.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "drop_order",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/drop_order.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "expandtest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/expandtest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "lint",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/lint.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "no-std",
+                "rust-patterns"
+            ],
+            "keywords": [
+                "pin",
+                "macros"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/taiki-e/pin-project-lite",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.37"
+        },
+        {
+            "name": "proc-macro-crate",
+            "version": "1.2.1",
+            "id": "proc-macro-crate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0/MIT",
+            "license_file": null,
+            "description": "Replacement for crate (macro_rules keyword) in proc-macros\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "once_cell",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.13.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thiserror",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.24",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "toml",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.18",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "proc-macro-crate",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro-crate-1.2.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro-crate-1.2.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Bastian K\u00f6cher <git@kchr.de>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "keywords": [
+                "macro-rules",
+                "crate",
+                "macro",
+                "proc-macro"
+            ],
+            "readme": "./README.md",
+            "repository": "https://github.com/bkchr/proc-macro-crate",
+            "homepage": null,
+            "documentation": "https://docs.rs/proc-macro-crate",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "proc-macro2",
+            "version": "1.0.52",
+            "id": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "unicode-ident",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "proc-macro2",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.52/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "features",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.52/tests/features.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.52/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.52/tests/test_size.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_fmt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.52/tests/test_fmt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "comments",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.52/tests/comments.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "marker",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.52/tests/marker.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.52/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "nightly": [],
+                "proc-macro": [],
+                "span-locations": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.52/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt",
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "span-locations"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>",
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/proc-macro2",
+            "homepage": null,
+            "documentation": "https://docs.rs/proc-macro2",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "quote",
+            "version": "1.0.26",
+            "id": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Quasi-quoting macro quote!(...)",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.52",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.66",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "diff"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "quote",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.26/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/quote",
+            "homepage": null,
+            "documentation": "https://docs.rs/quote/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "ruma",
+            "version": "0.6.4",
+            "id": "ruma 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Types and traits for working with the Matrix protocol.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "assign",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js_int",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-appservice-api",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-client",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-client-api",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-common",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-federation-api",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-identity-service-api",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-push-gateway-api",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-signatures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-state-res",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.118",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "ruma",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-0.6.4/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "outgoing",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-0.6.4/tests/outgoing.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "__ci": [
+                    "full",
+                    "unstable-pre-spec",
+                    "unstable-msc1767",
+                    "unstable-msc2448",
+                    "unstable-msc2654",
+                    "unstable-msc2675",
+                    "unstable-msc2676",
+                    "unstable-msc2677",
+                    "unstable-msc2870",
+                    "unstable-msc3245",
+                    "unstable-msc3246",
+                    "unstable-msc3440",
+                    "unstable-msc3488",
+                    "unstable-msc3551",
+                    "unstable-msc3552",
+                    "unstable-msc3553",
+                    "unstable-msc3554",
+                    "unstable-msc3618",
+                    "unstable-msc3723"
+                ],
+                "api": [
+                    "ruma-common/api"
+                ],
+                "appservice-api": [
+                    "appservice-api-c",
+                    "appservice-api-s"
+                ],
+                "appservice-api-c": [
+                    "api",
+                    "events",
+                    "ruma-appservice-api/client"
+                ],
+                "appservice-api-helper": [
+                    "ruma-appservice-api/helper"
+                ],
+                "appservice-api-s": [
+                    "api",
+                    "events",
+                    "ruma-appservice-api/server"
+                ],
+                "client": [
+                    "ruma-client"
+                ],
+                "client-api": [
+                    "client-api-c",
+                    "client-api-s"
+                ],
+                "client-api-c": [
+                    "api",
+                    "events",
+                    "ruma-client-api/client"
+                ],
+                "client-api-s": [
+                    "api",
+                    "events",
+                    "ruma-client-api/server"
+                ],
+                "client-ext-client-api": [
+                    "client",
+                    "ruma-client/client-api"
+                ],
+                "client-hyper": [
+                    "client",
+                    "ruma-client/hyper"
+                ],
+                "client-hyper-native-tls": [
+                    "client",
+                    "ruma-client/hyper-native-tls"
+                ],
+                "client-isahc": [
+                    "client",
+                    "ruma-client/isahc"
+                ],
+                "client-reqwest": [
+                    "client",
+                    "ruma-client/reqwest"
+                ],
+                "client-reqwest-native-tls": [
+                    "client",
+                    "ruma-client/reqwest-native-tls"
+                ],
+                "client-reqwest-native-tls-vendored": [
+                    "client",
+                    "ruma-client/reqwest-native-tls-vendored"
+                ],
+                "client-reqwest-rustls-manual-roots": [
+                    "client",
+                    "ruma-client/reqwest-rustls-manual-roots"
+                ],
+                "client-reqwest-rustls-native-roots": [
+                    "client",
+                    "ruma-client/reqwest-rustls-native-roots"
+                ],
+                "client-reqwest-rustls-webpki-roots": [
+                    "client",
+                    "ruma-client/reqwest-rustls-webpki-roots"
+                ],
+                "compat": [
+                    "ruma-common/compat",
+                    "ruma-client-api/compat",
+                    "ruma-signatures/compat",
+                    "ruma-state-res/compat"
+                ],
+                "events": [
+                    "ruma-common/events"
+                ],
+                "federation-api": [
+                    "federation-api-c",
+                    "federation-api-s"
+                ],
+                "federation-api-c": [
+                    "api",
+                    "signatures",
+                    "ruma-federation-api/client"
+                ],
+                "federation-api-s": [
+                    "api",
+                    "signatures",
+                    "ruma-federation-api/server"
+                ],
+                "full": [
+                    "api",
+                    "client",
+                    "client-ext-client-api",
+                    "events",
+                    "signatures",
+                    "state-res",
+                    "appservice-api",
+                    "client-api",
+                    "federation-api",
+                    "identity-service-api",
+                    "push-gateway-api",
+                    "rand",
+                    "markdown"
+                ],
+                "identity-service-api": [
+                    "identity-service-api-c",
+                    "identity-service-api-s"
+                ],
+                "identity-service-api-c": [
+                    "api",
+                    "ruma-identity-service-api/client"
+                ],
+                "identity-service-api-s": [
+                    "api",
+                    "ruma-identity-service-api/server"
+                ],
+                "js": [
+                    "ruma-common/js"
+                ],
+                "markdown": [
+                    "ruma-common/markdown"
+                ],
+                "push-gateway-api": [
+                    "push-gateway-api-c",
+                    "push-gateway-api-s"
+                ],
+                "push-gateway-api-c": [
+                    "api",
+                    "ruma-push-gateway-api/client"
+                ],
+                "push-gateway-api-s": [
+                    "api",
+                    "ruma-push-gateway-api/server"
+                ],
+                "rand": [
+                    "ruma-common/rand"
+                ],
+                "ruma-appservice-api": [
+                    "dep:ruma-appservice-api"
+                ],
+                "ruma-client": [
+                    "dep:ruma-client"
+                ],
+                "ruma-client-api": [
+                    "dep:ruma-client-api"
+                ],
+                "ruma-federation-api": [
+                    "dep:ruma-federation-api"
+                ],
+                "ruma-identity-service-api": [
+                    "dep:ruma-identity-service-api"
+                ],
+                "ruma-push-gateway-api": [
+                    "dep:ruma-push-gateway-api"
+                ],
+                "ruma-signatures": [
+                    "dep:ruma-signatures"
+                ],
+                "ruma-state-res": [
+                    "dep:ruma-state-res"
+                ],
+                "signatures": [
+                    "ruma-signatures"
+                ],
+                "state-res": [
+                    "ruma-state-res"
+                ],
+                "unstable-exhaustive-types": [
+                    "ruma-common/unstable-exhaustive-types",
+                    "ruma-appservice-api/unstable-exhaustive-types",
+                    "ruma-client-api/unstable-exhaustive-types",
+                    "ruma-federation-api/unstable-exhaustive-types",
+                    "ruma-identity-service-api/unstable-exhaustive-types",
+                    "ruma-push-gateway-api/unstable-exhaustive-types",
+                    "ruma-state-res/unstable-exhaustive-types"
+                ],
+                "unstable-extensible-events": [
+                    "unstable-msc3246",
+                    "unstable-msc3488",
+                    "unstable-msc3553"
+                ],
+                "unstable-msc1767": [
+                    "ruma-common/unstable-msc1767"
+                ],
+                "unstable-msc2448": [
+                    "ruma-client-api/unstable-msc2448",
+                    "ruma-common/unstable-msc2448",
+                    "ruma-federation-api/unstable-msc2448"
+                ],
+                "unstable-msc2654": [
+                    "ruma-client-api/unstable-msc2654"
+                ],
+                "unstable-msc2675": [
+                    "ruma-common/unstable-msc2675"
+                ],
+                "unstable-msc2676": [
+                    "ruma-common/unstable-msc2676"
+                ],
+                "unstable-msc2677": [
+                    "ruma-common/unstable-msc2677"
+                ],
+                "unstable-msc2870": [
+                    "ruma-signatures/unstable-msc2870"
+                ],
+                "unstable-msc3245": [
+                    "ruma-common/unstable-msc3245"
+                ],
+                "unstable-msc3246": [
+                    "ruma-common/unstable-msc3246"
+                ],
+                "unstable-msc3440": [
+                    "ruma-client-api/unstable-msc3440",
+                    "ruma-common/unstable-msc3440"
+                ],
+                "unstable-msc3488": [
+                    "ruma-client-api/unstable-msc3488",
+                    "ruma-common/unstable-msc3488"
+                ],
+                "unstable-msc3551": [
+                    "ruma-common/unstable-msc3551"
+                ],
+                "unstable-msc3552": [
+                    "ruma-common/unstable-msc3552"
+                ],
+                "unstable-msc3553": [
+                    "ruma-common/unstable-msc3553"
+                ],
+                "unstable-msc3554": [
+                    "ruma-common/unstable-msc3554"
+                ],
+                "unstable-msc3618": [
+                    "ruma-federation-api/unstable-msc3618"
+                ],
+                "unstable-msc3723": [
+                    "ruma-federation-api/unstable-msc3723"
+                ],
+                "unstable-pdu": [
+                    "ruma-common/unstable-pdu"
+                ],
+                "unstable-pre-spec": [
+                    "ruma-common/unstable-pre-spec",
+                    "ruma-federation-api/unstable-pre-spec",
+                    "ruma-push-gateway-api/unstable-pre-spec"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-0.6.4/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "api-bindings",
+                "web-programming"
+            ],
+            "keywords": [
+                "matrix",
+                "chat",
+                "messaging",
+                "ruma"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/ruma/ruma",
+            "homepage": "https://www.ruma.io/",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "ruma-common",
+            "version": "0.9.3",
+            "id": "ruma-common 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Common types for other ruma crates.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "base64",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.13.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bytes",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "form_urlencoded",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "getrandom",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "http",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "indexmap",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.6.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "serde-1"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "itoa",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js_int",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "serde"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js_option",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "percent-encoding",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pulldown-cmark",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.3",
+                    "kind": null,
+                    "rename": "rand_crate",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-identifiers-validation",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-macros",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.118",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.64",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "raw_value"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thiserror",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.26",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.25",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "url",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.2.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "uuid",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "v4"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wildmatch",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "assign",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "http",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "maplit",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "matches",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.42",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "ruma-common",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-common-0.9.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-common-0.9.3/tests/tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "event_deserialize",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-common-0.9.3/benches/event_deserialize.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "api": [
+                    "http",
+                    "thiserror"
+                ],
+                "client": [],
+                "compat": [
+                    "ruma-macros/compat",
+                    "ruma-identifiers-validation/compat"
+                ],
+                "criterion": [
+                    "dep:criterion"
+                ],
+                "default": [
+                    "client",
+                    "server"
+                ],
+                "events": [
+                    "thiserror"
+                ],
+                "getrandom": [
+                    "dep:getrandom"
+                ],
+                "http": [
+                    "dep:http"
+                ],
+                "js": [
+                    "js-sys",
+                    "getrandom/js",
+                    "uuid/js"
+                ],
+                "js-sys": [
+                    "dep:js-sys"
+                ],
+                "markdown": [
+                    "pulldown-cmark"
+                ],
+                "pulldown-cmark": [
+                    "dep:pulldown-cmark"
+                ],
+                "rand": [
+                    "rand_crate",
+                    "uuid"
+                ],
+                "rand_crate": [
+                    "dep:rand_crate"
+                ],
+                "server": [],
+                "thiserror": [
+                    "dep:thiserror"
+                ],
+                "unstable-exhaustive-types": [],
+                "unstable-msc1767": [],
+                "unstable-msc2448": [],
+                "unstable-msc2675": [],
+                "unstable-msc2676": [],
+                "unstable-msc2677": [],
+                "unstable-msc3245": [
+                    "unstable-msc3246"
+                ],
+                "unstable-msc3246": [
+                    "unstable-msc3551",
+                    "thiserror"
+                ],
+                "unstable-msc3440": [],
+                "unstable-msc3488": [
+                    "unstable-msc1767"
+                ],
+                "unstable-msc3551": [
+                    "unstable-msc1767"
+                ],
+                "unstable-msc3552": [
+                    "unstable-msc3551"
+                ],
+                "unstable-msc3553": [
+                    "unstable-msc3552"
+                ],
+                "unstable-msc3554": [
+                    "unstable-msc1767"
+                ],
+                "unstable-msc3700": [],
+                "unstable-pdu": [],
+                "unstable-pre-spec": [],
+                "uuid": [
+                    "dep:uuid"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-common-0.9.3/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [
+                "matrix",
+                "chat",
+                "messaging",
+                "ruma"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/ruma/ruma",
+            "homepage": "https://www.ruma.io/",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "ruma-identifiers-validation",
+            "version": "0.8.1",
+            "id": "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Validation logic for ruma-common and ruma-macros",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "thiserror",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.26",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "ruma-identifiers-validation",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-identifiers-validation-0.8.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compat": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-identifiers-validation-0.8.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/ruma/ruma",
+            "homepage": "https://www.ruma.io/",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "ruma-macros",
+            "version": "0.9.3",
+            "id": "ruma-macros 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Procedural macros used by the Ruma crates.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro-crate",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.24",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ruma-identifiers-validation",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.57",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "extra-traits",
+                        "full",
+                        "visit"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "name": "ruma-macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-macros-0.9.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compat": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ruma-macros-0.9.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "api-bindings",
+                "web-programming"
+            ],
+            "keywords": [
+                "matrix",
+                "chat",
+                "messaging",
+                "ruma"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/ruma/ruma",
+            "homepage": "https://www.ruma.io/",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "ryu",
+            "version": "1.0.13",
+            "id": "ryu 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR BSL-1.0",
+            "license_file": null,
+            "description": "Fast floating point to string conversion",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "no-panic",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "num_cpus",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand_xorshift",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "ryu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "upstream_benchmark",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/examples/upstream_benchmark.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "d2s_table_test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/tests/d2s_table_test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "common_test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/tests/common_test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "d2s_test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/tests/d2s_test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "s2d_test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/tests/s2d_test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "exhaustive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/tests/exhaustive.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "f2s_test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/tests/f2s_test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "s2f_test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/tests/s2f_test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/benches/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "no-panic": [
+                    "dep:no-panic"
+                ],
+                "small": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ryu-1.0.13/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "value-formatting",
+                "no-std"
+            ],
+            "keywords": [
+                "float"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/ryu",
+            "homepage": null,
+            "documentation": "https://docs.rs/ryu",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.36"
+        },
+        {
+            "name": "serde",
+            "version": "1.0.158",
+            "id": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A generic serialization/deserialization framework",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.158",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "serde",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde-1.0.158/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde-1.0.158/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "alloc": [],
+                "default": [
+                    "std"
+                ],
+                "derive": [
+                    "serde_derive"
+                ],
+                "rc": [],
+                "serde_derive": [
+                    "dep:serde_derive"
+                ],
+                "std": [],
+                "unstable": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde-1.0.158/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "derive"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "derive",
+                        "rc"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Erick Tryzelaar <erick.tryzelaar@gmail.com>",
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "encoding",
+                "no-std"
+            ],
+            "keywords": [
+                "serde",
+                "serialization",
+                "no_std"
+            ],
+            "readme": "crates-io.md",
+            "repository": "https://github.com/serde-rs/serde",
+            "homepage": "https://serde.rs",
+            "documentation": "https://docs.rs/serde",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.19"
+        },
+        {
+            "name": "serde_derive",
+            "version": "1.0.158",
+            "id": "serde_derive 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Macros 1.1 implementation of #[derive(Serialize, Deserialize)]",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "name": "serde_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_derive-1.0.158/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_derive-1.0.158/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [],
+                "deserialize_in_place": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_derive-1.0.158/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Erick Tryzelaar <erick.tryzelaar@gmail.com>",
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "no-std"
+            ],
+            "keywords": [
+                "serde",
+                "serialization",
+                "no_std",
+                "derive"
+            ],
+            "readme": "crates-io.md",
+            "repository": "https://github.com/serde-rs/serde",
+            "homepage": "https://serde.rs",
+            "documentation": "https://serde.rs/derive.html",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "serde_json",
+            "version": "1.0.94",
+            "id": "serde_json 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A JSON serialization file format",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "indexmap",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.5.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "std"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "itoa",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ryu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.100",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "automod",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "indoc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ref-cast",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.100",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_bytes",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_stacker",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.49",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "diff"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "serde_json",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/tests/stream.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "regression",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/tests/regression.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "debug",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/tests/debug.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "lexical",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/tests/lexical.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "map",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/tests/map.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "alloc": [
+                    "serde/alloc"
+                ],
+                "arbitrary_precision": [],
+                "default": [
+                    "std"
+                ],
+                "float_roundtrip": [],
+                "indexmap": [
+                    "dep:indexmap"
+                ],
+                "preserve_order": [
+                    "indexmap",
+                    "std"
+                ],
+                "raw_value": [],
+                "std": [
+                    "serde/std"
+                ],
+                "unbounded_depth": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/serde_json-1.0.94/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "raw_value",
+                            "unbounded_depth"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "raw_value"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Erick Tryzelaar <erick.tryzelaar@gmail.com>",
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "encoding",
+                "parser-implementations",
+                "no-std"
+            ],
+            "keywords": [
+                "json",
+                "serde",
+                "serialization"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/serde-rs/json",
+            "homepage": null,
+            "documentation": "https://docs.rs/serde_json",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.36"
+        },
+        {
+            "name": "syn",
+            "version": "1.0.109",
+            "id": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Parser for Rust source code",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.46",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-ident",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "automod",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "flate2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "insta",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ref-cast",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "regex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "reqwest",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "blocking"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn-test-suite",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tar",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.16",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "walkdir",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "syn",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_should_parse",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_should_parse.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_visibility",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_visibility.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_stmt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_stmt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_round_trip",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_round_trip.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_size.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_shebang",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_shebang.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_pat",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_pat.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_receiver",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_receiver.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_precedence",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_precedence.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_lit",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_lit.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "regression",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/regression.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_parse_stream.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_grouping",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_grouping.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ident",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_ident.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_iterators",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_iterators.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_parse_buffer.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_asyncness",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_asyncness.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_token_trees",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_token_trees.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ty",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_ty.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "zzz_stable",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/zzz_stable.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_meta",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_meta.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_expr.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_item",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_item.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_path.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_derive_input",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_derive_input.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_generics.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_attribute",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/tests/test_attribute.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rust",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/benches/rust.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/benches/file.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "clone-impls": [],
+                "default": [
+                    "derive",
+                    "parsing",
+                    "printing",
+                    "clone-impls",
+                    "proc-macro"
+                ],
+                "derive": [],
+                "extra-traits": [],
+                "fold": [],
+                "full": [],
+                "parsing": [],
+                "printing": [
+                    "quote"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro",
+                    "quote/proc-macro"
+                ],
+                "quote": [
+                    "dep:quote"
+                ],
+                "test": [
+                    "syn-test-suite/all-features"
+                ],
+                "visit": [],
+                "visit-mut": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.109/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "full",
+                        "visit",
+                        "visit-mut",
+                        "fold",
+                        "extra-traits"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "parser-implementations"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/syn",
+            "homepage": null,
+            "documentation": "https://docs.rs/syn",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "syn",
+            "version": "2.0.3",
+            "id": "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Parser for Rust source code",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.52",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.25",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-ident",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "automod",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "flate2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "insta",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ref-cast",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "regex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "reqwest",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "blocking"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn-test-suite",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tar",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.16",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "walkdir",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "syn",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_should_parse",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_should_parse.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_visibility",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_visibility.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_stmt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_stmt.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_round_trip",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_round_trip.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_size.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_shebang",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_shebang.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_pat",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_pat.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_receiver",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_receiver.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_precedence",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_precedence.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_lit",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_lit.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "regression",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/regression.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_parse_stream.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_grouping",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_grouping.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ident",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_ident.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_iterators",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_iterators.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_parse_buffer.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_asyncness",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_asyncness.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_token_trees",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_token_trees.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ty",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_ty.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "zzz_stable",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/zzz_stable.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_meta",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_meta.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_expr.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_item",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_item.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_path.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_derive_input",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_derive_input.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_generics.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_attribute",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/tests/test_attribute.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rust",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/benches/rust.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/benches/file.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "clone-impls": [],
+                "default": [
+                    "derive",
+                    "parsing",
+                    "printing",
+                    "clone-impls",
+                    "proc-macro"
+                ],
+                "derive": [],
+                "extra-traits": [],
+                "fold": [],
+                "full": [],
+                "parsing": [],
+                "printing": [
+                    "quote"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro",
+                    "quote/proc-macro"
+                ],
+                "quote": [
+                    "dep:quote"
+                ],
+                "test": [
+                    "syn-test-suite/all-features"
+                ],
+                "visit": [],
+                "visit-mut": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-2.0.3/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "full",
+                        "visit",
+                        "visit-mut",
+                        "fold",
+                        "extra-traits"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "parser-implementations"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/syn",
+            "homepage": null,
+            "documentation": "https://docs.rs/syn",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "thiserror",
+            "version": "1.0.40",
+            "id": "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "derive(Error)",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "thiserror-impl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.40",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.65",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ref-cast",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.66",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "diff"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "thiserror",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_source",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_source.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_backtrace",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_backtrace.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_display",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_display.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_lints",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_lints.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_transparent",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_transparent.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_from",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_from.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_expr.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_path.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_error",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_error.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_generics.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_option",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_option.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_deprecated",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/tests/test_deprecated.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.40/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "rust-patterns"
+            ],
+            "keywords": [
+                "error",
+                "error-handling",
+                "derive"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/thiserror",
+            "homepage": null,
+            "documentation": "https://docs.rs/thiserror",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "thiserror-impl",
+            "version": "1.0.40",
+            "id": "thiserror-impl 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Implementation detail of the `thiserror` crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "name": "thiserror-impl",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-impl-1.0.40/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-impl-1.0.40/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/dtolnay/thiserror",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "tinyvec",
+            "version": "1.6.0",
+            "id": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Zlib OR Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "`tinyvec` provides 100% safe vec-like data structures.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arbitrary",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tinyvec_macros",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "tinyvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tinyvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/tests/tinyvec.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "alloc",
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "arrayvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/tests/arrayvec.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/benches/macros.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "alloc"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "smallvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/benches/smallvec.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "alloc",
+                        "real_blackbox"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "alloc": [
+                    "tinyvec_macros"
+                ],
+                "arbitrary": [
+                    "dep:arbitrary"
+                ],
+                "default": [],
+                "experimental_write_impl": [],
+                "grab_spare_slice": [],
+                "nightly_slice_partition_dedup": [],
+                "real_blackbox": [
+                    "criterion/real_blackbox"
+                ],
+                "rustc_1_40": [],
+                "rustc_1_55": [
+                    "rustc_1_40"
+                ],
+                "rustc_1_57": [
+                    "rustc_1_55"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [
+                    "alloc"
+                ],
+                "tinyvec_macros": [
+                    "dep:tinyvec_macros"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec-1.6.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "alloc",
+                            "std",
+                            "grab_spare_slice",
+                            "rustc_1_40",
+                            "rustc_1_55",
+                            "serde"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docs_rs"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "alloc",
+                        "std",
+                        "grab_spare_slice",
+                        "rustc_1_40",
+                        "rustc_1_55",
+                        "serde"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Lokathor <zefria@gmail.com>"
+            ],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "vec",
+                "no_std",
+                "no-std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/Lokathor/tinyvec",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "tinyvec_macros",
+            "version": "0.1.1",
+            "id": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0 OR Zlib",
+            "license_file": null,
+            "description": "Some macros for tiny containers",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "tinyvec_macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec_macros-0.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tinyvec_macros-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Soveu <marx.tomasz@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/Soveu/tinyvec_macros",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "toml",
+            "version": "0.5.11",
+            "id": "toml 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A native Rust encoder and decoder of TOML-formatted files and streams. Provides\nimplementations of the standard Serialize/Deserialize traits for TOML data to\nfacilitate deserializing and serializing Rust structures.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "indexmap",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.97",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "toml",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/toml-0.5.11/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "toml2json",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/toml-0.5.11/examples/toml2json.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "enum_external",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/toml-0.5.11/examples/enum_external.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "decode",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/toml-0.5.11/examples/decode.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "enum_external_deserialize",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/toml-0.5.11/tests/enum_external_deserialize.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [],
+                "indexmap": [
+                    "dep:indexmap"
+                ],
+                "preserve_order": [
+                    "indexmap"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/toml-0.5.11/Cargo.toml",
+            "metadata": {
+                "release": {
+                    "pre-release-replacements": [
+                        {
+                            "file": "CHANGELOG.md",
+                            "min": 1,
+                            "replace": "{{version}}",
+                            "search": "Unreleased"
+                        },
+                        {
+                            "exactly": 1,
+                            "file": "CHANGELOG.md",
+                            "replace": "...{{tag_name}}",
+                            "search": "\\.\\.\\.HEAD"
+                        },
+                        {
+                            "file": "CHANGELOG.md",
+                            "min": 1,
+                            "replace": "{{date}}",
+                            "search": "ReleaseDate"
+                        },
+                        {
+                            "exactly": 1,
+                            "file": "CHANGELOG.md",
+                            "replace": "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n",
+                            "search": "<!-- next-header -->"
+                        },
+                        {
+                            "exactly": 1,
+                            "file": "CHANGELOG.md",
+                            "replace": "<!-- next-url -->\n[Unreleased]: https://github.com/toml-rs/toml_edit/compare/{{tag_name}}...HEAD",
+                            "search": "<!-- next-url -->"
+                        }
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "encoding",
+                "parser-implementations",
+                "parsing",
+                "config"
+            ],
+            "keywords": [
+                "encoding",
+                "toml"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/toml-rs/toml",
+            "homepage": "https://github.com/toml-rs/toml",
+            "documentation": "https://docs.rs/toml",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.48.0"
+        },
+        {
+            "name": "tracing",
+            "version": "0.1.37",
+            "id": "tracing 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Application-level tracing for Rust.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.17",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pin-project-lite",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing-attributes",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.23",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.30",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.17",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "tracing",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "max_level_hint",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/max_level_hint.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "filter_caching_is_lexically_scoped",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/filter_caching_is_lexically_scoped.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "register_callsite_deadlock",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/register_callsite_deadlock.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "filters_dont_leak",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/filters_dont_leak.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "subscriber",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/subscriber.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "no_subscriber",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/no_subscriber.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "future_send",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/future_send.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "filters_are_reevaluated_for_different_call_sites",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/filters_are_reevaluated_for_different_call_sites.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "enabled",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/enabled.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "event",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/event.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "multiple_max_level_hints",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/multiple_max_level_hints.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "filters_are_not_reevaluated_for_the_same_span",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/filters_are_not_reevaluated_for_the_same_span.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "span",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/span.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_redefined_core",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/macros_redefined_core.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macro_imports",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/macro_imports.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/macros.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_incompatible_concat",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/macros_incompatible_concat.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "scoped_clobbers_default",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/tests/scoped_clobbers_default.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "baseline",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/baseline.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "dispatch_get_clone",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/dispatch_get_clone.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "dispatch_get_ref",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/dispatch_get_ref.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "empty_span",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/empty_span.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "enter_span",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/enter_span.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "event",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/event.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "span_fields",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/span_fields.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "span_no_fields",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/span_no_fields.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "span_repeated",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/span_repeated.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "shared",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/benches/shared.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "async-await": [],
+                "attributes": [
+                    "tracing-attributes"
+                ],
+                "default": [
+                    "std",
+                    "attributes"
+                ],
+                "log": [
+                    "dep:log"
+                ],
+                "log-always": [
+                    "log"
+                ],
+                "max_level_debug": [],
+                "max_level_error": [],
+                "max_level_info": [],
+                "max_level_off": [],
+                "max_level_trace": [],
+                "max_level_warn": [],
+                "release_max_level_debug": [],
+                "release_max_level_error": [],
+                "release_max_level_info": [],
+                "release_max_level_off": [],
+                "release_max_level_trace": [],
+                "release_max_level_warn": [],
+                "std": [
+                    "tracing-core/std"
+                ],
+                "tracing-attributes": [
+                    "dep:tracing-attributes"
+                ],
+                "valuable": [
+                    "tracing-core/valuable"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustc-args": [
+                            "--cfg",
+                            "tracing_unstable"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs",
+                            "--cfg",
+                            "tracing_unstable"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Eliza Weisman <eliza@buoyant.io>",
+                "Tokio Contributors <team@tokio.rs>"
+            ],
+            "categories": [
+                "development-tools::debugging",
+                "development-tools::profiling",
+                "asynchronous",
+                "no-std"
+            ],
+            "keywords": [
+                "logging",
+                "tracing",
+                "metrics",
+                "async"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/tokio-rs/tracing",
+            "homepage": "https://tokio.rs",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.49.0"
+        },
+        {
+            "name": "tracing-attributes",
+            "version": "0.1.23",
+            "id": "tracing-attributes 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Procedural macro attributes for automatically instrumenting functions.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.98",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "full",
+                        "parsing",
+                        "printing",
+                        "visit",
+                        "visit-mut",
+                        "clone-impls",
+                        "extra-traits",
+                        "proc-macro"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "async-trait",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.56",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tokio-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.35",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.28",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing-subscriber",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "env-filter"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.64",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "name": "tracing-attributes",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "ui",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/ui.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "async_fn",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/async_fn.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "targets",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/targets.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fields",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/fields.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "destructuring",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/destructuring.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "err",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/err.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "ret",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/ret.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "levels",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/levels.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "follows_from",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/follows_from.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "instrument",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/instrument.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "names",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/names.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "parents",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/tests/parents.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "async-await": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-attributes-0.1.23/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Tokio Contributors <team@tokio.rs>",
+                "Eliza Weisman <eliza@buoyant.io>",
+                "David Barsky <dbarsky@amazon.com>"
+            ],
+            "categories": [
+                "development-tools::debugging",
+                "development-tools::profiling",
+                "asynchronous"
+            ],
+            "keywords": [
+                "logging",
+                "tracing",
+                "macro",
+                "instrument",
+                "log"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/tokio-rs/tracing",
+            "homepage": "https://tokio.rs",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.49.0"
+        },
+        {
+            "name": "tracing-core",
+            "version": "0.1.30",
+            "id": "tracing-core 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Core primitives for application-level tracing.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "once_cell",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.13.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "valuable",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(tracing_unstable)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "tracing-core",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-core-0.1.30/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "dispatch",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-core-0.1.30/tests/dispatch.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-core-0.1.30/tests/macros.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "global_dispatch",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-core-0.1.30/tests/global_dispatch.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std",
+                    "valuable/std"
+                ],
+                "once_cell": [
+                    "dep:once_cell"
+                ],
+                "std": [
+                    "once_cell"
+                ],
+                "valuable": [
+                    "dep:valuable"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tracing-core-0.1.30/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustc-args": [
+                            "--cfg",
+                            "tracing_unstable"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs",
+                            "--cfg",
+                            "tracing_unstable"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Tokio Contributors <team@tokio.rs>"
+            ],
+            "categories": [
+                "development-tools::debugging",
+                "development-tools::profiling",
+                "asynchronous"
+            ],
+            "keywords": [
+                "logging",
+                "tracing",
+                "profiling"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/tokio-rs/tracing",
+            "homepage": "https://tokio.rs",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.49.0"
+        },
+        {
+            "name": "unicode-bidi",
+            "version": "0.3.13",
+            "id": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Implementation of the Unicode Bidirectional Algorithm",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "flame",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "flamer",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.8, <2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.8, <2.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode_bidi",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-bidi-0.3.13/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "conformance_tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-bidi-0.3.13/tests/conformance_tests.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "hardcoded-data"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "bench_it": [],
+                "default": [
+                    "std",
+                    "hardcoded-data"
+                ],
+                "flame": [
+                    "dep:flame"
+                ],
+                "flame_it": [
+                    "flame",
+                    "flamer"
+                ],
+                "flamer": [
+                    "dep:flamer"
+                ],
+                "hardcoded-data": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "unstable": [],
+                "with_serde": [
+                    "serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-bidi-0.3.13/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [
+                "no-std",
+                "encoding",
+                "text-processing"
+            ],
+            "keywords": [
+                "rtl",
+                "unicode",
+                "text",
+                "layout",
+                "bidi"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/servo/unicode-bidi",
+            "homepage": null,
+            "documentation": "https://docs.rs/unicode-bidi/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "unicode-ident",
+            "version": "1.0.8",
+            "id": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
+            "license_file": null,
+            "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fst",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "roaring",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ucd-trie",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-xid",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-ident",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "static_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/tests/static_size.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compare",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/tests/compare.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xid",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/benches/xid.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.8/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "no-std"
+            ],
+            "keywords": [
+                "unicode",
+                "xid"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/unicode-ident",
+            "homepage": null,
+            "documentation": "https://docs.rs/unicode-ident",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "unicode-normalization",
+            "version": "0.1.22",
+            "id": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "This crate provides functions for normalization of\nUnicode strings, including Canonical and Compatible\nDecomposition and Recomposition, as described in\nUnicode Standard Annex #15.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "tinyvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "alloc"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-normalization",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-normalization-0.1.22/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-normalization-0.1.22/benches/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-normalization-0.1.22/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "kwantam <kwantam@gmail.com>",
+                "Manish Goregaokar <manishsmail@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "text",
+                "unicode",
+                "normalization",
+                "decomposition",
+                "recomposition"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/unicode-rs/unicode-normalization",
+            "homepage": "https://github.com/unicode-rs/unicode-normalization",
+            "documentation": "https://docs.rs/unicode-normalization/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "url",
+            "version": "2.3.1",
+            "id": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "URL library for Rust, based on the WHATWG URL Standard",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "form_urlencoded",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "idna",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "percent-encoding",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bencher",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "debugger_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "debugger_test_parser",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "url",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "debugger_visualizer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/tests/debugger_visualizer.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "debugger_visualizer"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "data",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/tests/data.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "unit",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/tests/unit.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "parse_url",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/benches/parse_url.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "debugger_visualizer": [],
+                "default": [],
+                "expose_internals": [],
+                "serde": [
+                    "dep:serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/url-2.3.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The rust-url developers"
+            ],
+            "categories": [
+                "parser-implementations",
+                "web-programming",
+                "encoding"
+            ],
+            "keywords": [
+                "url",
+                "parser"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/servo/rust-url",
+            "homepage": null,
+            "documentation": "https://docs.rs/url",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.51"
+        },
+        {
+            "name": "wildmatch",
+            "version": "2.1.1",
+            "id": "wildmatch 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Simple string matching  with questionmark and star wildcard operator.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "glob",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ntest",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "regex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wildmatch",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wildmatch-2.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "patterns",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wildmatch-2.1.1/benches/patterns.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wildmatch-2.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Armin Becher <armin.becher@gmail.com>"
+            ],
+            "categories": [
+                "algorithms"
+            ],
+            "keywords": [
+                "globbing",
+                "matching",
+                "questionmark",
+                "star",
+                "string-matching"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/becheran/wildmatch",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        }
+    ],
+    "workspace_members": [
+        "crate-combined-features 0.1.0 (path+file://{TEMP_DIR}/crate_combined_features)"
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "id": "assign 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "bytes 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "crate-combined-features 0.1.0 (path+file://{TEMP_DIR}/crate_combined_features)",
+                "dependencies": [
+                    "ruma 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "ruma",
+                        "pkg": "ruma 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "percent_encoding",
+                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "raw"
+                ]
+            },
+            {
+                "id": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "unicode_bidi",
+                        "pkg": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_normalization",
+                        "pkg": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "autocfg",
+                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hashbrown",
+                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "serde",
+                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "serde",
+                    "serde-1"
+                ]
+            },
+            {
+                "id": "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "serde",
+                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "serde",
+                    "std"
+                ]
+            },
+            {
+                "id": "js_option 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "serde_crate",
+                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "serde",
+                    "serde_crate"
+                ]
+            },
+            {
+                "id": "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "alloc",
+                    "default",
+                    "race",
+                    "std"
+                ]
+            },
+            {
+                "id": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "alloc",
+                    "default"
+                ]
+            },
+            {
+                "id": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "proc-macro-crate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "toml 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "once_cell",
+                        "pkg": "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "thiserror",
+                        "pkg": "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "toml",
+                        "pkg": "toml 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "unicode_ident",
+                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ]
+            },
+            {
+                "id": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ]
+            },
+            {
+                "id": "ruma 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "assign 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "ruma-common 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "assign",
+                        "pkg": "assign 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "js_int",
+                        "pkg": "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ruma_common",
+                        "pkg": "ruma-common 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "ruma-common 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bytes 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "js_option 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "ruma-macros 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "serde_json 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "tracing 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wildmatch 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "base64",
+                        "pkg": "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bytes",
+                        "pkg": "bytes 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "form_urlencoded",
+                        "pkg": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "indexmap",
+                        "pkg": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "itoa",
+                        "pkg": "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "js_int",
+                        "pkg": "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "js_option",
+                        "pkg": "js_option 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "percent_encoding",
+                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ruma_identifiers_validation",
+                        "pkg": "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ruma_macros",
+                        "pkg": "ruma-macros 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "serde",
+                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "serde_json",
+                        "pkg": "serde_json 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "tracing",
+                        "pkg": "tracing 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "url",
+                        "pkg": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wildmatch",
+                        "pkg": "wildmatch 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "client",
+                    "default",
+                    "server"
+                ]
+            },
+            {
+                "id": "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "thiserror",
+                        "pkg": "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "ruma-macros 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro-crate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro_crate",
+                        "pkg": "proc-macro-crate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ruma_identifiers_validation",
+                        "pkg": "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "ryu 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "serde_derive 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "serde_derive",
+                        "pkg": "serde_derive 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "derive",
+                    "serde_derive",
+                    "std"
+                ]
+            },
+            {
+                "id": "serde_derive 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "serde_json 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "ryu 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "itoa",
+                        "pkg": "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ryu",
+                        "pkg": "ryu 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "serde",
+                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "raw_value",
+                    "std"
+                ]
+            },
+            {
+                "id": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_ident",
+                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "clone-impls",
+                    "default",
+                    "derive",
+                    "extra-traits",
+                    "full",
+                    "parsing",
+                    "printing",
+                    "proc-macro",
+                    "quote",
+                    "visit",
+                    "visit-mut"
+                ]
+            },
+            {
+                "id": "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_ident",
+                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "clone-impls",
+                    "default",
+                    "derive",
+                    "parsing",
+                    "printing",
+                    "proc-macro",
+                    "quote"
+                ]
+            },
+            {
+                "id": "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "thiserror-impl 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "thiserror_impl",
+                        "pkg": "thiserror-impl 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "thiserror-impl 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "tinyvec_macros",
+                        "pkg": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "alloc",
+                    "default",
+                    "tinyvec_macros"
+                ]
+            },
+            {
+                "id": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "toml 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "serde",
+                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "tracing 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "tracing-attributes 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "tracing-core 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "pin_project_lite",
+                        "pkg": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "tracing_attributes",
+                        "pkg": "tracing-attributes 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "tracing_core",
+                        "pkg": "tracing-core 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "attributes",
+                    "default",
+                    "std",
+                    "tracing-attributes"
+                ]
+            },
+            {
+                "id": "tracing-attributes 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "tracing-core 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "once_cell",
+                        "pkg": "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "once_cell",
+                    "std"
+                ]
+            },
+            {
+                "id": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "hardcoded-data",
+                    "std"
+                ]
+            },
+            {
+                "id": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "tinyvec",
+                        "pkg": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "form_urlencoded",
+                        "pkg": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "idna",
+                        "pkg": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "percent_encoding",
+                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "wildmatch 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            }
+        ],
+        "root": "crate-combined-features 0.1.0 (path+file://{TEMP_DIR}/crate_combined_features)"
+    },
+    "target_directory": "{TEMP_DIR}/crate_combined_features/target",
+    "version": 1,
+    "workspace_root": "{TEMP_DIR}/crate_combined_features",
+    "metadata": null
+}

--- a/crate_universe/test_data/metadata/crate_optional_deps_disabled/metadata.json
+++ b/crate_universe/test_data/metadata/crate_optional_deps_disabled/metadata.json
@@ -1453,16 +1453,16 @@
             "metadata": {
                 "docs": {
                     "rs": {
+                        "cargo-args": [
+                            "-Zunstable-options",
+                            "-Zrustdoc-scrape-examples"
+                        ],
                         "features": [
                             "unstable-doc"
                         ],
                         "rustdoc-args": [
                             "--cfg",
                             "docsrs"
-                        ],
-                        "cargo-args": [
-                            "-Zunstable-options",
-                            "-Zrustdoc-scrape-examples"
                         ]
                     }
                 },
@@ -1477,33 +1477,33 @@
                     "pre-release-replacements": [
                         {
                             "file": "CHANGELOG.md",
-                            "search": "Unreleased",
+                            "min": 1,
                             "replace": "{{version}}",
-                            "min": 1
+                            "search": "Unreleased"
                         },
                         {
+                            "exactly": 1,
                             "file": "CHANGELOG.md",
-                            "search": "\\.\\.\\.HEAD",
                             "replace": "...{{tag_name}}",
-                            "exactly": 1
+                            "search": "\\.\\.\\.HEAD"
                         },
                         {
                             "file": "CHANGELOG.md",
-                            "search": "ReleaseDate",
+                            "min": 1,
                             "replace": "{{date}}",
-                            "min": 1
+                            "search": "ReleaseDate"
                         },
                         {
+                            "exactly": 1,
                             "file": "CHANGELOG.md",
-                            "search": "<!-- next-header -->",
                             "replace": "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n",
-                            "exactly": 1
+                            "search": "<!-- next-header -->"
                         },
                         {
+                            "exactly": 1,
                             "file": "CHANGELOG.md",
-                            "search": "<!-- next-url -->",
                             "replace": "<!-- next-url -->\n[Unreleased]: https://github.com/clap-rs/clap/compare/{{tag_name}}...HEAD",
-                            "exactly": 1
+                            "search": "<!-- next-url -->"
                         }
                     ]
                 }
@@ -1576,40 +1576,40 @@
                     "pre-release-replacements": [
                         {
                             "file": "CHANGELOG.md",
-                            "search": "Unreleased",
+                            "min": 1,
                             "replace": "{{version}}",
-                            "min": 1
+                            "search": "Unreleased"
                         },
                         {
+                            "exactly": 1,
                             "file": "CHANGELOG.md",
-                            "search": "\\.\\.\\.HEAD",
                             "replace": "...{{tag_name}}",
-                            "exactly": 1
+                            "search": "\\.\\.\\.HEAD"
                         },
                         {
                             "file": "CHANGELOG.md",
-                            "search": "ReleaseDate",
+                            "min": 1,
                             "replace": "{{date}}",
-                            "min": 1
+                            "search": "ReleaseDate"
                         },
                         {
+                            "exactly": 1,
                             "file": "CHANGELOG.md",
-                            "search": "<!-- next-header -->",
                             "replace": "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n",
-                            "exactly": 1
+                            "search": "<!-- next-header -->"
                         },
                         {
+                            "exactly": 1,
                             "file": "CHANGELOG.md",
-                            "search": "<!-- next-url -->",
                             "replace": "<!-- next-url -->\n[Unreleased]: https://github.com/clap-rs/clap/compare/{{tag_name}}...HEAD",
-                            "exactly": 1
+                            "search": "<!-- next-url -->"
                         },
                         {
-                            "file": "README.md",
-                            "search": "github.com/clap-rs/clap/blob/[^/]+/",
-                            "replace": "github.com/clap-rs/clap/blob/{{tag_name}}/",
                             "exactly": 4,
-                            "prerelease": true
+                            "file": "README.md",
+                            "prerelease": true,
+                            "replace": "github.com/clap-rs/clap/blob/{{tag_name}}/",
+                            "search": "github.com/clap-rs/clap/blob/[^/]+/"
                         }
                     ]
                 }

--- a/crate_universe/test_data/metadata/crate_optional_deps_enabled/metadata.json
+++ b/crate_universe/test_data/metadata/crate_optional_deps_enabled/metadata.json
@@ -1,10710 +1,10710 @@
 {
-  "packages": [
-    {
-      "name": "bitflags",
-      "version": "1.3.2",
-      "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT/Apache-2.0",
-      "license_file": null,
-      "description": "A macro to generate structures which behave like bitflags.\n",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
+    "packages": [
         {
-          "name": "compiler_builtins",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.2",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustc-std-workspace-core",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": "core",
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustversion",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "serde",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "serde_derive",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "serde_json",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "trybuild",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "walkdir",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^2.3",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "bitflags",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "basic",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/tests/basic.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "compile",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/tests/compile.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        }
-      ],
-      "features": {
-        "compiler_builtins": [
-          "dep:compiler_builtins"
-        ],
-        "core": [
-          "dep:core"
-        ],
-        "default": [],
-        "example_generated": [],
-        "rustc-dep-of-std": [
-          "core",
-          "compiler_builtins"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "features": [
-              "example_generated"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "The Rust Project Developers"
-      ],
-      "categories": [
-        "no-std"
-      ],
-      "keywords": [
-        "bit",
-        "bitmask",
-        "bitflags",
-        "flags"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/bitflags/bitflags",
-      "homepage": "https://github.com/bitflags/bitflags",
-      "documentation": "https://docs.rs/bitflags",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "cc",
-      "version": "1.0.79",
-      "id": "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "A build-time dependency for Cargo build scripts to assist in invoking the native\nC compiler to compile native C code into a static archive to be linked into Rust\ncode.\n",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "jobserver",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.16",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tempfile",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^3",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "cc",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "bin"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "gcc-shim",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/src/bin/gcc-shim.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "cc_env",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/tests/cc_env.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "cflags",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/tests/cflags.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "cxxflags",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/tests/cxxflags.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/tests/test.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        }
-      ],
-      "features": {
-        "jobserver": [
-          "dep:jobserver"
-        ],
-        "parallel": [
-          "jobserver"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Alex Crichton <alex@alexcrichton.com>"
-      ],
-      "categories": [
-        "development-tools::build-utils"
-      ],
-      "keywords": [
-        "build-dependencies"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/rust-lang/cc-rs",
-      "homepage": "https://github.com/rust-lang/cc-rs",
-      "documentation": "https://docs.rs/cc",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "cfg-if",
-      "version": "1.0.0",
-      "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT/Apache-2.0",
-      "license_file": null,
-      "description": "A macro to ergonomically define an item depending on a large number of #[cfg]\nparameters. Structured like an if-else chain, the first matching branch is the\nitem that gets emitted.\n",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "compiler_builtins",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.2",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustc-std-workspace-core",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": "core",
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "cfg-if",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "xcrate",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/tests/xcrate.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        }
-      ],
-      "features": {
-        "compiler_builtins": [
-          "dep:compiler_builtins"
-        ],
-        "core": [
-          "dep:core"
-        ],
-        "rustc-dep-of-std": [
-          "core",
-          "compiler_builtins"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Alex Crichton <alex@alexcrichton.com>"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": "README.md",
-      "repository": "https://github.com/alexcrichton/cfg-if",
-      "homepage": "https://github.com/alexcrichton/cfg-if",
-      "documentation": "https://docs.rs/cfg-if",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "clap",
-      "version": "4.1.1",
-      "id": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "backtrace",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "bitflags",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "clap_derive",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "=4.1.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "clap_lex",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "is-terminal",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4.1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "once_cell",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.12.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "strsim",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.10",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "termcolor",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.1.1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "terminal_size",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "unicase",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^2.6",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "unicode-width",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.9",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "humantime",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^2",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustversion",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "shlex",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "snapbox",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "static_assertions",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "trybuild",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.73",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "trycmd",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.14.9",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [
-            "color-auto",
-            "diff",
-            "examples"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "unic-emoji-char",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.9.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "clap",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "bin"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "stdio-fixture",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/src/bin/stdio-fixture.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "demo",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/demo.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "cargo-example",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/cargo-example.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "cargo-example-derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/cargo-example-derive.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "escaped-positional",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/escaped-positional.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "escaped-positional-derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/escaped-positional-derive.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "find",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/find.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "git-derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/git-derive.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "typed-derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/typed-derive.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "busybox",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/multicall-busybox.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "hostname",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/multicall-hostname.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "repl",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/repl.rs",
-          "edition": "2021",
-          "required-features": [
-            "help"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "01_quick",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/01_quick.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "02_apps",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/02_apps.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "02_crate",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/02_crate.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "02_app_settings",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/02_app_settings.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_01_flag_bool",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_01_flag_bool.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_01_flag_count",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_01_flag_count.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_02_option",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_02_option.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_02_option_mult",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_02_option_mult.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_03_positional",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_03_positional.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_03_positional_mult",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_03_positional_mult.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_04_subcommands",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_04_subcommands.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_05_default_values",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_05_default_values.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_01_possible",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_01_possible.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_01_enum",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_01_enum.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_02_parse",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_02_parse.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_02_validate",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_02_validate.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_03_relations",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_03_relations.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_04_custom",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_04_custom.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "05_01_assert",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/05_01_assert.rs",
-          "edition": "2021",
-          "required-features": [
-            "cargo"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "01_quick_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/01_quick.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "02_apps_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/02_apps.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "02_crate_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/02_crate.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "02_app_settings_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/02_app_settings.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_01_flag_bool_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_01_flag_bool.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_01_flag_count_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_01_flag_count.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_02_option_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_02_option.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_02_option_mult_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_02_option_mult.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_03_positional_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_03_positional.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_03_positional_mult_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_03_positional_mult.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_04_subcommands_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_04_subcommands.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_04_subcommands_alt_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_04_subcommands_alt.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "03_05_default_values_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_05_default_values.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_01_enum_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_01_enum.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_02_parse_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_02_parse.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_02_validate_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_02_validate.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_03_relations_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_03_relations.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "04_04_custom_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_04_custom.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "05_01_assert_derive",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/05_01_assert.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "interop_augment_args",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/derive_ref/augment_args.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "interop_augment_subcommands",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/derive_ref/augment_subcommands.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "interop_hand_subcommand",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/derive_ref/hand_subcommand.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "interop_flatten_hand_args",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/derive_ref/flatten_hand_args.rs",
-          "edition": "2021",
-          "required-features": [
-            "derive"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "git",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/git.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "pacman",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/pacman.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "cargo": [
-          "dep:once_cell"
-        ],
-        "color": [
-          "dep:is-terminal",
-          "dep:termcolor"
-        ],
-        "debug": [
-          "clap_derive?/debug",
-          "dep:backtrace"
-        ],
-        "default": [
-          "std",
-          "color",
-          "help",
-          "usage",
-          "error-context",
-          "suggestions"
-        ],
-        "deprecated": [
-          "clap_derive?/deprecated"
-        ],
-        "derive": [
-          "dep:clap_derive",
-          "dep:once_cell"
-        ],
-        "env": [],
-        "error-context": [],
-        "help": [],
-        "std": [],
-        "string": [],
-        "suggestions": [
-          "dep:strsim",
-          "error-context"
-        ],
-        "unicode": [
-          "dep:unicode-width",
-          "dep:unicase"
-        ],
-        "unstable-doc": [
-          "derive",
-          "cargo",
-          "wrap_help",
-          "env",
-          "unicode",
-          "string",
-          "unstable-replace"
-        ],
-        "unstable-grouped": [],
-        "unstable-replace": [],
-        "unstable-v5": [
-          "clap_derive?/unstable-v5",
-          "deprecated"
-        ],
-        "usage": [],
-        "wrap_help": [
-          "help",
-          "dep:terminal_size"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "features": [
-              "unstable-doc"
-            ],
-            "rustdoc-args": [
-              "--cfg",
-              "docsrs"
-            ],
-            "cargo-args": [
-              "-Zunstable-options",
-              "-Zrustdoc-scrape-examples"
-            ]
-          }
-        },
-        "playground": {
-          "features": [
-            "unstable-doc"
-          ]
-        },
-        "release": {
-          "shared-version": true,
-          "tag-name": "v{{version}}",
-          "pre-release-replacements": [
-            {
-              "file": "CHANGELOG.md",
-              "search": "Unreleased",
-              "replace": "{{version}}",
-              "min": 1
-            },
-            {
-              "file": "CHANGELOG.md",
-              "search": "\\.\\.\\.HEAD",
-              "replace": "...{{tag_name}}",
-              "exactly": 1
-            },
-            {
-              "file": "CHANGELOG.md",
-              "search": "ReleaseDate",
-              "replace": "{{date}}",
-              "min": 1
-            },
-            {
-              "file": "CHANGELOG.md",
-              "search": "<!-- next-header -->",
-              "replace": "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n",
-              "exactly": 1
-            },
-            {
-              "file": "CHANGELOG.md",
-              "search": "<!-- next-url -->",
-              "replace": "<!-- next-url -->\n[Unreleased]: https://github.com/clap-rs/clap/compare/{{tag_name}}...HEAD",
-              "exactly": 1
-            }
-          ]
-        }
-      },
-      "publish": null,
-      "authors": [],
-      "categories": [
-        "command-line-interface"
-      ],
-      "keywords": [
-        "argument",
-        "cli",
-        "arg",
-        "parser",
-        "parse"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/clap-rs/clap",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.64.0"
-    },
-    {
-      "name": "clap_lex",
-      "version": "0.3.3",
-      "id": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Minimal, flexible command line parser",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "os_str_bytes",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^6.0.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [
-            "raw_os_str"
-          ],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "clap_lex",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap_lex-0.3.3/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/clap_lex-0.3.3/Cargo.toml",
-      "metadata": {
-        "release": {
-          "pre-release-replacements": [
-            {
-              "file": "CHANGELOG.md",
-              "search": "Unreleased",
-              "replace": "{{version}}",
-              "min": 1
-            },
-            {
-              "file": "CHANGELOG.md",
-              "search": "\\.\\.\\.HEAD",
-              "replace": "...{{tag_name}}",
-              "exactly": 1
-            },
-            {
-              "file": "CHANGELOG.md",
-              "search": "ReleaseDate",
-              "replace": "{{date}}",
-              "min": 1
-            },
-            {
-              "file": "CHANGELOG.md",
-              "search": "<!-- next-header -->",
-              "replace": "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n",
-              "exactly": 1
-            },
-            {
-              "file": "CHANGELOG.md",
-              "search": "<!-- next-url -->",
-              "replace": "<!-- next-url -->\n[Unreleased]: https://github.com/clap-rs/clap/compare/{{tag_name}}...HEAD",
-              "exactly": 1
-            },
-            {
-              "file": "README.md",
-              "search": "github.com/clap-rs/clap/blob/[^/]+/",
-              "replace": "github.com/clap-rs/clap/blob/{{tag_name}}/",
-              "exactly": 4,
-              "prerelease": true
-            }
-          ]
-        }
-      },
-      "publish": null,
-      "authors": [],
-      "categories": [
-        "command-line-interface"
-      ],
-      "keywords": [
-        "argument",
-        "cli",
-        "arg",
-        "parser",
-        "parse"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/clap-rs/clap/tree/master/clap_lex",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.64.0"
-    },
-    {
-      "name": "crate-with-optional-deps",
-      "version": "0.1.0",
-      "id": "crate-with-optional-deps 0.1.0 (path+file:///home/gabe/Development/rules_rust/crate_universe/test_data/metadata/crate_optional_deps_enabled)",
-      "license": null,
-      "license_file": null,
-      "description": null,
-      "source": null,
-      "dependencies": [
-        {
-          "name": "clap",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "=4.1.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [
-            "color"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "notify",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^5.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "crate-with-optional-deps",
-          "src_path": "/home/gabe/Development/rules_rust/crate_universe/test_data/metadata/crate_optional_deps_enabled/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/Development/rules_rust/crate_universe/test_data/metadata/crate_optional_deps_enabled/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": null,
-      "homepage": null,
-      "documentation": null,
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "crossbeam-channel",
-      "version": "0.5.7",
-      "id": "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Multi-producer multi-consumer channels for message passing",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "cfg-if",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "crossbeam-utils",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "num_cpus",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.13.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rand",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "signal-hook",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "crossbeam-channel",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "fibonacci",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/examples/fibonacci.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "matching",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/examples/matching.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "stopwatch",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/examples/stopwatch.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "after",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/after.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "array",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/array.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "golang",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/golang.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "iter",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/iter.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "list",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/list.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "mpsc",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/mpsc.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "never",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/never.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "ready",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/ready.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "same_channel",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/same_channel.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "select",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/select.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "select_macro",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/select_macro.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "thread_locals",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/thread_locals.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "tick",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/tick.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "zero",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/zero.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "bench"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "crossbeam",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/benches/crossbeam.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "crossbeam-utils": [
-          "dep:crossbeam-utils"
-        ],
-        "default": [
-          "std"
-        ],
-        "std": [
-          "crossbeam-utils/std"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [],
-      "categories": [
-        "algorithms",
-        "concurrency",
-        "data-structures"
-      ],
-      "keywords": [
-        "channel",
-        "mpmc",
-        "select",
-        "golang",
-        "message"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/crossbeam-rs/crossbeam",
-      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel",
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.38"
-    },
-    {
-      "name": "crossbeam-utils",
-      "version": "0.8.15",
-      "id": "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Utilities for concurrent programming",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "cfg-if",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rand",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustversion",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "loom",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.5",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(crossbeam_loom)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "crossbeam-utils",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "atomic_cell",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/atomic_cell.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "cache_padded",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/cache_padded.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "parker",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/parker.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "sharded_lock",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/sharded_lock.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "thread",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/thread.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "wait_group",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/wait_group.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "bench"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "atomic_cell",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/benches/atomic_cell.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "default": [
-          "std"
-        ],
-        "loom": [
-          "dep:loom"
-        ],
-        "nightly": [],
-        "std": []
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [],
-      "categories": [
-        "algorithms",
-        "concurrency",
-        "data-structures",
-        "no-std"
-      ],
-      "keywords": [
-        "scoped",
-        "thread",
-        "atomic",
-        "cache"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/crossbeam-rs/crossbeam",
-      "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils",
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.38"
-    },
-    {
-      "name": "errno",
-      "version": "0.2.8",
-      "id": "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT/Apache-2.0",
-      "license_file": null,
-      "description": "Cross-platform interface to the `errno` variable.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "errno-dragonfly",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"dragonfly\")",
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"hermit\")",
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"wasi\")",
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(unix)",
-          "registry": null
-        },
-        {
-          "name": "winapi",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "errhandlingapi",
-            "minwindef",
-            "ntdef",
-            "winbase"
-          ],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "errno",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/errno-0.2.8/src/lib.rs",
-          "edition": "2015",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {
-        "default": [
-          "std"
-        ],
-        "std": []
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/errno-0.2.8/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Chris Wong <lambda.fairy@gmail.com>"
-      ],
-      "categories": [
-        "os"
-      ],
-      "keywords": [],
-      "readme": "README.md",
-      "repository": "https://github.com/lambda-fairy/rust-errno",
-      "homepage": null,
-      "documentation": "https://docs.rs/errno",
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "errno-dragonfly",
-      "version": "0.1.2",
-      "id": "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT",
-      "license_file": null,
-      "description": "Exposes errno functionality to stable Rust on DragonFlyBSD",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "cc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "build",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "errno-dragonfly",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/errno-dragonfly-0.1.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/errno-dragonfly-0.1.2/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/errno-dragonfly-0.1.2/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Michael Neumann <mneumann@ntecs.de>"
-      ],
-      "categories": [],
-      "keywords": [
-        "dragonfly"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/mneumann/errno-dragonfly-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "filetime",
-      "version": "0.2.20",
-      "id": "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT/Apache-2.0",
-      "license_file": null,
-      "description": "Platform-agnostic accessors of timestamps in File metadata\n",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "cfg-if",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tempfile",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^3",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "redox_syscall",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.9",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"redox\")",
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.27",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(unix)",
-          "registry": null
-        },
-        {
-          "name": "windows-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.45.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "Win32_Foundation",
-            "Win32_Storage_FileSystem"
-          ],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "filetime",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/filetime-0.2.20/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/filetime-0.2.20/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Alex Crichton <alex@alexcrichton.com>"
-      ],
-      "categories": [],
-      "keywords": [
-        "timestamp",
-        "mtime"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/alexcrichton/filetime",
-      "homepage": "https://github.com/alexcrichton/filetime",
-      "documentation": "https://docs.rs/filetime",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "fsevent-sys",
-      "version": "4.1.0",
-      "id": "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT",
-      "license_file": null,
-      "description": "Rust bindings to the fsevent macOS API for file changes notifications",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.68",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "fsevent-sys",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/fsevent-sys-4.1.0/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/fsevent-sys-4.1.0/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "targets": [
-              "x86_64-apple-darwin"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Pierre Baillet <pierre@baillet.name>"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": "https://github.com/octplane/fsevent-rust/tree/master/fsevent-sys",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "hermit-abi",
-      "version": "0.3.1",
-      "id": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Hermit system calls definitions.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "rustc-std-workspace-alloc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": "alloc",
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "compiler_builtins",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustc-std-workspace-core",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": "core",
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "hermit-abi",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/hermit-abi-0.3.1/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {
-        "alloc": [
-          "dep:alloc"
-        ],
-        "compiler_builtins": [
-          "dep:compiler_builtins"
-        ],
-        "core": [
-          "dep:core"
-        ],
-        "default": [],
-        "rustc-dep-of-std": [
-          "core",
-          "alloc",
-          "compiler_builtins/rustc-dep-of-std"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/hermit-abi-0.3.1/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Stefan Lankes"
-      ],
-      "categories": [
-        "os"
-      ],
-      "keywords": [
-        "unikernel",
-        "libos"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/hermitcore/rusty-hermit",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "inotify",
-      "version": "0.9.6",
-      "id": "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "ISC",
-      "license_file": null,
-      "description": "Idiomatic wrapper for inotify",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "bitflags",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "futures-core",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3.1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "inotify-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.3",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tokio",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [
-            "net"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "futures-util",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3.1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tempfile",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^3.1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tokio",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "macros",
-            "rt-multi-thread"
-          ],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "inotify",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "stream",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/examples/stream.rs",
-          "edition": "2018",
-          "required-features": [
-            "stream"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "watch",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/examples/watch.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "main",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/tests/main.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        }
-      ],
-      "features": {
-        "default": [
-          "stream"
-        ],
-        "futures-core": [
-          "dep:futures-core"
-        ],
-        "stream": [
-          "futures-core",
-          "tokio"
-        ],
-        "tokio": [
-          "dep:tokio"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Hanno Braun <mail@hannobraun.de>",
-        "Félix Saparelli <me@passcod.name>",
-        "Cristian Kubis <cristian.kubis@tsunix.de>",
-        "Frank Denis <github@pureftpd.org>"
-      ],
-      "categories": [
-        "api-bindings",
-        "filesystem"
-      ],
-      "keywords": [
-        "inotify",
-        "linux"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/hannobraun/inotify",
-      "homepage": null,
-      "documentation": "https://docs.rs/inotify",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "inotify-sys",
-      "version": "0.1.5",
-      "id": "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "ISC",
-      "license_file": null,
-      "description": "inotify bindings for the Rust programming language",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "inotify-sys",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/inotify-sys-0.1.5/src/lib.rs",
-          "edition": "2015",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/inotify-sys-0.1.5/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Hanno Braun <hb@hannobraun.de>"
-      ],
-      "categories": [
-        "external-ffi-bindings",
-        "filesystem"
-      ],
-      "keywords": [
-        "inotify",
-        "linux"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/hannobraun/inotify-sys",
-      "homepage": null,
-      "documentation": "https://docs.rs/inotify-sys",
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "io-lifetimes",
-      "version": "1.0.9",
-      "id": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_file": null,
-      "description": "A low-level I/O ownership and borrowing library",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "fs-err",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^2.6.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "async-std",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.12.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(not(target_os = \"wasi\"))",
-          "registry": null
-        },
-        {
-          "name": "mio",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [
-            "net",
-            "os-ext"
-          ],
-          "target": "cfg(not(target_os = \"wasi\"))",
-          "registry": null
-        },
-        {
-          "name": "os_pipe",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [
-            "io_safety"
-          ],
-          "target": "cfg(not(target_os = \"wasi\"))",
-          "registry": null
-        },
-        {
-          "name": "socket2",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(not(target_os = \"wasi\"))",
-          "registry": null
-        },
-        {
-          "name": "tokio",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.6.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [
-            "io-std",
-            "fs",
-            "net",
-            "process"
-          ],
-          "target": "cfg(not(target_os = \"wasi\"))",
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.96",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(not(windows))",
-          "registry": null
-        },
-        {
-          "name": "hermit-abi",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"hermit\")",
-          "registry": null
-        },
-        {
-          "name": "windows-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.45.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [
-            "Win32_Foundation",
-            "Win32_Storage_FileSystem",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_System_IO",
-            "Win32_System_Threading"
-          ],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "io-lifetimes",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/io-lifetimes-1.0.9/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/io-lifetimes-1.0.9/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "async-std": [
-          "dep:async-std"
-        ],
-        "close": [
-          "libc",
-          "hermit-abi",
-          "windows-sys"
-        ],
-        "default": [
-          "close"
-        ],
-        "fs-err": [
-          "dep:fs-err"
-        ],
-        "hermit-abi": [
-          "dep:hermit-abi"
-        ],
-        "libc": [
-          "dep:libc"
-        ],
-        "mio": [
-          "dep:mio"
-        ],
-        "os_pipe": [
-          "dep:os_pipe"
-        ],
-        "socket2": [
-          "dep:socket2"
-        ],
-        "tokio": [
-          "dep:tokio"
-        ],
-        "windows-sys": [
-          "dep:windows-sys"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/io-lifetimes-1.0.9/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Dan Gohman <dev@sunfishcode.online>"
-      ],
-      "categories": [
-        "os",
-        "rust-patterns"
-      ],
-      "keywords": [
-        "api",
-        "io"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/sunfishcode/io-lifetimes",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "is-terminal",
-      "version": "0.4.5",
-      "id": "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT",
-      "license_file": null,
-      "description": "Test whether a given stream is a terminal",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "io-lifetimes",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "atty",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.14",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.110",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(any(unix, target_os = \"wasi\"))",
-          "registry": null
-        },
-        {
-          "name": "rustix",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.36.4",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "termios"
-          ],
-          "target": "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))",
-          "registry": null
-        },
-        {
-          "name": "hermit-abi",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"hermit\")",
-          "registry": null
-        },
-        {
-          "name": "windows-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.45.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "Win32_Foundation",
-            "Win32_Storage_FileSystem",
-            "Win32_System_Console"
-          ],
-          "target": "cfg(windows)",
-          "registry": null
-        },
-        {
-          "name": "tempfile",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^3",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "is-terminal",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/is-terminal-0.4.5/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/is-terminal-0.4.5/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "softprops <d.tangren@gmail.com>",
-        "Dan Gohman <dev@sunfishcode.online>"
-      ],
-      "categories": [
-        "command-line-interface"
-      ],
-      "keywords": [
-        "terminal",
-        "tty",
-        "isatty"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/sunfishcode/is-terminal",
-      "homepage": null,
-      "documentation": "http://docs.rs/is-terminal",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.48"
-    },
-    {
-      "name": "kqueue",
-      "version": "1.0.7",
-      "id": "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT",
-      "license_file": null,
-      "description": "kqueue interface for BSDs",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "kqueue-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.3",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.17",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tempfile",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^3.1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "kqueue",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/kqueue-1.0.7/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "file",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/kqueue-1.0.7/examples/file.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "pid",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/kqueue-1.0.7/examples/pid.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/kqueue-1.0.7/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "targets": [
-              "x86_64-unknown-freebsd",
-              "x86_64-unknown-dragonfly",
-              "x86_64-unknown-openbsd",
-              "x86_64-unknown-netbsd",
-              "x86_64-apple-darwin"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "William Orr <will@worrbase.com>"
-      ],
-      "categories": [
-        "os::unix-apis",
-        "filesystem"
-      ],
-      "keywords": [
-        "kqueue",
-        "kevent",
-        "bsd"
-      ],
-      "readme": "README.md",
-      "repository": "https://gitlab.com/rust-kqueue/rust-kqueue",
-      "homepage": null,
-      "documentation": "https://docs.worrbase.com/rust/kqueue/",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "kqueue-sys",
-      "version": "1.0.3",
-      "id": "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT",
-      "license_file": null,
-      "description": "Low-level kqueue interface for BSDs",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "bitflags",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.2.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.74",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "kqueue-sys",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/kqueue-sys-1.0.3/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/kqueue-sys-1.0.3/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "William Orr <will@worrbase.com>",
-        "Daniel (dmilith) Dettlaff <dmilith@me.com>"
-      ],
-      "categories": [
-        "external-ffi-bindings",
-        "no-std",
-        "os::unix-apis",
-        "filesystem"
-      ],
-      "keywords": [
-        "kqueue",
-        "kevent",
-        "bsd",
-        "darwin",
-        "macos"
-      ],
-      "readme": "README.md",
-      "repository": "https://gitlab.com/worr/rust-kqueue-sys",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "libc",
-      "version": "0.2.140",
-      "id": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Raw FFI bindings to platform libraries like libc.\n",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "rustc-std-workspace-core",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "libc",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.140/src/lib.rs",
-          "edition": "2015",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "const_fn",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.140/tests/const_fn.rs",
-          "edition": "2015",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.140/build.rs",
-          "edition": "2015",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "align": [],
-        "const-extern-fn": [],
-        "default": [
-          "std"
-        ],
-        "extra_traits": [],
-        "rustc-dep-of-std": [
-          "align",
-          "rustc-std-workspace-core"
-        ],
-        "rustc-std-workspace-core": [
-          "dep:rustc-std-workspace-core"
-        ],
-        "std": [],
-        "use_std": [
-          "std"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.140/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "features": [
-              "const-extern-fn",
-              "extra_traits"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "The Rust Project Developers"
-      ],
-      "categories": [
-        "external-ffi-bindings",
-        "no-std",
-        "os"
-      ],
-      "keywords": [
-        "libc",
-        "ffi",
-        "bindings",
-        "operating",
-        "system"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/rust-lang/libc",
-      "homepage": "https://github.com/rust-lang/libc",
-      "documentation": "https://docs.rs/libc/",
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "linux-raw-sys",
-      "version": "0.1.4",
-      "id": "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_file": null,
-      "description": "Generated bindings for Linux's userspace API",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "compiler_builtins",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.49",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustc-std-workspace-core",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": "core",
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.100",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "static_assertions",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "linux-raw-sys",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/linux-raw-sys-0.1.4/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {
-        "compiler_builtins": [
-          "dep:compiler_builtins"
-        ],
-        "core": [
-          "dep:core"
-        ],
-        "default": [
-          "std",
-          "general",
-          "errno"
-        ],
-        "errno": [],
-        "general": [],
-        "ioctl": [],
-        "netlink": [],
-        "no_std": [],
-        "rustc-dep-of-std": [
-          "core",
-          "compiler_builtins",
-          "no_std"
-        ],
-        "std": []
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/linux-raw-sys-0.1.4/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "features": [
-              "default",
-              "ioctl",
-              "netlink"
-            ],
-            "targets": [
-              "x86_64-unknown-linux-gnu",
-              "i686-unknown-linux-gnu"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Dan Gohman <dev@sunfishcode.online>"
-      ],
-      "categories": [
-        "external-ffi-bindings"
-      ],
-      "keywords": [
-        "linux",
-        "uapi",
-        "ffi"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/sunfishcode/linux-raw-sys",
-      "homepage": null,
-      "documentation": "https://docs.rs/linux-raw-sys",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.48"
-    },
-    {
-      "name": "log",
-      "version": "0.4.17",
-      "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "A lightweight logging facade for Rust\n",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "cfg-if",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "serde",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "sval",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "=1.0.0-alpha.5",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "value-bag",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "=1.0.0-alpha.9",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustversion",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "serde",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "derive"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "serde_test",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "sval",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "=1.0.0-alpha.5",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "derive"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "value-bag",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "=1.0.0-alpha.9",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "test"
-          ],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "log",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/src/lib.rs",
-          "edition": "2015",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "filters",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/filters.rs",
-          "edition": "2015",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "macros",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/macros.rs",
-          "edition": "2015",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "bench"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "value",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/benches/value.rs",
-          "edition": "2015",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/build.rs",
-          "edition": "2015",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "kv_unstable": [
-          "value-bag"
-        ],
-        "kv_unstable_serde": [
-          "kv_unstable_std",
-          "value-bag/serde",
-          "serde"
-        ],
-        "kv_unstable_std": [
-          "std",
-          "kv_unstable",
-          "value-bag/error"
-        ],
-        "kv_unstable_sval": [
-          "kv_unstable",
-          "value-bag/sval",
-          "sval"
-        ],
-        "max_level_debug": [],
-        "max_level_error": [],
-        "max_level_info": [],
-        "max_level_off": [],
-        "max_level_trace": [],
-        "max_level_warn": [],
-        "release_max_level_debug": [],
-        "release_max_level_error": [],
-        "release_max_level_info": [],
-        "release_max_level_off": [],
-        "release_max_level_trace": [],
-        "release_max_level_warn": [],
-        "serde": [
-          "dep:serde"
-        ],
-        "std": [],
-        "sval": [
-          "dep:sval"
-        ],
-        "value-bag": [
-          "dep:value-bag"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "features": [
-              "std",
-              "serde",
-              "kv_unstable_std",
-              "kv_unstable_sval",
-              "kv_unstable_serde"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "The Rust Project Developers"
-      ],
-      "categories": [
-        "development-tools::debugging"
-      ],
-      "keywords": [
-        "logging"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/rust-lang/log",
-      "homepage": null,
-      "documentation": "https://docs.rs/log",
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "mio",
-      "version": "0.8.6",
-      "id": "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT",
-      "license_file": null,
-      "description": "Lightweight non-blocking I/O.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "log",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4.8",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "env_logger",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8.4",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rand",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.121",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"wasi\")",
-          "registry": null
-        },
-        {
-          "name": "wasi",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.11.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"wasi\")",
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.121",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(unix)",
-          "registry": null
-        },
-        {
-          "name": "windows-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.45",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "Win32_Foundation",
-            "Win32_Networking_WinSock",
-            "Win32_Storage_FileSystem",
-            "Win32_System_IO",
-            "Win32_System_WindowsProgramming"
-          ],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "mio",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "tcp_server",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/examples/tcp_server.rs",
-          "edition": "2018",
-          "required-features": [
-            "os-poll",
-            "net"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "tcp_listenfd_server",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/examples/tcp_listenfd_server.rs",
-          "edition": "2018",
-          "required-features": [
-            "os-poll",
-            "net"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "udp_server",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/examples/udp_server.rs",
-          "edition": "2018",
-          "required-features": [
-            "os-poll",
-            "net"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "default": [],
-        "net": [],
-        "os-ext": [
-          "os-poll",
-          "windows-sys/Win32_System_Pipes",
-          "windows-sys/Win32_Security"
-        ],
-        "os-poll": []
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "all-features": true,
-            "rustdoc-args": [
-              "--cfg",
-              "docsrs"
-            ],
-            "targets": [
-              "aarch64-apple-ios",
-              "aarch64-linux-android",
-              "wasm32-wasi",
-              "x86_64-apple-darwin",
-              "x86_64-pc-windows-msvc",
-              "x86_64-unknown-dragonfly",
-              "x86_64-unknown-freebsd",
-              "x86_64-unknown-illumos",
-              "x86_64-unknown-linux-gnu",
-              "x86_64-unknown-netbsd",
-              "x86_64-unknown-openbsd"
-            ]
-          }
-        },
-        "playground": {
-          "features": [
-            "os-poll",
-            "os-ext",
-            "net"
-          ]
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Carl Lerche <me@carllerche.com>",
-        "Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
-        "Tokio Contributors <team@tokio.rs>"
-      ],
-      "categories": [
-        "asynchronous"
-      ],
-      "keywords": [
-        "io",
-        "async",
-        "non-blocking"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/tokio-rs/mio",
-      "homepage": "https://github.com/tokio-rs/mio",
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "notify",
-      "version": "5.1.0",
-      "id": "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "CC0-1.0 OR Artistic-2.0",
-      "license_file": null,
-      "description": "Cross-platform filesystem notification library",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "bitflags",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.4",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "crossbeam-channel",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.5.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "filetime",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.6",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.4",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "serde",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.89",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [
-            "derive"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "walkdir",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^2.2.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "nix",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.23.1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "serde_json",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.39",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tempfile",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^3.2.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "kqueue",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.4",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(any(target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonflybsd\"))",
-          "registry": null
-        },
-        {
-          "name": "mio",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "os-ext"
-          ],
-          "target": "cfg(any(target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonflybsd\"))",
-          "registry": null
-        },
-        {
-          "name": "inotify",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.9",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": "cfg(target_os = \"linux\")",
-          "registry": null
-        },
-        {
-          "name": "mio",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "os-ext"
-          ],
-          "target": "cfg(target_os = \"linux\")",
-          "registry": null
-        },
-        {
-          "name": "fsevent-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^4",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"macos\")",
-          "registry": null
-        },
-        {
-          "name": "kqueue",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(target_os = \"macos\")",
-          "registry": null
-        },
-        {
-          "name": "mio",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [
-            "os-ext"
-          ],
-          "target": "cfg(target_os = \"macos\")",
-          "registry": null
-        },
-        {
-          "name": "windows-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "Win32_System_Threading",
-            "Win32_Foundation",
-            "Win32_Storage_FileSystem",
-            "Win32_Security",
-            "Win32_System_WindowsProgramming",
-            "Win32_System_IO"
-          ],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "notify",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/notify-5.1.0/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {
-        "crossbeam-channel": [
-          "dep:crossbeam-channel"
-        ],
-        "default": [
-          "macos_fsevent",
-          "crossbeam-channel"
-        ],
-        "fsevent-sys": [
-          "dep:fsevent-sys"
-        ],
-        "kqueue": [
-          "dep:kqueue"
-        ],
-        "macos_fsevent": [
-          "fsevent-sys"
-        ],
-        "macos_kqueue": [
-          "kqueue",
-          "mio"
-        ],
-        "manual_tests": [],
-        "mio": [
-          "dep:mio"
-        ],
-        "serde": [
-          "dep:serde"
-        ],
-        "timing_tests": []
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/notify-5.1.0/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Félix Saparelli <me@passcod.name>",
-        "Daniel Faust <hessijames@gmail.com>"
-      ],
-      "categories": [
-        "filesystem"
-      ],
-      "keywords": [
-        "events",
-        "filesystem",
-        "notify",
-        "watch"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/notify-rs/notify.git",
-      "homepage": "https://github.com/notify-rs/notify",
-      "documentation": "https://docs.rs/notify",
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.56"
-    },
-    {
-      "name": "os_str_bytes",
-      "version": "6.5.0",
-      "id": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Convert between byte sequences and platform-native strings\n",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "memchr",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^2.4",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "print_bytes",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "uniquote",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^3.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "fastrand",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.8",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "os_str_bytes",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/os_str_bytes-6.5.0/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {
-        "checked_conversions": [],
-        "default": [
-          "memchr",
-          "raw_os_str"
-        ],
-        "memchr": [
-          "dep:memchr"
-        ],
-        "print_bytes": [
-          "dep:print_bytes"
-        ],
-        "raw_os_str": [],
-        "uniquote": [
-          "dep:uniquote"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/os_str_bytes-6.5.0/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "all-features": true,
-            "rustc-args": [
-              "--cfg",
-              "os_str_bytes_docs_rs"
-            ],
-            "rustdoc-args": [
-              "--cfg",
-              "os_str_bytes_docs_rs"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "dylni"
-      ],
-      "categories": [
-        "command-line-interface",
-        "development-tools::ffi",
-        "encoding",
-        "os",
-        "rust-patterns"
-      ],
-      "keywords": [
-        "bytes",
-        "osstr",
-        "osstring",
-        "path",
-        "windows"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/dylni/os_str_bytes",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.57.0"
-    },
-    {
-      "name": "redox_syscall",
-      "version": "0.2.16",
-      "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT",
-      "license_file": null,
-      "description": "A Rust library to access raw Redox system calls",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "bitflags",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.1.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "syscall",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/redox_syscall-0.2.16/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/redox_syscall-0.2.16/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Jeremy Soller <jackpot51@gmail.com>"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": "README.md",
-      "repository": "https://gitlab.redox-os.org/redox-os/syscall",
-      "homepage": null,
-      "documentation": "https://docs.rs/redox_syscall",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "rustix",
-      "version": "0.36.11",
-      "id": "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_file": null,
-      "description": "Safe Rust bindings to POSIX/Unix/Linux/Winsock2-like syscalls",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "rustc-std-workspace-alloc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": "alloc",
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "bitflags",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.2.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "compiler_builtins",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.49",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustc-std-workspace-core",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": "core",
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "io-lifetimes",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": false,
-          "features": [
-            "close"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "itoa",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "flate2",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "io-lifetimes",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [
-            "close"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.133",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "errno",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.8",
-          "kind": "dev",
-          "rename": "libc_errno",
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "memoffset",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.7.1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "serial_test",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.6",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tempfile",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^3.2.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "cc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.68",
-          "kind": "build",
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "linux-raw-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [
-            "general",
-            "no_std"
-          ],
-          "target": "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))",
-          "registry": null
-        },
-        {
-          "name": "criterion",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(all(criterion, not(any(target_os = \"emscripten\", target_os = \"wasi\"))))",
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.133",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [
-            "extra_traits"
-          ],
-          "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))",
-          "registry": null
-        },
-        {
-          "name": "errno",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.8",
-          "kind": null,
-          "rename": "libc_errno",
-          "optional": true,
-          "uses_default_features": false,
-          "features": [],
-          "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))",
-          "registry": null
-        },
-        {
-          "name": "linux-raw-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [
-            "general",
-            "errno",
-            "ioctl",
-            "no_std"
-          ],
-          "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))",
-          "registry": null
-        },
-        {
-          "name": "libc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.133",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "extra_traits"
-          ],
-          "target": "cfg(any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))))",
-          "registry": null
-        },
-        {
-          "name": "errno",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.8",
-          "kind": null,
-          "rename": "libc_errno",
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": "cfg(any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))))",
-          "registry": null
-        },
-        {
-          "name": "once_cell",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.5.2",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(any(target_os = \"android\", target_os = \"linux\"))",
-          "registry": null
-        },
-        {
-          "name": "windows-sys",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.45.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "Win32_Foundation",
-            "Win32_Networking_WinSock",
-            "Win32_NetworkManagement_IpHelper",
-            "Win32_System_Threading"
-          ],
-          "target": "cfg(windows)",
-          "registry": null
-        },
-        {
-          "name": "ctor",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.21",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "rustix",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/rustix-0.36.11/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "bench"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "mod",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/rustix-0.36.11/benches/mod.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/rustix-0.36.11/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "all-apis": [
-          "fs",
-          "io_uring",
-          "mm",
-          "net",
-          "param",
-          "process",
-          "procfs",
-          "rand",
-          "runtime",
-          "termios",
-          "thread",
-          "time"
-        ],
-        "all-impls": [
-          "os_pipe",
-          "fs-err"
-        ],
-        "alloc": [
-          "dep:alloc"
-        ],
-        "cc": [
-          "dep:cc"
-        ],
-        "compiler_builtins": [
-          "dep:compiler_builtins"
-        ],
-        "core": [
-          "dep:core"
-        ],
-        "default": [
-          "std",
-          "use-libc-auxv"
-        ],
-        "fs": [],
-        "fs-err": [
-          "io-lifetimes/fs-err"
-        ],
-        "io-lifetimes": [
-          "dep:io-lifetimes"
-        ],
-        "io_uring": [
-          "fs",
-          "net"
-        ],
-        "itoa": [
-          "dep:itoa"
-        ],
-        "libc": [
-          "dep:libc"
-        ],
-        "libc_errno": [
-          "dep:libc_errno"
-        ],
-        "mm": [],
-        "net": [],
-        "once_cell": [
-          "dep:once_cell"
-        ],
-        "os_pipe": [
-          "io-lifetimes/os_pipe"
-        ],
-        "param": [
-          "fs"
-        ],
-        "process": [],
-        "procfs": [
-          "once_cell",
-          "itoa",
-          "fs"
-        ],
-        "rand": [],
-        "runtime": [],
-        "rustc-dep-of-std": [
-          "core",
-          "alloc",
-          "compiler_builtins",
-          "linux-raw-sys/rustc-dep-of-std",
-          "bitflags/rustc-dep-of-std"
-        ],
-        "std": [
-          "io-lifetimes"
-        ],
-        "termios": [],
-        "thread": [],
-        "time": [],
-        "use-libc": [
-          "libc_errno",
-          "libc"
-        ],
-        "use-libc-auxv": [
-          "libc"
-        ]
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/rustix-0.36.11/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "features": [
-              "all-apis"
-            ],
-            "rustdoc-args": [
-              "--cfg",
-              "doc_cfg"
-            ],
-            "targets": [
-              "x86_64-unknown-linux-gnu",
-              "i686-unknown-linux-gnu",
-              "x86_64-apple-darwin",
-              "x86_64-pc-windows-msvc"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Dan Gohman <dev@sunfishcode.online>",
-        "Jakub Konka <kubkon@jakubkonka.com>"
-      ],
-      "categories": [
-        "os::unix-apis",
-        "date-and-time",
-        "filesystem",
-        "network-programming"
-      ],
-      "keywords": [
-        "api",
-        "file",
-        "network",
-        "safe",
-        "syscall"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/bytecodealliance/rustix",
-      "homepage": null,
-      "documentation": "https://docs.rs/rustix",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.48"
-    },
-    {
-      "name": "same-file",
-      "version": "1.0.6",
-      "id": "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "Unlicense/MIT",
-      "license_file": null,
-      "description": "A simple crate for determining whether two file paths point to the same file.\n",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "doc-comment",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "winapi-util",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "same-file",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/same-file-1.0.6/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "is_same_file",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/same-file-1.0.6/examples/is_same_file.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "is_stderr",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/same-file-1.0.6/examples/is_stderr.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/same-file-1.0.6/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Andrew Gallant <jamslam@gmail.com>"
-      ],
-      "categories": [],
-      "keywords": [
-        "same",
-        "file",
-        "equal",
-        "inode"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/BurntSushi/same-file",
-      "homepage": "https://github.com/BurntSushi/same-file",
-      "documentation": "https://docs.rs/same-file",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "termcolor",
-      "version": "1.2.0",
-      "id": "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "Unlicense OR MIT",
-      "license_file": null,
-      "description": "A simple cross platform library for writing colored text to a terminal.\n",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "winapi-util",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.3",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "termcolor",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/termcolor-1.2.0/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/termcolor-1.2.0/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Andrew Gallant <jamslam@gmail.com>"
-      ],
-      "categories": [],
-      "keywords": [
-        "windows",
-        "win",
-        "color",
-        "ansi",
-        "console"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/BurntSushi/termcolor",
-      "homepage": "https://github.com/BurntSushi/termcolor",
-      "documentation": "https://docs.rs/termcolor",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "walkdir",
-      "version": "2.3.3",
-      "id": "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "Unlicense/MIT",
-      "license_file": null,
-      "description": "Recursively walk a directory.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "same-file",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "doc-comment",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "winapi-util",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "walkdir",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/walkdir-2.3.3/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/walkdir-2.3.3/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Andrew Gallant <jamslam@gmail.com>"
-      ],
-      "categories": [
-        "filesystem"
-      ],
-      "keywords": [
-        "directory",
-        "recursive",
-        "walk",
-        "iterator"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/BurntSushi/walkdir",
-      "homepage": "https://github.com/BurntSushi/walkdir",
-      "documentation": "https://docs.rs/walkdir/",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "wasi",
-      "version": "0.11.0+wasi-snapshot-preview1",
-      "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_file": null,
-      "description": "Experimental WASI API bindings for Rust",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "compiler_builtins",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustc-std-workspace-core",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": null,
-          "rename": "core",
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustc-std-workspace-alloc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "wasi",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/wasi-0.11.0+wasi-snapshot-preview1/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {
-        "compiler_builtins": [
-          "dep:compiler_builtins"
-        ],
-        "core": [
-          "dep:core"
-        ],
-        "default": [
-          "std"
-        ],
-        "rustc-dep-of-std": [
-          "compiler_builtins",
-          "core",
-          "rustc-std-workspace-alloc"
-        ],
-        "rustc-std-workspace-alloc": [
-          "dep:rustc-std-workspace-alloc"
-        ],
-        "std": []
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/wasi-0.11.0+wasi-snapshot-preview1/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "The Cranelift Project Developers"
-      ],
-      "categories": [
-        "no-std",
-        "wasm"
-      ],
-      "keywords": [
-        "webassembly",
-        "wasm"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/bytecodealliance/wasi",
-      "homepage": null,
-      "documentation": "https://docs.rs/wasi",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "winapi",
-      "version": "0.3.9",
-      "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT/Apache-2.0",
-      "license_file": null,
-      "description": "Raw FFI bindings for all of Windows API.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "winapi-i686-pc-windows-gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "i686-pc-windows-gnu",
-          "registry": null
-        },
-        {
-          "name": "winapi-x86_64-pc-windows-gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-pc-windows-gnu",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "winapi",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/src/lib.rs",
-          "edition": "2015",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/build.rs",
-          "edition": "2015",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "accctrl": [],
-        "aclapi": [],
-        "activation": [],
-        "adhoc": [],
-        "appmgmt": [],
-        "audioclient": [],
-        "audiosessiontypes": [],
-        "avrt": [],
-        "basetsd": [],
-        "bcrypt": [],
-        "bits": [],
-        "bits10_1": [],
-        "bits1_5": [],
-        "bits2_0": [],
-        "bits2_5": [],
-        "bits3_0": [],
-        "bits4_0": [],
-        "bits5_0": [],
-        "bitscfg": [],
-        "bitsmsg": [],
-        "bluetoothapis": [],
-        "bluetoothleapis": [],
-        "bthdef": [],
-        "bthioctl": [],
-        "bthledef": [],
-        "bthsdpdef": [],
-        "bugcodes": [],
-        "cderr": [],
-        "cfg": [],
-        "cfgmgr32": [],
-        "cguid": [],
-        "combaseapi": [],
-        "coml2api": [],
-        "commapi": [],
-        "commctrl": [],
-        "commdlg": [],
-        "commoncontrols": [],
-        "consoleapi": [],
-        "corecrt": [],
-        "corsym": [],
-        "d2d1": [],
-        "d2d1_1": [],
-        "d2d1_2": [],
-        "d2d1_3": [],
-        "d2d1effectauthor": [],
-        "d2d1effects": [],
-        "d2d1effects_1": [],
-        "d2d1effects_2": [],
-        "d2d1svg": [],
-        "d2dbasetypes": [],
-        "d3d": [],
-        "d3d10": [],
-        "d3d10_1": [],
-        "d3d10_1shader": [],
-        "d3d10effect": [],
-        "d3d10misc": [],
-        "d3d10sdklayers": [],
-        "d3d10shader": [],
-        "d3d11": [],
-        "d3d11_1": [],
-        "d3d11_2": [],
-        "d3d11_3": [],
-        "d3d11_4": [],
-        "d3d11on12": [],
-        "d3d11sdklayers": [],
-        "d3d11shader": [],
-        "d3d11tokenizedprogramformat": [],
-        "d3d12": [],
-        "d3d12sdklayers": [],
-        "d3d12shader": [],
-        "d3d9": [],
-        "d3d9caps": [],
-        "d3d9types": [],
-        "d3dcommon": [],
-        "d3dcompiler": [],
-        "d3dcsx": [],
-        "d3dkmdt": [],
-        "d3dkmthk": [],
-        "d3dukmdt": [],
-        "d3dx10core": [],
-        "d3dx10math": [],
-        "d3dx10mesh": [],
-        "datetimeapi": [],
-        "davclnt": [],
-        "dbghelp": [],
-        "dbt": [],
-        "dcommon": [],
-        "dcomp": [],
-        "dcompanimation": [],
-        "dcomptypes": [],
-        "dde": [],
-        "ddraw": [],
-        "ddrawi": [],
-        "ddrawint": [],
-        "debug": [
-          "impl-debug"
-        ],
-        "debugapi": [],
-        "devguid": [],
-        "devicetopology": [],
-        "devpkey": [],
-        "devpropdef": [],
-        "dinput": [],
-        "dinputd": [],
-        "dispex": [],
-        "dmksctl": [],
-        "dmusicc": [],
-        "docobj": [],
-        "documenttarget": [],
-        "dot1x": [],
-        "dpa_dsa": [],
-        "dpapi": [],
-        "dsgetdc": [],
-        "dsound": [],
-        "dsrole": [],
-        "dvp": [],
-        "dwmapi": [],
-        "dwrite": [],
-        "dwrite_1": [],
-        "dwrite_2": [],
-        "dwrite_3": [],
-        "dxdiag": [],
-        "dxfile": [],
-        "dxgi": [],
-        "dxgi1_2": [],
-        "dxgi1_3": [],
-        "dxgi1_4": [],
-        "dxgi1_5": [],
-        "dxgi1_6": [],
-        "dxgidebug": [],
-        "dxgiformat": [],
-        "dxgitype": [],
-        "dxva2api": [],
-        "dxvahd": [],
-        "eaptypes": [],
-        "enclaveapi": [],
-        "endpointvolume": [],
-        "errhandlingapi": [],
-        "everything": [],
-        "evntcons": [],
-        "evntprov": [],
-        "evntrace": [],
-        "excpt": [],
-        "exdisp": [],
-        "fibersapi": [],
-        "fileapi": [],
-        "functiondiscoverykeys_devpkey": [],
-        "gl-gl": [],
-        "guiddef": [],
-        "handleapi": [],
-        "heapapi": [],
-        "hidclass": [],
-        "hidpi": [],
-        "hidsdi": [],
-        "hidusage": [],
-        "highlevelmonitorconfigurationapi": [],
-        "hstring": [],
-        "http": [],
-        "ifdef": [],
-        "ifmib": [],
-        "imm": [],
-        "impl-debug": [],
-        "impl-default": [],
-        "in6addr": [],
-        "inaddr": [],
-        "inspectable": [],
-        "interlockedapi": [],
-        "intsafe": [],
-        "ioapiset": [],
-        "ipexport": [],
-        "iphlpapi": [],
-        "ipifcons": [],
-        "ipmib": [],
-        "iprtrmib": [],
-        "iptypes": [],
-        "jobapi": [],
-        "jobapi2": [],
-        "knownfolders": [],
-        "ks": [],
-        "ksmedia": [],
-        "ktmtypes": [],
-        "ktmw32": [],
-        "l2cmn": [],
-        "libloaderapi": [],
-        "limits": [],
-        "lmaccess": [],
-        "lmalert": [],
-        "lmapibuf": [],
-        "lmat": [],
-        "lmcons": [],
-        "lmdfs": [],
-        "lmerrlog": [],
-        "lmjoin": [],
-        "lmmsg": [],
-        "lmremutl": [],
-        "lmrepl": [],
-        "lmserver": [],
-        "lmshare": [],
-        "lmstats": [],
-        "lmsvc": [],
-        "lmuse": [],
-        "lmwksta": [],
-        "lowlevelmonitorconfigurationapi": [],
-        "lsalookup": [],
-        "memoryapi": [],
-        "minschannel": [],
-        "minwinbase": [],
-        "minwindef": [],
-        "mmdeviceapi": [],
-        "mmeapi": [],
-        "mmreg": [],
-        "mmsystem": [],
-        "mprapidef": [],
-        "msaatext": [],
-        "mscat": [],
-        "mschapp": [],
-        "mssip": [],
-        "mstcpip": [],
-        "mswsock": [],
-        "mswsockdef": [],
-        "namedpipeapi": [],
-        "namespaceapi": [],
-        "nb30": [],
-        "ncrypt": [],
-        "netioapi": [],
-        "nldef": [],
-        "ntddndis": [],
-        "ntddscsi": [],
-        "ntddser": [],
-        "ntdef": [],
-        "ntlsa": [],
-        "ntsecapi": [],
-        "ntstatus": [],
-        "oaidl": [],
-        "objbase": [],
-        "objidl": [],
-        "objidlbase": [],
-        "ocidl": [],
-        "ole2": [],
-        "oleauto": [],
-        "olectl": [],
-        "oleidl": [],
-        "opmapi": [],
-        "pdh": [],
-        "perflib": [],
-        "physicalmonitorenumerationapi": [],
-        "playsoundapi": [],
-        "portabledevice": [],
-        "portabledeviceapi": [],
-        "portabledevicetypes": [],
-        "powerbase": [],
-        "powersetting": [],
-        "powrprof": [],
-        "processenv": [],
-        "processsnapshot": [],
-        "processthreadsapi": [],
-        "processtopologyapi": [],
-        "profileapi": [],
-        "propidl": [],
-        "propkey": [],
-        "propkeydef": [],
-        "propsys": [],
-        "prsht": [],
-        "psapi": [],
-        "qos": [],
-        "realtimeapiset": [],
-        "reason": [],
-        "restartmanager": [],
-        "restrictederrorinfo": [],
-        "rmxfguid": [],
-        "roapi": [],
-        "robuffer": [],
-        "roerrorapi": [],
-        "rpc": [],
-        "rpcdce": [],
-        "rpcndr": [],
-        "rtinfo": [],
-        "sapi": [],
-        "sapi51": [],
-        "sapi53": [],
-        "sapiddk": [],
-        "sapiddk51": [],
-        "schannel": [],
-        "sddl": [],
-        "securityappcontainer": [],
-        "securitybaseapi": [],
-        "servprov": [],
-        "setupapi": [],
-        "shellapi": [],
-        "shellscalingapi": [],
-        "shlobj": [],
-        "shobjidl": [],
-        "shobjidl_core": [],
-        "shtypes": [],
-        "softpub": [],
-        "spapidef": [],
-        "spellcheck": [],
-        "sporder": [],
-        "sql": [],
-        "sqlext": [],
-        "sqltypes": [],
-        "sqlucode": [],
-        "sspi": [],
-        "std": [],
-        "stralign": [],
-        "stringapiset": [],
-        "strmif": [],
-        "subauth": [],
-        "synchapi": [],
-        "sysinfoapi": [],
-        "systemtopologyapi": [],
-        "taskschd": [],
-        "tcpestats": [],
-        "tcpmib": [],
-        "textstor": [],
-        "threadpoolapiset": [],
-        "threadpoollegacyapiset": [],
-        "timeapi": [],
-        "timezoneapi": [],
-        "tlhelp32": [],
-        "transportsettingcommon": [],
-        "tvout": [],
-        "udpmib": [],
-        "unknwnbase": [],
-        "urlhist": [],
-        "urlmon": [],
-        "usb": [],
-        "usbioctl": [],
-        "usbiodef": [],
-        "usbscan": [],
-        "usbspec": [],
-        "userenv": [],
-        "usp10": [],
-        "utilapiset": [],
-        "uxtheme": [],
-        "vadefs": [],
-        "vcruntime": [],
-        "vsbackup": [],
-        "vss": [],
-        "vsserror": [],
-        "vswriter": [],
-        "wbemads": [],
-        "wbemcli": [],
-        "wbemdisp": [],
-        "wbemprov": [],
-        "wbemtran": [],
-        "wct": [],
-        "werapi": [],
-        "winbase": [],
-        "wincodec": [],
-        "wincodecsdk": [],
-        "wincon": [],
-        "wincontypes": [],
-        "wincred": [],
-        "wincrypt": [],
-        "windef": [],
-        "windot11": [],
-        "windowsceip": [],
-        "windowsx": [],
-        "winefs": [],
-        "winerror": [],
-        "winevt": [],
-        "wingdi": [],
-        "winhttp": [],
-        "wininet": [],
-        "winineti": [],
-        "winioctl": [],
-        "winnetwk": [],
-        "winnls": [],
-        "winnt": [],
-        "winreg": [],
-        "winsafer": [],
-        "winscard": [],
-        "winsmcrd": [],
-        "winsock2": [],
-        "winspool": [],
-        "winstring": [],
-        "winsvc": [],
-        "wintrust": [],
-        "winusb": [],
-        "winusbio": [],
-        "winuser": [],
-        "winver": [],
-        "wlanapi": [],
-        "wlanihv": [],
-        "wlanihvtypes": [],
-        "wlantypes": [],
-        "wlclient": [],
-        "wmistr": [],
-        "wnnc": [],
-        "wow64apiset": [],
-        "wpdmtpextensions": [],
-        "ws2bth": [],
-        "ws2def": [],
-        "ws2ipdef": [],
-        "ws2spi": [],
-        "ws2tcpip": [],
-        "wtsapi32": [],
-        "wtypes": [],
-        "wtypesbase": [],
-        "xinput": []
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "features": [
-              "everything",
-              "impl-debug",
-              "impl-default"
-            ],
-            "targets": [
-              "aarch64-pc-windows-msvc",
-              "i686-pc-windows-msvc",
-              "x86_64-pc-windows-msvc"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Peter Atashian <retep998@gmail.com>"
-      ],
-      "categories": [
-        "external-ffi-bindings",
-        "no-std",
-        "os::windows-apis"
-      ],
-      "keywords": [
-        "windows",
-        "ffi",
-        "win32",
-        "com",
-        "directx"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/retep998/winapi-rs",
-      "homepage": null,
-      "documentation": "https://docs.rs/winapi/",
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "winapi-i686-pc-windows-gnu",
-      "version": "0.4.0",
-      "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT/Apache-2.0",
-      "license_file": null,
-      "description": "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "winapi-i686-pc-windows-gnu",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/src/lib.rs",
-          "edition": "2015",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/build.rs",
-          "edition": "2015",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Peter Atashian <retep998@gmail.com>"
-      ],
-      "categories": [],
-      "keywords": [
-        "windows"
-      ],
-      "readme": null,
-      "repository": "https://github.com/retep998/winapi-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "winapi-util",
-      "version": "0.1.5",
-      "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "Unlicense/MIT",
-      "license_file": null,
-      "description": "A dumping ground for high level safe wrappers over winapi.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "winapi",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.3",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "std",
-            "consoleapi",
-            "errhandlingapi",
-            "fileapi",
-            "minwindef",
-            "processenv",
-            "winbase",
-            "wincon",
-            "winerror",
-            "winnt"
-          ],
-          "target": "cfg(windows)",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "winapi-util",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-util-0.1.5/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-util-0.1.5/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "targets": [
-              "x86_64-pc-windows-msvc"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Andrew Gallant <jamslam@gmail.com>"
-      ],
-      "categories": [
-        "os::windows-apis",
-        "external-ffi-bindings"
-      ],
-      "keywords": [
-        "windows",
-        "winapi",
-        "util",
-        "win"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/BurntSushi/winapi-util",
-      "homepage": "https://github.com/BurntSushi/winapi-util",
-      "documentation": "https://docs.rs/winapi-util",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "winapi-x86_64-pc-windows-gnu",
-      "version": "0.4.0",
-      "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT/Apache-2.0",
-      "license_file": null,
-      "description": "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "winapi-x86_64-pc-windows-gnu",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/src/lib.rs",
-          "edition": "2015",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/build.rs",
-          "edition": "2015",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Peter Atashian <retep998@gmail.com>"
-      ],
-      "categories": [],
-      "keywords": [
-        "windows"
-      ],
-      "readme": null,
-      "repository": "https://github.com/retep998/winapi-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "windows-sys",
-      "version": "0.42.0",
-      "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Rust for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "windows_aarch64_gnullvm",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "aarch64-pc-windows-gnullvm",
-          "registry": null
-        },
-        {
-          "name": "windows_aarch64_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "aarch64-pc-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_aarch64_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "aarch64-uwp-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_i686_gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "i686-pc-windows-gnu",
-          "registry": null
-        },
-        {
-          "name": "windows_i686_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "i686-pc-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_i686_gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "i686-uwp-windows-gnu",
-          "registry": null
-        },
-        {
-          "name": "windows_i686_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "i686-uwp-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-pc-windows-gnu",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_gnullvm",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-pc-windows-gnullvm",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-pc-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-uwp-windows-gnu",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-uwp-windows-msvc",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows-sys",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {
-        "Win32": [],
-        "Win32_AI": [
-          "Win32"
-        ],
-        "Win32_AI_MachineLearning": [
-          "Win32_AI"
-        ],
-        "Win32_AI_MachineLearning_DirectML": [
-          "Win32_AI_MachineLearning"
-        ],
-        "Win32_AI_MachineLearning_WinML": [
-          "Win32_AI_MachineLearning"
-        ],
-        "Win32_Data": [
-          "Win32"
-        ],
-        "Win32_Data_HtmlHelp": [
-          "Win32_Data"
-        ],
-        "Win32_Data_RightsManagement": [
-          "Win32_Data"
-        ],
-        "Win32_Data_Xml": [
-          "Win32_Data"
-        ],
-        "Win32_Data_Xml_MsXml": [
-          "Win32_Data_Xml"
-        ],
-        "Win32_Data_Xml_XmlLite": [
-          "Win32_Data_Xml"
-        ],
-        "Win32_Devices": [
-          "Win32"
-        ],
-        "Win32_Devices_AllJoyn": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_BiometricFramework": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Bluetooth": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Communication": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_DeviceAccess": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_DeviceAndDriverInstallation": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_DeviceQuery": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Display": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Enumeration": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Enumeration_Pnp": [
-          "Win32_Devices_Enumeration"
-        ],
-        "Win32_Devices_Fax": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_FunctionDiscovery": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Geolocation": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_HumanInterfaceDevice": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_ImageAcquisition": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_PortableDevices": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Properties": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Pwm": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Sensors": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_SerialCommunication": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Tapi": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Usb": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_WebServicesOnDevices": [
-          "Win32_Devices"
-        ],
-        "Win32_Foundation": [
-          "Win32"
-        ],
-        "Win32_Gaming": [
-          "Win32"
-        ],
-        "Win32_Globalization": [
-          "Win32"
-        ],
-        "Win32_Graphics": [
-          "Win32"
-        ],
-        "Win32_Graphics_CompositionSwapchain": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_DXCore": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Direct2D": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Direct2D_Common": [
-          "Win32_Graphics_Direct2D"
-        ],
-        "Win32_Graphics_Direct3D": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Direct3D10": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Direct3D11": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Direct3D11on12": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Direct3D12": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Direct3D9": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Direct3D9on12": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Direct3D_Dxc": [
-          "Win32_Graphics_Direct3D"
-        ],
-        "Win32_Graphics_Direct3D_Fxc": [
-          "Win32_Graphics_Direct3D"
-        ],
-        "Win32_Graphics_DirectComposition": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_DirectDraw": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_DirectManipulation": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_DirectWrite": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Dwm": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Dxgi": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Dxgi_Common": [
-          "Win32_Graphics_Dxgi"
-        ],
-        "Win32_Graphics_Gdi": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Hlsl": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Imaging": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Imaging_D2D": [
-          "Win32_Graphics_Imaging"
-        ],
-        "Win32_Graphics_OpenGL": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Printing": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Printing_PrintTicket": [
-          "Win32_Graphics_Printing"
-        ],
-        "Win32_Management": [
-          "Win32"
-        ],
-        "Win32_Management_MobileDeviceManagementRegistration": [
-          "Win32_Management"
-        ],
-        "Win32_Media": [
-          "Win32"
-        ],
-        "Win32_Media_Audio": [
-          "Win32_Media"
-        ],
-        "Win32_Media_Audio_Apo": [
-          "Win32_Media_Audio"
-        ],
-        "Win32_Media_Audio_DirectMusic": [
-          "Win32_Media_Audio"
-        ],
-        "Win32_Media_Audio_DirectSound": [
-          "Win32_Media_Audio"
-        ],
-        "Win32_Media_Audio_Endpoints": [
-          "Win32_Media_Audio"
-        ],
-        "Win32_Media_Audio_XAudio2": [
-          "Win32_Media_Audio"
-        ],
-        "Win32_Media_DeviceManager": [
-          "Win32_Media"
-        ],
-        "Win32_Media_DirectShow": [
-          "Win32_Media"
-        ],
-        "Win32_Media_DirectShow_Xml": [
-          "Win32_Media_DirectShow"
-        ],
-        "Win32_Media_DxMediaObjects": [
-          "Win32_Media"
-        ],
-        "Win32_Media_KernelStreaming": [
-          "Win32_Media"
-        ],
-        "Win32_Media_LibrarySharingServices": [
-          "Win32_Media"
-        ],
-        "Win32_Media_MediaFoundation": [
-          "Win32_Media"
-        ],
-        "Win32_Media_MediaPlayer": [
-          "Win32_Media"
-        ],
-        "Win32_Media_Multimedia": [
-          "Win32_Media"
-        ],
-        "Win32_Media_PictureAcquisition": [
-          "Win32_Media"
-        ],
-        "Win32_Media_Speech": [
-          "Win32_Media"
-        ],
-        "Win32_Media_Streaming": [
-          "Win32_Media"
-        ],
-        "Win32_Media_WindowsMediaFormat": [
-          "Win32_Media"
-        ],
-        "Win32_NetworkManagement": [
-          "Win32"
-        ],
-        "Win32_NetworkManagement_Dhcp": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Dns": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_InternetConnectionWizard": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_IpHelper": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_MobileBroadband": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Multicast": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Ndis": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetBios": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetManagement": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetShell": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetworkDiagnosticsFramework": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetworkPolicyServer": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_P2P": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_QoS": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Rras": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Snmp": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WNet": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WebDav": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WiFi": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsConnectNow": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsConnectionManager": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsFilteringPlatform": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsFirewall": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsNetworkVirtualization": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_Networking": [
-          "Win32"
-        ],
-        "Win32_Networking_ActiveDirectory": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_BackgroundIntelligentTransferService": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_Clustering": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_HttpServer": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_Ldap": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_NetworkListManager": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_RemoteDifferentialCompression": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WebSocket": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WinHttp": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WinInet": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WinSock": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WindowsWebServices": [
-          "Win32_Networking"
-        ],
-        "Win32_Security": [
-          "Win32"
-        ],
-        "Win32_Security_AppLocker": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Authentication": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Authentication_Identity": [
-          "Win32_Security_Authentication"
-        ],
-        "Win32_Security_Authentication_Identity_Provider": [
-          "Win32_Security_Authentication_Identity"
-        ],
-        "Win32_Security_Authorization": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Authorization_UI": [
-          "Win32_Security_Authorization"
-        ],
-        "Win32_Security_ConfigurationSnapin": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Credentials": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Cryptography": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Cryptography_Catalog": [
-          "Win32_Security_Cryptography"
-        ],
-        "Win32_Security_Cryptography_Certificates": [
-          "Win32_Security_Cryptography"
-        ],
-        "Win32_Security_Cryptography_Sip": [
-          "Win32_Security_Cryptography"
-        ],
-        "Win32_Security_Cryptography_UI": [
-          "Win32_Security_Cryptography"
-        ],
-        "Win32_Security_DiagnosticDataQuery": [
-          "Win32_Security"
-        ],
-        "Win32_Security_DirectoryServices": [
-          "Win32_Security"
-        ],
-        "Win32_Security_EnterpriseData": [
-          "Win32_Security"
-        ],
-        "Win32_Security_ExtensibleAuthenticationProtocol": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Isolation": [
-          "Win32_Security"
-        ],
-        "Win32_Security_LicenseProtection": [
-          "Win32_Security"
-        ],
-        "Win32_Security_NetworkAccessProtection": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Tpm": [
-          "Win32_Security"
-        ],
-        "Win32_Security_WinTrust": [
-          "Win32_Security"
-        ],
-        "Win32_Security_WinWlx": [
-          "Win32_Security"
-        ],
-        "Win32_Storage": [
-          "Win32"
-        ],
-        "Win32_Storage_Cabinets": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_CloudFilters": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Compression": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_DataDeduplication": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_DistributedFileSystem": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_EnhancedStorage": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_FileHistory": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_FileServerResourceManager": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_FileSystem": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Imapi": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_IndexServer": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_InstallableFileSystems": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_IscsiDisc": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Jet": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_OfflineFiles": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_OperationRecorder": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Packaging": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Packaging_Appx": [
-          "Win32_Storage_Packaging"
-        ],
-        "Win32_Storage_Packaging_Opc": [
-          "Win32_Storage_Packaging"
-        ],
-        "Win32_Storage_ProjectedFileSystem": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_StructuredStorage": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Vhd": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_VirtualDiskService": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Vss": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Xps": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Xps_Printing": [
-          "Win32_Storage_Xps"
-        ],
-        "Win32_System": [
-          "Win32"
-        ],
-        "Win32_System_AddressBook": [
-          "Win32_System"
-        ],
-        "Win32_System_Antimalware": [
-          "Win32_System"
-        ],
-        "Win32_System_ApplicationInstallationAndServicing": [
-          "Win32_System"
-        ],
-        "Win32_System_ApplicationVerifier": [
-          "Win32_System"
-        ],
-        "Win32_System_AssessmentTool": [
-          "Win32_System"
-        ],
-        "Win32_System_Com": [
-          "Win32_System"
-        ],
-        "Win32_System_Com_CallObj": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_ChannelCredentials": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_Events": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_Marshal": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_StructuredStorage": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_UI": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_Urlmon": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_ComponentServices": [
-          "Win32_System"
-        ],
-        "Win32_System_Console": [
-          "Win32_System"
-        ],
-        "Win32_System_Contacts": [
-          "Win32_System"
-        ],
-        "Win32_System_CorrelationVector": [
-          "Win32_System"
-        ],
-        "Win32_System_DataExchange": [
-          "Win32_System"
-        ],
-        "Win32_System_DeploymentServices": [
-          "Win32_System"
-        ],
-        "Win32_System_DesktopSharing": [
-          "Win32_System"
-        ],
-        "Win32_System_DeveloperLicensing": [
-          "Win32_System"
-        ],
-        "Win32_System_Diagnostics": [
-          "Win32_System"
-        ],
-        "Win32_System_Diagnostics_Ceip": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_Diagnostics_Debug": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_Diagnostics_Etw": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_Diagnostics_ProcessSnapshotting": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_Diagnostics_ToolHelp": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_DistributedTransactionCoordinator": [
-          "Win32_System"
-        ],
-        "Win32_System_Environment": [
-          "Win32_System"
-        ],
-        "Win32_System_ErrorReporting": [
-          "Win32_System"
-        ],
-        "Win32_System_EventCollector": [
-          "Win32_System"
-        ],
-        "Win32_System_EventLog": [
-          "Win32_System"
-        ],
-        "Win32_System_EventNotificationService": [
-          "Win32_System"
-        ],
-        "Win32_System_GroupPolicy": [
-          "Win32_System"
-        ],
-        "Win32_System_HostCompute": [
-          "Win32_System"
-        ],
-        "Win32_System_HostComputeNetwork": [
-          "Win32_System"
-        ],
-        "Win32_System_HostComputeSystem": [
-          "Win32_System"
-        ],
-        "Win32_System_Hypervisor": [
-          "Win32_System"
-        ],
-        "Win32_System_IO": [
-          "Win32_System"
-        ],
-        "Win32_System_Iis": [
-          "Win32_System"
-        ],
-        "Win32_System_Ioctl": [
-          "Win32_System"
-        ],
-        "Win32_System_JobObjects": [
-          "Win32_System"
-        ],
-        "Win32_System_Js": [
-          "Win32_System"
-        ],
-        "Win32_System_Kernel": [
-          "Win32_System"
-        ],
-        "Win32_System_LibraryLoader": [
-          "Win32_System"
-        ],
-        "Win32_System_Mailslots": [
-          "Win32_System"
-        ],
-        "Win32_System_Mapi": [
-          "Win32_System"
-        ],
-        "Win32_System_Memory": [
-          "Win32_System"
-        ],
-        "Win32_System_Memory_NonVolatile": [
-          "Win32_System_Memory"
-        ],
-        "Win32_System_MessageQueuing": [
-          "Win32_System"
-        ],
-        "Win32_System_MixedReality": [
-          "Win32_System"
-        ],
-        "Win32_System_Mmc": [
-          "Win32_System"
-        ],
-        "Win32_System_Ole": [
-          "Win32_System"
-        ],
-        "Win32_System_ParentalControls": [
-          "Win32_System"
-        ],
-        "Win32_System_PasswordManagement": [
-          "Win32_System"
-        ],
-        "Win32_System_Performance": [
-          "Win32_System"
-        ],
-        "Win32_System_Performance_HardwareCounterProfiling": [
-          "Win32_System_Performance"
-        ],
-        "Win32_System_Pipes": [
-          "Win32_System"
-        ],
-        "Win32_System_Power": [
-          "Win32_System"
-        ],
-        "Win32_System_ProcessStatus": [
-          "Win32_System"
-        ],
-        "Win32_System_RealTimeCommunications": [
-          "Win32_System"
-        ],
-        "Win32_System_Recovery": [
-          "Win32_System"
-        ],
-        "Win32_System_Registry": [
-          "Win32_System"
-        ],
-        "Win32_System_RemoteAssistance": [
-          "Win32_System"
-        ],
-        "Win32_System_RemoteDesktop": [
-          "Win32_System"
-        ],
-        "Win32_System_RemoteManagement": [
-          "Win32_System"
-        ],
-        "Win32_System_RestartManager": [
-          "Win32_System"
-        ],
-        "Win32_System_Restore": [
-          "Win32_System"
-        ],
-        "Win32_System_Rpc": [
-          "Win32_System"
-        ],
-        "Win32_System_Search": [
-          "Win32_System"
-        ],
-        "Win32_System_Search_Common": [
-          "Win32_System_Search"
-        ],
-        "Win32_System_SecurityCenter": [
-          "Win32_System"
-        ],
-        "Win32_System_ServerBackup": [
-          "Win32_System"
-        ],
-        "Win32_System_Services": [
-          "Win32_System"
-        ],
-        "Win32_System_SettingsManagementInfrastructure": [
-          "Win32_System"
-        ],
-        "Win32_System_SetupAndMigration": [
-          "Win32_System"
-        ],
-        "Win32_System_Shutdown": [
-          "Win32_System"
-        ],
-        "Win32_System_SideShow": [
-          "Win32_System"
-        ],
-        "Win32_System_StationsAndDesktops": [
-          "Win32_System"
-        ],
-        "Win32_System_SubsystemForLinux": [
-          "Win32_System"
-        ],
-        "Win32_System_SystemInformation": [
-          "Win32_System"
-        ],
-        "Win32_System_SystemServices": [
-          "Win32_System"
-        ],
-        "Win32_System_TaskScheduler": [
-          "Win32_System"
-        ],
-        "Win32_System_Threading": [
-          "Win32_System"
-        ],
-        "Win32_System_Time": [
-          "Win32_System"
-        ],
-        "Win32_System_TpmBaseServices": [
-          "Win32_System"
-        ],
-        "Win32_System_TransactionServer": [
-          "Win32_System"
-        ],
-        "Win32_System_UpdateAgent": [
-          "Win32_System"
-        ],
-        "Win32_System_UpdateAssessment": [
-          "Win32_System"
-        ],
-        "Win32_System_UserAccessLogging": [
-          "Win32_System"
-        ],
-        "Win32_System_VirtualDosMachines": [
-          "Win32_System"
-        ],
-        "Win32_System_WinRT": [
-          "Win32_System"
-        ],
-        "Win32_System_WinRT_AllJoyn": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Composition": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_CoreInputView": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Direct3D11": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Display": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Graphics": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Graphics_Capture": [
-          "Win32_System_WinRT_Graphics"
-        ],
-        "Win32_System_WinRT_Graphics_Direct2D": [
-          "Win32_System_WinRT_Graphics"
-        ],
-        "Win32_System_WinRT_Graphics_Imaging": [
-          "Win32_System_WinRT_Graphics"
-        ],
-        "Win32_System_WinRT_Holographic": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Isolation": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_ML": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Media": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Pdf": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Printing": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Shell": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WinRT_Storage": [
-          "Win32_System_WinRT"
-        ],
-        "Win32_System_WindowsProgramming": [
-          "Win32_System"
-        ],
-        "Win32_System_WindowsSync": [
-          "Win32_System"
-        ],
-        "Win32_System_Wmi": [
-          "Win32_System"
-        ],
-        "Win32_UI": [
-          "Win32"
-        ],
-        "Win32_UI_Accessibility": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Animation": [
-          "Win32_UI"
-        ],
-        "Win32_UI_ColorSystem": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Controls": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Controls_Dialogs": [
-          "Win32_UI_Controls"
-        ],
-        "Win32_UI_Controls_RichEdit": [
-          "Win32_UI_Controls"
-        ],
-        "Win32_UI_HiDpi": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Input": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Input_Ime": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_Ink": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_KeyboardAndMouse": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_Pointer": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_Radial": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_Touch": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_XboxController": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_InteractionContext": [
-          "Win32_UI"
-        ],
-        "Win32_UI_LegacyWindowsEnvironmentFeatures": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Magnification": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Notifications": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Ribbon": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Shell": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Shell_Common": [
-          "Win32_UI_Shell"
-        ],
-        "Win32_UI_Shell_PropertiesSystem": [
-          "Win32_UI_Shell"
-        ],
-        "Win32_UI_TabletPC": [
-          "Win32_UI"
-        ],
-        "Win32_UI_TextServices": [
-          "Win32_UI"
-        ],
-        "Win32_UI_WindowsAndMessaging": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Wpf": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Xaml": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Xaml_Diagnostics": [
-          "Win32_UI_Xaml"
-        ],
-        "default": [],
-        "deprecated": []
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "targets": [],
-            "all-features": true
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": "readme.md",
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.49"
-    },
-    {
-      "name": "windows-sys",
-      "version": "0.45.0",
-      "id": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Rust for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "windows-targets",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "cfg(not(windows_raw_dylib))",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows-sys",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.45.0/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {
-        "Win32": [],
-        "Win32_Data": [
-          "Win32"
-        ],
-        "Win32_Data_HtmlHelp": [
-          "Win32_Data"
-        ],
-        "Win32_Data_RightsManagement": [
-          "Win32_Data"
-        ],
-        "Win32_Data_Xml": [
-          "Win32_Data"
-        ],
-        "Win32_Data_Xml_MsXml": [
-          "Win32_Data_Xml"
-        ],
-        "Win32_Data_Xml_XmlLite": [
-          "Win32_Data_Xml"
-        ],
-        "Win32_Devices": [
-          "Win32"
-        ],
-        "Win32_Devices_AllJoyn": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_BiometricFramework": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Bluetooth": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Communication": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_DeviceAccess": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_DeviceAndDriverInstallation": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_DeviceQuery": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Display": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Enumeration": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Enumeration_Pnp": [
-          "Win32_Devices_Enumeration"
-        ],
-        "Win32_Devices_Fax": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_FunctionDiscovery": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Geolocation": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_HumanInterfaceDevice": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_ImageAcquisition": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_PortableDevices": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Properties": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Pwm": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Sensors": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_SerialCommunication": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Tapi": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_Usb": [
-          "Win32_Devices"
-        ],
-        "Win32_Devices_WebServicesOnDevices": [
-          "Win32_Devices"
-        ],
-        "Win32_Foundation": [
-          "Win32"
-        ],
-        "Win32_Gaming": [
-          "Win32"
-        ],
-        "Win32_Globalization": [
-          "Win32"
-        ],
-        "Win32_Graphics": [
-          "Win32"
-        ],
-        "Win32_Graphics_Dwm": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Gdi": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Hlsl": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_OpenGL": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Printing": [
-          "Win32_Graphics"
-        ],
-        "Win32_Graphics_Printing_PrintTicket": [
-          "Win32_Graphics_Printing"
-        ],
-        "Win32_Management": [
-          "Win32"
-        ],
-        "Win32_Management_MobileDeviceManagementRegistration": [
-          "Win32_Management"
-        ],
-        "Win32_Media": [
-          "Win32"
-        ],
-        "Win32_Media_Audio": [
-          "Win32_Media"
-        ],
-        "Win32_Media_Audio_Apo": [
-          "Win32_Media_Audio"
-        ],
-        "Win32_Media_Audio_DirectMusic": [
-          "Win32_Media_Audio"
-        ],
-        "Win32_Media_Audio_Endpoints": [
-          "Win32_Media_Audio"
-        ],
-        "Win32_Media_Audio_XAudio2": [
-          "Win32_Media_Audio"
-        ],
-        "Win32_Media_DeviceManager": [
-          "Win32_Media"
-        ],
-        "Win32_Media_DxMediaObjects": [
-          "Win32_Media"
-        ],
-        "Win32_Media_KernelStreaming": [
-          "Win32_Media"
-        ],
-        "Win32_Media_LibrarySharingServices": [
-          "Win32_Media"
-        ],
-        "Win32_Media_MediaPlayer": [
-          "Win32_Media"
-        ],
-        "Win32_Media_Multimedia": [
-          "Win32_Media"
-        ],
-        "Win32_Media_Speech": [
-          "Win32_Media"
-        ],
-        "Win32_Media_Streaming": [
-          "Win32_Media"
-        ],
-        "Win32_Media_WindowsMediaFormat": [
-          "Win32_Media"
-        ],
-        "Win32_NetworkManagement": [
-          "Win32"
-        ],
-        "Win32_NetworkManagement_Dhcp": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Dns": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_InternetConnectionWizard": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_IpHelper": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_MobileBroadband": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Multicast": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Ndis": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetBios": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetManagement": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetShell": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetworkDiagnosticsFramework": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_NetworkPolicyServer": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_P2P": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_QoS": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Rras": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_Snmp": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WNet": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WebDav": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WiFi": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsConnectNow": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsConnectionManager": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsFilteringPlatform": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsFirewall": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_NetworkManagement_WindowsNetworkVirtualization": [
-          "Win32_NetworkManagement"
-        ],
-        "Win32_Networking": [
-          "Win32"
-        ],
-        "Win32_Networking_ActiveDirectory": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_BackgroundIntelligentTransferService": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_Clustering": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_HttpServer": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_Ldap": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_NetworkListManager": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_RemoteDifferentialCompression": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WebSocket": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WinHttp": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WinInet": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WinSock": [
-          "Win32_Networking"
-        ],
-        "Win32_Networking_WindowsWebServices": [
-          "Win32_Networking"
-        ],
-        "Win32_Security": [
-          "Win32"
-        ],
-        "Win32_Security_AppLocker": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Authentication": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Authentication_Identity": [
-          "Win32_Security_Authentication"
-        ],
-        "Win32_Security_Authentication_Identity_Provider": [
-          "Win32_Security_Authentication_Identity"
-        ],
-        "Win32_Security_Authorization": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Authorization_UI": [
-          "Win32_Security_Authorization"
-        ],
-        "Win32_Security_ConfigurationSnapin": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Credentials": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Cryptography": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Cryptography_Catalog": [
-          "Win32_Security_Cryptography"
-        ],
-        "Win32_Security_Cryptography_Certificates": [
-          "Win32_Security_Cryptography"
-        ],
-        "Win32_Security_Cryptography_Sip": [
-          "Win32_Security_Cryptography"
-        ],
-        "Win32_Security_Cryptography_UI": [
-          "Win32_Security_Cryptography"
-        ],
-        "Win32_Security_DiagnosticDataQuery": [
-          "Win32_Security"
-        ],
-        "Win32_Security_DirectoryServices": [
-          "Win32_Security"
-        ],
-        "Win32_Security_EnterpriseData": [
-          "Win32_Security"
-        ],
-        "Win32_Security_ExtensibleAuthenticationProtocol": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Isolation": [
-          "Win32_Security"
-        ],
-        "Win32_Security_LicenseProtection": [
-          "Win32_Security"
-        ],
-        "Win32_Security_NetworkAccessProtection": [
-          "Win32_Security"
-        ],
-        "Win32_Security_Tpm": [
-          "Win32_Security"
-        ],
-        "Win32_Security_WinTrust": [
-          "Win32_Security"
-        ],
-        "Win32_Security_WinWlx": [
-          "Win32_Security"
-        ],
-        "Win32_Storage": [
-          "Win32"
-        ],
-        "Win32_Storage_Cabinets": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_CloudFilters": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Compression": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_DataDeduplication": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_DistributedFileSystem": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_EnhancedStorage": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_FileHistory": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_FileServerResourceManager": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_FileSystem": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Imapi": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_IndexServer": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_InstallableFileSystems": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_IscsiDisc": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Jet": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_OfflineFiles": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_OperationRecorder": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Packaging": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Packaging_Appx": [
-          "Win32_Storage_Packaging"
-        ],
-        "Win32_Storage_Packaging_Opc": [
-          "Win32_Storage_Packaging"
-        ],
-        "Win32_Storage_ProjectedFileSystem": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_StructuredStorage": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Vhd": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_VirtualDiskService": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Vss": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Xps": [
-          "Win32_Storage"
-        ],
-        "Win32_Storage_Xps_Printing": [
-          "Win32_Storage_Xps"
-        ],
-        "Win32_System": [
-          "Win32"
-        ],
-        "Win32_System_AddressBook": [
-          "Win32_System"
-        ],
-        "Win32_System_Antimalware": [
-          "Win32_System"
-        ],
-        "Win32_System_ApplicationInstallationAndServicing": [
-          "Win32_System"
-        ],
-        "Win32_System_ApplicationVerifier": [
-          "Win32_System"
-        ],
-        "Win32_System_AssessmentTool": [
-          "Win32_System"
-        ],
-        "Win32_System_Com": [
-          "Win32_System"
-        ],
-        "Win32_System_Com_CallObj": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_ChannelCredentials": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_Events": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_Marshal": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_StructuredStorage": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_UI": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_Com_Urlmon": [
-          "Win32_System_Com"
-        ],
-        "Win32_System_ComponentServices": [
-          "Win32_System"
-        ],
-        "Win32_System_Console": [
-          "Win32_System"
-        ],
-        "Win32_System_Contacts": [
-          "Win32_System"
-        ],
-        "Win32_System_CorrelationVector": [
-          "Win32_System"
-        ],
-        "Win32_System_DataExchange": [
-          "Win32_System"
-        ],
-        "Win32_System_DeploymentServices": [
-          "Win32_System"
-        ],
-        "Win32_System_DesktopSharing": [
-          "Win32_System"
-        ],
-        "Win32_System_DeveloperLicensing": [
-          "Win32_System"
-        ],
-        "Win32_System_Diagnostics": [
-          "Win32_System"
-        ],
-        "Win32_System_Diagnostics_Ceip": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_Diagnostics_Debug": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_Diagnostics_Etw": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_Diagnostics_ProcessSnapshotting": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_Diagnostics_ToolHelp": [
-          "Win32_System_Diagnostics"
-        ],
-        "Win32_System_DistributedTransactionCoordinator": [
-          "Win32_System"
-        ],
-        "Win32_System_Environment": [
-          "Win32_System"
-        ],
-        "Win32_System_ErrorReporting": [
-          "Win32_System"
-        ],
-        "Win32_System_EventCollector": [
-          "Win32_System"
-        ],
-        "Win32_System_EventLog": [
-          "Win32_System"
-        ],
-        "Win32_System_EventNotificationService": [
-          "Win32_System"
-        ],
-        "Win32_System_GroupPolicy": [
-          "Win32_System"
-        ],
-        "Win32_System_HostCompute": [
-          "Win32_System"
-        ],
-        "Win32_System_HostComputeNetwork": [
-          "Win32_System"
-        ],
-        "Win32_System_HostComputeSystem": [
-          "Win32_System"
-        ],
-        "Win32_System_Hypervisor": [
-          "Win32_System"
-        ],
-        "Win32_System_IO": [
-          "Win32_System"
-        ],
-        "Win32_System_Iis": [
-          "Win32_System"
-        ],
-        "Win32_System_Ioctl": [
-          "Win32_System"
-        ],
-        "Win32_System_JobObjects": [
-          "Win32_System"
-        ],
-        "Win32_System_Js": [
-          "Win32_System"
-        ],
-        "Win32_System_Kernel": [
-          "Win32_System"
-        ],
-        "Win32_System_LibraryLoader": [
-          "Win32_System"
-        ],
-        "Win32_System_Mailslots": [
-          "Win32_System"
-        ],
-        "Win32_System_Mapi": [
-          "Win32_System"
-        ],
-        "Win32_System_Memory": [
-          "Win32_System"
-        ],
-        "Win32_System_Memory_NonVolatile": [
-          "Win32_System_Memory"
-        ],
-        "Win32_System_MessageQueuing": [
-          "Win32_System"
-        ],
-        "Win32_System_MixedReality": [
-          "Win32_System"
-        ],
-        "Win32_System_Mmc": [
-          "Win32_System"
-        ],
-        "Win32_System_Ole": [
-          "Win32_System"
-        ],
-        "Win32_System_ParentalControls": [
-          "Win32_System"
-        ],
-        "Win32_System_PasswordManagement": [
-          "Win32_System"
-        ],
-        "Win32_System_Performance": [
-          "Win32_System"
-        ],
-        "Win32_System_Performance_HardwareCounterProfiling": [
-          "Win32_System_Performance"
-        ],
-        "Win32_System_Pipes": [
-          "Win32_System"
-        ],
-        "Win32_System_Power": [
-          "Win32_System"
-        ],
-        "Win32_System_ProcessStatus": [
-          "Win32_System"
-        ],
-        "Win32_System_RealTimeCommunications": [
-          "Win32_System"
-        ],
-        "Win32_System_Recovery": [
-          "Win32_System"
-        ],
-        "Win32_System_Registry": [
-          "Win32_System"
-        ],
-        "Win32_System_RemoteAssistance": [
-          "Win32_System"
-        ],
-        "Win32_System_RemoteDesktop": [
-          "Win32_System"
-        ],
-        "Win32_System_RemoteManagement": [
-          "Win32_System"
-        ],
-        "Win32_System_RestartManager": [
-          "Win32_System"
-        ],
-        "Win32_System_Restore": [
-          "Win32_System"
-        ],
-        "Win32_System_Rpc": [
-          "Win32_System"
-        ],
-        "Win32_System_Search": [
-          "Win32_System"
-        ],
-        "Win32_System_Search_Common": [
-          "Win32_System_Search"
-        ],
-        "Win32_System_SecurityCenter": [
-          "Win32_System"
-        ],
-        "Win32_System_ServerBackup": [
-          "Win32_System"
-        ],
-        "Win32_System_Services": [
-          "Win32_System"
-        ],
-        "Win32_System_SettingsManagementInfrastructure": [
-          "Win32_System"
-        ],
-        "Win32_System_SetupAndMigration": [
-          "Win32_System"
-        ],
-        "Win32_System_Shutdown": [
-          "Win32_System"
-        ],
-        "Win32_System_StationsAndDesktops": [
-          "Win32_System"
-        ],
-        "Win32_System_SubsystemForLinux": [
-          "Win32_System"
-        ],
-        "Win32_System_SystemInformation": [
-          "Win32_System"
-        ],
-        "Win32_System_SystemServices": [
-          "Win32_System"
-        ],
-        "Win32_System_TaskScheduler": [
-          "Win32_System"
-        ],
-        "Win32_System_Threading": [
-          "Win32_System"
-        ],
-        "Win32_System_Time": [
-          "Win32_System"
-        ],
-        "Win32_System_TpmBaseServices": [
-          "Win32_System"
-        ],
-        "Win32_System_UpdateAgent": [
-          "Win32_System"
-        ],
-        "Win32_System_UpdateAssessment": [
-          "Win32_System"
-        ],
-        "Win32_System_UserAccessLogging": [
-          "Win32_System"
-        ],
-        "Win32_System_VirtualDosMachines": [
-          "Win32_System"
-        ],
-        "Win32_System_WindowsProgramming": [
-          "Win32_System"
-        ],
-        "Win32_System_WindowsSync": [
-          "Win32_System"
-        ],
-        "Win32_System_Wmi": [
-          "Win32_System"
-        ],
-        "Win32_UI": [
-          "Win32"
-        ],
-        "Win32_UI_Accessibility": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Animation": [
-          "Win32_UI"
-        ],
-        "Win32_UI_ColorSystem": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Controls": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Controls_Dialogs": [
-          "Win32_UI_Controls"
-        ],
-        "Win32_UI_Controls_RichEdit": [
-          "Win32_UI_Controls"
-        ],
-        "Win32_UI_HiDpi": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Input": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Input_Ime": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_Ink": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_KeyboardAndMouse": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_Pointer": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_Radial": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_Touch": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_Input_XboxController": [
-          "Win32_UI_Input"
-        ],
-        "Win32_UI_InteractionContext": [
-          "Win32_UI"
-        ],
-        "Win32_UI_LegacyWindowsEnvironmentFeatures": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Magnification": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Notifications": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Ribbon": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Shell": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Shell_Common": [
-          "Win32_UI_Shell"
-        ],
-        "Win32_UI_Shell_PropertiesSystem": [
-          "Win32_UI_Shell"
-        ],
-        "Win32_UI_TabletPC": [
-          "Win32_UI"
-        ],
-        "Win32_UI_TextServices": [
-          "Win32_UI"
-        ],
-        "Win32_UI_WindowsAndMessaging": [
-          "Win32_UI"
-        ],
-        "Win32_UI_Wpf": [
-          "Win32_UI"
-        ],
-        "default": []
-      },
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.45.0/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "targets": [],
-            "all-features": true
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": "readme.md",
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.48"
-    },
-    {
-      "name": "windows-targets",
-      "version": "0.42.2",
-      "id": "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Import libs for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "windows_aarch64_gnullvm",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "aarch64-pc-windows-gnullvm",
-          "registry": null
-        },
-        {
-          "name": "windows_aarch64_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "aarch64-pc-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_aarch64_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "aarch64-uwp-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_i686_gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "i686-pc-windows-gnu",
-          "registry": null
-        },
-        {
-          "name": "windows_i686_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "i686-pc-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_i686_gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "i686-uwp-windows-gnu",
-          "registry": null
-        },
-        {
-          "name": "windows_i686_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "i686-uwp-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-pc-windows-gnu",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_gnullvm",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-pc-windows-gnullvm",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-pc-windows-msvc",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_gnu",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-uwp-windows-gnu",
-          "registry": null
-        },
-        {
-          "name": "windows_x86_64_msvc",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.42.2",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": "x86_64-uwp-windows-msvc",
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows-targets",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows-targets-0.42.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows-targets-0.42.2/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "windows_aarch64_gnullvm",
-      "version": "0.42.2",
-      "id": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Import lib for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows_aarch64_gnullvm",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.2/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.2/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "targets": []
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "windows_aarch64_msvc",
-      "version": "0.42.2",
-      "id": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Import lib for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows_aarch64_msvc",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.2/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.2/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "targets": []
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "windows_i686_gnu",
-      "version": "0.42.2",
-      "id": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Import lib for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows_i686_gnu",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.2/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.2/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "targets": []
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "windows_i686_msvc",
-      "version": "0.42.2",
-      "id": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Import lib for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows_i686_msvc",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.2/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.2/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "targets": []
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "windows_x86_64_gnu",
-      "version": "0.42.2",
-      "id": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Import lib for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows_x86_64_gnu",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.2/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.2/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "targets": []
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "windows_x86_64_gnullvm",
-      "version": "0.42.2",
-      "id": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Import lib for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows_x86_64_gnullvm",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.2/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.2/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "targets": []
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "windows_x86_64_msvc",
-      "version": "0.42.2",
-      "id": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Import lib for Windows",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "windows_x86_64_msvc",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.2/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.2/build.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "/home/gabe/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.2/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "default-target": "x86_64-pc-windows-msvc",
-            "targets": []
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Microsoft"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": "https://github.com/microsoft/windows-rs",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    }
-  ],
-  "workspace_members": [
-    "crate-with-optional-deps 0.1.0 (path+file:///home/gabe/Development/rules_rust/crate_universe/test_data/metadata/crate_optional_deps_enabled)"
-  ],
-  "resolve": {
-    "nodes": [
-      {
-        "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": [
-          "default"
-        ]
-      },
-      {
-        "id": "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-          "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-          "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
             "name": "bitflags",
-            "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "clap_lex",
-            "pkg": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "is_terminal",
-            "pkg": "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "termcolor",
-            "pkg": "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": [
-          "color"
-        ]
-      },
-      {
-        "id": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "os_str_bytes",
-            "pkg": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "crate-with-optional-deps 0.1.0 (path+file:///home/gabe/Development/rules_rust/crate_universe/test_data/metadata/crate_optional_deps_enabled)",
-        "dependencies": [
-          "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "clap",
-            "pkg": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "notify",
-            "pkg": "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-          "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "cfg_if",
-            "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "crossbeam_utils",
-            "pkg": "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": [
-          "crossbeam-utils",
-          "default",
-          "std"
-        ]
-      },
-      {
-        "id": "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "cfg_if",
-            "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": [
-          "std"
-        ]
-      },
-      {
-        "id": "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-          "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "errno_dragonfly",
-            "pkg": "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"dragonfly\")"
-              }
-            ]
-          },
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(unix)"
-              },
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"hermit\")"
-              },
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"wasi\")"
-              }
-            ]
-          },
-          {
-            "name": "winapi",
-            "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
+            "version": "1.3.2",
+            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A macro to generate structures which behave like bitflags.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "walkdir",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bitflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compile",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/tests/compile.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "basic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/tests/basic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [],
+                "example_generated": [],
+                "rustc-dep-of-std": [
+                    "core",
+                    "compiler_builtins"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "example_generated"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "no-std"
+            ],
+            "keywords": [
+                "bit",
+                "bitmask",
+                "bitflags",
+                "flags"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bitflags/bitflags",
+            "homepage": "https://github.com/bitflags/bitflags",
+            "documentation": "https://docs.rs/bitflags",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "cc",
-            "pkg": "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": "build",
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-          "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "cfg_if",
-            "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(unix)"
-              }
-            ]
-          },
-          {
-            "name": "syscall",
-            "pkg": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"redox\")"
-              }
-            ]
-          },
-          {
-            "name": "windows_sys",
-            "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": [
-          "default"
-        ]
-      },
-      {
-        "id": "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "bitflags",
-            "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "inotify_sys",
-            "pkg": "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "hermit_abi",
-            "pkg": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"hermit\")"
-              }
-            ]
-          },
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(not(windows))"
-              }
-            ]
-          },
-          {
-            "name": "windows_sys",
-            "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": [
-          "close",
-          "default",
-          "hermit-abi",
-          "libc",
-          "windows-sys"
-        ]
-      },
-      {
-        "id": "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-          "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "hermit_abi",
-            "pkg": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"hermit\")"
-              }
-            ]
-          },
-          {
-            "name": "io_lifetimes",
-            "pkg": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "rustix",
-            "pkg": "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))"
-              }
-            ]
-          },
-          {
-            "name": "windows_sys",
-            "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "kqueue_sys",
-            "pkg": "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "bitflags",
-            "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": [
-          "default",
-          "extra_traits",
-          "std"
-        ]
-      },
-      {
-        "id": "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": [
-          "errno",
-          "general",
-          "ioctl",
-          "no_std"
-        ]
-      },
-      {
-        "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "cfg_if",
-            "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-          "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-          "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(unix)"
-              },
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"wasi\")"
-              }
-            ]
-          },
-          {
-            "name": "log",
-            "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "wasi",
-            "pkg": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"wasi\")"
-              }
-            ]
-          },
-          {
-            "name": "windows_sys",
-            "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": [
-          "default",
-          "os-ext",
-          "os-poll"
-        ]
-      },
-      {
-        "id": "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
-          "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
-          "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-          "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
-          "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-          "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
-          "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "bitflags",
-            "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "crossbeam_channel",
-            "pkg": "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
+            "version": "1.0.79",
+            "id": "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A build-time dependency for Cargo build scripts to assist in invoking the native\nC compiler to compile native C code into a static archive to be linked into Rust\ncode.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "jobserver",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.16",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bin"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "gcc-shim",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/src/bin/gcc-shim.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cxxflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/tests/cxxflags.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/tests/cflags.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cc_env",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/tests/cc_env.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "jobserver": [
+                    "dep:jobserver"
+                ],
+                "parallel": [
+                    "jobserver"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.79/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "development-tools::build-utils"
+            ],
+            "keywords": [
+                "build-dependencies"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/cc-rs",
+            "homepage": "https://github.com/rust-lang/cc-rs",
+            "documentation": "https://docs.rs/cc",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cfg-if",
+            "version": "1.0.0",
+            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A macro to ergonomically define an item depending on a large number of #[cfg]\nparameters. Structured like an if-else chain, the first matching branch is the\nitem that gets emitted.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cfg-if",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xcrate",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/tests/xcrate.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "rustc-dep-of-std": [
+                    "core",
+                    "compiler_builtins"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/alexcrichton/cfg-if",
+            "homepage": "https://github.com/alexcrichton/cfg-if",
+            "documentation": "https://docs.rs/cfg-if",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "clap",
+            "version": "4.1.1",
+            "id": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A simple to use, efficient, and full-featured Command Line Argument Parser",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "backtrace",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "clap_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=4.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "clap_lex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "is-terminal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "once_cell",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.12.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "strsim",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "terminal_size",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicase",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-width",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "humantime",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "shlex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "snapbox",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "static_assertions",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.73",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trycmd",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "color-auto",
+                        "diff",
+                        "examples"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unic-emoji-char",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "clap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bin"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "stdio-fixture",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/src/bin/stdio-fixture.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "demo",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/demo.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cargo-example",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/cargo-example.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cargo-example-derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/cargo-example-derive.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "escaped-positional",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/escaped-positional.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "escaped-positional-derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/escaped-positional-derive.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "find",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/find.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "git-derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/git-derive.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "typed-derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/typed-derive.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "busybox",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/multicall-busybox.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hostname",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/multicall-hostname.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "repl",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/repl.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "help"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "01_quick",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/01_quick.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "02_apps",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/02_apps.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "02_crate",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/02_crate.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "02_app_settings",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/02_app_settings.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_01_flag_bool",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_01_flag_bool.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_01_flag_count",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_01_flag_count.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_02_option",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_02_option.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_02_option_mult",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_02_option_mult.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_03_positional",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_03_positional.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_03_positional_mult",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_03_positional_mult.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_04_subcommands",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_04_subcommands.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_05_default_values",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/03_05_default_values.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_01_possible",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_01_possible.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_01_enum",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_01_enum.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_02_parse",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_02_parse.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_02_validate",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_02_validate.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_03_relations",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_03_relations.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_04_custom",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/04_04_custom.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "05_01_assert",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_builder/05_01_assert.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "cargo"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "01_quick_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/01_quick.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "02_apps_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/02_apps.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "02_crate_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/02_crate.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "02_app_settings_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/02_app_settings.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_01_flag_bool_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_01_flag_bool.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_01_flag_count_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_01_flag_count.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_02_option_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_02_option.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_02_option_mult_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_02_option_mult.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_03_positional_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_03_positional.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_03_positional_mult_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_03_positional_mult.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_04_subcommands_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_04_subcommands.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_04_subcommands_alt_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_04_subcommands_alt.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "03_05_default_values_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/03_05_default_values.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_01_enum_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_01_enum.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_02_parse_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_02_parse.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_02_validate_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_02_validate.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_03_relations_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_03_relations.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "04_04_custom_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/04_04_custom.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "05_01_assert_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/tutorial_derive/05_01_assert.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "interop_augment_args",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/derive_ref/augment_args.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "interop_augment_subcommands",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/derive_ref/augment_subcommands.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "interop_hand_subcommand",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/derive_ref/hand_subcommand.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "interop_flatten_hand_args",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/derive_ref/flatten_hand_args.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "derive"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "pacman",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/pacman.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "git",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/examples/git.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "cargo": [
+                    "dep:once_cell"
+                ],
+                "color": [
+                    "dep:is-terminal",
+                    "dep:termcolor"
+                ],
+                "debug": [
+                    "clap_derive?/debug",
+                    "dep:backtrace"
+                ],
+                "default": [
+                    "std",
+                    "color",
+                    "help",
+                    "usage",
+                    "error-context",
+                    "suggestions"
+                ],
+                "deprecated": [
+                    "clap_derive?/deprecated"
+                ],
+                "derive": [
+                    "dep:clap_derive",
+                    "dep:once_cell"
+                ],
+                "env": [],
+                "error-context": [],
+                "help": [],
+                "std": [],
+                "string": [],
+                "suggestions": [
+                    "dep:strsim",
+                    "error-context"
+                ],
+                "unicode": [
+                    "dep:unicode-width",
+                    "dep:unicase"
+                ],
+                "unstable-doc": [
+                    "derive",
+                    "cargo",
+                    "wrap_help",
+                    "env",
+                    "unicode",
+                    "string",
+                    "unstable-replace"
+                ],
+                "unstable-grouped": [],
+                "unstable-replace": [],
+                "unstable-v5": [
+                    "clap_derive?/unstable-v5",
+                    "deprecated"
+                ],
+                "usage": [],
+                "wrap_help": [
+                    "help",
+                    "dep:terminal_size"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap-4.1.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "cargo-args": [
+                            "-Zunstable-options",
+                            "-Zrustdoc-scrape-examples"
+                        ],
+                        "features": [
+                            "unstable-doc"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "unstable-doc"
+                    ]
+                },
+                "release": {
+                    "shared-version": true,
+                    "tag-name": "v{{version}}",
+                    "pre-release-replacements": [
+                        {
+                            "file": "CHANGELOG.md",
+                            "min": 1,
+                            "replace": "{{version}}",
+                            "search": "Unreleased"
+                        },
+                        {
+                            "exactly": 1,
+                            "file": "CHANGELOG.md",
+                            "replace": "...{{tag_name}}",
+                            "search": "\\.\\.\\.HEAD"
+                        },
+                        {
+                            "file": "CHANGELOG.md",
+                            "min": 1,
+                            "replace": "{{date}}",
+                            "search": "ReleaseDate"
+                        },
+                        {
+                            "exactly": 1,
+                            "file": "CHANGELOG.md",
+                            "replace": "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n",
+                            "search": "<!-- next-header -->"
+                        },
+                        {
+                            "exactly": 1,
+                            "file": "CHANGELOG.md",
+                            "replace": "<!-- next-url -->\n[Unreleased]: https://github.com/clap-rs/clap/compare/{{tag_name}}...HEAD",
+                            "search": "<!-- next-url -->"
+                        }
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "command-line-interface"
+            ],
+            "keywords": [
+                "argument",
+                "cli",
+                "arg",
+                "parser",
+                "parse"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/clap-rs/clap",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.64.0"
+        },
+        {
+            "name": "clap_lex",
+            "version": "0.3.3",
+            "id": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Minimal, flexible command line parser",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "os_str_bytes",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^6.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "raw_os_str"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "clap_lex",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap_lex-0.3.3/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/clap_lex-0.3.3/Cargo.toml",
+            "metadata": {
+                "release": {
+                    "pre-release-replacements": [
+                        {
+                            "file": "CHANGELOG.md",
+                            "min": 1,
+                            "replace": "{{version}}",
+                            "search": "Unreleased"
+                        },
+                        {
+                            "exactly": 1,
+                            "file": "CHANGELOG.md",
+                            "replace": "...{{tag_name}}",
+                            "search": "\\.\\.\\.HEAD"
+                        },
+                        {
+                            "file": "CHANGELOG.md",
+                            "min": 1,
+                            "replace": "{{date}}",
+                            "search": "ReleaseDate"
+                        },
+                        {
+                            "exactly": 1,
+                            "file": "CHANGELOG.md",
+                            "replace": "<!-- next-header -->\n## [Unreleased] - ReleaseDate\n",
+                            "search": "<!-- next-header -->"
+                        },
+                        {
+                            "exactly": 1,
+                            "file": "CHANGELOG.md",
+                            "replace": "<!-- next-url -->\n[Unreleased]: https://github.com/clap-rs/clap/compare/{{tag_name}}...HEAD",
+                            "search": "<!-- next-url -->"
+                        },
+                        {
+                            "exactly": 4,
+                            "file": "README.md",
+                            "prerelease": true,
+                            "replace": "github.com/clap-rs/clap/blob/{{tag_name}}/",
+                            "search": "github.com/clap-rs/clap/blob/[^/]+/"
+                        }
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "command-line-interface"
+            ],
+            "keywords": [
+                "argument",
+                "cli",
+                "arg",
+                "parser",
+                "parse"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/clap-rs/clap/tree/master/clap_lex",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.64.0"
+        },
+        {
+            "name": "crate-with-optional-deps",
+            "version": "0.1.0",
+            "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_enabled)",
+            "license": null,
+            "license_file": null,
+            "description": null,
+            "source": null,
+            "dependencies": [
+                {
+                    "name": "clap",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=4.1.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "color"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "notify",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^5.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "crate-with-optional-deps",
+                    "src_path": "{TEMP_DIR}/crate_optional_deps_enabled/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{TEMP_DIR}/crate_optional_deps_enabled/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "crossbeam-channel",
+            "version": "0.5.7",
+            "id": "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Multi-producer multi-consumer channels for message passing",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "crossbeam-utils",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "num_cpus",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.13.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "signal-hook",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "crossbeam-channel",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fibonacci",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/examples/fibonacci.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "matching",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/examples/matching.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "stopwatch",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/examples/stopwatch.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "same_channel",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/same_channel.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "zero",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/zero.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "after",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/after.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "never",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/never.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "list",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/list.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "iter",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/iter.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "mpsc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/mpsc.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "select_macro",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/select_macro.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "select",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/select.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "array",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/array.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "golang",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/golang.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tick",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/tick.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "ready",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/ready.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "thread_locals",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/tests/thread_locals.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "crossbeam",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/benches/crossbeam.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "crossbeam-utils": [
+                    "dep:crossbeam-utils"
+                ],
+                "default": [
+                    "std"
+                ],
+                "std": [
+                    "crossbeam-utils/std"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-channel-0.5.7/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "algorithms",
+                "concurrency",
+                "data-structures"
+            ],
+            "keywords": [
+                "channel",
+                "mpmc",
+                "select",
+                "golang",
+                "message"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/crossbeam-rs/crossbeam",
+            "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.38"
+        },
+        {
+            "name": "crossbeam-utils",
+            "version": "0.8.15",
+            "id": "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Utilities for concurrent programming",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "loom",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(crossbeam_loom)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "crossbeam-utils",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wait_group",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/wait_group.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sharded_lock",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/sharded_lock.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "thread",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/thread.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cache_padded",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/cache_padded.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "atomic_cell",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/atomic_cell.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "parker",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/tests/parker.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "atomic_cell",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/benches/atomic_cell.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "loom": [
+                    "dep:loom"
+                ],
+                "nightly": [],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.8.15/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "algorithms",
+                "concurrency",
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "scoped",
+                "thread",
+                "atomic",
+                "cache"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/crossbeam-rs/crossbeam",
+            "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.38"
+        },
+        {
+            "name": "errno",
+            "version": "0.2.8",
+            "id": "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Cross-platform interface to the `errno` variable.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "errno-dragonfly",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"dragonfly\")",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"hermit\")",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"wasi\")",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "errhandlingapi",
+                        "minwindef",
+                        "ntdef",
+                        "winbase"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "errno",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/errno-0.2.8/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/errno-0.2.8/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Chris Wong <lambda.fairy@gmail.com>"
+            ],
+            "categories": [
+                "os"
+            ],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/lambda-fairy/rust-errno",
+            "homepage": null,
+            "documentation": "https://docs.rs/errno",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "errno-dragonfly",
+            "version": "0.1.2",
+            "id": "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Exposes errno functionality to stable Rust on DragonFlyBSD",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "errno-dragonfly",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/errno-dragonfly-0.1.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/errno-dragonfly-0.1.2/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/errno-dragonfly-0.1.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Michael Neumann <mneumann@ntecs.de>"
+            ],
+            "categories": [],
+            "keywords": [
+                "dragonfly"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/mneumann/errno-dragonfly-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "filetime",
-            "pkg": "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "fsevent_sys",
-            "pkg": "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"macos\")"
-              }
-            ]
-          },
-          {
+            "version": "0.2.20",
+            "id": "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Platform-agnostic accessors of timestamps in File metadata\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "redox_syscall",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"redox\")",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.27",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.45.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Win32_Foundation",
+                        "Win32_Storage_FileSystem"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "filetime",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/filetime-0.2.20/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/filetime-0.2.20/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "timestamp",
+                "mtime"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/alexcrichton/filetime",
+            "homepage": "https://github.com/alexcrichton/filetime",
+            "documentation": "https://docs.rs/filetime",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "fsevent-sys",
+            "version": "4.1.0",
+            "id": "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Rust bindings to the fsevent macOS API for file changes notifications",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.68",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "fsevent-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/fsevent-sys-4.1.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/fsevent-sys-4.1.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-apple-darwin"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Pierre Baillet <pierre@baillet.name>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/octplane/fsevent-rust/tree/master/fsevent-sys",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "hermit-abi",
+            "version": "0.3.1",
+            "id": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Hermit system calls definitions.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "rustc-std-workspace-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "alloc",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "hermit-abi",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hermit-abi-0.3.1/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "alloc": [
+                    "dep:alloc"
+                ],
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [],
+                "rustc-dep-of-std": [
+                    "core",
+                    "alloc",
+                    "compiler_builtins/rustc-dep-of-std"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hermit-abi-0.3.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Stefan Lankes"
+            ],
+            "categories": [
+                "os"
+            ],
+            "keywords": [
+                "unikernel",
+                "libos"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/hermitcore/rusty-hermit",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "inotify",
-            "pkg": "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"linux\")"
-              }
-            ]
-          },
-          {
+            "version": "0.9.6",
+            "id": "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "ISC",
+            "license_file": null,
+            "description": "Idiomatic wrapper for inotify",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "futures-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "inotify-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tokio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "net"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "futures-util",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tokio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "macros",
+                        "rt-multi-thread"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "inotify",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/examples/stream.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "stream"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "watch",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/examples/watch.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "main",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/tests/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "stream"
+                ],
+                "futures-core": [
+                    "dep:futures-core"
+                ],
+                "stream": [
+                    "futures-core",
+                    "tokio"
+                ],
+                "tokio": [
+                    "dep:tokio"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/inotify-0.9.6/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Hanno Braun <mail@hannobraun.de>",
+                "Fe\u0301lix Saparelli <me@passcod.name>",
+                "Cristian Kubis <cristian.kubis@tsunix.de>",
+                "Frank Denis <github@pureftpd.org>"
+            ],
+            "categories": [
+                "api-bindings",
+                "filesystem"
+            ],
+            "keywords": [
+                "inotify",
+                "linux"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/hannobraun/inotify",
+            "homepage": null,
+            "documentation": "https://docs.rs/inotify",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "inotify-sys",
+            "version": "0.1.5",
+            "id": "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "ISC",
+            "license_file": null,
+            "description": "inotify bindings for the Rust programming language",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "inotify-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/inotify-sys-0.1.5/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/inotify-sys-0.1.5/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Hanno Braun <hb@hannobraun.de>"
+            ],
+            "categories": [
+                "external-ffi-bindings",
+                "filesystem"
+            ],
+            "keywords": [
+                "inotify",
+                "linux"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/hannobraun/inotify-sys",
+            "homepage": null,
+            "documentation": "https://docs.rs/inotify-sys",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "io-lifetimes",
+            "version": "1.0.9",
+            "id": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "A low-level I/O ownership and borrowing library",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "fs-err",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.6.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "async-std",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.12.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "mio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "net",
+                        "os-ext"
+                    ],
+                    "target": "cfg(not(target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "os_pipe",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "io_safety"
+                    ],
+                    "target": "cfg(not(target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "socket2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "tokio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.6.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "io-std",
+                        "fs",
+                        "net",
+                        "process"
+                    ],
+                    "target": "cfg(not(target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.96",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(windows))",
+                    "registry": null
+                },
+                {
+                    "name": "hermit-abi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"hermit\")",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.45.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "Win32_Foundation",
+                        "Win32_Storage_FileSystem",
+                        "Win32_Networking_WinSock",
+                        "Win32_Security",
+                        "Win32_System_IO",
+                        "Win32_System_Threading"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "io-lifetimes",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/io-lifetimes-1.0.9/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/io-lifetimes-1.0.9/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "async-std": [
+                    "dep:async-std"
+                ],
+                "close": [
+                    "libc",
+                    "hermit-abi",
+                    "windows-sys"
+                ],
+                "default": [
+                    "close"
+                ],
+                "fs-err": [
+                    "dep:fs-err"
+                ],
+                "hermit-abi": [
+                    "dep:hermit-abi"
+                ],
+                "libc": [
+                    "dep:libc"
+                ],
+                "mio": [
+                    "dep:mio"
+                ],
+                "os_pipe": [
+                    "dep:os_pipe"
+                ],
+                "socket2": [
+                    "dep:socket2"
+                ],
+                "tokio": [
+                    "dep:tokio"
+                ],
+                "windows-sys": [
+                    "dep:windows-sys"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/io-lifetimes-1.0.9/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Dan Gohman <dev@sunfishcode.online>"
+            ],
+            "categories": [
+                "os",
+                "rust-patterns"
+            ],
+            "keywords": [
+                "api",
+                "io"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/sunfishcode/io-lifetimes",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "is-terminal",
+            "version": "0.4.5",
+            "id": "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Test whether a given stream is a terminal",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "io-lifetimes",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "atty",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.14",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.110",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(unix, target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "rustix",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.36.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "termios"
+                    ],
+                    "target": "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))",
+                    "registry": null
+                },
+                {
+                    "name": "hermit-abi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"hermit\")",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.45.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Win32_Foundation",
+                        "Win32_Storage_FileSystem",
+                        "Win32_System_Console"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "is-terminal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/is-terminal-0.4.5/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/is-terminal-0.4.5/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "softprops <d.tangren@gmail.com>",
+                "Dan Gohman <dev@sunfishcode.online>"
+            ],
+            "categories": [
+                "command-line-interface"
+            ],
+            "keywords": [
+                "terminal",
+                "tty",
+                "isatty"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/sunfishcode/is-terminal",
+            "homepage": null,
+            "documentation": "http://docs.rs/is-terminal",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.48"
+        },
+        {
             "name": "kqueue",
-            "pkg": "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(any(target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonflybsd\"))"
-              }
-            ]
-          },
-          {
+            "version": "1.0.7",
+            "id": "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "kqueue interface for BSDs",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "kqueue-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.17",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "kqueue",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/kqueue-1.0.7/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "pid",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/kqueue-1.0.7/examples/pid.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/kqueue-1.0.7/examples/file.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/kqueue-1.0.7/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-freebsd",
+                            "x86_64-unknown-dragonfly",
+                            "x86_64-unknown-openbsd",
+                            "x86_64-unknown-netbsd",
+                            "x86_64-apple-darwin"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "William Orr <will@worrbase.com>"
+            ],
+            "categories": [
+                "os::unix-apis",
+                "filesystem"
+            ],
+            "keywords": [
+                "kqueue",
+                "kevent",
+                "bsd"
+            ],
+            "readme": "README.md",
+            "repository": "https://gitlab.com/rust-kqueue/rust-kqueue",
+            "homepage": null,
+            "documentation": "https://docs.worrbase.com/rust/kqueue/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "kqueue-sys",
+            "version": "1.0.3",
+            "id": "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Low-level kqueue interface for BSDs",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.74",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "kqueue-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/kqueue-sys-1.0.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/kqueue-sys-1.0.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "William Orr <will@worrbase.com>",
+                "Daniel (dmilith) Dettlaff <dmilith@me.com>"
+            ],
+            "categories": [
+                "external-ffi-bindings",
+                "no-std",
+                "os::unix-apis",
+                "filesystem"
+            ],
+            "keywords": [
+                "kqueue",
+                "kevent",
+                "bsd",
+                "darwin",
+                "macos"
+            ],
+            "readme": "README.md",
+            "repository": "https://gitlab.com/worr/rust-kqueue-sys",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
+            "version": "0.2.140",
+            "id": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Raw FFI bindings to platform libraries like libc.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "libc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.140/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "const_fn",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.140/tests/const_fn.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.140/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "align": [],
+                "const-extern-fn": [],
+                "default": [
+                    "std"
+                ],
+                "extra_traits": [],
+                "rustc-dep-of-std": [
+                    "align",
+                    "rustc-std-workspace-core"
+                ],
+                "rustc-std-workspace-core": [
+                    "dep:rustc-std-workspace-core"
+                ],
+                "std": [],
+                "use_std": [
+                    "std"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.140/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "const-extern-fn",
+                            "extra_traits"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "external-ffi-bindings",
+                "no-std",
+                "os"
+            ],
+            "keywords": [
+                "libc",
+                "ffi",
+                "bindings",
+                "operating",
+                "system"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/libc",
+            "homepage": "https://github.com/rust-lang/libc",
+            "documentation": "https://docs.rs/libc/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "linux-raw-sys",
+            "version": "0.1.4",
+            "id": "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "Generated bindings for Linux's userspace API",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.49",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.100",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "static_assertions",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "linux-raw-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/linux-raw-sys-0.1.4/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [
+                    "std",
+                    "general",
+                    "errno"
+                ],
+                "errno": [],
+                "general": [],
+                "ioctl": [],
+                "netlink": [],
+                "no_std": [],
+                "rustc-dep-of-std": [
+                    "core",
+                    "compiler_builtins",
+                    "no_std"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/linux-raw-sys-0.1.4/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "default",
+                            "ioctl",
+                            "netlink"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu",
+                            "i686-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Dan Gohman <dev@sunfishcode.online>"
+            ],
+            "categories": [
+                "external-ffi-bindings"
+            ],
+            "keywords": [
+                "linux",
+                "uapi",
+                "ffi"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/sunfishcode/linux-raw-sys",
+            "homepage": null,
+            "documentation": "https://docs.rs/linux-raw-sys",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.48"
+        },
+        {
+            "name": "log",
+            "version": "0.4.17",
+            "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A lightweight logging facade for Rust\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sval",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "value-bag",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sval",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "value-bag",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "test"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "log",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "filters",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/filters.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/macros.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "value",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/benches/value.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "kv_unstable": [
+                    "value-bag"
+                ],
+                "kv_unstable_serde": [
+                    "kv_unstable_std",
+                    "value-bag/serde",
+                    "serde"
+                ],
+                "kv_unstable_std": [
+                    "std",
+                    "kv_unstable",
+                    "value-bag/error"
+                ],
+                "kv_unstable_sval": [
+                    "kv_unstable",
+                    "value-bag/sval",
+                    "sval"
+                ],
+                "max_level_debug": [],
+                "max_level_error": [],
+                "max_level_info": [],
+                "max_level_off": [],
+                "max_level_trace": [],
+                "max_level_warn": [],
+                "release_max_level_debug": [],
+                "release_max_level_error": [],
+                "release_max_level_info": [],
+                "release_max_level_off": [],
+                "release_max_level_trace": [],
+                "release_max_level_warn": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "sval": [
+                    "dep:sval"
+                ],
+                "value-bag": [
+                    "dep:value-bag"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std",
+                            "serde",
+                            "kv_unstable_std",
+                            "kv_unstable_sval",
+                            "kv_unstable_serde"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "development-tools::debugging"
+            ],
+            "keywords": [
+                "logging"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/log",
+            "homepage": null,
+            "documentation": "https://docs.rs/log",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "mio",
-            "pkg": "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(any(target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonflybsd\"))"
-              },
-              {
-                "kind": null,
-                "target": "cfg(target_os = \"linux\")"
-              }
-            ]
-          },
-          {
+            "version": "0.8.6",
+            "id": "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Lightweight non-blocking I/O.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.121",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"wasi\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"wasi\")",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.121",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.45",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Win32_Foundation",
+                        "Win32_Networking_WinSock",
+                        "Win32_Storage_FileSystem",
+                        "Win32_System_IO",
+                        "Win32_System_WindowsProgramming"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "mio",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_server",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/examples/tcp_server.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "os-poll",
+                        "net"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_listenfd_server",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/examples/tcp_listenfd_server.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "os-poll",
+                        "net"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "udp_server",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/examples/udp_server.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "os-poll",
+                        "net"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [],
+                "net": [],
+                "os-ext": [
+                    "os-poll",
+                    "windows-sys/Win32_System_Pipes",
+                    "windows-sys/Win32_Security"
+                ],
+                "os-poll": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/mio-0.8.6/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ],
+                        "targets": [
+                            "aarch64-apple-ios",
+                            "aarch64-linux-android",
+                            "wasm32-wasi",
+                            "x86_64-apple-darwin",
+                            "x86_64-pc-windows-msvc",
+                            "x86_64-unknown-dragonfly",
+                            "x86_64-unknown-freebsd",
+                            "x86_64-unknown-illumos",
+                            "x86_64-unknown-linux-gnu",
+                            "x86_64-unknown-netbsd",
+                            "x86_64-unknown-openbsd"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "os-poll",
+                        "os-ext",
+                        "net"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Carl Lerche <me@carllerche.com>",
+                "Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
+                "Tokio Contributors <team@tokio.rs>"
+            ],
+            "categories": [
+                "asynchronous"
+            ],
+            "keywords": [
+                "io",
+                "async",
+                "non-blocking"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/tokio-rs/mio",
+            "homepage": "https://github.com/tokio-rs/mio",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "notify",
+            "version": "5.1.0",
+            "id": "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "CC0-1.0 OR Artistic-2.0",
+            "license_file": null,
+            "description": "Cross-platform filesystem notification library",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "crossbeam-channel",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "filetime",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.89",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "walkdir",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.2.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "nix",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.23.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.39",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.2.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "kqueue",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonflybsd\"))",
+                    "registry": null
+                },
+                {
+                    "name": "mio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "os-ext"
+                    ],
+                    "target": "cfg(any(target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonflybsd\"))",
+                    "registry": null
+                },
+                {
+                    "name": "inotify",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(target_os = \"linux\")",
+                    "registry": null
+                },
+                {
+                    "name": "mio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "os-ext"
+                    ],
+                    "target": "cfg(target_os = \"linux\")",
+                    "registry": null
+                },
+                {
+                    "name": "fsevent-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"macos\")",
+                    "registry": null
+                },
+                {
+                    "name": "kqueue",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"macos\")",
+                    "registry": null
+                },
+                {
+                    "name": "mio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "os-ext"
+                    ],
+                    "target": "cfg(target_os = \"macos\")",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Win32_System_Threading",
+                        "Win32_Foundation",
+                        "Win32_Storage_FileSystem",
+                        "Win32_Security",
+                        "Win32_System_WindowsProgramming",
+                        "Win32_System_IO"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "notify",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/notify-5.1.0/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "crossbeam-channel": [
+                    "dep:crossbeam-channel"
+                ],
+                "default": [
+                    "macos_fsevent",
+                    "crossbeam-channel"
+                ],
+                "fsevent-sys": [
+                    "dep:fsevent-sys"
+                ],
+                "kqueue": [
+                    "dep:kqueue"
+                ],
+                "macos_fsevent": [
+                    "fsevent-sys"
+                ],
+                "macos_kqueue": [
+                    "kqueue",
+                    "mio"
+                ],
+                "manual_tests": [],
+                "mio": [
+                    "dep:mio"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "timing_tests": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/notify-5.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "F\u00e9lix Saparelli <me@passcod.name>",
+                "Daniel Faust <hessijames@gmail.com>"
+            ],
+            "categories": [
+                "filesystem"
+            ],
+            "keywords": [
+                "events",
+                "filesystem",
+                "notify",
+                "watch"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/notify-rs/notify.git",
+            "homepage": "https://github.com/notify-rs/notify",
+            "documentation": "https://docs.rs/notify",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "os_str_bytes",
+            "version": "6.5.0",
+            "id": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Convert between byte sequences and platform-native strings\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "memchr",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "print_bytes",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "uniquote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fastrand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "os_str_bytes",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/os_str_bytes-6.5.0/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "checked_conversions": [],
+                "default": [
+                    "memchr",
+                    "raw_os_str"
+                ],
+                "memchr": [
+                    "dep:memchr"
+                ],
+                "print_bytes": [
+                    "dep:print_bytes"
+                ],
+                "raw_os_str": [],
+                "uniquote": [
+                    "dep:uniquote"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/os_str_bytes-6.5.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustc-args": [
+                            "--cfg",
+                            "os_str_bytes_docs_rs"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "os_str_bytes_docs_rs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "dylni"
+            ],
+            "categories": [
+                "command-line-interface",
+                "development-tools::ffi",
+                "encoding",
+                "os",
+                "rust-patterns"
+            ],
+            "keywords": [
+                "bytes",
+                "osstr",
+                "osstring",
+                "path",
+                "windows"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dylni/os_str_bytes",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.57.0"
+        },
+        {
+            "name": "redox_syscall",
+            "version": "0.2.16",
+            "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "A Rust library to access raw Redox system calls",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "syscall",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/redox_syscall-0.2.16/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/redox_syscall-0.2.16/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Jeremy Soller <jackpot51@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://gitlab.redox-os.org/redox-os/syscall",
+            "homepage": null,
+            "documentation": "https://docs.rs/redox_syscall",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "rustix",
+            "version": "0.36.11",
+            "id": "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "Safe Rust bindings to POSIX/Unix/Linux/Winsock2-like syscalls",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "rustc-std-workspace-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "alloc",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.49",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "io-lifetimes",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "close"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "itoa",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "flate2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "io-lifetimes",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "close"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.133",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "errno",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.8",
+                    "kind": "dev",
+                    "rename": "libc_errno",
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "memoffset",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serial_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.2.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.68",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "linux-raw-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "general",
+                        "no_std"
+                    ],
+                    "target": "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))",
+                    "registry": null
+                },
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(criterion, not(any(target_os = \"emscripten\", target_os = \"wasi\"))))",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.133",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "extra_traits"
+                    ],
+                    "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))",
+                    "registry": null
+                },
+                {
+                    "name": "errno",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.8",
+                    "kind": null,
+                    "rename": "libc_errno",
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))",
+                    "registry": null
+                },
+                {
+                    "name": "linux-raw-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "general",
+                        "errno",
+                        "ioctl",
+                        "no_std"
+                    ],
+                    "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.133",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "extra_traits"
+                    ],
+                    "target": "cfg(any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))))",
+                    "registry": null
+                },
+                {
+                    "name": "errno",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.8",
+                    "kind": null,
+                    "rename": "libc_errno",
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))))",
+                    "registry": null
+                },
+                {
+                    "name": "once_cell",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.5.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"android\", target_os = \"linux\"))",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.45.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Win32_Foundation",
+                        "Win32_Networking_WinSock",
+                        "Win32_NetworkManagement_IpHelper",
+                        "Win32_System_Threading"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                },
+                {
+                    "name": "ctor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.21",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "rustix",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/rustix-0.36.11/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "mod",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/rustix-0.36.11/benches/mod.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/rustix-0.36.11/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "all-apis": [
+                    "fs",
+                    "io_uring",
+                    "mm",
+                    "net",
+                    "param",
+                    "process",
+                    "procfs",
+                    "rand",
+                    "runtime",
+                    "termios",
+                    "thread",
+                    "time"
+                ],
+                "all-impls": [
+                    "os_pipe",
+                    "fs-err"
+                ],
+                "alloc": [
+                    "dep:alloc"
+                ],
+                "cc": [
+                    "dep:cc"
+                ],
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [
+                    "std",
+                    "use-libc-auxv"
+                ],
+                "fs": [],
+                "fs-err": [
+                    "io-lifetimes/fs-err"
+                ],
+                "io-lifetimes": [
+                    "dep:io-lifetimes"
+                ],
+                "io_uring": [
+                    "fs",
+                    "net"
+                ],
+                "itoa": [
+                    "dep:itoa"
+                ],
+                "libc": [
+                    "dep:libc"
+                ],
+                "libc_errno": [
+                    "dep:libc_errno"
+                ],
+                "mm": [],
+                "net": [],
+                "once_cell": [
+                    "dep:once_cell"
+                ],
+                "os_pipe": [
+                    "io-lifetimes/os_pipe"
+                ],
+                "param": [
+                    "fs"
+                ],
+                "process": [],
+                "procfs": [
+                    "once_cell",
+                    "itoa",
+                    "fs"
+                ],
+                "rand": [],
+                "runtime": [],
+                "rustc-dep-of-std": [
+                    "core",
+                    "alloc",
+                    "compiler_builtins",
+                    "linux-raw-sys/rustc-dep-of-std",
+                    "bitflags/rustc-dep-of-std"
+                ],
+                "std": [
+                    "io-lifetimes"
+                ],
+                "termios": [],
+                "thread": [],
+                "time": [],
+                "use-libc": [
+                    "libc_errno",
+                    "libc"
+                ],
+                "use-libc-auxv": [
+                    "libc"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/rustix-0.36.11/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "all-apis"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu",
+                            "i686-unknown-linux-gnu",
+                            "x86_64-apple-darwin",
+                            "x86_64-pc-windows-msvc"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Dan Gohman <dev@sunfishcode.online>",
+                "Jakub Konka <kubkon@jakubkonka.com>"
+            ],
+            "categories": [
+                "os::unix-apis",
+                "date-and-time",
+                "filesystem",
+                "network-programming"
+            ],
+            "keywords": [
+                "api",
+                "file",
+                "network",
+                "safe",
+                "syscall"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bytecodealliance/rustix",
+            "homepage": null,
+            "documentation": "https://docs.rs/rustix",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.48"
+        },
+        {
+            "name": "same-file",
+            "version": "1.0.6",
+            "id": "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense/MIT",
+            "license_file": null,
+            "description": "A simple crate for determining whether two file paths point to the same file.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "doc-comment",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winapi-util",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "same-file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/same-file-1.0.6/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "is_stderr",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/same-file-1.0.6/examples/is_stderr.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "is_same_file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/same-file-1.0.6/examples/is_same_file.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/same-file-1.0.6/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "same",
+                "file",
+                "equal",
+                "inode"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/same-file",
+            "homepage": "https://github.com/BurntSushi/same-file",
+            "documentation": "https://docs.rs/same-file",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "termcolor",
+            "version": "1.2.0",
+            "id": "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense OR MIT",
+            "license_file": null,
+            "description": "A simple cross platform library for writing colored text to a terminal.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "winapi-util",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "termcolor",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/termcolor-1.2.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/termcolor-1.2.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windows",
+                "win",
+                "color",
+                "ansi",
+                "console"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/termcolor",
+            "homepage": "https://github.com/BurntSushi/termcolor",
+            "documentation": "https://docs.rs/termcolor",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "walkdir",
-            "pkg": "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "windows_sys",
-            "pkg": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": [
-          "crossbeam-channel",
-          "default",
-          "fsevent-sys",
-          "macos_fsevent"
-        ]
-      },
-      {
-        "id": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": [
-          "raw_os_str"
-        ]
-      },
-      {
-        "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "bitflags",
-            "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-          "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-          "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-          "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "bitflags",
-            "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "libc_errno",
-            "pkg": "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))))"
-              }
-            ]
-          },
-          {
-            "name": "io_lifetimes",
-            "pkg": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "libc",
-            "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))"
-              },
-              {
-                "kind": null,
-                "target": "cfg(any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))))"
-              }
-            ]
-          },
-          {
-            "name": "linux_raw_sys",
-            "pkg": "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))"
-              },
-              {
-                "kind": null,
-                "target": "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))"
-              }
-            ]
-          },
-          {
-            "name": "windows_sys",
-            "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": [
-          "default",
-          "io-lifetimes",
-          "libc",
-          "std",
-          "termios",
-          "use-libc-auxv"
-        ]
-      },
-      {
-        "id": "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "winapi_util",
-            "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "winapi_util",
-            "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-          "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "same_file",
-            "pkg": "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "winapi_util",
-            "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": [
-          "default",
-          "std"
-        ]
-      },
-      {
-        "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-          "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "winapi_i686_pc_windows_gnu",
-            "pkg": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "i686-pc-windows-gnu"
-              }
-            ]
-          },
-          {
-            "name": "winapi_x86_64_pc_windows_gnu",
-            "pkg": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "x86_64-pc-windows-gnu"
-              }
-            ]
-          }
-        ],
-        "features": [
-          "consoleapi",
-          "errhandlingapi",
-          "fileapi",
-          "minwindef",
-          "ntdef",
-          "processenv",
-          "std",
-          "winbase",
-          "wincon",
-          "winerror",
-          "winnt"
-        ]
-      },
-      {
-        "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
+            "version": "2.3.3",
+            "id": "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense/MIT",
+            "license_file": null,
+            "description": "Recursively walk a directory.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "same-file",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "doc-comment",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winapi-util",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "walkdir",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/walkdir-2.3.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/walkdir-2.3.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [
+                "filesystem"
+            ],
+            "keywords": [
+                "directory",
+                "recursive",
+                "walk",
+                "iterator"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/walkdir",
+            "homepage": "https://github.com/BurntSushi/walkdir",
+            "documentation": "https://docs.rs/walkdir/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasi",
+            "version": "0.11.0+wasi-snapshot-preview1",
+            "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "Experimental WASI API bindings for Rust",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasi",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasi-0.11.0+wasi-snapshot-preview1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [
+                    "std"
+                ],
+                "rustc-dep-of-std": [
+                    "compiler_builtins",
+                    "core",
+                    "rustc-std-workspace-alloc"
+                ],
+                "rustc-std-workspace-alloc": [
+                    "dep:rustc-std-workspace-alloc"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasi-0.11.0+wasi-snapshot-preview1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The Cranelift Project Developers"
+            ],
+            "categories": [
+                "no-std",
+                "wasm"
+            ],
+            "keywords": [
+                "webassembly",
+                "wasm"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bytecodealliance/wasi",
+            "homepage": null,
+            "documentation": "https://docs.rs/wasi",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "winapi",
-            "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
+            "version": "0.3.9",
+            "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Raw FFI bindings for all of Windows API.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "winapi-i686-pc-windows-gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "winapi-x86_64-pc-windows-gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnu",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "accctrl": [],
+                "aclapi": [],
+                "activation": [],
+                "adhoc": [],
+                "appmgmt": [],
+                "audioclient": [],
+                "audiosessiontypes": [],
+                "avrt": [],
+                "basetsd": [],
+                "bcrypt": [],
+                "bits": [],
+                "bits10_1": [],
+                "bits1_5": [],
+                "bits2_0": [],
+                "bits2_5": [],
+                "bits3_0": [],
+                "bits4_0": [],
+                "bits5_0": [],
+                "bitscfg": [],
+                "bitsmsg": [],
+                "bluetoothapis": [],
+                "bluetoothleapis": [],
+                "bthdef": [],
+                "bthioctl": [],
+                "bthledef": [],
+                "bthsdpdef": [],
+                "bugcodes": [],
+                "cderr": [],
+                "cfg": [],
+                "cfgmgr32": [],
+                "cguid": [],
+                "combaseapi": [],
+                "coml2api": [],
+                "commapi": [],
+                "commctrl": [],
+                "commdlg": [],
+                "commoncontrols": [],
+                "consoleapi": [],
+                "corecrt": [],
+                "corsym": [],
+                "d2d1": [],
+                "d2d1_1": [],
+                "d2d1_2": [],
+                "d2d1_3": [],
+                "d2d1effectauthor": [],
+                "d2d1effects": [],
+                "d2d1effects_1": [],
+                "d2d1effects_2": [],
+                "d2d1svg": [],
+                "d2dbasetypes": [],
+                "d3d": [],
+                "d3d10": [],
+                "d3d10_1": [],
+                "d3d10_1shader": [],
+                "d3d10effect": [],
+                "d3d10misc": [],
+                "d3d10sdklayers": [],
+                "d3d10shader": [],
+                "d3d11": [],
+                "d3d11_1": [],
+                "d3d11_2": [],
+                "d3d11_3": [],
+                "d3d11_4": [],
+                "d3d11on12": [],
+                "d3d11sdklayers": [],
+                "d3d11shader": [],
+                "d3d11tokenizedprogramformat": [],
+                "d3d12": [],
+                "d3d12sdklayers": [],
+                "d3d12shader": [],
+                "d3d9": [],
+                "d3d9caps": [],
+                "d3d9types": [],
+                "d3dcommon": [],
+                "d3dcompiler": [],
+                "d3dcsx": [],
+                "d3dkmdt": [],
+                "d3dkmthk": [],
+                "d3dukmdt": [],
+                "d3dx10core": [],
+                "d3dx10math": [],
+                "d3dx10mesh": [],
+                "datetimeapi": [],
+                "davclnt": [],
+                "dbghelp": [],
+                "dbt": [],
+                "dcommon": [],
+                "dcomp": [],
+                "dcompanimation": [],
+                "dcomptypes": [],
+                "dde": [],
+                "ddraw": [],
+                "ddrawi": [],
+                "ddrawint": [],
+                "debug": [
+                    "impl-debug"
+                ],
+                "debugapi": [],
+                "devguid": [],
+                "devicetopology": [],
+                "devpkey": [],
+                "devpropdef": [],
+                "dinput": [],
+                "dinputd": [],
+                "dispex": [],
+                "dmksctl": [],
+                "dmusicc": [],
+                "docobj": [],
+                "documenttarget": [],
+                "dot1x": [],
+                "dpa_dsa": [],
+                "dpapi": [],
+                "dsgetdc": [],
+                "dsound": [],
+                "dsrole": [],
+                "dvp": [],
+                "dwmapi": [],
+                "dwrite": [],
+                "dwrite_1": [],
+                "dwrite_2": [],
+                "dwrite_3": [],
+                "dxdiag": [],
+                "dxfile": [],
+                "dxgi": [],
+                "dxgi1_2": [],
+                "dxgi1_3": [],
+                "dxgi1_4": [],
+                "dxgi1_5": [],
+                "dxgi1_6": [],
+                "dxgidebug": [],
+                "dxgiformat": [],
+                "dxgitype": [],
+                "dxva2api": [],
+                "dxvahd": [],
+                "eaptypes": [],
+                "enclaveapi": [],
+                "endpointvolume": [],
+                "errhandlingapi": [],
+                "everything": [],
+                "evntcons": [],
+                "evntprov": [],
+                "evntrace": [],
+                "excpt": [],
+                "exdisp": [],
+                "fibersapi": [],
+                "fileapi": [],
+                "functiondiscoverykeys_devpkey": [],
+                "gl-gl": [],
+                "guiddef": [],
+                "handleapi": [],
+                "heapapi": [],
+                "hidclass": [],
+                "hidpi": [],
+                "hidsdi": [],
+                "hidusage": [],
+                "highlevelmonitorconfigurationapi": [],
+                "hstring": [],
+                "http": [],
+                "ifdef": [],
+                "ifmib": [],
+                "imm": [],
+                "impl-debug": [],
+                "impl-default": [],
+                "in6addr": [],
+                "inaddr": [],
+                "inspectable": [],
+                "interlockedapi": [],
+                "intsafe": [],
+                "ioapiset": [],
+                "ipexport": [],
+                "iphlpapi": [],
+                "ipifcons": [],
+                "ipmib": [],
+                "iprtrmib": [],
+                "iptypes": [],
+                "jobapi": [],
+                "jobapi2": [],
+                "knownfolders": [],
+                "ks": [],
+                "ksmedia": [],
+                "ktmtypes": [],
+                "ktmw32": [],
+                "l2cmn": [],
+                "libloaderapi": [],
+                "limits": [],
+                "lmaccess": [],
+                "lmalert": [],
+                "lmapibuf": [],
+                "lmat": [],
+                "lmcons": [],
+                "lmdfs": [],
+                "lmerrlog": [],
+                "lmjoin": [],
+                "lmmsg": [],
+                "lmremutl": [],
+                "lmrepl": [],
+                "lmserver": [],
+                "lmshare": [],
+                "lmstats": [],
+                "lmsvc": [],
+                "lmuse": [],
+                "lmwksta": [],
+                "lowlevelmonitorconfigurationapi": [],
+                "lsalookup": [],
+                "memoryapi": [],
+                "minschannel": [],
+                "minwinbase": [],
+                "minwindef": [],
+                "mmdeviceapi": [],
+                "mmeapi": [],
+                "mmreg": [],
+                "mmsystem": [],
+                "mprapidef": [],
+                "msaatext": [],
+                "mscat": [],
+                "mschapp": [],
+                "mssip": [],
+                "mstcpip": [],
+                "mswsock": [],
+                "mswsockdef": [],
+                "namedpipeapi": [],
+                "namespaceapi": [],
+                "nb30": [],
+                "ncrypt": [],
+                "netioapi": [],
+                "nldef": [],
+                "ntddndis": [],
+                "ntddscsi": [],
+                "ntddser": [],
+                "ntdef": [],
+                "ntlsa": [],
+                "ntsecapi": [],
+                "ntstatus": [],
+                "oaidl": [],
+                "objbase": [],
+                "objidl": [],
+                "objidlbase": [],
+                "ocidl": [],
+                "ole2": [],
+                "oleauto": [],
+                "olectl": [],
+                "oleidl": [],
+                "opmapi": [],
+                "pdh": [],
+                "perflib": [],
+                "physicalmonitorenumerationapi": [],
+                "playsoundapi": [],
+                "portabledevice": [],
+                "portabledeviceapi": [],
+                "portabledevicetypes": [],
+                "powerbase": [],
+                "powersetting": [],
+                "powrprof": [],
+                "processenv": [],
+                "processsnapshot": [],
+                "processthreadsapi": [],
+                "processtopologyapi": [],
+                "profileapi": [],
+                "propidl": [],
+                "propkey": [],
+                "propkeydef": [],
+                "propsys": [],
+                "prsht": [],
+                "psapi": [],
+                "qos": [],
+                "realtimeapiset": [],
+                "reason": [],
+                "restartmanager": [],
+                "restrictederrorinfo": [],
+                "rmxfguid": [],
+                "roapi": [],
+                "robuffer": [],
+                "roerrorapi": [],
+                "rpc": [],
+                "rpcdce": [],
+                "rpcndr": [],
+                "rtinfo": [],
+                "sapi": [],
+                "sapi51": [],
+                "sapi53": [],
+                "sapiddk": [],
+                "sapiddk51": [],
+                "schannel": [],
+                "sddl": [],
+                "securityappcontainer": [],
+                "securitybaseapi": [],
+                "servprov": [],
+                "setupapi": [],
+                "shellapi": [],
+                "shellscalingapi": [],
+                "shlobj": [],
+                "shobjidl": [],
+                "shobjidl_core": [],
+                "shtypes": [],
+                "softpub": [],
+                "spapidef": [],
+                "spellcheck": [],
+                "sporder": [],
+                "sql": [],
+                "sqlext": [],
+                "sqltypes": [],
+                "sqlucode": [],
+                "sspi": [],
+                "std": [],
+                "stralign": [],
+                "stringapiset": [],
+                "strmif": [],
+                "subauth": [],
+                "synchapi": [],
+                "sysinfoapi": [],
+                "systemtopologyapi": [],
+                "taskschd": [],
+                "tcpestats": [],
+                "tcpmib": [],
+                "textstor": [],
+                "threadpoolapiset": [],
+                "threadpoollegacyapiset": [],
+                "timeapi": [],
+                "timezoneapi": [],
+                "tlhelp32": [],
+                "transportsettingcommon": [],
+                "tvout": [],
+                "udpmib": [],
+                "unknwnbase": [],
+                "urlhist": [],
+                "urlmon": [],
+                "usb": [],
+                "usbioctl": [],
+                "usbiodef": [],
+                "usbscan": [],
+                "usbspec": [],
+                "userenv": [],
+                "usp10": [],
+                "utilapiset": [],
+                "uxtheme": [],
+                "vadefs": [],
+                "vcruntime": [],
+                "vsbackup": [],
+                "vss": [],
+                "vsserror": [],
+                "vswriter": [],
+                "wbemads": [],
+                "wbemcli": [],
+                "wbemdisp": [],
+                "wbemprov": [],
+                "wbemtran": [],
+                "wct": [],
+                "werapi": [],
+                "winbase": [],
+                "wincodec": [],
+                "wincodecsdk": [],
+                "wincon": [],
+                "wincontypes": [],
+                "wincred": [],
+                "wincrypt": [],
+                "windef": [],
+                "windot11": [],
+                "windowsceip": [],
+                "windowsx": [],
+                "winefs": [],
+                "winerror": [],
+                "winevt": [],
+                "wingdi": [],
+                "winhttp": [],
+                "wininet": [],
+                "winineti": [],
+                "winioctl": [],
+                "winnetwk": [],
+                "winnls": [],
+                "winnt": [],
+                "winreg": [],
+                "winsafer": [],
+                "winscard": [],
+                "winsmcrd": [],
+                "winsock2": [],
+                "winspool": [],
+                "winstring": [],
+                "winsvc": [],
+                "wintrust": [],
+                "winusb": [],
+                "winusbio": [],
+                "winuser": [],
+                "winver": [],
+                "wlanapi": [],
+                "wlanihv": [],
+                "wlanihvtypes": [],
+                "wlantypes": [],
+                "wlclient": [],
+                "wmistr": [],
+                "wnnc": [],
+                "wow64apiset": [],
+                "wpdmtpextensions": [],
+                "ws2bth": [],
+                "ws2def": [],
+                "ws2ipdef": [],
+                "ws2spi": [],
+                "ws2tcpip": [],
+                "wtsapi32": [],
+                "wtypes": [],
+                "wtypesbase": [],
+                "xinput": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "features": [
+                            "everything",
+                            "impl-debug",
+                            "impl-default"
+                        ],
+                        "targets": [
+                            "aarch64-pc-windows-msvc",
+                            "i686-pc-windows-msvc",
+                            "x86_64-pc-windows-msvc"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Peter Atashian <retep998@gmail.com>"
+            ],
+            "categories": [
+                "external-ffi-bindings",
+                "no-std",
+                "os::windows-apis"
+            ],
+            "keywords": [
+                "windows",
+                "ffi",
+                "win32",
+                "com",
+                "directx"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/retep998/winapi-rs",
+            "homepage": null,
+            "documentation": "https://docs.rs/winapi/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi-i686-pc-windows-gnu",
+            "version": "0.4.0",
+            "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi-i686-pc-windows-gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Peter Atashian <retep998@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windows"
+            ],
+            "readme": null,
+            "repository": "https://github.com/retep998/winapi-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi-util",
+            "version": "0.1.5",
+            "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense/MIT",
+            "license_file": null,
+            "description": "A dumping ground for high level safe wrappers over winapi.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "std",
+                        "consoleapi",
+                        "errhandlingapi",
+                        "fileapi",
+                        "minwindef",
+                        "processenv",
+                        "winbase",
+                        "wincon",
+                        "winerror",
+                        "winnt"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi-util",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-util-0.1.5/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-util-0.1.5/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-pc-windows-msvc"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [
+                "os::windows-apis",
+                "external-ffi-bindings"
+            ],
+            "keywords": [
+                "windows",
+                "winapi",
+                "util",
+                "win"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/winapi-util",
+            "homepage": "https://github.com/BurntSushi/winapi-util",
+            "documentation": "https://docs.rs/winapi-util",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi-x86_64-pc-windows-gnu",
+            "version": "0.4.0",
+            "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi-x86_64-pc-windows-gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Peter Atashian <retep998@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windows"
+            ],
+            "readme": null,
+            "repository": "https://github.com/retep998/winapi-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows-sys",
+            "version": "0.42.0",
+            "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Rust for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "windows_aarch64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-msvc",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "Win32": [],
+                "Win32_AI": [
+                    "Win32"
+                ],
+                "Win32_AI_MachineLearning": [
+                    "Win32_AI"
+                ],
+                "Win32_AI_MachineLearning_DirectML": [
+                    "Win32_AI_MachineLearning"
+                ],
+                "Win32_AI_MachineLearning_WinML": [
+                    "Win32_AI_MachineLearning"
+                ],
+                "Win32_Data": [
+                    "Win32"
+                ],
+                "Win32_Data_HtmlHelp": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_RightsManagement": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml_MsXml": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Data_Xml_XmlLite": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Devices": [
+                    "Win32"
+                ],
+                "Win32_Devices_AllJoyn": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_BiometricFramework": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Bluetooth": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Communication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAccess": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAndDriverInstallation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceQuery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Display": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration_Pnp": [
+                    "Win32_Devices_Enumeration"
+                ],
+                "Win32_Devices_Fax": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_FunctionDiscovery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Geolocation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_HumanInterfaceDevice": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_ImageAcquisition": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_PortableDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Properties": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Pwm": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Sensors": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_SerialCommunication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Tapi": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Usb": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_WebServicesOnDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Foundation": [
+                    "Win32"
+                ],
+                "Win32_Gaming": [
+                    "Win32"
+                ],
+                "Win32_Globalization": [
+                    "Win32"
+                ],
+                "Win32_Graphics": [
+                    "Win32"
+                ],
+                "Win32_Graphics_CompositionSwapchain": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DXCore": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct2D": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct2D_Common": [
+                    "Win32_Graphics_Direct2D"
+                ],
+                "Win32_Graphics_Direct3D": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D10": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D11": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D11on12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D9": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D9on12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D_Dxc": [
+                    "Win32_Graphics_Direct3D"
+                ],
+                "Win32_Graphics_Direct3D_Fxc": [
+                    "Win32_Graphics_Direct3D"
+                ],
+                "Win32_Graphics_DirectComposition": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectDraw": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectManipulation": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectWrite": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dwm": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dxgi": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dxgi_Common": [
+                    "Win32_Graphics_Dxgi"
+                ],
+                "Win32_Graphics_Gdi": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Hlsl": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Imaging": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Imaging_D2D": [
+                    "Win32_Graphics_Imaging"
+                ],
+                "Win32_Graphics_OpenGL": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing_PrintTicket": [
+                    "Win32_Graphics_Printing"
+                ],
+                "Win32_Management": [
+                    "Win32"
+                ],
+                "Win32_Management_MobileDeviceManagementRegistration": [
+                    "Win32_Management"
+                ],
+                "Win32_Media": [
+                    "Win32"
+                ],
+                "Win32_Media_Audio": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Audio_Apo": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_DirectMusic": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_DirectSound": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_Endpoints": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_XAudio2": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_DeviceManager": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_DirectShow": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_DirectShow_Xml": [
+                    "Win32_Media_DirectShow"
+                ],
+                "Win32_Media_DxMediaObjects": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_KernelStreaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_LibrarySharingServices": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_MediaFoundation": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_MediaPlayer": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Multimedia": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_PictureAcquisition": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Speech": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Streaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_WindowsMediaFormat": [
+                    "Win32_Media"
+                ],
+                "Win32_NetworkManagement": [
+                    "Win32"
+                ],
+                "Win32_NetworkManagement_Dhcp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Dns": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_InternetConnectionWizard": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_IpHelper": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_MobileBroadband": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Multicast": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Ndis": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetBios": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetManagement": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetShell": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkDiagnosticsFramework": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkPolicyServer": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_P2P": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_QoS": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Rras": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Snmp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WNet": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WebDav": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WiFi": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectNow": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectionManager": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFilteringPlatform": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFirewall": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsNetworkVirtualization": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_Networking": [
+                    "Win32"
+                ],
+                "Win32_Networking_ActiveDirectory": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_BackgroundIntelligentTransferService": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Clustering": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_HttpServer": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Ldap": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_NetworkListManager": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_RemoteDifferentialCompression": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WebSocket": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinHttp": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinInet": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinSock": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WindowsWebServices": [
+                    "Win32_Networking"
+                ],
+                "Win32_Security": [
+                    "Win32"
+                ],
+                "Win32_Security_AppLocker": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication_Identity": [
+                    "Win32_Security_Authentication"
+                ],
+                "Win32_Security_Authentication_Identity_Provider": [
+                    "Win32_Security_Authentication_Identity"
+                ],
+                "Win32_Security_Authorization": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authorization_UI": [
+                    "Win32_Security_Authorization"
+                ],
+                "Win32_Security_ConfigurationSnapin": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Credentials": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography_Catalog": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Certificates": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Sip": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_UI": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_DiagnosticDataQuery": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_DirectoryServices": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_EnterpriseData": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_ExtensibleAuthenticationProtocol": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Isolation": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_LicenseProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_NetworkAccessProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Tpm": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinTrust": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinWlx": [
+                    "Win32_Security"
+                ],
+                "Win32_Storage": [
+                    "Win32"
+                ],
+                "Win32_Storage_Cabinets": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_CloudFilters": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Compression": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DataDeduplication": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DistributedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_EnhancedStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileHistory": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileServerResourceManager": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Imapi": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IndexServer": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_InstallableFileSystems": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IscsiDisc": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Jet": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OfflineFiles": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OperationRecorder": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging_Appx": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_Packaging_Opc": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_ProjectedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_StructuredStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vhd": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_VirtualDiskService": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vss": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps_Printing": [
+                    "Win32_Storage_Xps"
+                ],
+                "Win32_System": [
+                    "Win32"
+                ],
+                "Win32_System_AddressBook": [
+                    "Win32_System"
+                ],
+                "Win32_System_Antimalware": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationInstallationAndServicing": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationVerifier": [
+                    "Win32_System"
+                ],
+                "Win32_System_AssessmentTool": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com_CallObj": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_ChannelCredentials": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Events": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Marshal": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_StructuredStorage": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_UI": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Urlmon": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_ComponentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_Console": [
+                    "Win32_System"
+                ],
+                "Win32_System_Contacts": [
+                    "Win32_System"
+                ],
+                "Win32_System_CorrelationVector": [
+                    "Win32_System"
+                ],
+                "Win32_System_DataExchange": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeploymentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_DesktopSharing": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeveloperLicensing": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics_Ceip": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Debug": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Etw": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ProcessSnapshotting": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ToolHelp": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_DistributedTransactionCoordinator": [
+                    "Win32_System"
+                ],
+                "Win32_System_Environment": [
+                    "Win32_System"
+                ],
+                "Win32_System_ErrorReporting": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventCollector": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventLog": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventNotificationService": [
+                    "Win32_System"
+                ],
+                "Win32_System_GroupPolicy": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostCompute": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeNetwork": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeSystem": [
+                    "Win32_System"
+                ],
+                "Win32_System_Hypervisor": [
+                    "Win32_System"
+                ],
+                "Win32_System_IO": [
+                    "Win32_System"
+                ],
+                "Win32_System_Iis": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ioctl": [
+                    "Win32_System"
+                ],
+                "Win32_System_JobObjects": [
+                    "Win32_System"
+                ],
+                "Win32_System_Js": [
+                    "Win32_System"
+                ],
+                "Win32_System_Kernel": [
+                    "Win32_System"
+                ],
+                "Win32_System_LibraryLoader": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mailslots": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mapi": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory_NonVolatile": [
+                    "Win32_System_Memory"
+                ],
+                "Win32_System_MessageQueuing": [
+                    "Win32_System"
+                ],
+                "Win32_System_MixedReality": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mmc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ole": [
+                    "Win32_System"
+                ],
+                "Win32_System_ParentalControls": [
+                    "Win32_System"
+                ],
+                "Win32_System_PasswordManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance_HardwareCounterProfiling": [
+                    "Win32_System_Performance"
+                ],
+                "Win32_System_Pipes": [
+                    "Win32_System"
+                ],
+                "Win32_System_Power": [
+                    "Win32_System"
+                ],
+                "Win32_System_ProcessStatus": [
+                    "Win32_System"
+                ],
+                "Win32_System_RealTimeCommunications": [
+                    "Win32_System"
+                ],
+                "Win32_System_Recovery": [
+                    "Win32_System"
+                ],
+                "Win32_System_Registry": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteAssistance": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteDesktop": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_RestartManager": [
+                    "Win32_System"
+                ],
+                "Win32_System_Restore": [
+                    "Win32_System"
+                ],
+                "Win32_System_Rpc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search_Common": [
+                    "Win32_System_Search"
+                ],
+                "Win32_System_SecurityCenter": [
+                    "Win32_System"
+                ],
+                "Win32_System_ServerBackup": [
+                    "Win32_System"
+                ],
+                "Win32_System_Services": [
+                    "Win32_System"
+                ],
+                "Win32_System_SettingsManagementInfrastructure": [
+                    "Win32_System"
+                ],
+                "Win32_System_SetupAndMigration": [
+                    "Win32_System"
+                ],
+                "Win32_System_Shutdown": [
+                    "Win32_System"
+                ],
+                "Win32_System_SideShow": [
+                    "Win32_System"
+                ],
+                "Win32_System_StationsAndDesktops": [
+                    "Win32_System"
+                ],
+                "Win32_System_SubsystemForLinux": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemInformation": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_TaskScheduler": [
+                    "Win32_System"
+                ],
+                "Win32_System_Threading": [
+                    "Win32_System"
+                ],
+                "Win32_System_Time": [
+                    "Win32_System"
+                ],
+                "Win32_System_TpmBaseServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_TransactionServer": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAgent": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAssessment": [
+                    "Win32_System"
+                ],
+                "Win32_System_UserAccessLogging": [
+                    "Win32_System"
+                ],
+                "Win32_System_VirtualDosMachines": [
+                    "Win32_System"
+                ],
+                "Win32_System_WinRT": [
+                    "Win32_System"
+                ],
+                "Win32_System_WinRT_AllJoyn": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Composition": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_CoreInputView": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Direct3D11": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Display": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Graphics": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Graphics_Capture": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Graphics_Direct2D": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Graphics_Imaging": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Holographic": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Isolation": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_ML": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Media": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Pdf": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Printing": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Shell": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Storage": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WindowsProgramming": [
+                    "Win32_System"
+                ],
+                "Win32_System_WindowsSync": [
+                    "Win32_System"
+                ],
+                "Win32_System_Wmi": [
+                    "Win32_System"
+                ],
+                "Win32_UI": [
+                    "Win32"
+                ],
+                "Win32_UI_Accessibility": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Animation": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_ColorSystem": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls_Dialogs": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_Controls_RichEdit": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_HiDpi": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input_Ime": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Ink": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_KeyboardAndMouse": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Pointer": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Radial": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Touch": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_XboxController": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_InteractionContext": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_LegacyWindowsEnvironmentFeatures": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Magnification": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Notifications": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Ribbon": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell_Common": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_Shell_PropertiesSystem": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_TabletPC": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_TextServices": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_WindowsAndMessaging": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Wpf": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Xaml": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Xaml_Diagnostics": [
+                    "Win32_UI_Xaml"
+                ],
+                "default": [],
+                "deprecated": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "readme.md",
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.49"
+        },
+        {
+            "name": "windows-sys",
+            "version": "0.45.0",
+            "id": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Rust for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "windows-targets",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(windows_raw_dylib))",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.45.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "Win32": [],
+                "Win32_Data": [
+                    "Win32"
+                ],
+                "Win32_Data_HtmlHelp": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_RightsManagement": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml_MsXml": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Data_Xml_XmlLite": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Devices": [
+                    "Win32"
+                ],
+                "Win32_Devices_AllJoyn": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_BiometricFramework": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Bluetooth": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Communication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAccess": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAndDriverInstallation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceQuery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Display": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration_Pnp": [
+                    "Win32_Devices_Enumeration"
+                ],
+                "Win32_Devices_Fax": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_FunctionDiscovery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Geolocation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_HumanInterfaceDevice": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_ImageAcquisition": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_PortableDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Properties": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Pwm": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Sensors": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_SerialCommunication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Tapi": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Usb": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_WebServicesOnDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Foundation": [
+                    "Win32"
+                ],
+                "Win32_Gaming": [
+                    "Win32"
+                ],
+                "Win32_Globalization": [
+                    "Win32"
+                ],
+                "Win32_Graphics": [
+                    "Win32"
+                ],
+                "Win32_Graphics_Dwm": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Gdi": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Hlsl": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_OpenGL": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing_PrintTicket": [
+                    "Win32_Graphics_Printing"
+                ],
+                "Win32_Management": [
+                    "Win32"
+                ],
+                "Win32_Management_MobileDeviceManagementRegistration": [
+                    "Win32_Management"
+                ],
+                "Win32_Media": [
+                    "Win32"
+                ],
+                "Win32_Media_Audio": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Audio_Apo": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_DirectMusic": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_Endpoints": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_XAudio2": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_DeviceManager": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_DxMediaObjects": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_KernelStreaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_LibrarySharingServices": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_MediaPlayer": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Multimedia": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Speech": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Streaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_WindowsMediaFormat": [
+                    "Win32_Media"
+                ],
+                "Win32_NetworkManagement": [
+                    "Win32"
+                ],
+                "Win32_NetworkManagement_Dhcp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Dns": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_InternetConnectionWizard": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_IpHelper": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_MobileBroadband": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Multicast": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Ndis": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetBios": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetManagement": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetShell": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkDiagnosticsFramework": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkPolicyServer": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_P2P": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_QoS": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Rras": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Snmp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WNet": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WebDav": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WiFi": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectNow": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectionManager": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFilteringPlatform": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFirewall": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsNetworkVirtualization": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_Networking": [
+                    "Win32"
+                ],
+                "Win32_Networking_ActiveDirectory": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_BackgroundIntelligentTransferService": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Clustering": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_HttpServer": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Ldap": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_NetworkListManager": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_RemoteDifferentialCompression": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WebSocket": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinHttp": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinInet": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinSock": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WindowsWebServices": [
+                    "Win32_Networking"
+                ],
+                "Win32_Security": [
+                    "Win32"
+                ],
+                "Win32_Security_AppLocker": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication_Identity": [
+                    "Win32_Security_Authentication"
+                ],
+                "Win32_Security_Authentication_Identity_Provider": [
+                    "Win32_Security_Authentication_Identity"
+                ],
+                "Win32_Security_Authorization": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authorization_UI": [
+                    "Win32_Security_Authorization"
+                ],
+                "Win32_Security_ConfigurationSnapin": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Credentials": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography_Catalog": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Certificates": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Sip": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_UI": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_DiagnosticDataQuery": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_DirectoryServices": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_EnterpriseData": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_ExtensibleAuthenticationProtocol": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Isolation": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_LicenseProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_NetworkAccessProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Tpm": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinTrust": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinWlx": [
+                    "Win32_Security"
+                ],
+                "Win32_Storage": [
+                    "Win32"
+                ],
+                "Win32_Storage_Cabinets": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_CloudFilters": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Compression": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DataDeduplication": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DistributedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_EnhancedStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileHistory": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileServerResourceManager": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Imapi": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IndexServer": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_InstallableFileSystems": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IscsiDisc": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Jet": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OfflineFiles": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OperationRecorder": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging_Appx": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_Packaging_Opc": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_ProjectedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_StructuredStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vhd": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_VirtualDiskService": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vss": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps_Printing": [
+                    "Win32_Storage_Xps"
+                ],
+                "Win32_System": [
+                    "Win32"
+                ],
+                "Win32_System_AddressBook": [
+                    "Win32_System"
+                ],
+                "Win32_System_Antimalware": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationInstallationAndServicing": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationVerifier": [
+                    "Win32_System"
+                ],
+                "Win32_System_AssessmentTool": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com_CallObj": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_ChannelCredentials": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Events": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Marshal": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_StructuredStorage": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_UI": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Urlmon": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_ComponentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_Console": [
+                    "Win32_System"
+                ],
+                "Win32_System_Contacts": [
+                    "Win32_System"
+                ],
+                "Win32_System_CorrelationVector": [
+                    "Win32_System"
+                ],
+                "Win32_System_DataExchange": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeploymentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_DesktopSharing": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeveloperLicensing": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics_Ceip": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Debug": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Etw": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ProcessSnapshotting": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ToolHelp": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_DistributedTransactionCoordinator": [
+                    "Win32_System"
+                ],
+                "Win32_System_Environment": [
+                    "Win32_System"
+                ],
+                "Win32_System_ErrorReporting": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventCollector": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventLog": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventNotificationService": [
+                    "Win32_System"
+                ],
+                "Win32_System_GroupPolicy": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostCompute": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeNetwork": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeSystem": [
+                    "Win32_System"
+                ],
+                "Win32_System_Hypervisor": [
+                    "Win32_System"
+                ],
+                "Win32_System_IO": [
+                    "Win32_System"
+                ],
+                "Win32_System_Iis": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ioctl": [
+                    "Win32_System"
+                ],
+                "Win32_System_JobObjects": [
+                    "Win32_System"
+                ],
+                "Win32_System_Js": [
+                    "Win32_System"
+                ],
+                "Win32_System_Kernel": [
+                    "Win32_System"
+                ],
+                "Win32_System_LibraryLoader": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mailslots": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mapi": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory_NonVolatile": [
+                    "Win32_System_Memory"
+                ],
+                "Win32_System_MessageQueuing": [
+                    "Win32_System"
+                ],
+                "Win32_System_MixedReality": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mmc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ole": [
+                    "Win32_System"
+                ],
+                "Win32_System_ParentalControls": [
+                    "Win32_System"
+                ],
+                "Win32_System_PasswordManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance_HardwareCounterProfiling": [
+                    "Win32_System_Performance"
+                ],
+                "Win32_System_Pipes": [
+                    "Win32_System"
+                ],
+                "Win32_System_Power": [
+                    "Win32_System"
+                ],
+                "Win32_System_ProcessStatus": [
+                    "Win32_System"
+                ],
+                "Win32_System_RealTimeCommunications": [
+                    "Win32_System"
+                ],
+                "Win32_System_Recovery": [
+                    "Win32_System"
+                ],
+                "Win32_System_Registry": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteAssistance": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteDesktop": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_RestartManager": [
+                    "Win32_System"
+                ],
+                "Win32_System_Restore": [
+                    "Win32_System"
+                ],
+                "Win32_System_Rpc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search_Common": [
+                    "Win32_System_Search"
+                ],
+                "Win32_System_SecurityCenter": [
+                    "Win32_System"
+                ],
+                "Win32_System_ServerBackup": [
+                    "Win32_System"
+                ],
+                "Win32_System_Services": [
+                    "Win32_System"
+                ],
+                "Win32_System_SettingsManagementInfrastructure": [
+                    "Win32_System"
+                ],
+                "Win32_System_SetupAndMigration": [
+                    "Win32_System"
+                ],
+                "Win32_System_Shutdown": [
+                    "Win32_System"
+                ],
+                "Win32_System_StationsAndDesktops": [
+                    "Win32_System"
+                ],
+                "Win32_System_SubsystemForLinux": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemInformation": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_TaskScheduler": [
+                    "Win32_System"
+                ],
+                "Win32_System_Threading": [
+                    "Win32_System"
+                ],
+                "Win32_System_Time": [
+                    "Win32_System"
+                ],
+                "Win32_System_TpmBaseServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAgent": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAssessment": [
+                    "Win32_System"
+                ],
+                "Win32_System_UserAccessLogging": [
+                    "Win32_System"
+                ],
+                "Win32_System_VirtualDosMachines": [
+                    "Win32_System"
+                ],
+                "Win32_System_WindowsProgramming": [
+                    "Win32_System"
+                ],
+                "Win32_System_WindowsSync": [
+                    "Win32_System"
+                ],
+                "Win32_System_Wmi": [
+                    "Win32_System"
+                ],
+                "Win32_UI": [
+                    "Win32"
+                ],
+                "Win32_UI_Accessibility": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Animation": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_ColorSystem": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls_Dialogs": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_Controls_RichEdit": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_HiDpi": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input_Ime": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Ink": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_KeyboardAndMouse": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Pointer": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Radial": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Touch": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_XboxController": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_InteractionContext": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_LegacyWindowsEnvironmentFeatures": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Magnification": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Notifications": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Ribbon": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell_Common": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_Shell_PropertiesSystem": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_TabletPC": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_TextServices": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_WindowsAndMessaging": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Wpf": [
+                    "Win32_UI"
+                ],
+                "default": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.45.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "readme.md",
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.48"
+        },
+        {
+            "name": "windows-targets",
+            "version": "0.42.2",
+            "id": "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Import libs for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "windows_aarch64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-msvc",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows-targets",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-targets-0.42.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-targets-0.42.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "windows_aarch64_gnullvm",
-            "pkg": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "aarch64-pc-windows-gnullvm"
-              }
-            ]
-          },
-          {
+            "version": "0.42.2",
+            "id": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Import lib for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_aarch64_gnullvm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.2/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "windows_aarch64_msvc",
-            "pkg": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "aarch64-pc-windows-msvc"
-              },
-              {
-                "kind": null,
-                "target": "aarch64-uwp-windows-msvc"
-              }
-            ]
-          },
-          {
+            "version": "0.42.2",
+            "id": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Import lib for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_aarch64_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.2/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "windows_i686_gnu",
-            "pkg": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "i686-pc-windows-gnu"
-              },
-              {
-                "kind": null,
-                "target": "i686-uwp-windows-gnu"
-              }
-            ]
-          },
-          {
+            "version": "0.42.2",
+            "id": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Import lib for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_i686_gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.2/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "windows_i686_msvc",
-            "pkg": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "i686-pc-windows-msvc"
-              },
-              {
-                "kind": null,
-                "target": "i686-uwp-windows-msvc"
-              }
-            ]
-          },
-          {
+            "version": "0.42.2",
+            "id": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Import lib for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_i686_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.2/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "windows_x86_64_gnu",
-            "pkg": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "x86_64-pc-windows-gnu"
-              },
-              {
-                "kind": null,
-                "target": "x86_64-uwp-windows-gnu"
-              }
-            ]
-          },
-          {
+            "version": "0.42.2",
+            "id": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Import lib for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.2/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "windows_x86_64_gnullvm",
-            "pkg": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "x86_64-pc-windows-gnullvm"
-              }
-            ]
-          },
-          {
+            "version": "0.42.2",
+            "id": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Import lib for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_gnullvm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.2/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
             "name": "windows_x86_64_msvc",
-            "pkg": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "x86_64-pc-windows-msvc"
-              },
-              {
-                "kind": null,
-                "target": "x86_64-uwp-windows-msvc"
-              }
-            ]
-          }
-        ],
-        "features": [
-          "Win32",
-          "Win32_Foundation",
-          "Win32_Security",
-          "Win32_Storage",
-          "Win32_Storage_FileSystem",
-          "Win32_System",
-          "Win32_System_IO",
-          "Win32_System_Threading",
-          "Win32_System_WindowsProgramming",
-          "default"
-        ]
-      },
-      {
-        "id": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "windows_targets",
-            "pkg": "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(not(windows_raw_dylib))"
-              }
-            ]
-          }
-        ],
-        "features": [
-          "Win32",
-          "Win32_Foundation",
-          "Win32_NetworkManagement",
-          "Win32_NetworkManagement_IpHelper",
-          "Win32_Networking",
-          "Win32_Networking_WinSock",
-          "Win32_Security",
-          "Win32_Storage",
-          "Win32_Storage_FileSystem",
-          "Win32_System",
-          "Win32_System_Console",
-          "Win32_System_IO",
-          "Win32_System_Pipes",
-          "Win32_System_Threading",
-          "Win32_System_WindowsProgramming",
-          "default"
-        ]
-      },
-      {
-        "id": "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [
-          "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-          "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
-        ],
-        "deps": [
-          {
-            "name": "windows_aarch64_gnullvm",
-            "pkg": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "aarch64-pc-windows-gnullvm"
-              }
-            ]
-          },
-          {
-            "name": "windows_aarch64_msvc",
-            "pkg": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "aarch64-pc-windows-msvc"
-              },
-              {
-                "kind": null,
-                "target": "aarch64-uwp-windows-msvc"
-              }
-            ]
-          },
-          {
-            "name": "windows_i686_gnu",
-            "pkg": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "i686-pc-windows-gnu"
-              },
-              {
-                "kind": null,
-                "target": "i686-uwp-windows-gnu"
-              }
-            ]
-          },
-          {
-            "name": "windows_i686_msvc",
-            "pkg": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "i686-pc-windows-msvc"
-              },
-              {
-                "kind": null,
-                "target": "i686-uwp-windows-msvc"
-              }
-            ]
-          },
-          {
-            "name": "windows_x86_64_gnu",
-            "pkg": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "x86_64-pc-windows-gnu"
-              },
-              {
-                "kind": null,
-                "target": "x86_64-uwp-windows-gnu"
-              }
-            ]
-          },
-          {
-            "name": "windows_x86_64_gnullvm",
-            "pkg": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "x86_64-pc-windows-gnullvm"
-              }
-            ]
-          },
-          {
-            "name": "windows_x86_64_msvc",
-            "pkg": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "x86_64-pc-windows-msvc"
-              },
-              {
-                "kind": null,
-                "target": "x86_64-uwp-windows-msvc"
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      }
+            "version": "0.42.2",
+            "id": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Import lib for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.2/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        }
     ],
-    "root": "crate-with-optional-deps 0.1.0 (path+file:///home/gabe/Development/rules_rust/crate_universe/test_data/metadata/crate_optional_deps_enabled)"
-  },
-  "target_directory": "/home/gabe/Development/rules_rust/crate_universe/test_data/metadata/crate_optional_deps_enabled/target",
-  "version": 1,
-  "workspace_root": "/home/gabe/Development/rules_rust/crate_universe/test_data/metadata/crate_optional_deps_enabled",
-  "metadata": null
+    "workspace_members": [
+        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_enabled)"
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "clap_lex",
+                        "pkg": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "is_terminal",
+                        "pkg": "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "termcolor",
+                        "pkg": "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "color"
+                ]
+            },
+            {
+                "id": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "os_str_bytes",
+                        "pkg": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_enabled)",
+                "dependencies": [
+                    "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "clap",
+                        "pkg": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "notify",
+                        "pkg": "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "crossbeam_utils",
+                        "pkg": "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "crossbeam-utils",
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "std"
+                ]
+            },
+            {
+                "id": "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "errno_dragonfly",
+                        "pkg": "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"dragonfly\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"hermit\")"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"wasi\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cc",
+                        "pkg": "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syscall",
+                        "pkg": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"redox\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_sys",
+                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "inotify_sys",
+                        "pkg": "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "hermit_abi",
+                        "pkg": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"hermit\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(windows))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_sys",
+                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "close",
+                    "default",
+                    "hermit-abi",
+                    "libc",
+                    "windows-sys"
+                ]
+            },
+            {
+                "id": "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "hermit_abi",
+                        "pkg": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"hermit\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "io_lifetimes",
+                        "pkg": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rustix",
+                        "pkg": "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_sys",
+                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "kqueue_sys",
+                        "pkg": "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "extra_traits",
+                    "std"
+                ]
+            },
+            {
+                "id": "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "errno",
+                    "general",
+                    "ioctl",
+                    "no_std"
+                ]
+            },
+            {
+                "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"wasi\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasi",
+                        "pkg": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"wasi\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_sys",
+                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "os-ext",
+                    "os-poll"
+                ]
+            },
+            {
+                "id": "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "crossbeam_channel",
+                        "pkg": "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "filetime",
+                        "pkg": "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "fsevent_sys",
+                        "pkg": "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"macos\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "inotify",
+                        "pkg": "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"linux\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "kqueue",
+                        "pkg": "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonflybsd\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "mio",
+                        "pkg": "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonflybsd\"))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"linux\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "walkdir",
+                        "pkg": "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_sys",
+                        "pkg": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "crossbeam-channel",
+                    "default",
+                    "fsevent-sys",
+                    "macos_fsevent"
+                ]
+            },
+            {
+                "id": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "raw_os_str"
+                ]
+            },
+            {
+                "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc_errno",
+                        "pkg": "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "io_lifetimes",
+                        "pkg": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "linux_raw_sys",
+                        "pkg": "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_sys",
+                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "io-lifetimes",
+                    "libc",
+                    "std",
+                    "termios",
+                    "use-libc-auxv"
+                ]
+            },
+            {
+                "id": "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi_util",
+                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi_util",
+                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "same_file",
+                        "pkg": "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi_util",
+                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi_i686_pc_windows_gnu",
+                        "pkg": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi_x86_64_pc_windows_gnu",
+                        "pkg": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnu"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "consoleapi",
+                    "errhandlingapi",
+                    "fileapi",
+                    "minwindef",
+                    "ntdef",
+                    "processenv",
+                    "std",
+                    "winbase",
+                    "wincon",
+                    "winerror",
+                    "winnt"
+                ]
+            },
+            {
+                "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "windows_aarch64_gnullvm",
+                        "pkg": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_aarch64_msvc",
+                        "pkg": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "aarch64-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_gnu",
+                        "pkg": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_msvc",
+                        "pkg": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnu",
+                        "pkg": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnullvm",
+                        "pkg": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_msvc",
+                        "pkg": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-msvc"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "Win32",
+                    "Win32_Foundation",
+                    "Win32_Security",
+                    "Win32_Storage",
+                    "Win32_Storage_FileSystem",
+                    "Win32_System",
+                    "Win32_System_IO",
+                    "Win32_System_Threading",
+                    "Win32_System_WindowsProgramming",
+                    "default"
+                ]
+            },
+            {
+                "id": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "windows_targets",
+                        "pkg": "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(windows_raw_dylib))"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "Win32",
+                    "Win32_Foundation",
+                    "Win32_NetworkManagement",
+                    "Win32_NetworkManagement_IpHelper",
+                    "Win32_Networking",
+                    "Win32_Networking_WinSock",
+                    "Win32_Security",
+                    "Win32_Storage",
+                    "Win32_Storage_FileSystem",
+                    "Win32_System",
+                    "Win32_System_Console",
+                    "Win32_System_IO",
+                    "Win32_System_Pipes",
+                    "Win32_System_Threading",
+                    "Win32_System_WindowsProgramming",
+                    "default"
+                ]
+            },
+            {
+                "id": "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "windows_aarch64_gnullvm",
+                        "pkg": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_aarch64_msvc",
+                        "pkg": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "aarch64-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_gnu",
+                        "pkg": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_msvc",
+                        "pkg": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnu",
+                        "pkg": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnullvm",
+                        "pkg": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_msvc",
+                        "pkg": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-msvc"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            }
+        ],
+        "root": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_enabled)"
+    },
+    "target_directory": "{TEMP_DIR}/crate_optional_deps_enabled/target",
+    "version": 1,
+    "workspace_root": "{TEMP_DIR}/crate_optional_deps_enabled",
+    "metadata": null
 }

--- a/crate_universe/test_data/metadata/crate_types/metadata.json
+++ b/crate_universe/test_data/metadata/crate_types/metadata.json
@@ -270,6 +270,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "default": [],
                 "example_generated": [],
                 "rustc-dep-of-std": [
@@ -374,6 +380,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "rustc-dep-of-std": [
                     "core",
                     "compiler_builtins"
@@ -867,6 +879,9 @@
                 }
             ],
             "features": {
+                "crossbeam-utils": [
+                    "dep:crossbeam-utils"
+                ],
                 "default": [
                     "std"
                 ],
@@ -1030,6 +1045,12 @@
                 }
             ],
             "features": {
+                "crossbeam-epoch": [
+                    "dep:crossbeam-epoch"
+                ],
+                "crossbeam-utils": [
+                    "dep:crossbeam-utils"
+                ],
                 "default": [
                     "std"
                 ],
@@ -1272,12 +1293,21 @@
             ],
             "features": {
                 "alloc": [],
+                "const_fn": [
+                    "dep:const_fn"
+                ],
                 "default": [
                     "std"
+                ],
+                "lazy_static": [
+                    "dep:lazy_static"
                 ],
                 "loom": [
                     "loom-crate",
                     "crossbeam-utils/loom"
+                ],
+                "loom-crate": [
+                    "dep:loom-crate"
                 ],
                 "nightly": [
                     "crossbeam-utils/nightly",
@@ -1515,6 +1545,12 @@
                 "default": [
                     "std"
                 ],
+                "lazy_static": [
+                    "dep:lazy_static"
+                ],
+                "loom": [
+                    "dep:loom"
+                ],
                 "nightly": [],
                 "std": [
                     "lazy_static"
@@ -1600,6 +1636,9 @@
             "features": {
                 "default": [
                     "use_std"
+                ],
+                "serde": [
+                    "dep:serde"
                 ],
                 "use_std": []
             },
@@ -1701,6 +1740,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "default": [],
                 "docs": [],
                 "rustc-dep-of-std": [
@@ -1819,6 +1864,9 @@
                 }
             ],
             "features": {
+                "spin": [
+                    "dep:spin"
+                ],
                 "spin_no_std": [
                     "spin"
                 ]
@@ -1924,6 +1972,9 @@
                 "rustc-dep-of-std": [
                     "align",
                     "rustc-std-workspace-core"
+                ],
+                "rustc-std-workspace-core": [
+                    "dep:rustc-std-workspace-core"
                 ],
                 "std": [],
                 "use_std": [
@@ -2483,8 +2534,14 @@
                 "alloc": [
                     "race"
                 ],
+                "atomic-polyfill": [
+                    "dep:atomic-polyfill"
+                ],
                 "default": [
                     "std"
+                ],
+                "parking_lot": [
+                    "dep:parking_lot"
                 ],
                 "race": [],
                 "std": [
@@ -3546,6 +3603,9 @@
                 ],
                 "multithread": [
                     "rayon"
+                ],
+                "rayon": [
+                    "dep:rayon"
                 ],
                 "unknown-ci": []
             },

--- a/crate_universe/test_data/metadata/git_repos/metadata.json
+++ b/crate_universe/test_data/metadata/git_repos/metadata.json
@@ -65,6 +65,12 @@
                 }
             ],
             "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
                 "rustc-dep-of-std": [
                     "core",
                     "compiler_builtins"
@@ -220,6 +226,9 @@
                 }
             ],
             "features": {
+                "spin": [
+                    "dep:spin"
+                ],
                 "spin_no_std": [
                     "spin"
                 ]
@@ -1410,6 +1419,9 @@
                     "proc-macro2/proc-macro",
                     "quote/proc-macro"
                 ],
+                "quote": [
+                    "dep:quote"
+                ],
                 "test": [
                     "syn-test-suite/all-features"
                 ],
@@ -1812,6 +1824,9 @@
                     "std",
                     "attributes"
                 ],
+                "log": [
+                    "dep:log"
+                ],
                 "log-always": [
                     "log"
                 ],
@@ -1830,6 +1845,9 @@
                 "std": [
                     "tracing-core/std",
                     "alloc"
+                ],
+                "tracing-attributes": [
+                    "dep:tracing-attributes"
                 ]
             },
             "manifest_path": "{CARGO_HOME}/git/checkouts/tracing-e9bbb56ea31f0c18/1e09e50/tracing/Cargo.toml",
@@ -2229,6 +2247,9 @@
                 "alloc": [],
                 "default": [
                     "std"
+                ],
+                "lazy_static": [
+                    "dep:lazy_static"
                 ],
                 "std": [
                     "lazy_static",

--- a/crate_universe/test_data/metadata/multi_cfg_dep/Cargo.lock
+++ b/crate_universe/test_data/metadata/multi_cfg_dep/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]

--- a/crate_universe/test_data/metadata/multi_cfg_dep/Cargo.toml
+++ b/crate_universe/test_data/metadata/multi_cfg_dep/Cargo.toml
@@ -11,4 +11,4 @@ path = "lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cpufeatures = "=0.2.1"
+cpufeatures = "=0.2.7"

--- a/crate_universe/test_data/metadata/multi_cfg_dep/metadata.json
+++ b/crate_universe/test_data/metadata/multi_cfg_dep/metadata.json
@@ -2,35 +2,47 @@
     "packages": [
         {
             "name": "cpufeatures",
-            "version": "0.2.1",
-            "id": "cpufeatures 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "version": "0.2.7",
+            "id": "cpufeatures 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
             "license": "MIT OR Apache-2.0",
             "license_file": null,
-            "description": "Lightweight and efficient no-std compatible alternative to the\nis_x86_feature_detected! macro\n",
+            "description": "Lightweight runtime CPU feature detection for x86/x86_64 and aarch64 with\nno_std support and support for mobile targets including Android and iOS\n",
             "source": "registry+https://github.com/rust-lang/crates.io-index",
             "dependencies": [
                 {
                     "name": "libc",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "req": "^0.2.101",
+                    "req": "^0.2.95",
                     "kind": null,
                     "rename": null,
                     "optional": false,
                     "uses_default_features": true,
                     "features": [],
-                    "target": "aarch64-apple-darwin",
+                    "target": "aarch64-linux-android",
                     "registry": null
                 },
                 {
                     "name": "libc",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "req": "^0.2.101",
+                    "req": "^0.2.95",
                     "kind": null,
                     "rename": null,
                     "optional": false,
                     "uses_default_features": true,
                     "features": [],
                     "target": "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.95",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))",
                     "registry": null
                 }
             ],
@@ -43,7 +55,7 @@
                         "lib"
                     ],
                     "name": "cpufeatures",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cpufeatures-0.2.1/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cpufeatures-0.2.7/src/lib.rs",
                     "edition": "2018",
                     "doc": true,
                     "doctest": true,
@@ -57,7 +69,7 @@
                         "bin"
                     ],
                     "name": "x86",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cpufeatures-0.2.1/tests/x86.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cpufeatures-0.2.7/tests/x86.rs",
                     "edition": "2018",
                     "doc": false,
                     "doctest": false,
@@ -71,7 +83,7 @@
                         "bin"
                     ],
                     "name": "aarch64",
-                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cpufeatures-0.2.1/tests/aarch64.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cpufeatures-0.2.7/tests/aarch64.rs",
                     "edition": "2018",
                     "doc": false,
                     "doctest": false,
@@ -79,13 +91,14 @@
                 }
             ],
             "features": {},
-            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cpufeatures-0.2.1/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cpufeatures-0.2.7/Cargo.toml",
             "metadata": null,
             "publish": null,
             "authors": [
                 "RustCrypto Developers"
             ],
             "categories": [
+                "hardware-support",
                 "no-std"
             ],
             "keywords": [
@@ -178,6 +191,9 @@
                     "align",
                     "rustc-std-workspace-core"
                 ],
+                "rustc-std-workspace-core": [
+                    "dep:rustc-std-workspace-core"
+                ],
                 "std": [],
                 "use_std": [
                     "std"
@@ -231,7 +247,7 @@
                 {
                     "name": "cpufeatures",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "req": "=0.2.1",
+                    "req": "=0.2.7",
                     "kind": null,
                     "rename": null,
                     "optional": false,
@@ -280,7 +296,7 @@
     "resolve": {
         "nodes": [
             {
-                "id": "cpufeatures 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "id": "cpufeatures 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
                 "dependencies": [
                     "libc 0.2.117 (registry+https://github.com/rust-lang/crates.io-index)"
                 ],
@@ -291,11 +307,15 @@
                         "dep_kinds": [
                             {
                                 "kind": null,
-                                "target": "aarch64-apple-darwin"
+                                "target": "aarch64-linux-android"
                             },
                             {
                                 "kind": null,
                                 "target": "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))"
                             }
                         ]
                     }
@@ -314,12 +334,12 @@
             {
                 "id": "multi_cfg_dep 0.1.0 (path+file://{TEMP_DIR}/multi_cfg_dep)",
                 "dependencies": [
-                    "cpufeatures 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "cpufeatures 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
                 ],
                 "deps": [
                     {
                         "name": "cpufeatures",
-                        "pkg": "cpufeatures 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "pkg": "cpufeatures 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
                         "dep_kinds": [
                             {
                                 "kind": null,

--- a/crate_universe/test_data/metadata/target_cfg_features/metadata.json
+++ b/crate_universe/test_data/metadata/target_cfg_features/metadata.json
@@ -1,0 +1,4410 @@
+{
+    "packages": [
+        {
+            "name": "autocfg",
+            "version": "1.1.0",
+            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "Automatic cfg for Rust compiler features",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "autocfg",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "integers",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/integers.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "paths",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/paths.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "versions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/versions.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "traits",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/traits.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rustflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/tests/rustflags.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Josh Stone <cuviper@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::build-utils"
+            ],
+            "keywords": [
+                "rustc",
+                "build",
+                "autoconf"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/cuviper/autocfg",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "pin-project-lite",
+            "version": "0.2.9",
+            "id": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "A lightweight version of pin-project written with declarative macros.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "static_assertions",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.49",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "pin-project-lite",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "proper_unpin",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/proper_unpin.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "drop_order",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/drop_order.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "expandtest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/expandtest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "lint",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/lint.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pin-project-lite-0.2.9/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "no-std",
+                "rust-patterns"
+            ],
+            "keywords": [
+                "pin",
+                "macros"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/taiki-e/pin-project-lite",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.37"
+        },
+        {
+            "name": "target_cfg_features",
+            "version": "0.1.0",
+            "id": "target_cfg_features 0.1.0 (path+file://{TEMP_DIR}/target_cfg_features)",
+            "license": null,
+            "license_file": null,
+            "description": null,
+            "source": null,
+            "dependencies": [
+                {
+                    "name": "tokio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.25.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tokio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "*",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "fs"
+                    ],
+                    "target": "cfg(unix)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "target_cfg_features",
+                    "src_path": "{TEMP_DIR}/target_cfg_features/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{TEMP_DIR}/target_cfg_features/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "tokio",
+            "version": "1.25.0",
+            "id": "tokio 1.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "An event-driven, non-blocking I/O platform for writing asynchronous I/O\nbacked applications.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bytes",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "memchr",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "mio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "num_cpus",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.8.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.12.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pin-project-lite",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tokio-macros",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.7.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "async-stream",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "async-await"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "mockall",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tokio-stream",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tokio-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "autocfg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(any(target_arch = \"wasm32\", target_arch = \"wasm64\"), not(target_os = \"wasi\")))",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Win32_Foundation",
+                        "Win32_Security_Authorization"
+                    ],
+                    "target": "cfg(docsrs)",
+                    "registry": null
+                },
+                {
+                    "name": "loom",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "futures",
+                        "checkpoint"
+                    ],
+                    "target": "cfg(loom)",
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(all(any(target_arch = \"wasm32\", target_arch = \"wasm64\"), target_os = \"unknown\")))",
+                    "registry": null
+                },
+                {
+                    "name": "socket2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "all"
+                    ],
+                    "target": "cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))",
+                    "registry": null
+                },
+                {
+                    "name": "proptest",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))",
+                    "registry": null
+                },
+                {
+                    "name": "socket2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))",
+                    "registry": null
+                },
+                {
+                    "name": "mio-aio",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "tokio"
+                    ],
+                    "target": "cfg(target_os = \"freebsd\")",
+                    "registry": null
+                },
+                {
+                    "name": "tracing",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.25",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "std"
+                    ],
+                    "target": "cfg(tokio_unstable)",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.42",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "signal-hook-registry",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.42",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "nix",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.26",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "fs",
+                        "socket"
+                    ],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                },
+                {
+                    "name": "ntapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "tokio",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "task_panic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/task_panic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_chain",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_chain.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_no_rt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_no_rt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "task_local",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/task_local.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_usr1",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_usr1.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_panic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_panic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "task_abort",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/task_abort.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "process_arg0",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/process_arg0.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fs_link",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/fs_link.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "task_join_set",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/task_join_set.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_socket",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_socket.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "time_sleep",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/time_sleep.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_driver",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_driver.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_read_buf",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_read_buf.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_read",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_read.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "process_issue_2174",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/process_issue_2174.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_split",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_split.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_drop_recv",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_drop_recv.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rt_panic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/rt_panic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "time_pause",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/time_pause.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_errors",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_errors.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_accept",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_accept.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "uds_split",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/uds_split.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_rename_test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/macros_rename_test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_read_to_end",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_read_to_end.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_panic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_panic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "task_local_set",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/task_local_set.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_semaphore_owned",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_semaphore_owned.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_notify_both",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_notify_both.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_driver_drop",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_driver_drop.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_ctrl_c",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_ctrl_c.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_once_cell",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_once_cell.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "process_issue_42",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/process_issue_42.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_write_int",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_write_int.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_drop_rt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_drop_rt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "time_rt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/time_rt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "time_interval",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/time_interval.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_take",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_take.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_connect",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_connect.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fs_dir",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/fs_dir.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_into_std",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_into_std.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_semaphore",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_semaphore.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_select",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/macros_select.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fs_copy",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/fs_copy.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_write",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_write.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "buffered",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/buffered.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "no_rt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/no_rt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_mutex_owned",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_mutex_owned.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_mpsc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_mpsc.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_panic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_panic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "net_bind_resource",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/net_bind_resource.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_util_empty",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_util_empty.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "net_panic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/net_panic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rt_common",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/rt_common.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "task_blocking",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/task_blocking.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_echo",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_echo.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rt_handle_block_on",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/rt_handle_block_on.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fs_file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/fs_file.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_poll_aio",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_poll_aio.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_notify",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_notify.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_buf_writer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_buf_writer.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "time_timeout",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/time_timeout.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "unwindsafe",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/unwindsafe.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "task_id",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/task_id.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_fill_buf",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_fill_buf.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_write_buf",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_write_buf.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_buf_reader",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_buf_reader.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "process_raw_handle",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/process_raw_handle.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_copy",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_copy.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_oneshot",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_oneshot.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_read_until",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_read_until.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "process_kill_on_drop",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/process_kill_on_drop.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "task_builder",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/task_builder.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rt_metrics",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/rt_metrics.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "uds_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/uds_stream.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_clock",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/test_clock.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_write_all_buf",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_write_all_buf.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "async_send_sync",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/async_send_sync.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_read_exact",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_read_exact.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_stream.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_barrier",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_barrier.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_read_line",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_read_line.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_copy_bidirectional",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_copy_bidirectional.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_try_join",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/macros_try_join.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_mutex",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_mutex.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rt_threaded",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/rt_threaded.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_lines",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_lines.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_mem_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_mem_stream.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "uds_cred",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/uds_cred.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_drop_signal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_drop_signal.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_read_to_string",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_read_to_string.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "uds_datagram",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/uds_datagram.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "net_named_pipe",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/net_named_pipe.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fs",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/fs.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "process_smoke",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/process_smoke.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_join",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/macros_join.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "_require_full",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/_require_full.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_peek",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_peek.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_async_read",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_async_read.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_multi_rt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_multi_rt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "time_panic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/time_panic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "net_lookup_host",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/net_lookup_host.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_split",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_split.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/macros_test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rt_basic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/rt_basic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "signal_twice",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/signal_twice.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_pin",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/macros_pin.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_rwlock",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_rwlock.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "join_handle_panic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/join_handle_panic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_broadcast",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_broadcast.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_mpsc_weak",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_mpsc_weak.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_into_split",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_into_split.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "sync_watch",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/sync_watch.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tcp_shutdown",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/tcp_shutdown.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "udp",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/udp.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_write_all",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_write_all.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "io_async_fd",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/tests/io_async_fd.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "bytes": [
+                    "dep:bytes"
+                ],
+                "default": [],
+                "fs": [],
+                "full": [
+                    "fs",
+                    "io-util",
+                    "io-std",
+                    "macros",
+                    "net",
+                    "parking_lot",
+                    "process",
+                    "rt",
+                    "rt-multi-thread",
+                    "signal",
+                    "sync",
+                    "time"
+                ],
+                "io-std": [],
+                "io-util": [
+                    "memchr",
+                    "bytes"
+                ],
+                "libc": [
+                    "dep:libc"
+                ],
+                "macros": [
+                    "tokio-macros"
+                ],
+                "memchr": [
+                    "dep:memchr"
+                ],
+                "mio": [
+                    "dep:mio"
+                ],
+                "net": [
+                    "libc",
+                    "mio/os-poll",
+                    "mio/os-ext",
+                    "mio/net",
+                    "socket2",
+                    "windows-sys/Win32_Foundation",
+                    "windows-sys/Win32_Security",
+                    "windows-sys/Win32_Storage_FileSystem",
+                    "windows-sys/Win32_System_Pipes",
+                    "windows-sys/Win32_System_SystemServices"
+                ],
+                "num_cpus": [
+                    "dep:num_cpus"
+                ],
+                "parking_lot": [
+                    "dep:parking_lot"
+                ],
+                "process": [
+                    "bytes",
+                    "libc",
+                    "mio/os-poll",
+                    "mio/os-ext",
+                    "mio/net",
+                    "signal-hook-registry",
+                    "windows-sys/Win32_Foundation",
+                    "windows-sys/Win32_System_Threading",
+                    "windows-sys/Win32_System_WindowsProgramming"
+                ],
+                "rt": [],
+                "rt-multi-thread": [
+                    "num_cpus",
+                    "rt"
+                ],
+                "signal": [
+                    "libc",
+                    "mio/os-poll",
+                    "mio/net",
+                    "mio/os-ext",
+                    "signal-hook-registry",
+                    "windows-sys/Win32_Foundation",
+                    "windows-sys/Win32_System_Console"
+                ],
+                "signal-hook-registry": [
+                    "dep:signal-hook-registry"
+                ],
+                "socket2": [
+                    "dep:socket2"
+                ],
+                "stats": [],
+                "sync": [],
+                "test-util": [
+                    "rt",
+                    "sync",
+                    "time"
+                ],
+                "time": [],
+                "tokio-macros": [
+                    "dep:tokio-macros"
+                ],
+                "tracing": [
+                    "dep:tracing"
+                ],
+                "windows-sys": [
+                    "dep:windows-sys"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustc-args": [
+                            "--cfg",
+                            "tokio_unstable"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs",
+                            "--cfg",
+                            "tokio_unstable"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "full",
+                        "test-util"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Tokio Contributors <team@tokio.rs>"
+            ],
+            "categories": [
+                "asynchronous",
+                "network-programming"
+            ],
+            "keywords": [
+                "io",
+                "async",
+                "non-blocking",
+                "futures"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/tokio-rs/tokio",
+            "homepage": "https://tokio.rs",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.49"
+        },
+        {
+            "name": "windows-sys",
+            "version": "0.42.0",
+            "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Rust for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "windows_aarch64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-msvc",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "Win32": [],
+                "Win32_AI": [
+                    "Win32"
+                ],
+                "Win32_AI_MachineLearning": [
+                    "Win32_AI"
+                ],
+                "Win32_AI_MachineLearning_DirectML": [
+                    "Win32_AI_MachineLearning"
+                ],
+                "Win32_AI_MachineLearning_WinML": [
+                    "Win32_AI_MachineLearning"
+                ],
+                "Win32_Data": [
+                    "Win32"
+                ],
+                "Win32_Data_HtmlHelp": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_RightsManagement": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml_MsXml": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Data_Xml_XmlLite": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Devices": [
+                    "Win32"
+                ],
+                "Win32_Devices_AllJoyn": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_BiometricFramework": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Bluetooth": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Communication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAccess": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAndDriverInstallation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceQuery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Display": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration_Pnp": [
+                    "Win32_Devices_Enumeration"
+                ],
+                "Win32_Devices_Fax": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_FunctionDiscovery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Geolocation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_HumanInterfaceDevice": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_ImageAcquisition": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_PortableDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Properties": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Pwm": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Sensors": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_SerialCommunication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Tapi": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Usb": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_WebServicesOnDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Foundation": [
+                    "Win32"
+                ],
+                "Win32_Gaming": [
+                    "Win32"
+                ],
+                "Win32_Globalization": [
+                    "Win32"
+                ],
+                "Win32_Graphics": [
+                    "Win32"
+                ],
+                "Win32_Graphics_CompositionSwapchain": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DXCore": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct2D": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct2D_Common": [
+                    "Win32_Graphics_Direct2D"
+                ],
+                "Win32_Graphics_Direct3D": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D10": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D11": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D11on12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D9": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D9on12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D_Dxc": [
+                    "Win32_Graphics_Direct3D"
+                ],
+                "Win32_Graphics_Direct3D_Fxc": [
+                    "Win32_Graphics_Direct3D"
+                ],
+                "Win32_Graphics_DirectComposition": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectDraw": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectManipulation": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectWrite": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dwm": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dxgi": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dxgi_Common": [
+                    "Win32_Graphics_Dxgi"
+                ],
+                "Win32_Graphics_Gdi": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Hlsl": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Imaging": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Imaging_D2D": [
+                    "Win32_Graphics_Imaging"
+                ],
+                "Win32_Graphics_OpenGL": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing_PrintTicket": [
+                    "Win32_Graphics_Printing"
+                ],
+                "Win32_Management": [
+                    "Win32"
+                ],
+                "Win32_Management_MobileDeviceManagementRegistration": [
+                    "Win32_Management"
+                ],
+                "Win32_Media": [
+                    "Win32"
+                ],
+                "Win32_Media_Audio": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Audio_Apo": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_DirectMusic": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_DirectSound": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_Endpoints": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_XAudio2": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_DeviceManager": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_DirectShow": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_DirectShow_Xml": [
+                    "Win32_Media_DirectShow"
+                ],
+                "Win32_Media_DxMediaObjects": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_KernelStreaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_LibrarySharingServices": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_MediaFoundation": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_MediaPlayer": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Multimedia": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_PictureAcquisition": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Speech": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Streaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_WindowsMediaFormat": [
+                    "Win32_Media"
+                ],
+                "Win32_NetworkManagement": [
+                    "Win32"
+                ],
+                "Win32_NetworkManagement_Dhcp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Dns": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_InternetConnectionWizard": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_IpHelper": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_MobileBroadband": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Multicast": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Ndis": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetBios": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetManagement": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetShell": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkDiagnosticsFramework": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkPolicyServer": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_P2P": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_QoS": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Rras": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Snmp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WNet": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WebDav": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WiFi": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectNow": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectionManager": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFilteringPlatform": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFirewall": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsNetworkVirtualization": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_Networking": [
+                    "Win32"
+                ],
+                "Win32_Networking_ActiveDirectory": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_BackgroundIntelligentTransferService": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Clustering": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_HttpServer": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Ldap": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_NetworkListManager": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_RemoteDifferentialCompression": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WebSocket": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinHttp": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinInet": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinSock": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WindowsWebServices": [
+                    "Win32_Networking"
+                ],
+                "Win32_Security": [
+                    "Win32"
+                ],
+                "Win32_Security_AppLocker": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication_Identity": [
+                    "Win32_Security_Authentication"
+                ],
+                "Win32_Security_Authentication_Identity_Provider": [
+                    "Win32_Security_Authentication_Identity"
+                ],
+                "Win32_Security_Authorization": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authorization_UI": [
+                    "Win32_Security_Authorization"
+                ],
+                "Win32_Security_ConfigurationSnapin": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Credentials": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography_Catalog": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Certificates": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Sip": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_UI": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_DiagnosticDataQuery": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_DirectoryServices": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_EnterpriseData": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_ExtensibleAuthenticationProtocol": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Isolation": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_LicenseProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_NetworkAccessProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Tpm": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinTrust": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinWlx": [
+                    "Win32_Security"
+                ],
+                "Win32_Storage": [
+                    "Win32"
+                ],
+                "Win32_Storage_Cabinets": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_CloudFilters": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Compression": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DataDeduplication": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DistributedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_EnhancedStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileHistory": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileServerResourceManager": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Imapi": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IndexServer": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_InstallableFileSystems": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IscsiDisc": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Jet": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OfflineFiles": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OperationRecorder": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging_Appx": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_Packaging_Opc": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_ProjectedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_StructuredStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vhd": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_VirtualDiskService": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vss": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps_Printing": [
+                    "Win32_Storage_Xps"
+                ],
+                "Win32_System": [
+                    "Win32"
+                ],
+                "Win32_System_AddressBook": [
+                    "Win32_System"
+                ],
+                "Win32_System_Antimalware": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationInstallationAndServicing": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationVerifier": [
+                    "Win32_System"
+                ],
+                "Win32_System_AssessmentTool": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com_CallObj": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_ChannelCredentials": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Events": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Marshal": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_StructuredStorage": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_UI": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Urlmon": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_ComponentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_Console": [
+                    "Win32_System"
+                ],
+                "Win32_System_Contacts": [
+                    "Win32_System"
+                ],
+                "Win32_System_CorrelationVector": [
+                    "Win32_System"
+                ],
+                "Win32_System_DataExchange": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeploymentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_DesktopSharing": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeveloperLicensing": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics_Ceip": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Debug": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Etw": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ProcessSnapshotting": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ToolHelp": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_DistributedTransactionCoordinator": [
+                    "Win32_System"
+                ],
+                "Win32_System_Environment": [
+                    "Win32_System"
+                ],
+                "Win32_System_ErrorReporting": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventCollector": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventLog": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventNotificationService": [
+                    "Win32_System"
+                ],
+                "Win32_System_GroupPolicy": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostCompute": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeNetwork": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeSystem": [
+                    "Win32_System"
+                ],
+                "Win32_System_Hypervisor": [
+                    "Win32_System"
+                ],
+                "Win32_System_IO": [
+                    "Win32_System"
+                ],
+                "Win32_System_Iis": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ioctl": [
+                    "Win32_System"
+                ],
+                "Win32_System_JobObjects": [
+                    "Win32_System"
+                ],
+                "Win32_System_Js": [
+                    "Win32_System"
+                ],
+                "Win32_System_Kernel": [
+                    "Win32_System"
+                ],
+                "Win32_System_LibraryLoader": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mailslots": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mapi": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory_NonVolatile": [
+                    "Win32_System_Memory"
+                ],
+                "Win32_System_MessageQueuing": [
+                    "Win32_System"
+                ],
+                "Win32_System_MixedReality": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mmc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ole": [
+                    "Win32_System"
+                ],
+                "Win32_System_ParentalControls": [
+                    "Win32_System"
+                ],
+                "Win32_System_PasswordManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance_HardwareCounterProfiling": [
+                    "Win32_System_Performance"
+                ],
+                "Win32_System_Pipes": [
+                    "Win32_System"
+                ],
+                "Win32_System_Power": [
+                    "Win32_System"
+                ],
+                "Win32_System_ProcessStatus": [
+                    "Win32_System"
+                ],
+                "Win32_System_RealTimeCommunications": [
+                    "Win32_System"
+                ],
+                "Win32_System_Recovery": [
+                    "Win32_System"
+                ],
+                "Win32_System_Registry": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteAssistance": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteDesktop": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_RestartManager": [
+                    "Win32_System"
+                ],
+                "Win32_System_Restore": [
+                    "Win32_System"
+                ],
+                "Win32_System_Rpc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search_Common": [
+                    "Win32_System_Search"
+                ],
+                "Win32_System_SecurityCenter": [
+                    "Win32_System"
+                ],
+                "Win32_System_ServerBackup": [
+                    "Win32_System"
+                ],
+                "Win32_System_Services": [
+                    "Win32_System"
+                ],
+                "Win32_System_SettingsManagementInfrastructure": [
+                    "Win32_System"
+                ],
+                "Win32_System_SetupAndMigration": [
+                    "Win32_System"
+                ],
+                "Win32_System_Shutdown": [
+                    "Win32_System"
+                ],
+                "Win32_System_SideShow": [
+                    "Win32_System"
+                ],
+                "Win32_System_StationsAndDesktops": [
+                    "Win32_System"
+                ],
+                "Win32_System_SubsystemForLinux": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemInformation": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_TaskScheduler": [
+                    "Win32_System"
+                ],
+                "Win32_System_Threading": [
+                    "Win32_System"
+                ],
+                "Win32_System_Time": [
+                    "Win32_System"
+                ],
+                "Win32_System_TpmBaseServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_TransactionServer": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAgent": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAssessment": [
+                    "Win32_System"
+                ],
+                "Win32_System_UserAccessLogging": [
+                    "Win32_System"
+                ],
+                "Win32_System_VirtualDosMachines": [
+                    "Win32_System"
+                ],
+                "Win32_System_WinRT": [
+                    "Win32_System"
+                ],
+                "Win32_System_WinRT_AllJoyn": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Composition": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_CoreInputView": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Direct3D11": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Display": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Graphics": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Graphics_Capture": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Graphics_Direct2D": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Graphics_Imaging": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Holographic": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Isolation": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_ML": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Media": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Pdf": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Printing": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Shell": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Storage": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WindowsProgramming": [
+                    "Win32_System"
+                ],
+                "Win32_System_WindowsSync": [
+                    "Win32_System"
+                ],
+                "Win32_System_Wmi": [
+                    "Win32_System"
+                ],
+                "Win32_UI": [
+                    "Win32"
+                ],
+                "Win32_UI_Accessibility": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Animation": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_ColorSystem": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls_Dialogs": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_Controls_RichEdit": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_HiDpi": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input_Ime": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Ink": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_KeyboardAndMouse": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Pointer": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Radial": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Touch": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_XboxController": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_InteractionContext": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_LegacyWindowsEnvironmentFeatures": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Magnification": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Notifications": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Ribbon": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell_Common": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_Shell_PropertiesSystem": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_TabletPC": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_TextServices": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_WindowsAndMessaging": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Wpf": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Xaml": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Xaml_Diagnostics": [
+                    "Win32_UI_Xaml"
+                ],
+                "default": [],
+                "deprecated": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "readme.md",
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.49"
+        },
+        {
+            "name": "windows_aarch64_gnullvm",
+            "version": "0.42.1",
+            "id": "windows_aarch64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_aarch64_gnullvm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.1/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_aarch64_msvc",
+            "version": "0.42.1",
+            "id": "windows_aarch64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_aarch64_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.1/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_i686_gnu",
+            "version": "0.42.1",
+            "id": "windows_i686_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_i686_gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.1/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_i686_msvc",
+            "version": "0.42.1",
+            "id": "windows_i686_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_i686_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.1/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_x86_64_gnu",
+            "version": "0.42.1",
+            "id": "windows_x86_64_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.1/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_x86_64_gnullvm",
+            "version": "0.42.1",
+            "id": "windows_x86_64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_gnullvm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.1/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_x86_64_msvc",
+            "version": "0.42.1",
+            "id": "windows_x86_64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.1/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        }
+    ],
+    "workspace_members": [
+        "target_cfg_features 0.1.0 (path+file://{TEMP_DIR}/target_cfg_features)"
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "target_cfg_features 0.1.0 (path+file://{TEMP_DIR}/target_cfg_features)",
+                "dependencies": [
+                    "tokio 1.25.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "tokio",
+                        "pkg": "tokio 1.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "tokio 1.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "autocfg",
+                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "pin_project_lite",
+                        "pkg": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_sys",
+                        "pkg": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(docsrs)"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "fs"
+                ]
+            },
+            {
+                "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "windows_aarch64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_aarch64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "windows_aarch64_gnullvm",
+                        "pkg": "windows_aarch64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_aarch64_msvc",
+                        "pkg": "windows_aarch64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "aarch64-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_gnu",
+                        "pkg": "windows_i686_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_msvc",
+                        "pkg": "windows_i686_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnu",
+                        "pkg": "windows_x86_64_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnullvm",
+                        "pkg": "windows_x86_64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_msvc",
+                        "pkg": "windows_x86_64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-msvc"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "Win32",
+                    "Win32_Foundation",
+                    "Win32_Security",
+                    "Win32_Security_Authorization",
+                    "default"
+                ]
+            },
+            {
+                "id": "windows_aarch64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_aarch64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_i686_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_i686_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            }
+        ],
+        "root": "target_cfg_features 0.1.0 (path+file://{TEMP_DIR}/target_cfg_features)"
+    },
+    "target_directory": "{TEMP_DIR}/target_cfg_features/target",
+    "version": 1,
+    "workspace_root": "{TEMP_DIR}/target_cfg_features",
+    "metadata": null
+}

--- a/crate_universe/test_data/metadata/target_features/metadata.json
+++ b/crate_universe/test_data/metadata/target_features/metadata.json
@@ -1,0 +1,21982 @@
+{
+    "packages": [
+        {
+            "name": "ahash",
+            "version": "0.7.6",
+            "id": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A non-cryptographic hash function using AES-NI for high performance",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "hex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "no-panic",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "seahash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^4.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.59",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "version_check",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "const-random",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "getrandom",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.117",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "once_cell",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "alloc"
+                    ],
+                    "target": "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))",
+                    "registry": null
+                },
+                {
+                    "name": "const-random",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\")))",
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.117",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\")))",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "ahash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "nopanic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/nopanic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "map_tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/map_tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "ahash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "map",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/map_tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/./build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "compile-time-rng": [
+                    "const-random"
+                ],
+                "const-random": [
+                    "dep:const-random"
+                ],
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std"
+                        ],
+                        "rustc-args": [
+                            "-C",
+                            "target-feature=+aes"
+                        ],
+                        "rustdoc-args": [
+                            "-C",
+                            "target-feature=+aes"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Tom Kaitchuck <Tom.Kaitchuck@gmail.com>"
+            ],
+            "categories": [
+                "algorithms",
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "hash",
+                "hasher",
+                "hashmap",
+                "aes",
+                "no-std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/tkaitchuck/ahash",
+            "homepage": null,
+            "documentation": "https://docs.rs/ahash",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "android_system_properties",
+            "version": "0.1.5",
+            "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Minimal Android system properties wrapper",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.126",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "android_system_properties",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/android_system_properties-0.1.5/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "time_zone",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/android_system_properties-0.1.5/examples/time_zone.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/android_system_properties-0.1.5/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "arm-linux-androideabi",
+                            "armv7-linux-androideabi",
+                            "aarch64-linux-android",
+                            "i686-linux-android",
+                            "x86_64-linux-android",
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Nicolas Silva <nical@fastmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "android"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/nical/android_system_properties",
+            "homepage": "https://github.com/nical/android_system_properties",
+            "documentation": "https://docs.rs/android_system_properties",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "arrayvec",
+            "version": "0.7.2",
+            "id": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A vector with fixed capacity, backed by an array (it can be stored on the stack too). Implements fixed capacity ArrayVec and ArrayString.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bencher",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "matches",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "arrayvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "serde",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/tests/serde.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/tests/tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "extend",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/benches/extend.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "arraystring",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/benches/arraystring.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "serde"
+                        ]
+                    }
+                },
+                "release": {
+                    "no-dev-version": true,
+                    "tag-name": "{{version}}"
+                }
+            },
+            "publish": null,
+            "authors": [
+                "bluss"
+            ],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "stack",
+                "vector",
+                "array",
+                "data-structure",
+                "no_std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bluss/arrayvec",
+            "homepage": null,
+            "documentation": "https://docs.rs/arrayvec/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "ash",
+            "version": "0.37.1+1.3.235",
+            "id": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Vulkan bindings for Rust",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "ash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "display",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/tests/display.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "constant_size_arrays",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/tests/constant_size_arrays.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "debug": [],
+                "default": [
+                    "loaded",
+                    "debug"
+                ],
+                "libloading": [
+                    "dep:libloading"
+                ],
+                "linked": [],
+                "loaded": [
+                    "libloading"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                },
+                "release": {
+                    "no-dev-version": true
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Maik Klein <maikklein@googlemail.com>",
+                "Benjamin Saunders <ben.e.saunders@gmail.com>",
+                "Marijn Suijten <marijn@traverseresearch.nl>"
+            ],
+            "categories": [],
+            "keywords": [
+                "vulkan",
+                "graphic"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/MaikKlein/ash",
+            "homepage": null,
+            "documentation": "https://docs.rs/ash",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.59.0"
+        },
+        {
+            "name": "autocfg",
+            "version": "1.1.0",
+            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "Automatic cfg for Rust compiler features",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "autocfg",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "integers",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/integers.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "paths",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/paths.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "versions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/versions.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "traits",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/traits.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rustflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/tests/rustflags.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Josh Stone <cuviper@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::build-utils"
+            ],
+            "keywords": [
+                "rustc",
+                "build",
+                "autoconf"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/cuviper/autocfg",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "bit-set",
+            "version": "0.5.3",
+            "id": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A set of bits",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bit-vec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bit-set",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-set-0.5.3/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "std": [
+                    "bit-vec/std"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-set-0.5.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alexis Beingessner <a.beingessner@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "data-structures",
+                "bitset"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/contain-rs/bit-set",
+            "homepage": "https://github.com/contain-rs/bit-set",
+            "documentation": "https://contain-rs.github.io/bit-set/bit_set",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "bit-vec",
+            "version": "0.6.3",
+            "id": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A vector of bits",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand_xorshift",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bit-vec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-vec-0.6.3/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-vec-0.6.3/benches/bench.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serde_no_std": [
+                    "serde/alloc"
+                ],
+                "serde_std": [
+                    "std",
+                    "serde/std"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-vec-0.6.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alexis Beingessner <a.beingessner@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "data-structures",
+                "bitvec",
+                "bitmask",
+                "bitmap",
+                "bit"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/contain-rs/bit-vec",
+            "homepage": "https://github.com/contain-rs/bit-vec",
+            "documentation": "https://contain-rs.github.io/bit-vec/bit_vec",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "bitflags",
+            "version": "1.3.2",
+            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A macro to generate structures which behave like bitflags.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "walkdir",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bitflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compile",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/tests/compile.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "basic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/tests/basic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [],
+                "example_generated": [],
+                "rustc-dep-of-std": [
+                    "core",
+                    "compiler_builtins"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "example_generated"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "no-std"
+            ],
+            "keywords": [
+                "bit",
+                "bitmask",
+                "bitflags",
+                "flags"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bitflags/bitflags",
+            "homepage": "https://github.com/bitflags/bitflags",
+            "documentation": "https://docs.rs/bitflags",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "block",
+            "version": "0.1.6",
+            "id": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Rust interface for Apple's C language extension of blocks.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "objc_test_utils",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "block",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/block-0.1.6/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/block-0.1.6/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Sheldon"
+            ],
+            "categories": [],
+            "keywords": [
+                "blocks",
+                "osx",
+                "ios",
+                "objective-c"
+            ],
+            "readme": "README.md",
+            "repository": "http://github.com/SSheldon/rust-block",
+            "homepage": null,
+            "documentation": "http://ssheldon.github.io/rust-objc/block/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "bumpalo",
+            "version": "3.11.1",
+            "id": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A fast bump allocation arena for Rust.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bumpalo",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.1/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "try_alloc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.1/tests/try_alloc.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "benches",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.1/benches/benches.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "collections"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "allocator_api": [],
+                "boxed": [],
+                "collections": [],
+                "default": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Nick Fitzgerald <fitzgen@gmail.com>"
+            ],
+            "categories": [
+                "memory-management",
+                "rust-patterns",
+                "no-std"
+            ],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/fitzgen/bumpalo",
+            "homepage": null,
+            "documentation": "https://docs.rs/bumpalo",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "byteorder",
+            "version": "1.4.3",
+            "id": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense OR MIT",
+            "license_file": null,
+            "description": "Library for reading/writing numbers in big-endian and little-endian.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "byteorder",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/byteorder-1.4.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/byteorder-1.4.3/benches/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "i128": [],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/byteorder-1.4.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [
+                "encoding",
+                "parsing",
+                "no-std"
+            ],
+            "keywords": [
+                "byte",
+                "endian",
+                "big-endian",
+                "little-endian",
+                "binary"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/byteorder",
+            "homepage": "https://github.com/BurntSushi/byteorder",
+            "documentation": "https://docs.rs/byteorder",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cc",
+            "version": "1.0.77",
+            "id": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A build-time dependency for Cargo build scripts to assist in invoking the native\nC compiler to compile native C code into a static archive to be linked into Rust\ncode.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "jobserver",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.16",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bin"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "gcc-shim",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/src/bin/gcc-shim.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cxxflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/tests/cxxflags.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/tests/cflags.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cc_env",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/tests/cc_env.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "jobserver": [
+                    "dep:jobserver"
+                ],
+                "parallel": [
+                    "jobserver"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "development-tools::build-utils"
+            ],
+            "keywords": [
+                "build-dependencies"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/cc-rs",
+            "homepage": "https://github.com/rust-lang/cc-rs",
+            "documentation": "https://docs.rs/cc",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cfg-if",
+            "version": "1.0.0",
+            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A macro to ergonomically define an item depending on a large number of #[cfg]\nparameters. Structured like an if-else chain, the first matching branch is the\nitem that gets emitted.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cfg-if",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xcrate",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/tests/xcrate.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "rustc-dep-of-std": [
+                    "core",
+                    "compiler_builtins"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/alexcrichton/cfg-if",
+            "homepage": "https://github.com/alexcrichton/cfg-if",
+            "documentation": "https://docs.rs/cfg-if",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cfg_aliases",
+            "version": "0.1.1",
+            "id": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cfg_aliases",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg_aliases-0.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg_aliases-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zicklag <zicklag@katharostech.com>"
+            ],
+            "categories": [
+                "development-tools",
+                "development-tools::build-utils"
+            ],
+            "keywords": [
+                "cfg",
+                "alias",
+                "conditional",
+                "compilation",
+                "build"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/katharostech/cfg_aliases",
+            "homepage": "https://github.com/katharostech/cfg_aliases",
+            "documentation": "https://docs.rs/cfg_aliases",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "codespan-reporting",
+            "version": "0.11.1",
+            "id": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0",
+            "license_file": null,
+            "description": "Beautiful diagnostic reporting for text-based programming languages",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-width",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "insta",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.6.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "peg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustyline",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "structopt",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unindent",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "codespan-reporting",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "term",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/term.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "custom_files",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/custom_files.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "peg_calculator",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/peg_calculator.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "reusable_diagnostic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/reusable_diagnostic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "readme_preview",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/readme_preview.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "term",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/tests/term.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "ascii-only": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serialization": [
+                    "serde",
+                    "serde/rc"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Brendan Zabarauskas <bjzaba@yahoo.com.au>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "../README.md",
+            "repository": "https://github.com/brendanzab/codespan",
+            "homepage": "https://github.com/brendanzab/codespan",
+            "documentation": "https://docs.rs/codespan-reporting",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "core-foundation",
+            "version": "0.9.3",
+            "id": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT / Apache-2.0",
+            "license_file": null,
+            "description": "Bindings to Core Foundation for macOS",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "chrono",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "core-foundation-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "uuid",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "core-foundation",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-0.9.3/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "use_macro_outside_crate",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-0.9.3/tests/use_macro_outside_crate.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "chrono": [
+                    "dep:chrono"
+                ],
+                "mac_os_10_7_support": [
+                    "core-foundation-sys/mac_os_10_7_support"
+                ],
+                "mac_os_10_8_features": [
+                    "core-foundation-sys/mac_os_10_8_features"
+                ],
+                "uuid": [
+                    "dep:uuid"
+                ],
+                "with-chrono": [
+                    "chrono"
+                ],
+                "with-uuid": [
+                    "uuid"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-0.9.3/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-apple-darwin"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [
+                "os::macos-apis"
+            ],
+            "keywords": [
+                "macos",
+                "framework",
+                "objc"
+            ],
+            "readme": null,
+            "repository": "https://github.com/servo/core-foundation-rs",
+            "homepage": "https://github.com/servo/core-foundation-rs",
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "core-foundation-sys",
+            "version": "0.8.3",
+            "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT / Apache-2.0",
+            "license_file": null,
+            "description": "Bindings to Core Foundation for macOS",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "core-foundation-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-sys-0.8.3/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-sys-0.8.3/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "mac_os_10_7_support": [],
+                "mac_os_10_8_features": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-sys-0.8.3/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-apple-darwin"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/core-foundation-rs",
+            "homepage": "https://github.com/servo/core-foundation-rs",
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "core-graphics-types",
+            "version": "0.1.1",
+            "id": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT / Apache-2.0",
+            "license_file": null,
+            "description": "Bindings for some fundamental Core Graphics types",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "core-foundation",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "foreign-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "core-graphics-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-graphics-types-0.1.1/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-graphics-types-0.1.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-apple-darwin"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/core-foundation-rs",
+            "homepage": "https://github.com/servo/core-foundation-rs",
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cty",
+            "version": "0.2.2",
+            "id": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Type aliases to C types like c_int for use with bindgen",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cty",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cty-0.2.2/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cty-0.2.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Jorge Aparicio <jorge@japaric.io>"
+            ],
+            "categories": [
+                "embedded",
+                "external-ffi-bindings",
+                "no-std"
+            ],
+            "keywords": [
+                "c",
+                "types",
+                "bindgen",
+                "ffi"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/japaric/cty",
+            "homepage": null,
+            "documentation": "https://docs.rs/cty",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "d3d12",
+            "version": "0.5.0",
+            "id": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Low level D3D12 API wrapper",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "dxgi1_2",
+                        "dxgi1_3",
+                        "dxgi1_4",
+                        "dxgi1_5",
+                        "dxgi1_6",
+                        "dxgidebug",
+                        "d3d12",
+                        "d3d12sdklayers",
+                        "d3dcommon",
+                        "d3dcompiler",
+                        "dxgiformat",
+                        "synchapi",
+                        "winerror"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "d3d12",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/d3d12-0.5.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "implicit-link": [],
+                "libloading": [
+                    "dep:libloading"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/d3d12-0.5.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "gfx-rs developers"
+            ],
+            "categories": [
+                "api-bindings",
+                "graphics",
+                "memory-management",
+                "os::windows-apis"
+            ],
+            "keywords": [
+                "windows",
+                "graphics"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/d3d12-rs",
+            "homepage": null,
+            "documentation": "https://docs.rs/d3d12",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "foreign-types",
+            "version": "0.3.2",
+            "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A framework for Rust wrappers over C APIs",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "foreign-types-shared",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "foreign-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/foreign-types-0.3.2/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/foreign-types-0.3.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Fackler <sfackler@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/sfackler/foreign-types",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "foreign-types-shared",
+            "version": "0.1.1",
+            "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "An internal crate used by foreign-types",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "foreign-types-shared",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/foreign-types-shared-0.1.1/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/foreign-types-shared-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Fackler <sfackler@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/sfackler/foreign-types",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "fxhash",
+            "version": "0.2.1",
+            "id": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0/MIT",
+            "license_file": null,
+            "description": "A fast, non-secure, hashing algorithm derived from an internal hasher used in FireFox and Rustc.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "byteorder",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "seahash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.0.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "fxhash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/fxhash-0.2.1/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fxhash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/fxhash-0.2.1/bench.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/fxhash-0.2.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "cbreeden <github@u.breeden.cc>"
+            ],
+            "categories": [
+                "algorithms"
+            ],
+            "keywords": [
+                "hash"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/cbreeden/fxhash",
+            "homepage": null,
+            "documentation": "https://docs.rs/fxhash",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "getrandom",
+            "version": "0.2.8",
+            "id": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A small cross-platform library for retrieving random data from system source",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.62",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.18",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "registry": null
+                },
+                {
+                    "name": "wasi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"wasi\")",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.120",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "getrandom",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "normal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/tests/normal.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "custom",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/tests/custom.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rdrand",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/tests/rdrand.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "mod",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/benches/mod.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "custom": [],
+                "js": [
+                    "wasm-bindgen",
+                    "js-sys"
+                ],
+                "js-sys": [
+                    "dep:js-sys"
+                ],
+                "rdrand": [],
+                "rustc-dep-of-std": [
+                    "compiler_builtins",
+                    "core",
+                    "libc/rustc-dep-of-std",
+                    "wasi/rustc-dep-of-std"
+                ],
+                "std": [],
+                "test-in-browser": [],
+                "wasm-bindgen": [
+                    "dep:wasm-bindgen"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std",
+                            "custom"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rand Project Developers"
+            ],
+            "categories": [
+                "os",
+                "no-std"
+            ],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-random/getrandom",
+            "homepage": null,
+            "documentation": "https://docs.rs/getrandom",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "glow",
+            "version": "0.11.2",
+            "id": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "GL on Whatever: a set of bindings to run GL (Open GL, OpenGL ES, and WebGL) anywhere, and avoid target-specific code.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "~0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "slotmap",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "~0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "~0.3.37",
+                    "kind": null,
+                    "rename": "web_sys",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Document",
+                        "Element",
+                        "HtmlCanvasElement",
+                        "HtmlImageElement",
+                        "ImageBitmap",
+                        "WebGlActiveInfo",
+                        "WebGlBuffer",
+                        "WebGlFramebuffer",
+                        "WebGlProgram",
+                        "WebGlQuery",
+                        "WebGlRenderbuffer",
+                        "WebGlRenderingContext",
+                        "WebGl2RenderingContext",
+                        "WebGlSampler",
+                        "WebGlShader",
+                        "WebGlSync",
+                        "WebGlTexture",
+                        "WebGlTransformFeedback",
+                        "WebGlUniformLocation",
+                        "WebGlVertexArrayObject",
+                        "Window",
+                        "AngleInstancedArrays",
+                        "ExtBlendMinmax",
+                        "ExtColorBufferFloat",
+                        "ExtColorBufferHalfFloat",
+                        "ExtDisjointTimerQuery",
+                        "ExtFragDepth",
+                        "ExtShaderTextureLod",
+                        "ExtSRgb",
+                        "ExtTextureFilterAnisotropic",
+                        "OesElementIndexUint",
+                        "OesStandardDerivatives",
+                        "OesTextureFloat",
+                        "OesTextureFloatLinear",
+                        "OesTextureHalfFloat",
+                        "OesTextureHalfFloatLinear",
+                        "OesVertexArrayObject",
+                        "WebglColorBufferFloat",
+                        "WebglCompressedTextureAstc",
+                        "WebglCompressedTextureEtc",
+                        "WebglCompressedTextureEtc1",
+                        "WebglCompressedTexturePvrtc",
+                        "WebglCompressedTextureS3tc",
+                        "WebglCompressedTextureS3tcSrgb",
+                        "WebglDebugRendererInfo",
+                        "WebglDebugShaders",
+                        "WebglDepthTexture",
+                        "WebglDrawBuffers",
+                        "WebglLoseContext"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "glow",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/glow-0.11.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/glow-0.11.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-unknown-linux-gnu",
+                        "targets": [
+                            "x86_64-unknown-linux-gnu",
+                            "x86_64-apple-darwin",
+                            "x86_64-pc-windows-msvc",
+                            "i686-unknown-linux-gnu",
+                            "i686-pc-windows-msvc",
+                            "wasm32-unknown-unknown"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Joshua Groves <josh@joshgroves.com>",
+                "Dzmitry Malyshau <kvarkus@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/grovesNL/glow",
+            "homepage": "https://github.com/grovesNL/glow.git",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "gpu-alloc",
+            "version": "0.5.3",
+            "id": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Implementation agnostic memory allocator for Vulkan like APIs",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gpu-alloc-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.27",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "attributes"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "gpu-alloc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-alloc-0.5.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "tracing": [
+                    "dep:tracing"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-alloc-0.5.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zakarum <zakarumych@ya.ru>"
+            ],
+            "categories": [
+                "graphics",
+                "memory-management",
+                "no-std",
+                "game-development"
+            ],
+            "keywords": [
+                "gpu",
+                "vulkan",
+                "allocation",
+                "no-std"
+            ],
+            "readme": "../README.md",
+            "repository": "https://github.com/zakarumych/gpu-alloc",
+            "homepage": "https://github.com/zakarumych/gpu-alloc",
+            "documentation": "https://docs.rs/gpu-alloc-types",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "gpu-alloc-types",
+            "version": "0.2.0",
+            "id": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Core types of gpu-alloc crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "gpu-alloc-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-alloc-types-0.2.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-alloc-types-0.2.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zakarum <zakarumych@ya.ru>"
+            ],
+            "categories": [],
+            "keywords": [
+                "gpu",
+                "vulkan",
+                "allocation",
+                "no-std"
+            ],
+            "readme": null,
+            "repository": "https://github.com/zakarumych/gpu-alloc",
+            "homepage": "https://github.com/zakarumych/gpu-alloc",
+            "documentation": "https://docs.rs/gpu-alloc-types/0.2.0",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "gpu-descriptor",
+            "version": "0.2.3",
+            "id": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Implementation agnostic descriptor allocator for Vulkan like APIs",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gpu-descriptor-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "hashbrown",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "gpu-descriptor",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-descriptor-0.2.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "tracing": [
+                    "dep:tracing"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-descriptor-0.2.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zakarum <zakarumych@ya.ru>"
+            ],
+            "categories": [],
+            "keywords": [
+                "gpu",
+                "vulkan",
+                "no-std"
+            ],
+            "readme": "../README.md",
+            "repository": "https://github.com/zakarumych/gpu-descriptor",
+            "homepage": "https://github.com/zakarumych/gpu-descriptor",
+            "documentation": "https://docs.rs/gpu-descriptor",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "gpu-descriptor-types",
+            "version": "0.1.1",
+            "id": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Core types of gpu-descriptor crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "gpu-descriptor-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-descriptor-types-0.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-descriptor-types-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zakarum <zakarumych@ya.ru>"
+            ],
+            "categories": [],
+            "keywords": [
+                "gpu",
+                "vulkan",
+                "allocation",
+                "no-std"
+            ],
+            "readme": null,
+            "repository": "https://github.com/zakarumych/gpu-descriptor",
+            "homepage": "https://github.com/zakarumych/gpu-descriptor",
+            "documentation": "https://docs.rs/gpu-descriptor-types/0.1.0",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "hashbrown",
+            "version": "0.12.3",
+            "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A Rust port of Google's SwissTable hash map",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "ahash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "alloc",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bumpalo",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.5.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.25",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "doc-comment",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "hashbrown",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "serde",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/serde.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rayon",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/rayon.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "set",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/set.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hasher",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/hasher.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "insert_unique_unchecked",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/benches/insert_unique_unchecked.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/benches/bench.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "ahash": [
+                    "dep:ahash"
+                ],
+                "ahash-compile-time-rng": [
+                    "ahash/compile-time-rng"
+                ],
+                "alloc": [
+                    "dep:alloc"
+                ],
+                "bumpalo": [
+                    "dep:bumpalo"
+                ],
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [
+                    "ahash",
+                    "inline-more"
+                ],
+                "inline-more": [],
+                "nightly": [],
+                "raw": [],
+                "rayon": [
+                    "dep:rayon"
+                ],
+                "rustc-dep-of-std": [
+                    "nightly",
+                    "core",
+                    "compiler_builtins",
+                    "alloc",
+                    "rustc-internal-api"
+                ],
+                "rustc-internal-api": [],
+                "serde": [
+                    "dep:serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "nightly",
+                            "rayon",
+                            "serde",
+                            "raw"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Amanieu d'Antras <amanieu@gmail.com>"
+            ],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "hash",
+                "no_std",
+                "hashmap",
+                "swisstable"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/hashbrown",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56.0"
+        },
+        {
+            "name": "hexf-parse",
+            "version": "0.2.1",
+            "id": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "CC0-1.0",
+            "license_file": null,
+            "description": "Parses hexadecimal floats (see also hexf)",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "hexf-parse",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hexf-parse-0.2.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hexf-parse-0.2.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Kang Seonghoon <public+rust@mearie.org>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/lifthrasiir/hexf",
+            "homepage": "https://github.com/lifthrasiir/hexf",
+            "documentation": "https://docs.rs/hexf-parse/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "indexmap",
+            "version": "1.9.2",
+            "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "A hash table with consistent order and fast iteration.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arbitrary",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "hashbrown",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "raw"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "itertools",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "autocfg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "indexmap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "quick",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/quick.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_full_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/macros_full_path.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "equivalent_trait",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/equivalent_trait.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/tests.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "faststring",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/benches/faststring.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/benches/bench.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/build.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "arbitrary": [
+                    "dep:arbitrary"
+                ],
+                "quickcheck": [
+                    "dep:quickcheck"
+                ],
+                "rayon": [
+                    "dep:rayon"
+                ],
+                "rustc-rayon": [
+                    "dep:rustc-rayon"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serde-1": [
+                    "serde"
+                ],
+                "std": [],
+                "test_debug": [],
+                "test_low_transition_point": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "arbitrary",
+                            "quickcheck",
+                            "serde-1",
+                            "rayon"
+                        ]
+                    }
+                },
+                "release": {
+                    "no-dev-version": true,
+                    "tag-name": "{{version}}"
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "hashmap",
+                "no_std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bluss/indexmap",
+            "homepage": null,
+            "documentation": "https://docs.rs/indexmap/",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "js-sys",
+            "version": "0.3.60",
+            "id": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Bindings for all JS global objects and functions in all JS environments like\nNode.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.3.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Headers",
+                        "Response",
+                        "ResponseInit"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "js-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js-sys-0.3.60/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wasm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js-sys-0.3.60/tests/wasm/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "headless",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js-sys-0.3.60/tests/headless.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js-sys-0.3.60/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [
+                "wasm"
+            ],
+            "keywords": [],
+            "readme": "./README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/js-sys",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "khronos-egl",
+            "version": "4.1.0",
+            "id": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Rust bindings for EGL",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wayland-client",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.28",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wayland-egl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.28",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wayland-protocols",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.28",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "client"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pkg-config",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "khronos-egl",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wayland-static",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/examples/wayland-static.rs",
+                    "edition": "2015",
+                    "required-features": [
+                        "static"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wayland-dynamic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/examples/wayland-dynamic.rs",
+                    "edition": "2015",
+                    "required-features": [
+                        "dynamic"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "load-minimal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/examples/load-minimal.rs",
+                    "edition": "2015",
+                    "required-features": [
+                        "dynamic",
+                        "1_4"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "1_0": [],
+                "1_1": [
+                    "1_0"
+                ],
+                "1_2": [
+                    "1_1"
+                ],
+                "1_3": [
+                    "1_2"
+                ],
+                "1_4": [
+                    "1_3"
+                ],
+                "1_5": [
+                    "1_4"
+                ],
+                "default": [
+                    "1_5"
+                ],
+                "dynamic": [
+                    "libloading"
+                ],
+                "libloading": [
+                    "dep:libloading"
+                ],
+                "no-pkg-config": [],
+                "pkg-config": [
+                    "dep:pkg-config"
+                ],
+                "static": [
+                    "pkg-config"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Timoth\u00e9e Haudebourg <author@haudebourg.net>",
+                "Sean Kerr <sean@metatomic.io>"
+            ],
+            "categories": [],
+            "keywords": [
+                "egl",
+                "gl",
+                "khronos",
+                "opengl"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/timothee-haudebourg/khronos-egl",
+            "homepage": null,
+            "documentation": "https://docs.rs/khronos-egl",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "libc",
+            "version": "0.2.137",
+            "id": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Raw FFI bindings to platform libraries like libc.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "libc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "const_fn",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/tests/const_fn.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "align": [],
+                "const-extern-fn": [],
+                "default": [
+                    "std"
+                ],
+                "extra_traits": [],
+                "rustc-dep-of-std": [
+                    "align",
+                    "rustc-std-workspace-core"
+                ],
+                "rustc-std-workspace-core": [
+                    "dep:rustc-std-workspace-core"
+                ],
+                "std": [],
+                "use_std": [
+                    "std"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "const-extern-fn",
+                            "extra_traits"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "external-ffi-bindings",
+                "no-std",
+                "os"
+            ],
+            "keywords": [
+                "libc",
+                "ffi",
+                "bindings",
+                "operating",
+                "system"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/libc",
+            "homepage": "https://github.com/rust-lang/libc",
+            "documentation": "https://docs.rs/libc/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "libloading",
+            "version": "0.7.4",
+            "id": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "ISC",
+            "license_file": null,
+            "description": "Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "static_assertions",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "errhandlingapi",
+                        "libloaderapi"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "libloading",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "constants",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/constants.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "functions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/functions.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "library_filename",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/library_filename.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "windows",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/windows.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "markers",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/markers.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "libloading_docs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Simonas Kazlauskas <libloading@kazlauskas.me>"
+            ],
+            "categories": [
+                "api-bindings"
+            ],
+            "keywords": [
+                "dlopen",
+                "load",
+                "shared",
+                "dylib"
+            ],
+            "readme": "README.mkd",
+            "repository": "https://github.com/nagisa/rust_libloading/",
+            "homepage": null,
+            "documentation": "https://docs.rs/libloading/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.40.0"
+        },
+        {
+            "name": "lock_api",
+            "version": "0.4.9",
+            "id": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "owning_ref",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "scopeguard",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.126",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "autocfg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "lock_api",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.9/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.9/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "arc_lock": [],
+                "nightly": [],
+                "owning_ref": [
+                    "dep:owning_ref"
+                ],
+                "serde": [
+                    "dep:serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.9/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Amanieu d'Antras <amanieu@gmail.com>"
+            ],
+            "categories": [
+                "concurrency",
+                "no-std"
+            ],
+            "keywords": [
+                "mutex",
+                "rwlock",
+                "lock",
+                "no_std"
+            ],
+            "readme": null,
+            "repository": "https://github.com/Amanieu/parking_lot",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "log",
+            "version": "0.4.17",
+            "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A lightweight logging facade for Rust\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sval",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "value-bag",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sval",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "value-bag",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "test"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "log",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "filters",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/filters.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/macros.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "value",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/benches/value.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "kv_unstable": [
+                    "value-bag"
+                ],
+                "kv_unstable_serde": [
+                    "kv_unstable_std",
+                    "value-bag/serde",
+                    "serde"
+                ],
+                "kv_unstable_std": [
+                    "std",
+                    "kv_unstable",
+                    "value-bag/error"
+                ],
+                "kv_unstable_sval": [
+                    "kv_unstable",
+                    "value-bag/sval",
+                    "sval"
+                ],
+                "max_level_debug": [],
+                "max_level_error": [],
+                "max_level_info": [],
+                "max_level_off": [],
+                "max_level_trace": [],
+                "max_level_warn": [],
+                "release_max_level_debug": [],
+                "release_max_level_error": [],
+                "release_max_level_info": [],
+                "release_max_level_off": [],
+                "release_max_level_trace": [],
+                "release_max_level_warn": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "sval": [
+                    "dep:sval"
+                ],
+                "value-bag": [
+                    "dep:value-bag"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std",
+                            "serde",
+                            "kv_unstable_std",
+                            "kv_unstable_sval",
+                            "kv_unstable_serde"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "development-tools::debugging"
+            ],
+            "keywords": [
+                "logging"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/log",
+            "homepage": null,
+            "documentation": "https://docs.rs/log",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "malloc_buf",
+            "version": "0.0.6",
+            "id": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Structs for handling malloc'd memory passed to Rust.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.1, <0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "malloc_buf",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/malloc_buf-0.0.6/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/malloc_buf-0.0.6/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Sheldon"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/SSheldon/malloc_buf",
+            "homepage": null,
+            "documentation": "http://ssheldon.github.io/malloc_buf/malloc_buf/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "metal",
+            "version": "0.24.0",
+            "id": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Rust bindings for Metal",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "block",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "core-graphics-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "dispatch",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "foreign-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "objc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "objc_exception"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cocoa",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.24.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cty",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "png",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.16",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sema",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winit",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.24",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "metal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "window",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/window/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "headless-render",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/headless-render/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "library",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/library/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "reflection",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/reflection/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "caps",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/caps/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "argument-buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/argument-buffer/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bindless",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/bindless/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "circle",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/circle/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compute",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/compute/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "mps",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/mps/main.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "mps"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "embedded-lib",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/compute/embedded-lib.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compute-argument-buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/compute/compute-argument-buffer.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bind",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/bind/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "events",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/events/main.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "dispatch"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fence",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/fence/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "shader-dylib",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/shader-dylib/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [],
+                "dispatch": [
+                    "dep:dispatch"
+                ],
+                "mps": [],
+                "private": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-apple-darwin"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "GFX Developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "metal",
+                "graphics",
+                "bindings"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/metal-rs",
+            "homepage": "https://github.com/gfx-rs/metal-rs",
+            "documentation": "https://docs.rs/crate/metal",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "naga",
+            "version": "0.10.0",
+            "id": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Shader translation infrastructure",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arbitrary",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bit-set",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "codespan-reporting",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "hexf-parse",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "indexmap",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "std"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "num-traits",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "petgraph",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pp-rs",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-hash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.103",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "spirv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thiserror",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.21",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-xid",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bincode",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "diff",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ron",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "~0.7.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rspirv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "spirv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "deserialize"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "naga",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/naga-0.10.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "criterion",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/naga-0.10.0/benches/criterion.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "arbitrary": [
+                    "dep:arbitrary"
+                ],
+                "clone": [],
+                "codespan-reporting": [
+                    "dep:codespan-reporting"
+                ],
+                "default": [],
+                "deserialize": [
+                    "serde",
+                    "indexmap/serde-1"
+                ],
+                "dot-out": [],
+                "glsl-in": [
+                    "pp-rs"
+                ],
+                "glsl-out": [],
+                "hexf-parse": [
+                    "dep:hexf-parse"
+                ],
+                "hlsl-out": [],
+                "msl-out": [],
+                "petgraph": [
+                    "dep:petgraph"
+                ],
+                "pp-rs": [
+                    "dep:pp-rs"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serialize": [
+                    "serde",
+                    "indexmap/serde-1"
+                ],
+                "span": [
+                    "codespan-reporting",
+                    "termcolor"
+                ],
+                "spirv": [
+                    "dep:spirv"
+                ],
+                "spv-in": [
+                    "petgraph",
+                    "spirv"
+                ],
+                "spv-out": [
+                    "spirv"
+                ],
+                "termcolor": [
+                    "dep:termcolor"
+                ],
+                "unicode-xid": [
+                    "dep:unicode-xid"
+                ],
+                "validate": [],
+                "wgsl-in": [
+                    "codespan-reporting",
+                    "hexf-parse",
+                    "termcolor",
+                    "unicode-xid"
+                ],
+                "wgsl-out": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/naga-0.10.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Naga Developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "shader",
+                "SPIR-V",
+                "GLSL",
+                "MSL"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/naga/tree/v0.9",
+            "homepage": "https://github.com/gfx-rs/naga",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "num-traits",
+            "version": "0.2.15",
+            "id": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Numeric traits for generic mathematics",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "autocfg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "num-traits",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.15/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cast",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.15/tests/cast.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.15/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "i128": [],
+                "libm": [
+                    "dep:libm"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.15/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "algorithms",
+                "science",
+                "no-std"
+            ],
+            "keywords": [
+                "mathematics",
+                "numerics"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-num/num-traits",
+            "homepage": "https://github.com/rust-num/num-traits",
+            "documentation": "https://docs.rs/num-traits",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "objc",
+            "version": "0.2.7",
+            "id": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Objective-C Runtime bindings and wrapper for Rust.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "malloc_buf",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "objc_exception",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "objc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc-0.2.7/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "example",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc-0.2.7/examples/example.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "exception": [
+                    "objc_exception"
+                ],
+                "objc_exception": [
+                    "dep:objc_exception"
+                ],
+                "verify_message": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc-0.2.7/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Sheldon"
+            ],
+            "categories": [],
+            "keywords": [
+                "objective-c",
+                "osx",
+                "ios",
+                "cocoa",
+                "uikit"
+            ],
+            "readme": "README.md",
+            "repository": "http://github.com/SSheldon/rust-objc",
+            "homepage": null,
+            "documentation": "http://ssheldon.github.io/rust-objc/objc/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "objc_exception",
+            "version": "0.1.2",
+            "id": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Rust interface for Objective-C's throw and try/catch statements.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "objc_exception",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc_exception-0.1.2/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc_exception-0.1.2/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc_exception-0.1.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Sheldon"
+            ],
+            "categories": [],
+            "keywords": [
+                "objective-c",
+                "osx",
+                "ios"
+            ],
+            "readme": null,
+            "repository": "http://github.com/SSheldon/rust-objc-exception",
+            "homepage": null,
+            "documentation": "http://ssheldon.github.io/rust-objc/objc_exception/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "once_cell",
+            "version": "1.16.0",
+            "id": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Single assignment cells and lazy values.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "atomic-polyfill",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": "atomic_polyfill",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "critical-section",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": "critical_section",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot_core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "critical-section",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.1",
+                    "kind": "dev",
+                    "rename": "critical_section",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "std"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "crossbeam-utils",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "regex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "once_cell",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/bench.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench_acquire",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/bench_acquire.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench_vs_lazy_static",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/bench_vs_lazy_static.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "lazy_static",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/lazy_static.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "reentrant_init_deadlocks",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/reentrant_init_deadlocks.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "regex",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/regex.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_synchronization",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/test_synchronization.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "it",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/tests/it.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "alloc": [
+                    "race"
+                ],
+                "atomic-polyfill": [
+                    "critical-section"
+                ],
+                "atomic_polyfill": [
+                    "dep:atomic_polyfill"
+                ],
+                "critical-section": [
+                    "critical_section",
+                    "atomic_polyfill"
+                ],
+                "critical_section": [
+                    "dep:critical_section"
+                ],
+                "default": [
+                    "std"
+                ],
+                "parking_lot": [
+                    "parking_lot_core"
+                ],
+                "parking_lot_core": [
+                    "dep:parking_lot_core"
+                ],
+                "race": [],
+                "std": [
+                    "alloc"
+                ],
+                "unstable": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Aleksey Kladov <aleksey.kladov@gmail.com>"
+            ],
+            "categories": [
+                "rust-patterns",
+                "memory-management"
+            ],
+            "keywords": [
+                "lazy",
+                "static"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/matklad/once_cell",
+            "homepage": null,
+            "documentation": "https://docs.rs/once_cell",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "parking_lot",
+            "version": "0.12.1",
+            "id": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "More compact and efficient implementations of the standard synchronization primitives.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "lock_api",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot_core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bincode",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "parking_lot",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.12.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "issue_203",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.12.1/tests/issue_203.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "arc_lock": [
+                    "lock_api/arc_lock"
+                ],
+                "deadlock_detection": [
+                    "parking_lot_core/deadlock_detection"
+                ],
+                "default": [],
+                "hardware-lock-elision": [],
+                "nightly": [
+                    "parking_lot_core/nightly",
+                    "lock_api/nightly"
+                ],
+                "owning_ref": [
+                    "lock_api/owning_ref"
+                ],
+                "send_guard": [],
+                "serde": [
+                    "lock_api/serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.12.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Amanieu d'Antras <amanieu@gmail.com>"
+            ],
+            "categories": [
+                "concurrency"
+            ],
+            "keywords": [
+                "mutex",
+                "condvar",
+                "rwlock",
+                "once",
+                "thread"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/Amanieu/parking_lot",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "parking_lot_core",
+            "version": "0.9.4",
+            "id": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "An advanced API for creating custom synchronization primitives.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "backtrace",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "petgraph",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.6.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thread-id",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^4.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "redox_syscall",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"redox\")",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.95",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Win32_Foundation",
+                        "Win32_System_LibraryLoader",
+                        "Win32_System_SystemServices",
+                        "Win32_System_WindowsProgramming"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "parking_lot_core",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.4/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.4/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "backtrace": [
+                    "dep:backtrace"
+                ],
+                "deadlock_detection": [
+                    "petgraph",
+                    "thread-id",
+                    "backtrace"
+                ],
+                "nightly": [],
+                "petgraph": [
+                    "dep:petgraph"
+                ],
+                "thread-id": [
+                    "dep:thread-id"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.4/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Amanieu d'Antras <amanieu@gmail.com>"
+            ],
+            "categories": [
+                "concurrency"
+            ],
+            "keywords": [
+                "mutex",
+                "condvar",
+                "rwlock",
+                "once",
+                "thread"
+            ],
+            "readme": null,
+            "repository": "https://github.com/Amanieu/parking_lot",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "pkg-config",
+            "version": "0.3.26",
+            "id": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A library to run the pkg-config system tool at build time in order to be used in\nCargo build scripts.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "pkg-config",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pkg-config-0.3.26/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pkg-config-0.3.26/tests/test.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pkg-config-0.3.26/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "build-dependencies"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/pkg-config-rs",
+            "homepage": null,
+            "documentation": "https://docs.rs/pkg-config",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "proc-macro2",
+            "version": "1.0.47",
+            "id": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "unicode-ident",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "proc-macro2",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "features",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/features.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_fmt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/test_fmt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "comments",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/comments.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "marker",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/marker.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "nightly": [],
+                "proc-macro": [],
+                "span-locations": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt",
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "span-locations"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>",
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/proc-macro2",
+            "homepage": null,
+            "documentation": "https://docs.rs/proc-macro2",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "profiling",
+            "version": "1.0.7",
+            "id": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "This crate provides a very thin abstraction over other profiler crates.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "optick",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "profiling-procmacros",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "puffin",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.12.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "superluminal-perf",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracy-client",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bincode",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "glam",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "imgui",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "imgui-winit-support",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "puffin-imgui",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.15.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rafx",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.0.14",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "rafx-vulkan",
+                        "framework"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing-subscriber",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing-tracy",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winit",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.25",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "profiling",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/profiling-1.0.7/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "puffin",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/profiling-1.0.7/examples/puffin/puffin.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "profile-with-puffin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "simple",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/profiling-1.0.7/examples/simple.rs",
+                    "edition": "2018",
+                    "required-features": [],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "procmacros"
+                ],
+                "optick": [
+                    "dep:optick"
+                ],
+                "procmacros": [
+                    "profiling-procmacros"
+                ],
+                "profile-with-optick": [
+                    "optick",
+                    "profiling-procmacros/profile-with-optick"
+                ],
+                "profile-with-puffin": [
+                    "puffin",
+                    "profiling-procmacros/profile-with-puffin"
+                ],
+                "profile-with-superluminal": [
+                    "superluminal-perf",
+                    "profiling-procmacros/profile-with-superluminal"
+                ],
+                "profile-with-tracing": [
+                    "tracing",
+                    "profiling-procmacros/profile-with-tracing"
+                ],
+                "profile-with-tracy": [
+                    "tracy-client",
+                    "profiling-procmacros/profile-with-tracy"
+                ],
+                "profiling-procmacros": [
+                    "dep:profiling-procmacros"
+                ],
+                "puffin": [
+                    "dep:puffin"
+                ],
+                "superluminal-perf": [
+                    "dep:superluminal-perf"
+                ],
+                "tracing": [
+                    "dep:tracing"
+                ],
+                "tracy-client": [
+                    "dep:tracy-client"
+                ],
+                "type-check": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/profiling-1.0.7/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Philip Degarmo <aclysma@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::profiling"
+            ],
+            "keywords": [
+                "performance",
+                "profiling"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/aclysma/profiling",
+            "homepage": "https://github.com/aclysma/profiling",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "quote",
+            "version": "1.0.21",
+            "id": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Quasi-quoting macro quote!(...)",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.40",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.52",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "diff"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "quote",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/quote",
+            "homepage": null,
+            "documentation": "https://docs.rs/quote/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "range-alloc",
+            "version": "0.1.2",
+            "id": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Generic range allocator used by gfx-rs backends",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "range_alloc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/range-alloc-0.1.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/range-alloc-0.1.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The Gfx-rs Developers"
+            ],
+            "categories": [
+                "memory-management"
+            ],
+            "keywords": [
+                "allocator"
+            ],
+            "readme": null,
+            "repository": "https://github.com/gfx-rs/gfx",
+            "homepage": "https://github.com/gfx-rs/gfx",
+            "documentation": "https://docs.rs/range-alloc",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "raw-window-handle",
+            "version": "0.5.0",
+            "id": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0 OR Zlib",
+            "license_file": null,
+            "description": "Interoperability library for Rust Windowing applications.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cty",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "raw-window-handle",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/raw-window-handle-0.5.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "alloc": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/raw-window-handle-0.5.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Osspial <osspial@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windowing"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-windowing/raw-window-handle",
+            "homepage": null,
+            "documentation": "https://docs.rs/raw-window-handle",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "redox_syscall",
+            "version": "0.2.16",
+            "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "A Rust library to access raw Redox system calls",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "syscall",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/redox_syscall-0.2.16/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/redox_syscall-0.2.16/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Jeremy Soller <jackpot51@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://gitlab.redox-os.org/redox-os/syscall",
+            "homepage": null,
+            "documentation": "https://docs.rs/redox_syscall",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "renderdoc-sys",
+            "version": "0.7.1",
+            "id": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Raw FFI bindings to the RenderDoc API",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "renderdoc-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/renderdoc-sys-0.7.1/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/renderdoc-sys-0.7.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Eyal Kalderon <ebkalderon@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "ffi",
+                "renderdoc"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/ebkalderon/renderdoc-rs",
+            "homepage": "https://github.com/ebkalderon/renderdoc-rs/tree/master/renderdoc-sys",
+            "documentation": "https://docs.rs/renderdoc-sys/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "rustc-hash",
+            "version": "1.1.0",
+            "id": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0/MIT",
+            "license_file": null,
+            "description": "speed, non-cryptographic hash used in rustc",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "rustc-hash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/rustc-hash-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/rustc-hash-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "hash",
+                "fxhash",
+                "rustc"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang-nursery/rustc-hash",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "scopeguard",
+            "version": "1.1.0",
+            "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A RAII scope guard that will run a given closure when it goes out of scope,\neven if the code between panics (assuming unwinding panic).\n\nDefines the macros `defer!`, `defer_on_unwind!`, `defer_on_success!` as\nshorthands for guards with one of the implemented strategies.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "scopeguard",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/scopeguard-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "readme",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/scopeguard-1.1.0/examples/readme.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "use_std"
+                ],
+                "use_std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/scopeguard-1.1.0/Cargo.toml",
+            "metadata": {
+                "release": {
+                    "no-dev-version": true
+                }
+            },
+            "publish": null,
+            "authors": [
+                "bluss"
+            ],
+            "categories": [
+                "rust-patterns",
+                "no-std"
+            ],
+            "keywords": [
+                "scope-guard",
+                "defer",
+                "panic",
+                "unwind"
+            ],
+            "readme": null,
+            "repository": "https://github.com/bluss/scopeguard",
+            "homepage": null,
+            "documentation": "https://docs.rs/scopeguard/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "slotmap",
+            "version": "1.0.6",
+            "id": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Zlib",
+            "license_file": null,
+            "description": "Slotmap data structure",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive",
+                        "alloc"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "version_check",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "slotmap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rand_meld_heap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/examples/rand_meld_heap.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "doubly_linked_list",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/examples/doubly_linked_list.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "unstable": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Orson Peters <orsonpeters@gmail.com>"
+            ],
+            "categories": [
+                "data-structures",
+                "memory-management",
+                "caching"
+            ],
+            "keywords": [
+                "slotmap",
+                "storage",
+                "allocator",
+                "arena",
+                "reference"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/orlp/slotmap",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "smallvec",
+            "version": "1.10.0",
+            "id": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "'Small vector' optimization: store up to a small number of items on the stack",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arbitrary",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bincode",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "debugger_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "debugger_test_parser",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "smallvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "debugger_visualizer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/tests/debugger_visualizer.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "debugger_visualizer"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macro",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/tests/macro.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/benches/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "arbitrary": [
+                    "dep:arbitrary"
+                ],
+                "const_generics": [],
+                "const_new": [
+                    "const_generics"
+                ],
+                "debugger_visualizer": [],
+                "may_dangle": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "specialization": [],
+                "union": [],
+                "write": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [
+                "data-structures"
+            ],
+            "keywords": [
+                "small",
+                "vec",
+                "vector",
+                "stack",
+                "no_std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/servo/rust-smallvec",
+            "homepage": null,
+            "documentation": "https://docs.rs/smallvec/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "spirv",
+            "version": "0.2.0+1.5.4",
+            "id": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0",
+            "license_file": null,
+            "description": "Rust definition of SPIR-V structs and enums",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "num-traits",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "spirv",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/spirv-0.2.0+1.5.4/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "deserialize": [
+                    "serde"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serialize": [
+                    "serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/spirv-0.2.0+1.5.4/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Lei Zhang <antiagainst@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "spirv",
+                "definition",
+                "struct",
+                "enum"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/rspirv",
+            "homepage": null,
+            "documentation": "https://docs.rs/spirv",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "static_assertions",
+            "version": "1.1.0",
+            "id": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Compile-time assertions to ensure that invariants are met.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "static_assertions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/static_assertions-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "nightly": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/static_assertions-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Nikolai Vazquez"
+            ],
+            "categories": [
+                "no-std",
+                "rust-patterns",
+                "development-tools::testing"
+            ],
+            "keywords": [
+                "assert",
+                "static",
+                "testing"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/nvzqz/static-assertions-rs",
+            "homepage": "https://github.com/nvzqz/static-assertions-rs",
+            "documentation": "https://docs.rs/static_assertions/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "syn",
+            "version": "1.0.104",
+            "id": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Parser for Rust source code",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.46",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-ident",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "automod",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "flate2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "insta",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ref-cast",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "regex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "reqwest",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "blocking"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn-test-suite",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tar",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.16",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "walkdir",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "syn",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_should_parse",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_should_parse.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_visibility",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_visibility.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_stmt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_stmt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_round_trip",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_round_trip.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_size.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_shebang",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_shebang.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_pat",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_pat.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_receiver",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_receiver.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_precedence",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_precedence.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_lit",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_lit.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "regression",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/regression.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_parse_stream.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_grouping",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_grouping.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ident",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_ident.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_iterators",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_iterators.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_parse_buffer.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_asyncness",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_asyncness.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_token_trees",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_token_trees.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ty",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_ty.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "zzz_stable",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/zzz_stable.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_meta",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_meta.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_expr.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_item",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_item.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_path.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_derive_input",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_derive_input.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_generics.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_attribute",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_attribute.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rust",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/benches/rust.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/benches/file.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "clone-impls": [],
+                "default": [
+                    "derive",
+                    "parsing",
+                    "printing",
+                    "clone-impls",
+                    "proc-macro"
+                ],
+                "derive": [],
+                "extra-traits": [],
+                "fold": [],
+                "full": [],
+                "parsing": [],
+                "printing": [
+                    "quote"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro",
+                    "quote/proc-macro"
+                ],
+                "quote": [
+                    "dep:quote"
+                ],
+                "test": [
+                    "syn-test-suite/all-features"
+                ],
+                "visit": [],
+                "visit-mut": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "full",
+                        "visit",
+                        "visit-mut",
+                        "fold",
+                        "extra-traits"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "parser-implementations"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/syn",
+            "homepage": null,
+            "documentation": "https://docs.rs/syn",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "target_features",
+            "version": "0.1.0",
+            "id": "target_features 0.1.0 (path+file://{TEMP_DIR}/target_features)",
+            "license": null,
+            "license_file": null,
+            "description": null,
+            "source": null,
+            "dependencies": [
+                {
+                    "name": "wgpu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.14.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "target_features",
+                    "src_path": "{TEMP_DIR}/target_features/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{TEMP_DIR}/target_features/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "termcolor",
+            "version": "1.1.3",
+            "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense OR MIT",
+            "license_file": null,
+            "description": "A simple cross platform library for writing colored text to a terminal.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "winapi-util",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "termcolor",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/termcolor-1.1.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/termcolor-1.1.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windows",
+                "win",
+                "color",
+                "ansi",
+                "console"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/termcolor",
+            "homepage": "https://github.com/BurntSushi/termcolor",
+            "documentation": "https://docs.rs/termcolor",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "thiserror",
+            "version": "1.0.37",
+            "id": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "derive(Error)",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "thiserror-impl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.37",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.65",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ref-cast",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.49",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "diff"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "thiserror",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_source",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_source.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_backtrace",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_backtrace.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_display",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_display.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_lints",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_lints.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_transparent",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_transparent.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_from",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_from.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_expr.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_path.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_error",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_error.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_generics.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_option",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_option.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_deprecated",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_deprecated.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "rust-patterns"
+            ],
+            "keywords": [
+                "error",
+                "error-handling",
+                "derive"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/thiserror",
+            "homepage": null,
+            "documentation": "https://docs.rs/thiserror",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "thiserror-impl",
+            "version": "1.0.37",
+            "id": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Implementation detail of the `thiserror` crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.45",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "name": "thiserror-impl",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-impl-1.0.37/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-impl-1.0.37/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/dtolnay/thiserror",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "unicode-ident",
+            "version": "1.0.5",
+            "id": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
+            "license_file": null,
+            "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fst",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "roaring",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ucd-trie",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-xid",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-ident",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "static_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/tests/static_size.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compare",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/tests/compare.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xid",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/benches/xid.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "no-std"
+            ],
+            "keywords": [
+                "unicode",
+                "xid"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/unicode-ident",
+            "homepage": null,
+            "documentation": "https://docs.rs/unicode-ident",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "unicode-width",
+            "version": "0.1.10",
+            "id": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Determine displayed width of `char` and `str` types\naccording to Unicode Standard Annex #11 rules.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-std",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": "std",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-width",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-width-0.1.10/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "bench": [],
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [],
+                "no_std": [],
+                "rustc-dep-of-std": [
+                    "std",
+                    "core",
+                    "compiler_builtins"
+                ],
+                "std": [
+                    "dep:std"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-width-0.1.10/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "kwantam <kwantam@gmail.com>",
+                "Manish Goregaokar <manishsmail@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "text",
+                "width",
+                "unicode"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/unicode-rs/unicode-width",
+            "homepage": "https://github.com/unicode-rs/unicode-width",
+            "documentation": "https://unicode-rs.github.io/unicode-width",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "unicode-xid",
+            "version": "0.2.4",
+            "id": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Determine whether characters have the XID_Start\nor XID_Continue properties according to\nUnicode Standard Annex #31.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-xid",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.4/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "exhaustive_tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.4/tests/exhaustive_tests.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xid",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.4/benches/xid.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "bench": [],
+                "default": [],
+                "no_std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.4/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "erick.tryzelaar <erick.tryzelaar@gmail.com>",
+                "kwantam <kwantam@gmail.com>",
+                "Manish Goregaokar <manishsmail@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "text",
+                "unicode",
+                "xid"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/unicode-rs/unicode-xid",
+            "homepage": "https://github.com/unicode-rs/unicode-xid",
+            "documentation": "https://unicode-rs.github.io/unicode-xid",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.17"
+        },
+        {
+            "name": "version_check",
+            "version": "0.9.4",
+            "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Tiny crate to check the version of the installed/running rustc.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "version_check",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/version_check-0.9.4/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/version_check-0.9.4/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Sergio Benitez <sb@sergio.bz>"
+            ],
+            "categories": [],
+            "keywords": [
+                "version",
+                "rustc",
+                "minimum",
+                "check"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/SergioBenitez/version_check",
+            "homepage": null,
+            "documentation": "https://docs.rs/version_check/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasi",
+            "version": "0.11.0+wasi-snapshot-preview1",
+            "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "Experimental WASI API bindings for Rust",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasi",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasi-0.11.0+wasi-snapshot-preview1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [
+                    "std"
+                ],
+                "rustc-dep-of-std": [
+                    "compiler_builtins",
+                    "core",
+                    "rustc-std-workspace-alloc"
+                ],
+                "rustc-std-workspace-alloc": [
+                    "dep:rustc-std-workspace-alloc"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasi-0.11.0+wasi-snapshot-preview1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The Cranelift Project Developers"
+            ],
+            "categories": [
+                "no-std",
+                "wasm"
+            ],
+            "keywords": [
+                "webassembly",
+                "wasm"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bytecodealliance/wasi",
+            "homepage": null,
+            "documentation": "https://docs.rs/wasi",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen",
+            "version": "0.2.83",
+            "id": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Easy support for interacting between JS and Rust.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-macro",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.4.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.3.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test-crate-a",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test-crate-b",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wasm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/wasm/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "non_wasm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/non_wasm.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "std-crate-no-std-dep",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/std-crate-no-std-dep.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "must_use",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/must_use.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "headless",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/headless/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "unwrap_throw",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/unwrap_throw.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "spans",
+                    "std"
+                ],
+                "enable-interning": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serde-serialize": [
+                    "serde",
+                    "serde_json",
+                    "std"
+                ],
+                "serde_json": [
+                    "dep:serde_json"
+                ],
+                "spans": [
+                    "wasm-bindgen-macro/spans"
+                ],
+                "std": [],
+                "strict-macro": [
+                    "wasm-bindgen-macro/strict-macro"
+                ],
+                "xxx_debug_only_print_generated_code": [
+                    "wasm-bindgen-macro/xxx_debug_only_print_generated_code"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "serde-serialize"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [
+                "wasm"
+            ],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen",
+            "homepage": "https://rustwasm.github.io/",
+            "documentation": "https://docs.rs/wasm-bindgen",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-backend",
+            "version": "0.2.83",
+            "id": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Backend code generation of the wasm-bindgen tool\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bumpalo",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "once_cell",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "full"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-shared",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen-backend",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-backend-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "extra-traits": [
+                    "syn/extra-traits"
+                ],
+                "spans": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-backend-0.2.83/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen-backend",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-futures",
+            "version": "0.4.33",
+            "id": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Bridging the gap between Rust Futures and JavaScript Promises",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "futures-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "futures-channel-preview",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0-alpha.18",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "futures-lite",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.11.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.24",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "MessageEvent",
+                        "Worker"
+                    ],
+                    "target": "cfg(target_feature = \"atomics\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen-futures",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-futures-0.4.33/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-futures-0.4.33/tests/tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "futures-core": [
+                    "dep:futures-core"
+                ],
+                "futures-core-03-stream": [
+                    "futures-core"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-futures-0.4.33/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "./README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen-futures",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-macro",
+            "version": "0.2.83",
+            "id": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Definition of the `#[wasm_bindgen]` attribute, an internal dependency\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-macro-support",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "name": "wasm-bindgen-macro",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "ui",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-0.2.83/tests/ui.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "spans": [
+                    "wasm-bindgen-macro-support/spans"
+                ],
+                "strict-macro": [
+                    "wasm-bindgen-macro-support/strict-macro"
+                ],
+                "xxx_debug_only_print_generated_code": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-0.2.83/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-macro-support",
+            "version": "0.2.83",
+            "id": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "The part of the implementation of the `#[wasm_bindgen]` attribute that is not in the shared backend crate\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.67",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "visit",
+                        "full"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-backend",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-shared",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen-macro-support",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-support-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "extra-traits": [
+                    "syn/extra-traits"
+                ],
+                "spans": [
+                    "wasm-bindgen-backend/spans"
+                ],
+                "strict-macro": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-support-0.2.83/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-shared",
+            "version": "0.2.83",
+            "id": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Shared support between wasm-bindgen and wasm-bindgen cli, an internal\ndependency.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen-shared",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-shared-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-shared-0.2.83/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-shared-0.2.83/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen-shared",
+            "edition": "2018",
+            "links": "wasm_bindgen",
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "web-sys",
+            "version": "0.3.60",
+            "id": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Bindings for all Web APIs, a procedurally generated crate from WebIDL\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "web-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/web-sys-0.3.60/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wasm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/web-sys-0.3.60/tests/wasm/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "AbortController": [],
+                "AbortSignal": [
+                    "EventTarget"
+                ],
+                "AddEventListenerOptions": [],
+                "AesCbcParams": [],
+                "AesCtrParams": [],
+                "AesDerivedKeyParams": [],
+                "AesGcmParams": [],
+                "AesKeyAlgorithm": [],
+                "AesKeyGenParams": [],
+                "Algorithm": [],
+                "AlignSetting": [],
+                "AllowedBluetoothDevice": [],
+                "AllowedUsbDevice": [],
+                "AlphaOption": [],
+                "AnalyserNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "AnalyserOptions": [],
+                "AngleInstancedArrays": [],
+                "Animation": [
+                    "EventTarget"
+                ],
+                "AnimationEffect": [],
+                "AnimationEvent": [
+                    "Event"
+                ],
+                "AnimationEventInit": [],
+                "AnimationPlayState": [],
+                "AnimationPlaybackEvent": [
+                    "Event"
+                ],
+                "AnimationPlaybackEventInit": [],
+                "AnimationPropertyDetails": [],
+                "AnimationPropertyValueDetails": [],
+                "AnimationTimeline": [],
+                "AssignedNodesOptions": [],
+                "AttestationConveyancePreference": [],
+                "Attr": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "AttributeNameValue": [],
+                "AudioBuffer": [],
+                "AudioBufferOptions": [],
+                "AudioBufferSourceNode": [
+                    "AudioNode",
+                    "AudioScheduledSourceNode",
+                    "EventTarget"
+                ],
+                "AudioBufferSourceOptions": [],
+                "AudioConfiguration": [],
+                "AudioContext": [
+                    "BaseAudioContext",
+                    "EventTarget"
+                ],
+                "AudioContextOptions": [],
+                "AudioContextState": [],
+                "AudioData": [],
+                "AudioDataCopyToOptions": [],
+                "AudioDataInit": [],
+                "AudioDecoder": [],
+                "AudioDecoderConfig": [],
+                "AudioDecoderInit": [],
+                "AudioDecoderSupport": [],
+                "AudioDestinationNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "AudioEncoder": [],
+                "AudioEncoderConfig": [],
+                "AudioEncoderInit": [],
+                "AudioEncoderSupport": [],
+                "AudioListener": [],
+                "AudioNode": [
+                    "EventTarget"
+                ],
+                "AudioNodeOptions": [],
+                "AudioParam": [],
+                "AudioParamMap": [],
+                "AudioProcessingEvent": [
+                    "Event"
+                ],
+                "AudioSampleFormat": [],
+                "AudioScheduledSourceNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "AudioStreamTrack": [
+                    "EventTarget",
+                    "MediaStreamTrack"
+                ],
+                "AudioTrack": [],
+                "AudioTrackList": [
+                    "EventTarget"
+                ],
+                "AudioWorklet": [
+                    "Worklet"
+                ],
+                "AudioWorkletGlobalScope": [
+                    "WorkletGlobalScope"
+                ],
+                "AudioWorkletNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "AudioWorkletNodeOptions": [],
+                "AudioWorkletProcessor": [],
+                "AuthenticationExtensionsClientInputs": [],
+                "AuthenticationExtensionsClientOutputs": [],
+                "AuthenticatorAssertionResponse": [
+                    "AuthenticatorResponse"
+                ],
+                "AuthenticatorAttachment": [],
+                "AuthenticatorAttestationResponse": [
+                    "AuthenticatorResponse"
+                ],
+                "AuthenticatorResponse": [],
+                "AuthenticatorSelectionCriteria": [],
+                "AuthenticatorTransport": [],
+                "AutoKeyword": [],
+                "AutocompleteInfo": [],
+                "BarProp": [],
+                "BaseAudioContext": [
+                    "EventTarget"
+                ],
+                "BaseComputedKeyframe": [],
+                "BaseKeyframe": [],
+                "BasePropertyIndexedKeyframe": [],
+                "BasicCardRequest": [],
+                "BasicCardResponse": [],
+                "BasicCardType": [],
+                "BatteryManager": [
+                    "EventTarget"
+                ],
+                "BeforeUnloadEvent": [
+                    "Event"
+                ],
+                "BinaryType": [],
+                "BiquadFilterNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "BiquadFilterOptions": [],
+                "BiquadFilterType": [],
+                "Blob": [],
+                "BlobEvent": [
+                    "Event"
+                ],
+                "BlobEventInit": [],
+                "BlobPropertyBag": [],
+                "BlockParsingOptions": [],
+                "Bluetooth": [
+                    "EventTarget"
+                ],
+                "BluetoothAdvertisingEvent": [
+                    "Event"
+                ],
+                "BluetoothAdvertisingEventInit": [],
+                "BluetoothCharacteristicProperties": [],
+                "BluetoothDataFilterInit": [],
+                "BluetoothDevice": [
+                    "EventTarget"
+                ],
+                "BluetoothLeScanFilterInit": [],
+                "BluetoothManufacturerDataMap": [],
+                "BluetoothPermissionDescriptor": [],
+                "BluetoothPermissionResult": [
+                    "EventTarget",
+                    "PermissionStatus"
+                ],
+                "BluetoothPermissionStorage": [],
+                "BluetoothRemoteGattCharacteristic": [
+                    "EventTarget"
+                ],
+                "BluetoothRemoteGattDescriptor": [],
+                "BluetoothRemoteGattServer": [],
+                "BluetoothRemoteGattService": [
+                    "EventTarget"
+                ],
+                "BluetoothServiceDataMap": [],
+                "BluetoothUuid": [],
+                "BoxQuadOptions": [],
+                "BroadcastChannel": [
+                    "EventTarget"
+                ],
+                "BrowserElementDownloadOptions": [],
+                "BrowserElementExecuteScriptOptions": [],
+                "BrowserFeedWriter": [],
+                "BrowserFindCaseSensitivity": [],
+                "BrowserFindDirection": [],
+                "ByteLengthQueuingStrategy": [],
+                "Cache": [],
+                "CacheBatchOperation": [],
+                "CacheQueryOptions": [],
+                "CacheStorage": [],
+                "CacheStorageNamespace": [],
+                "CanvasCaptureMediaStream": [
+                    "EventTarget",
+                    "MediaStream"
+                ],
+                "CanvasGradient": [],
+                "CanvasPattern": [],
+                "CanvasRenderingContext2d": [],
+                "CanvasWindingRule": [],
+                "CaretChangedReason": [],
+                "CaretPosition": [],
+                "CaretStateChangedEventInit": [],
+                "CdataSection": [
+                    "CharacterData",
+                    "EventTarget",
+                    "Node",
+                    "Text"
+                ],
+                "ChannelCountMode": [],
+                "ChannelInterpretation": [],
+                "ChannelMergerNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "ChannelMergerOptions": [],
+                "ChannelPixelLayout": [],
+                "ChannelPixelLayoutDataType": [],
+                "ChannelSplitterNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "ChannelSplitterOptions": [],
+                "CharacterData": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "CheckerboardReason": [],
+                "CheckerboardReport": [],
+                "CheckerboardReportService": [],
+                "ChromeFilePropertyBag": [],
+                "ChromeWorker": [
+                    "EventTarget",
+                    "Worker"
+                ],
+                "Client": [],
+                "ClientQueryOptions": [],
+                "ClientRectsAndTexts": [],
+                "ClientType": [],
+                "Clients": [],
+                "Clipboard": [
+                    "EventTarget"
+                ],
+                "ClipboardEvent": [
+                    "Event"
+                ],
+                "ClipboardEventInit": [],
+                "ClipboardItem": [],
+                "ClipboardItemOptions": [],
+                "ClipboardPermissionDescriptor": [],
+                "CloseEvent": [
+                    "Event"
+                ],
+                "CloseEventInit": [],
+                "CodecState": [],
+                "CollectedClientData": [],
+                "Comment": [
+                    "CharacterData",
+                    "EventTarget",
+                    "Node"
+                ],
+                "CompositeOperation": [],
+                "CompositionEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "CompositionEventInit": [],
+                "ComputedEffectTiming": [],
+                "ConnStatusDict": [],
+                "ConnectionType": [],
+                "ConsoleCounter": [],
+                "ConsoleCounterError": [],
+                "ConsoleEvent": [],
+                "ConsoleInstance": [],
+                "ConsoleInstanceOptions": [],
+                "ConsoleLevel": [],
+                "ConsoleLogLevel": [],
+                "ConsoleProfileEvent": [],
+                "ConsoleStackEntry": [],
+                "ConsoleTimerError": [],
+                "ConsoleTimerLogOrEnd": [],
+                "ConsoleTimerStart": [],
+                "ConstantSourceNode": [
+                    "AudioNode",
+                    "AudioScheduledSourceNode",
+                    "EventTarget"
+                ],
+                "ConstantSourceOptions": [],
+                "ConstrainBooleanParameters": [],
+                "ConstrainDomStringParameters": [],
+                "ConstrainDoubleRange": [],
+                "ConstrainLongRange": [],
+                "ContextAttributes2d": [],
+                "ConvertCoordinateOptions": [],
+                "ConvolverNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "ConvolverOptions": [],
+                "Coordinates": [],
+                "CountQueuingStrategy": [],
+                "Credential": [],
+                "CredentialCreationOptions": [],
+                "CredentialRequestOptions": [],
+                "CredentialsContainer": [],
+                "Crypto": [],
+                "CryptoKey": [],
+                "CryptoKeyPair": [],
+                "Csp": [],
+                "CspPolicies": [],
+                "CspReport": [],
+                "CspReportProperties": [],
+                "CssAnimation": [
+                    "Animation",
+                    "EventTarget"
+                ],
+                "CssBoxType": [],
+                "CssConditionRule": [
+                    "CssGroupingRule",
+                    "CssRule"
+                ],
+                "CssCounterStyleRule": [
+                    "CssRule"
+                ],
+                "CssFontFaceRule": [
+                    "CssRule"
+                ],
+                "CssFontFeatureValuesRule": [
+                    "CssRule"
+                ],
+                "CssGroupingRule": [
+                    "CssRule"
+                ],
+                "CssImportRule": [
+                    "CssRule"
+                ],
+                "CssKeyframeRule": [
+                    "CssRule"
+                ],
+                "CssKeyframesRule": [
+                    "CssRule"
+                ],
+                "CssMediaRule": [
+                    "CssConditionRule",
+                    "CssGroupingRule",
+                    "CssRule"
+                ],
+                "CssNamespaceRule": [
+                    "CssRule"
+                ],
+                "CssPageRule": [
+                    "CssRule"
+                ],
+                "CssPseudoElement": [],
+                "CssRule": [],
+                "CssRuleList": [],
+                "CssStyleDeclaration": [],
+                "CssStyleRule": [
+                    "CssRule"
+                ],
+                "CssStyleSheet": [
+                    "StyleSheet"
+                ],
+                "CssStyleSheetParsingMode": [],
+                "CssSupportsRule": [
+                    "CssConditionRule",
+                    "CssGroupingRule",
+                    "CssRule"
+                ],
+                "CssTransition": [
+                    "Animation",
+                    "EventTarget"
+                ],
+                "CustomElementRegistry": [],
+                "CustomEvent": [
+                    "Event"
+                ],
+                "CustomEventInit": [],
+                "DataTransfer": [],
+                "DataTransferItem": [],
+                "DataTransferItemList": [],
+                "DateTimeValue": [],
+                "DecoderDoctorNotification": [],
+                "DecoderDoctorNotificationType": [],
+                "DedicatedWorkerGlobalScope": [
+                    "EventTarget",
+                    "WorkerGlobalScope"
+                ],
+                "DelayNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "DelayOptions": [],
+                "DeviceAcceleration": [],
+                "DeviceAccelerationInit": [],
+                "DeviceLightEvent": [
+                    "Event"
+                ],
+                "DeviceLightEventInit": [],
+                "DeviceMotionEvent": [
+                    "Event"
+                ],
+                "DeviceMotionEventInit": [],
+                "DeviceOrientationEvent": [
+                    "Event"
+                ],
+                "DeviceOrientationEventInit": [],
+                "DeviceProximityEvent": [
+                    "Event"
+                ],
+                "DeviceProximityEventInit": [],
+                "DeviceRotationRate": [],
+                "DeviceRotationRateInit": [],
+                "DhKeyDeriveParams": [],
+                "DirectionSetting": [],
+                "Directory": [],
+                "DisplayMediaStreamConstraints": [],
+                "DisplayNameOptions": [],
+                "DisplayNameResult": [],
+                "DistanceModelType": [],
+                "DnsCacheDict": [],
+                "DnsCacheEntry": [],
+                "DnsLookupDict": [],
+                "Document": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "DocumentFragment": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "DocumentTimeline": [
+                    "AnimationTimeline"
+                ],
+                "DocumentTimelineOptions": [],
+                "DocumentType": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "DomError": [],
+                "DomException": [],
+                "DomImplementation": [],
+                "DomMatrix": [
+                    "DomMatrixReadOnly"
+                ],
+                "DomMatrixReadOnly": [],
+                "DomParser": [],
+                "DomPoint": [
+                    "DomPointReadOnly"
+                ],
+                "DomPointInit": [],
+                "DomPointReadOnly": [],
+                "DomQuad": [],
+                "DomQuadInit": [],
+                "DomQuadJson": [],
+                "DomRect": [
+                    "DomRectReadOnly"
+                ],
+                "DomRectInit": [],
+                "DomRectList": [],
+                "DomRectReadOnly": [],
+                "DomRequest": [
+                    "EventTarget"
+                ],
+                "DomRequestReadyState": [],
+                "DomStringList": [],
+                "DomStringMap": [],
+                "DomTokenList": [],
+                "DomWindowResizeEventDetail": [],
+                "DragEvent": [
+                    "Event",
+                    "MouseEvent",
+                    "UiEvent"
+                ],
+                "DragEventInit": [],
+                "DynamicsCompressorNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "DynamicsCompressorOptions": [],
+                "EcKeyAlgorithm": [],
+                "EcKeyGenParams": [],
+                "EcKeyImportParams": [],
+                "EcdhKeyDeriveParams": [],
+                "EcdsaParams": [],
+                "EffectTiming": [],
+                "Element": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "ElementCreationOptions": [],
+                "ElementDefinitionOptions": [],
+                "EncodedAudioChunk": [],
+                "EncodedAudioChunkInit": [],
+                "EncodedAudioChunkMetadata": [],
+                "EncodedAudioChunkType": [],
+                "EncodedVideoChunk": [],
+                "EncodedVideoChunkInit": [],
+                "EncodedVideoChunkMetadata": [],
+                "EncodedVideoChunkType": [],
+                "EndingTypes": [],
+                "ErrorCallback": [],
+                "ErrorEvent": [
+                    "Event"
+                ],
+                "ErrorEventInit": [],
+                "Event": [],
+                "EventInit": [],
+                "EventListener": [],
+                "EventListenerOptions": [],
+                "EventModifierInit": [],
+                "EventSource": [
+                    "EventTarget"
+                ],
+                "EventSourceInit": [],
+                "EventTarget": [],
+                "Exception": [],
+                "ExtBlendMinmax": [],
+                "ExtColorBufferFloat": [],
+                "ExtColorBufferHalfFloat": [],
+                "ExtDisjointTimerQuery": [],
+                "ExtFragDepth": [],
+                "ExtSRgb": [],
+                "ExtShaderTextureLod": [],
+                "ExtTextureFilterAnisotropic": [],
+                "ExtendableEvent": [
+                    "Event"
+                ],
+                "ExtendableEventInit": [],
+                "ExtendableMessageEvent": [
+                    "Event",
+                    "ExtendableEvent"
+                ],
+                "ExtendableMessageEventInit": [],
+                "External": [],
+                "FakePluginMimeEntry": [],
+                "FakePluginTagInit": [],
+                "FetchEvent": [
+                    "Event",
+                    "ExtendableEvent"
+                ],
+                "FetchEventInit": [],
+                "FetchObserver": [
+                    "EventTarget"
+                ],
+                "FetchReadableStreamReadDataArray": [],
+                "FetchReadableStreamReadDataDone": [],
+                "FetchState": [],
+                "File": [
+                    "Blob"
+                ],
+                "FileCallback": [],
+                "FileList": [],
+                "FilePropertyBag": [],
+                "FileReader": [
+                    "EventTarget"
+                ],
+                "FileReaderSync": [],
+                "FileSystem": [],
+                "FileSystemDirectoryEntry": [
+                    "FileSystemEntry"
+                ],
+                "FileSystemDirectoryReader": [],
+                "FileSystemEntriesCallback": [],
+                "FileSystemEntry": [],
+                "FileSystemEntryCallback": [],
+                "FileSystemFileEntry": [
+                    "FileSystemEntry"
+                ],
+                "FileSystemFlags": [],
+                "FillMode": [],
+                "FlashClassification": [],
+                "FlexLineGrowthState": [],
+                "FocusEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "FocusEventInit": [],
+                "FontFace": [],
+                "FontFaceDescriptors": [],
+                "FontFaceLoadStatus": [],
+                "FontFaceSet": [
+                    "EventTarget"
+                ],
+                "FontFaceSetIterator": [],
+                "FontFaceSetIteratorResult": [],
+                "FontFaceSetLoadEvent": [
+                    "Event"
+                ],
+                "FontFaceSetLoadEventInit": [],
+                "FontFaceSetLoadStatus": [],
+                "FormData": [],
+                "FrameType": [],
+                "FuzzingFunctions": [],
+                "GainNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "GainOptions": [],
+                "Gamepad": [],
+                "GamepadAxisMoveEvent": [
+                    "Event",
+                    "GamepadEvent"
+                ],
+                "GamepadAxisMoveEventInit": [],
+                "GamepadButton": [],
+                "GamepadButtonEvent": [
+                    "Event",
+                    "GamepadEvent"
+                ],
+                "GamepadButtonEventInit": [],
+                "GamepadEvent": [
+                    "Event"
+                ],
+                "GamepadEventInit": [],
+                "GamepadHand": [],
+                "GamepadHapticActuator": [],
+                "GamepadHapticActuatorType": [],
+                "GamepadMappingType": [],
+                "GamepadPose": [],
+                "GamepadServiceTest": [],
+                "Geolocation": [],
+                "GetNotificationOptions": [],
+                "GetRootNodeOptions": [],
+                "GetUserMediaRequest": [],
+                "Gpu": [],
+                "GpuAdapter": [],
+                "GpuAdapterInfo": [],
+                "GpuAddressMode": [],
+                "GpuAutoLayoutMode": [],
+                "GpuBindGroup": [],
+                "GpuBindGroupDescriptor": [],
+                "GpuBindGroupEntry": [],
+                "GpuBindGroupLayout": [],
+                "GpuBindGroupLayoutDescriptor": [],
+                "GpuBindGroupLayoutEntry": [],
+                "GpuBlendComponent": [],
+                "GpuBlendFactor": [],
+                "GpuBlendOperation": [],
+                "GpuBlendState": [],
+                "GpuBuffer": [],
+                "GpuBufferBinding": [],
+                "GpuBufferBindingLayout": [],
+                "GpuBufferBindingType": [],
+                "GpuBufferDescriptor": [],
+                "GpuCanvasAlphaMode": [],
+                "GpuCanvasConfiguration": [],
+                "GpuCanvasContext": [],
+                "GpuColorDict": [],
+                "GpuColorTargetState": [],
+                "GpuCommandBuffer": [],
+                "GpuCommandBufferDescriptor": [],
+                "GpuCommandEncoder": [],
+                "GpuCommandEncoderDescriptor": [],
+                "GpuCompareFunction": [],
+                "GpuCompilationInfo": [],
+                "GpuCompilationMessage": [],
+                "GpuCompilationMessageType": [],
+                "GpuComputePassDescriptor": [],
+                "GpuComputePassEncoder": [],
+                "GpuComputePassTimestampLocation": [],
+                "GpuComputePassTimestampWrite": [],
+                "GpuComputePipeline": [],
+                "GpuComputePipelineDescriptor": [],
+                "GpuCullMode": [],
+                "GpuDepthStencilState": [],
+                "GpuDevice": [
+                    "EventTarget"
+                ],
+                "GpuDeviceDescriptor": [],
+                "GpuDeviceLostInfo": [],
+                "GpuDeviceLostReason": [],
+                "GpuError": [],
+                "GpuErrorFilter": [],
+                "GpuExtent3dDict": [],
+                "GpuExternalTexture": [],
+                "GpuExternalTextureBindingLayout": [],
+                "GpuExternalTextureDescriptor": [],
+                "GpuFeatureName": [],
+                "GpuFilterMode": [],
+                "GpuFragmentState": [],
+                "GpuFrontFace": [],
+                "GpuImageCopyBuffer": [],
+                "GpuImageCopyExternalImage": [],
+                "GpuImageCopyTexture": [],
+                "GpuImageCopyTextureTagged": [],
+                "GpuImageDataLayout": [],
+                "GpuIndexFormat": [],
+                "GpuLoadOp": [],
+                "GpuMipmapFilterMode": [],
+                "GpuMultisampleState": [],
+                "GpuObjectDescriptorBase": [],
+                "GpuOrigin2dDict": [],
+                "GpuOrigin3dDict": [],
+                "GpuOutOfMemoryError": [
+                    "GpuError"
+                ],
+                "GpuPipelineDescriptorBase": [],
+                "GpuPipelineLayout": [],
+                "GpuPipelineLayoutDescriptor": [],
+                "GpuPowerPreference": [],
+                "GpuPrimitiveState": [],
+                "GpuPrimitiveTopology": [],
+                "GpuProgrammableStage": [],
+                "GpuQuerySet": [],
+                "GpuQuerySetDescriptor": [],
+                "GpuQueryType": [],
+                "GpuQueue": [],
+                "GpuQueueDescriptor": [],
+                "GpuRenderBundle": [],
+                "GpuRenderBundleDescriptor": [],
+                "GpuRenderBundleEncoder": [],
+                "GpuRenderBundleEncoderDescriptor": [],
+                "GpuRenderPassColorAttachment": [],
+                "GpuRenderPassDepthStencilAttachment": [],
+                "GpuRenderPassDescriptor": [],
+                "GpuRenderPassEncoder": [],
+                "GpuRenderPassLayout": [],
+                "GpuRenderPassTimestampLocation": [],
+                "GpuRenderPassTimestampWrite": [],
+                "GpuRenderPipeline": [],
+                "GpuRenderPipelineDescriptor": [],
+                "GpuRequestAdapterOptions": [],
+                "GpuSampler": [],
+                "GpuSamplerBindingLayout": [],
+                "GpuSamplerBindingType": [],
+                "GpuSamplerDescriptor": [],
+                "GpuShaderModule": [],
+                "GpuShaderModuleCompilationHint": [],
+                "GpuShaderModuleDescriptor": [],
+                "GpuStencilFaceState": [],
+                "GpuStencilOperation": [],
+                "GpuStorageTextureAccess": [],
+                "GpuStorageTextureBindingLayout": [],
+                "GpuStoreOp": [],
+                "GpuSupportedFeatures": [],
+                "GpuSupportedLimits": [],
+                "GpuTexture": [],
+                "GpuTextureAspect": [],
+                "GpuTextureBindingLayout": [],
+                "GpuTextureDescriptor": [],
+                "GpuTextureDimension": [],
+                "GpuTextureFormat": [],
+                "GpuTextureSampleType": [],
+                "GpuTextureView": [],
+                "GpuTextureViewDescriptor": [],
+                "GpuTextureViewDimension": [],
+                "GpuUncapturedErrorEvent": [
+                    "Event"
+                ],
+                "GpuUncapturedErrorEventInit": [],
+                "GpuValidationError": [
+                    "GpuError"
+                ],
+                "GpuVertexAttribute": [],
+                "GpuVertexBufferLayout": [],
+                "GpuVertexFormat": [],
+                "GpuVertexState": [],
+                "GpuVertexStepMode": [],
+                "GridDeclaration": [],
+                "GridTrackState": [],
+                "GroupedHistoryEventInit": [],
+                "HalfOpenInfoDict": [],
+                "HardwareAcceleration": [],
+                "HashChangeEvent": [
+                    "Event"
+                ],
+                "HashChangeEventInit": [],
+                "Headers": [],
+                "HeadersGuardEnum": [],
+                "Hid": [
+                    "EventTarget"
+                ],
+                "HidCollectionInfo": [],
+                "HidConnectionEvent": [
+                    "Event"
+                ],
+                "HidConnectionEventInit": [],
+                "HidDevice": [
+                    "EventTarget"
+                ],
+                "HidDeviceFilter": [],
+                "HidDeviceRequestOptions": [],
+                "HidInputReportEvent": [
+                    "Event"
+                ],
+                "HidInputReportEventInit": [],
+                "HidReportInfo": [],
+                "HidReportItem": [],
+                "HidUnitSystem": [],
+                "HiddenPluginEventInit": [],
+                "History": [],
+                "HitRegionOptions": [],
+                "HkdfParams": [],
+                "HmacDerivedKeyParams": [],
+                "HmacImportParams": [],
+                "HmacKeyAlgorithm": [],
+                "HmacKeyGenParams": [],
+                "HtmlAllCollection": [],
+                "HtmlAnchorElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlAreaElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlAudioElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "HtmlMediaElement",
+                    "Node"
+                ],
+                "HtmlBaseElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlBodyElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlBrElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlButtonElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlCanvasElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlCollection": [],
+                "HtmlDListElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDataElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDataListElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDetailsElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDialogElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDirectoryElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDivElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDocument": [
+                    "Document",
+                    "EventTarget",
+                    "Node"
+                ],
+                "HtmlElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node"
+                ],
+                "HtmlEmbedElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFieldSetElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFontElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFormControlsCollection": [
+                    "HtmlCollection"
+                ],
+                "HtmlFormElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFrameElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFrameSetElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlHeadElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlHeadingElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlHrElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlHtmlElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlIFrameElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlImageElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlInputElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlLabelElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlLegendElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlLiElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlLinkElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMapElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMediaElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMenuElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMenuItemElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMetaElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMeterElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlModElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlOListElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlObjectElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlOptGroupElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlOptionElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlOptionsCollection": [
+                    "HtmlCollection"
+                ],
+                "HtmlOutputElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlParagraphElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlParamElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlPictureElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlPreElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlProgressElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlQuoteElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlScriptElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlSelectElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlSlotElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlSourceElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlSpanElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlStyleElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableCaptionElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableCellElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableColElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableRowElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableSectionElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTemplateElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTextAreaElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTimeElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTitleElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTrackElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlUListElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlUnknownElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlVideoElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "HtmlMediaElement",
+                    "Node"
+                ],
+                "HttpConnDict": [],
+                "HttpConnInfo": [],
+                "HttpConnectionElement": [],
+                "IdbCursor": [],
+                "IdbCursorDirection": [],
+                "IdbCursorWithValue": [
+                    "IdbCursor"
+                ],
+                "IdbDatabase": [
+                    "EventTarget"
+                ],
+                "IdbFactory": [],
+                "IdbFileHandle": [
+                    "EventTarget"
+                ],
+                "IdbFileMetadataParameters": [],
+                "IdbFileRequest": [
+                    "DomRequest",
+                    "EventTarget"
+                ],
+                "IdbIndex": [],
+                "IdbIndexParameters": [],
+                "IdbKeyRange": [],
+                "IdbLocaleAwareKeyRange": [
+                    "IdbKeyRange"
+                ],
+                "IdbMutableFile": [
+                    "EventTarget"
+                ],
+                "IdbObjectStore": [],
+                "IdbObjectStoreParameters": [],
+                "IdbOpenDbOptions": [],
+                "IdbOpenDbRequest": [
+                    "EventTarget",
+                    "IdbRequest"
+                ],
+                "IdbRequest": [
+                    "EventTarget"
+                ],
+                "IdbRequestReadyState": [],
+                "IdbTransaction": [
+                    "EventTarget"
+                ],
+                "IdbTransactionMode": [],
+                "IdbVersionChangeEvent": [
+                    "Event"
+                ],
+                "IdbVersionChangeEventInit": [],
+                "IdleDeadline": [],
+                "IdleRequestOptions": [],
+                "IirFilterNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "IirFilterOptions": [],
+                "ImageBitmap": [],
+                "ImageBitmapFormat": [],
+                "ImageBitmapRenderingContext": [],
+                "ImageCapture": [],
+                "ImageCaptureError": [],
+                "ImageCaptureErrorEvent": [
+                    "Event"
+                ],
+                "ImageCaptureErrorEventInit": [],
+                "ImageData": [],
+                "ImageDecodeOptions": [],
+                "ImageDecodeResult": [],
+                "ImageDecoder": [],
+                "ImageDecoderInit": [],
+                "ImageTrack": [
+                    "EventTarget"
+                ],
+                "ImageTrackList": [],
+                "InputEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "InputEventInit": [],
+                "InstallTriggerData": [],
+                "IntersectionObserver": [],
+                "IntersectionObserverEntry": [],
+                "IntersectionObserverEntryInit": [],
+                "IntersectionObserverInit": [],
+                "IntlUtils": [],
+                "IterableKeyAndValueResult": [],
+                "IterableKeyOrValueResult": [],
+                "IterationCompositeOperation": [],
+                "JsonWebKey": [],
+                "KeyAlgorithm": [],
+                "KeyEvent": [],
+                "KeyIdsInitData": [],
+                "KeyboardEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "KeyboardEventInit": [],
+                "KeyframeEffect": [
+                    "AnimationEffect"
+                ],
+                "KeyframeEffectOptions": [],
+                "L10nElement": [],
+                "L10nValue": [],
+                "LatencyMode": [],
+                "LifecycleCallbacks": [],
+                "LineAlignSetting": [],
+                "ListBoxObject": [],
+                "LocalMediaStream": [
+                    "EventTarget",
+                    "MediaStream"
+                ],
+                "LocaleInfo": [],
+                "Location": [],
+                "MediaCapabilities": [],
+                "MediaCapabilitiesInfo": [],
+                "MediaConfiguration": [],
+                "MediaDecodingConfiguration": [],
+                "MediaDecodingType": [],
+                "MediaDeviceInfo": [],
+                "MediaDeviceKind": [],
+                "MediaDevices": [
+                    "EventTarget"
+                ],
+                "MediaElementAudioSourceNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "MediaElementAudioSourceOptions": [],
+                "MediaEncodingConfiguration": [],
+                "MediaEncodingType": [],
+                "MediaEncryptedEvent": [
+                    "Event"
+                ],
+                "MediaError": [],
+                "MediaImage": [],
+                "MediaKeyError": [
+                    "Event"
+                ],
+                "MediaKeyMessageEvent": [
+                    "Event"
+                ],
+                "MediaKeyMessageEventInit": [],
+                "MediaKeyMessageType": [],
+                "MediaKeyNeededEventInit": [],
+                "MediaKeySession": [
+                    "EventTarget"
+                ],
+                "MediaKeySessionType": [],
+                "MediaKeyStatus": [],
+                "MediaKeyStatusMap": [],
+                "MediaKeySystemAccess": [],
+                "MediaKeySystemConfiguration": [],
+                "MediaKeySystemMediaCapability": [],
+                "MediaKeySystemStatus": [],
+                "MediaKeys": [],
+                "MediaKeysPolicy": [],
+                "MediaKeysRequirement": [],
+                "MediaList": [],
+                "MediaMetadata": [],
+                "MediaMetadataInit": [],
+                "MediaPositionState": [],
+                "MediaQueryList": [
+                    "EventTarget"
+                ],
+                "MediaQueryListEvent": [
+                    "Event"
+                ],
+                "MediaQueryListEventInit": [],
+                "MediaRecorder": [
+                    "EventTarget"
+                ],
+                "MediaRecorderErrorEvent": [
+                    "Event"
+                ],
+                "MediaRecorderErrorEventInit": [],
+                "MediaRecorderOptions": [],
+                "MediaSession": [],
+                "MediaSessionAction": [],
+                "MediaSessionActionDetails": [],
+                "MediaSessionPlaybackState": [],
+                "MediaSource": [
+                    "EventTarget"
+                ],
+                "MediaSourceEndOfStreamError": [],
+                "MediaSourceEnum": [],
+                "MediaSourceReadyState": [],
+                "MediaStream": [
+                    "EventTarget"
+                ],
+                "MediaStreamAudioDestinationNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "MediaStreamAudioSourceNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "MediaStreamAudioSourceOptions": [],
+                "MediaStreamConstraints": [],
+                "MediaStreamError": [],
+                "MediaStreamEvent": [
+                    "Event"
+                ],
+                "MediaStreamEventInit": [],
+                "MediaStreamTrack": [
+                    "EventTarget"
+                ],
+                "MediaStreamTrackEvent": [
+                    "Event"
+                ],
+                "MediaStreamTrackEventInit": [],
+                "MediaStreamTrackGenerator": [
+                    "EventTarget",
+                    "MediaStreamTrack"
+                ],
+                "MediaStreamTrackGeneratorInit": [],
+                "MediaStreamTrackProcessor": [],
+                "MediaStreamTrackProcessorInit": [],
+                "MediaStreamTrackState": [],
+                "MediaTrackConstraintSet": [],
+                "MediaTrackConstraints": [],
+                "MediaTrackSettings": [],
+                "MediaTrackSupportedConstraints": [],
+                "MessageChannel": [],
+                "MessageEvent": [
+                    "Event"
+                ],
+                "MessageEventInit": [],
+                "MessagePort": [
+                    "EventTarget"
+                ],
+                "MidiAccess": [
+                    "EventTarget"
+                ],
+                "MidiConnectionEvent": [
+                    "Event"
+                ],
+                "MidiConnectionEventInit": [],
+                "MidiInput": [
+                    "EventTarget",
+                    "MidiPort"
+                ],
+                "MidiInputMap": [],
+                "MidiMessageEvent": [
+                    "Event"
+                ],
+                "MidiMessageEventInit": [],
+                "MidiOptions": [],
+                "MidiOutput": [
+                    "EventTarget",
+                    "MidiPort"
+                ],
+                "MidiOutputMap": [],
+                "MidiPort": [
+                    "EventTarget"
+                ],
+                "MidiPortConnectionState": [],
+                "MidiPortDeviceState": [],
+                "MidiPortType": [],
+                "MimeType": [],
+                "MimeTypeArray": [],
+                "MouseEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "MouseEventInit": [],
+                "MouseScrollEvent": [
+                    "Event",
+                    "MouseEvent",
+                    "UiEvent"
+                ],
+                "MozDebug": [],
+                "MutationEvent": [
+                    "Event"
+                ],
+                "MutationObserver": [],
+                "MutationObserverInit": [],
+                "MutationObservingInfo": [],
+                "MutationRecord": [],
+                "NamedNodeMap": [],
+                "NativeOsFileReadOptions": [],
+                "NativeOsFileWriteAtomicOptions": [],
+                "NavigationType": [],
+                "Navigator": [],
+                "NavigatorAutomationInformation": [],
+                "NetworkCommandOptions": [],
+                "NetworkInformation": [
+                    "EventTarget"
+                ],
+                "NetworkResultOptions": [],
+                "Node": [
+                    "EventTarget"
+                ],
+                "NodeFilter": [],
+                "NodeIterator": [],
+                "NodeList": [],
+                "Notification": [
+                    "EventTarget"
+                ],
+                "NotificationBehavior": [],
+                "NotificationDirection": [],
+                "NotificationEvent": [
+                    "Event",
+                    "ExtendableEvent"
+                ],
+                "NotificationEventInit": [],
+                "NotificationOptions": [],
+                "NotificationPermission": [],
+                "ObserverCallback": [],
+                "OesElementIndexUint": [],
+                "OesStandardDerivatives": [],
+                "OesTextureFloat": [],
+                "OesTextureFloatLinear": [],
+                "OesTextureHalfFloat": [],
+                "OesTextureHalfFloatLinear": [],
+                "OesVertexArrayObject": [],
+                "OfflineAudioCompletionEvent": [
+                    "Event"
+                ],
+                "OfflineAudioCompletionEventInit": [],
+                "OfflineAudioContext": [
+                    "BaseAudioContext",
+                    "EventTarget"
+                ],
+                "OfflineAudioContextOptions": [],
+                "OfflineResourceList": [
+                    "EventTarget"
+                ],
+                "OffscreenCanvas": [
+                    "EventTarget"
+                ],
+                "OpenWindowEventDetail": [],
+                "OptionalEffectTiming": [],
+                "OrientationLockType": [],
+                "OrientationType": [],
+                "OscillatorNode": [
+                    "AudioNode",
+                    "AudioScheduledSourceNode",
+                    "EventTarget"
+                ],
+                "OscillatorOptions": [],
+                "OscillatorType": [],
+                "OverSampleType": [],
+                "OvrMultiview2": [],
+                "PageTransitionEvent": [
+                    "Event"
+                ],
+                "PageTransitionEventInit": [],
+                "PaintRequest": [],
+                "PaintRequestList": [],
+                "PaintWorkletGlobalScope": [
+                    "WorkletGlobalScope"
+                ],
+                "PannerNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "PannerOptions": [],
+                "PanningModelType": [],
+                "Path2d": [],
+                "PaymentAddress": [],
+                "PaymentComplete": [],
+                "PaymentMethodChangeEvent": [
+                    "Event",
+                    "PaymentRequestUpdateEvent"
+                ],
+                "PaymentMethodChangeEventInit": [],
+                "PaymentRequestUpdateEvent": [
+                    "Event"
+                ],
+                "PaymentRequestUpdateEventInit": [],
+                "PaymentResponse": [],
+                "Pbkdf2Params": [],
+                "PcImplIceConnectionState": [],
+                "PcImplIceGatheringState": [],
+                "PcImplSignalingState": [],
+                "PcObserverStateType": [],
+                "Performance": [
+                    "EventTarget"
+                ],
+                "PerformanceEntry": [],
+                "PerformanceEntryEventInit": [],
+                "PerformanceEntryFilterOptions": [],
+                "PerformanceMark": [
+                    "PerformanceEntry"
+                ],
+                "PerformanceMeasure": [
+                    "PerformanceEntry"
+                ],
+                "PerformanceNavigation": [],
+                "PerformanceNavigationTiming": [
+                    "PerformanceEntry",
+                    "PerformanceResourceTiming"
+                ],
+                "PerformanceObserver": [],
+                "PerformanceObserverEntryList": [],
+                "PerformanceObserverInit": [],
+                "PerformanceResourceTiming": [
+                    "PerformanceEntry"
+                ],
+                "PerformanceServerTiming": [],
+                "PerformanceTiming": [],
+                "PeriodicWave": [],
+                "PeriodicWaveConstraints": [],
+                "PeriodicWaveOptions": [],
+                "PermissionDescriptor": [],
+                "PermissionName": [],
+                "PermissionState": [],
+                "PermissionStatus": [
+                    "EventTarget"
+                ],
+                "Permissions": [],
+                "PlaneLayout": [],
+                "PlaybackDirection": [],
+                "Plugin": [],
+                "PluginArray": [],
+                "PluginCrashedEventInit": [],
+                "PointerEvent": [
+                    "Event",
+                    "MouseEvent",
+                    "UiEvent"
+                ],
+                "PointerEventInit": [],
+                "PopStateEvent": [
+                    "Event"
+                ],
+                "PopStateEventInit": [],
+                "PopupBlockedEvent": [
+                    "Event"
+                ],
+                "PopupBlockedEventInit": [],
+                "Position": [],
+                "PositionAlignSetting": [],
+                "PositionError": [],
+                "PositionOptions": [],
+                "Presentation": [],
+                "PresentationAvailability": [
+                    "EventTarget"
+                ],
+                "PresentationConnection": [
+                    "EventTarget"
+                ],
+                "PresentationConnectionAvailableEvent": [
+                    "Event"
+                ],
+                "PresentationConnectionAvailableEventInit": [],
+                "PresentationConnectionBinaryType": [],
+                "PresentationConnectionCloseEvent": [
+                    "Event"
+                ],
+                "PresentationConnectionCloseEventInit": [],
+                "PresentationConnectionClosedReason": [],
+                "PresentationConnectionList": [
+                    "EventTarget"
+                ],
+                "PresentationConnectionState": [],
+                "PresentationReceiver": [],
+                "PresentationRequest": [
+                    "EventTarget"
+                ],
+                "PresentationStyle": [],
+                "ProcessingInstruction": [
+                    "CharacterData",
+                    "EventTarget",
+                    "Node"
+                ],
+                "ProfileTimelineLayerRect": [],
+                "ProfileTimelineMarker": [],
+                "ProfileTimelineMessagePortOperationType": [],
+                "ProfileTimelineStackFrame": [],
+                "ProfileTimelineWorkerOperationType": [],
+                "ProgressEvent": [
+                    "Event"
+                ],
+                "ProgressEventInit": [],
+                "PromiseNativeHandler": [],
+                "PromiseRejectionEvent": [
+                    "Event"
+                ],
+                "PromiseRejectionEventInit": [],
+                "PublicKeyCredential": [
+                    "Credential"
+                ],
+                "PublicKeyCredentialCreationOptions": [],
+                "PublicKeyCredentialDescriptor": [],
+                "PublicKeyCredentialEntity": [],
+                "PublicKeyCredentialParameters": [],
+                "PublicKeyCredentialRequestOptions": [],
+                "PublicKeyCredentialRpEntity": [],
+                "PublicKeyCredentialType": [],
+                "PublicKeyCredentialUserEntity": [],
+                "PushEncryptionKeyName": [],
+                "PushEvent": [
+                    "Event",
+                    "ExtendableEvent"
+                ],
+                "PushEventInit": [],
+                "PushManager": [],
+                "PushMessageData": [],
+                "PushPermissionState": [],
+                "PushSubscription": [],
+                "PushSubscriptionInit": [],
+                "PushSubscriptionJson": [],
+                "PushSubscriptionKeys": [],
+                "PushSubscriptionOptions": [],
+                "PushSubscriptionOptionsInit": [],
+                "QueuingStrategy": [],
+                "QueuingStrategyInit": [],
+                "RadioNodeList": [
+                    "NodeList"
+                ],
+                "Range": [],
+                "RcwnPerfStats": [],
+                "RcwnStatus": [],
+                "ReadableByteStreamController": [],
+                "ReadableStream": [],
+                "ReadableStreamByobReader": [],
+                "ReadableStreamByobRequest": [],
+                "ReadableStreamDefaultController": [],
+                "ReadableStreamDefaultReader": [],
+                "ReadableStreamGetReaderOptions": [],
+                "ReadableStreamIteratorOptions": [],
+                "ReadableStreamReadResult": [],
+                "ReadableStreamReaderMode": [],
+                "ReadableStreamType": [],
+                "ReadableWritablePair": [],
+                "RecordingState": [],
+                "ReferrerPolicy": [],
+                "RegisterRequest": [],
+                "RegisterResponse": [],
+                "RegisteredKey": [],
+                "RegistrationOptions": [],
+                "Request": [],
+                "RequestCache": [],
+                "RequestCredentials": [],
+                "RequestDestination": [],
+                "RequestDeviceOptions": [],
+                "RequestInit": [],
+                "RequestMediaKeySystemAccessNotification": [],
+                "RequestMode": [],
+                "RequestRedirect": [],
+                "ResizeObserver": [],
+                "ResizeObserverBoxOptions": [],
+                "ResizeObserverEntry": [],
+                "ResizeObserverOptions": [],
+                "ResizeObserverSize": [],
+                "Response": [],
+                "ResponseInit": [],
+                "ResponseType": [],
+                "RsaHashedImportParams": [],
+                "RsaOaepParams": [],
+                "RsaOtherPrimesInfo": [],
+                "RsaPssParams": [],
+                "RtcAnswerOptions": [],
+                "RtcBundlePolicy": [],
+                "RtcCertificate": [],
+                "RtcCertificateExpiration": [],
+                "RtcCodecStats": [],
+                "RtcConfiguration": [],
+                "RtcDataChannel": [
+                    "EventTarget"
+                ],
+                "RtcDataChannelEvent": [
+                    "Event"
+                ],
+                "RtcDataChannelEventInit": [],
+                "RtcDataChannelInit": [],
+                "RtcDataChannelState": [],
+                "RtcDataChannelType": [],
+                "RtcDegradationPreference": [],
+                "RtcFecParameters": [],
+                "RtcIceCandidate": [],
+                "RtcIceCandidateInit": [],
+                "RtcIceCandidatePairStats": [],
+                "RtcIceCandidateStats": [],
+                "RtcIceComponentStats": [],
+                "RtcIceConnectionState": [],
+                "RtcIceCredentialType": [],
+                "RtcIceGatheringState": [],
+                "RtcIceServer": [],
+                "RtcIceTransportPolicy": [],
+                "RtcIdentityAssertion": [],
+                "RtcIdentityAssertionResult": [],
+                "RtcIdentityProvider": [],
+                "RtcIdentityProviderDetails": [],
+                "RtcIdentityProviderOptions": [],
+                "RtcIdentityProviderRegistrar": [],
+                "RtcIdentityValidationResult": [],
+                "RtcInboundRtpStreamStats": [],
+                "RtcLifecycleEvent": [],
+                "RtcMediaStreamStats": [],
+                "RtcMediaStreamTrackStats": [],
+                "RtcOfferAnswerOptions": [],
+                "RtcOfferOptions": [],
+                "RtcOutboundRtpStreamStats": [],
+                "RtcPeerConnection": [
+                    "EventTarget"
+                ],
+                "RtcPeerConnectionIceEvent": [
+                    "Event"
+                ],
+                "RtcPeerConnectionIceEventInit": [],
+                "RtcPriorityType": [],
+                "RtcRtcpParameters": [],
+                "RtcRtpCodecParameters": [],
+                "RtcRtpContributingSource": [],
+                "RtcRtpEncodingParameters": [],
+                "RtcRtpHeaderExtensionParameters": [],
+                "RtcRtpParameters": [],
+                "RtcRtpReceiver": [],
+                "RtcRtpSender": [],
+                "RtcRtpSourceEntry": [],
+                "RtcRtpSourceEntryType": [],
+                "RtcRtpSynchronizationSource": [],
+                "RtcRtpTransceiver": [],
+                "RtcRtpTransceiverDirection": [],
+                "RtcRtpTransceiverInit": [],
+                "RtcRtxParameters": [],
+                "RtcSdpType": [],
+                "RtcSessionDescription": [],
+                "RtcSessionDescriptionInit": [],
+                "RtcSignalingState": [],
+                "RtcStats": [],
+                "RtcStatsIceCandidatePairState": [],
+                "RtcStatsIceCandidateType": [],
+                "RtcStatsReport": [],
+                "RtcStatsReportInternal": [],
+                "RtcStatsType": [],
+                "RtcTrackEvent": [
+                    "Event"
+                ],
+                "RtcTrackEventInit": [],
+                "RtcTransportStats": [],
+                "RtcdtmfSender": [
+                    "EventTarget"
+                ],
+                "RtcdtmfToneChangeEvent": [
+                    "Event"
+                ],
+                "RtcdtmfToneChangeEventInit": [],
+                "RtcrtpContributingSourceStats": [],
+                "RtcrtpStreamStats": [],
+                "Screen": [
+                    "EventTarget"
+                ],
+                "ScreenColorGamut": [],
+                "ScreenLuminance": [],
+                "ScreenOrientation": [
+                    "EventTarget"
+                ],
+                "ScriptProcessorNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "ScrollAreaEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "ScrollBehavior": [],
+                "ScrollBoxObject": [],
+                "ScrollIntoViewOptions": [],
+                "ScrollLogicalPosition": [],
+                "ScrollOptions": [],
+                "ScrollRestoration": [],
+                "ScrollSetting": [],
+                "ScrollState": [],
+                "ScrollToOptions": [],
+                "ScrollViewChangeEventInit": [],
+                "SecurityPolicyViolationEvent": [
+                    "Event"
+                ],
+                "SecurityPolicyViolationEventDisposition": [],
+                "SecurityPolicyViolationEventInit": [],
+                "Selection": [],
+                "ServerSocketOptions": [],
+                "ServiceWorker": [
+                    "EventTarget"
+                ],
+                "ServiceWorkerContainer": [
+                    "EventTarget"
+                ],
+                "ServiceWorkerGlobalScope": [
+                    "EventTarget",
+                    "WorkerGlobalScope"
+                ],
+                "ServiceWorkerRegistration": [
+                    "EventTarget"
+                ],
+                "ServiceWorkerState": [],
+                "ServiceWorkerUpdateViaCache": [],
+                "ShadowRoot": [
+                    "DocumentFragment",
+                    "EventTarget",
+                    "Node"
+                ],
+                "ShadowRootInit": [],
+                "ShadowRootMode": [],
+                "ShareData": [],
+                "SharedWorker": [
+                    "EventTarget"
+                ],
+                "SharedWorkerGlobalScope": [
+                    "EventTarget",
+                    "WorkerGlobalScope"
+                ],
+                "SignResponse": [],
+                "SocketElement": [],
+                "SocketOptions": [],
+                "SocketReadyState": [],
+                "SocketsDict": [],
+                "SourceBuffer": [
+                    "EventTarget"
+                ],
+                "SourceBufferAppendMode": [],
+                "SourceBufferList": [
+                    "EventTarget"
+                ],
+                "SpeechGrammar": [],
+                "SpeechGrammarList": [],
+                "SpeechRecognition": [
+                    "EventTarget"
+                ],
+                "SpeechRecognitionAlternative": [],
+                "SpeechRecognitionError": [
+                    "Event"
+                ],
+                "SpeechRecognitionErrorCode": [],
+                "SpeechRecognitionErrorInit": [],
+                "SpeechRecognitionEvent": [
+                    "Event"
+                ],
+                "SpeechRecognitionEventInit": [],
+                "SpeechRecognitionResult": [],
+                "SpeechRecognitionResultList": [],
+                "SpeechSynthesis": [
+                    "EventTarget"
+                ],
+                "SpeechSynthesisErrorCode": [],
+                "SpeechSynthesisErrorEvent": [
+                    "Event",
+                    "SpeechSynthesisEvent"
+                ],
+                "SpeechSynthesisErrorEventInit": [],
+                "SpeechSynthesisEvent": [
+                    "Event"
+                ],
+                "SpeechSynthesisEventInit": [],
+                "SpeechSynthesisUtterance": [
+                    "EventTarget"
+                ],
+                "SpeechSynthesisVoice": [],
+                "StereoPannerNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "StereoPannerOptions": [],
+                "Storage": [],
+                "StorageEstimate": [],
+                "StorageEvent": [
+                    "Event"
+                ],
+                "StorageEventInit": [],
+                "StorageManager": [],
+                "StorageType": [],
+                "StreamPipeOptions": [],
+                "StyleRuleChangeEventInit": [],
+                "StyleSheet": [],
+                "StyleSheetApplicableStateChangeEventInit": [],
+                "StyleSheetChangeEventInit": [],
+                "StyleSheetList": [],
+                "SubmitEvent": [
+                    "Event"
+                ],
+                "SubmitEventInit": [],
+                "SubtleCrypto": [],
+                "SupportedType": [],
+                "SvcOutputMetadata": [],
+                "SvgAngle": [],
+                "SvgAnimateElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgAnimationElement",
+                    "SvgElement"
+                ],
+                "SvgAnimateMotionElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgAnimationElement",
+                    "SvgElement"
+                ],
+                "SvgAnimateTransformElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgAnimationElement",
+                    "SvgElement"
+                ],
+                "SvgAnimatedAngle": [],
+                "SvgAnimatedBoolean": [],
+                "SvgAnimatedEnumeration": [],
+                "SvgAnimatedInteger": [],
+                "SvgAnimatedLength": [],
+                "SvgAnimatedLengthList": [],
+                "SvgAnimatedNumber": [],
+                "SvgAnimatedNumberList": [],
+                "SvgAnimatedPreserveAspectRatio": [],
+                "SvgAnimatedRect": [],
+                "SvgAnimatedString": [],
+                "SvgAnimatedTransformList": [],
+                "SvgAnimationElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgBoundingBoxOptions": [],
+                "SvgCircleElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgClipPathElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgComponentTransferFunctionElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgDefsElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgDescElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node"
+                ],
+                "SvgEllipseElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgFilterElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgForeignObjectElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgGeometryElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgGradientElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgGraphicsElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgImageElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgLength": [],
+                "SvgLengthList": [],
+                "SvgLineElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgLinearGradientElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGradientElement"
+                ],
+                "SvgMarkerElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgMaskElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgMatrix": [],
+                "SvgMetadataElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgNumber": [],
+                "SvgNumberList": [],
+                "SvgPathElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgPathSeg": [],
+                "SvgPathSegArcAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegArcRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegClosePath": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoCubicAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoCubicRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoCubicSmoothAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoCubicSmoothRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoQuadraticAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoQuadraticRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoQuadraticSmoothAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoQuadraticSmoothRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoHorizontalAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoHorizontalRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoVerticalAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoVerticalRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegList": [],
+                "SvgPathSegMovetoAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegMovetoRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPatternElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgPoint": [],
+                "SvgPointList": [],
+                "SvgPolygonElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgPolylineElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgPreserveAspectRatio": [],
+                "SvgRadialGradientElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGradientElement"
+                ],
+                "SvgRect": [],
+                "SvgRectElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgScriptElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgSetElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgAnimationElement",
+                    "SvgElement"
+                ],
+                "SvgStopElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgStringList": [],
+                "SvgStyleElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgSwitchElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgSymbolElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgTextContentElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgTextElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement",
+                    "SvgTextContentElement",
+                    "SvgTextPositioningElement"
+                ],
+                "SvgTextPathElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement",
+                    "SvgTextContentElement"
+                ],
+                "SvgTextPositioningElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement",
+                    "SvgTextContentElement"
+                ],
+                "SvgTitleElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgTransform": [],
+                "SvgTransformList": [],
+                "SvgUnitTypes": [],
+                "SvgUseElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgViewElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgZoomAndPan": [],
+                "SvgaElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgfeBlendElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeColorMatrixElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeComponentTransferElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeCompositeElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeConvolveMatrixElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeDiffuseLightingElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeDisplacementMapElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeDistantLightElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeDropShadowElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeFloodElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeFuncAElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgComponentTransferFunctionElement",
+                    "SvgElement"
+                ],
+                "SvgfeFuncBElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgComponentTransferFunctionElement",
+                    "SvgElement"
+                ],
+                "SvgfeFuncGElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgComponentTransferFunctionElement",
+                    "SvgElement"
+                ],
+                "SvgfeFuncRElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgComponentTransferFunctionElement",
+                    "SvgElement"
+                ],
+                "SvgfeGaussianBlurElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeImageElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeMergeElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeMergeNodeElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeMorphologyElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeOffsetElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfePointLightElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeSpecularLightingElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeSpotLightElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeTileElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeTurbulenceElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvggElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgmPathElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgsvgElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgtSpanElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement",
+                    "SvgTextContentElement",
+                    "SvgTextPositioningElement"
+                ],
+                "TcpReadyState": [],
+                "TcpServerSocket": [
+                    "EventTarget"
+                ],
+                "TcpServerSocketEvent": [
+                    "Event"
+                ],
+                "TcpServerSocketEventInit": [],
+                "TcpSocket": [
+                    "EventTarget"
+                ],
+                "TcpSocketBinaryType": [],
+                "TcpSocketErrorEvent": [
+                    "Event"
+                ],
+                "TcpSocketErrorEventInit": [],
+                "TcpSocketEvent": [
+                    "Event"
+                ],
+                "TcpSocketEventInit": [],
+                "Text": [
+                    "CharacterData",
+                    "EventTarget",
+                    "Node"
+                ],
+                "TextDecodeOptions": [],
+                "TextDecoder": [],
+                "TextDecoderOptions": [],
+                "TextEncoder": [],
+                "TextMetrics": [],
+                "TextTrack": [
+                    "EventTarget"
+                ],
+                "TextTrackCue": [
+                    "EventTarget"
+                ],
+                "TextTrackCueList": [],
+                "TextTrackKind": [],
+                "TextTrackList": [
+                    "EventTarget"
+                ],
+                "TextTrackMode": [],
+                "TimeEvent": [
+                    "Event"
+                ],
+                "TimeRanges": [],
+                "Touch": [],
+                "TouchEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "TouchEventInit": [],
+                "TouchInit": [],
+                "TouchList": [],
+                "TrackEvent": [
+                    "Event"
+                ],
+                "TrackEventInit": [],
+                "TransformStream": [],
+                "TransformStreamDefaultController": [],
+                "Transformer": [],
+                "TransitionEvent": [
+                    "Event"
+                ],
+                "TransitionEventInit": [],
+                "Transport": [],
+                "TreeBoxObject": [],
+                "TreeCellInfo": [],
+                "TreeView": [],
+                "TreeWalker": [],
+                "U2f": [],
+                "U2fClientData": [],
+                "UdpMessageEventInit": [],
+                "UdpOptions": [],
+                "UiEvent": [
+                    "Event"
+                ],
+                "UiEventInit": [],
+                "UnderlyingSink": [],
+                "UnderlyingSource": [],
+                "Url": [],
+                "UrlSearchParams": [],
+                "Usb": [
+                    "EventTarget"
+                ],
+                "UsbAlternateInterface": [],
+                "UsbConfiguration": [],
+                "UsbConnectionEvent": [
+                    "Event"
+                ],
+                "UsbConnectionEventInit": [],
+                "UsbControlTransferParameters": [],
+                "UsbDevice": [],
+                "UsbDeviceFilter": [],
+                "UsbDeviceRequestOptions": [],
+                "UsbDirection": [],
+                "UsbEndpoint": [],
+                "UsbEndpointType": [],
+                "UsbInTransferResult": [],
+                "UsbInterface": [],
+                "UsbIsochronousInTransferPacket": [],
+                "UsbIsochronousInTransferResult": [],
+                "UsbIsochronousOutTransferPacket": [],
+                "UsbIsochronousOutTransferResult": [],
+                "UsbOutTransferResult": [],
+                "UsbPermissionDescriptor": [],
+                "UsbPermissionResult": [
+                    "EventTarget",
+                    "PermissionStatus"
+                ],
+                "UsbPermissionStorage": [],
+                "UsbRecipient": [],
+                "UsbRequestType": [],
+                "UsbTransferStatus": [],
+                "UserProximityEvent": [
+                    "Event"
+                ],
+                "UserProximityEventInit": [],
+                "UserVerificationRequirement": [],
+                "ValidityState": [],
+                "ValueEvent": [
+                    "Event"
+                ],
+                "ValueEventInit": [],
+                "VideoColorPrimaries": [],
+                "VideoColorSpace": [],
+                "VideoColorSpaceInit": [],
+                "VideoConfiguration": [],
+                "VideoDecoder": [],
+                "VideoDecoderConfig": [],
+                "VideoDecoderInit": [],
+                "VideoDecoderSupport": [],
+                "VideoEncoder": [],
+                "VideoEncoderConfig": [],
+                "VideoEncoderEncodeOptions": [],
+                "VideoEncoderInit": [],
+                "VideoEncoderSupport": [],
+                "VideoFacingModeEnum": [],
+                "VideoFrame": [],
+                "VideoFrameBufferInit": [],
+                "VideoFrameCopyToOptions": [],
+                "VideoFrameInit": [],
+                "VideoMatrixCoefficients": [],
+                "VideoPixelFormat": [],
+                "VideoPlaybackQuality": [],
+                "VideoStreamTrack": [
+                    "EventTarget",
+                    "MediaStreamTrack"
+                ],
+                "VideoTrack": [],
+                "VideoTrackList": [
+                    "EventTarget"
+                ],
+                "VideoTransferCharacteristics": [],
+                "VisibilityState": [],
+                "VoidCallback": [],
+                "VrDisplay": [
+                    "EventTarget"
+                ],
+                "VrDisplayCapabilities": [],
+                "VrEye": [],
+                "VrEyeParameters": [],
+                "VrFieldOfView": [],
+                "VrFrameData": [],
+                "VrLayer": [],
+                "VrMockController": [],
+                "VrMockDisplay": [],
+                "VrPose": [],
+                "VrServiceTest": [],
+                "VrStageParameters": [],
+                "VrSubmitFrameResult": [],
+                "VttCue": [
+                    "EventTarget",
+                    "TextTrackCue"
+                ],
+                "VttRegion": [],
+                "WakeLock": [],
+                "WakeLockSentinel": [
+                    "EventTarget"
+                ],
+                "WakeLockType": [],
+                "WatchAdvertisementsOptions": [],
+                "WaveShaperNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "WaveShaperOptions": [],
+                "WebGl2RenderingContext": [],
+                "WebGlActiveInfo": [],
+                "WebGlBuffer": [],
+                "WebGlContextAttributes": [],
+                "WebGlContextEvent": [
+                    "Event"
+                ],
+                "WebGlContextEventInit": [],
+                "WebGlFramebuffer": [],
+                "WebGlPowerPreference": [],
+                "WebGlProgram": [],
+                "WebGlQuery": [],
+                "WebGlRenderbuffer": [],
+                "WebGlRenderingContext": [],
+                "WebGlSampler": [],
+                "WebGlShader": [],
+                "WebGlShaderPrecisionFormat": [],
+                "WebGlSync": [],
+                "WebGlTexture": [],
+                "WebGlTransformFeedback": [],
+                "WebGlUniformLocation": [],
+                "WebGlVertexArrayObject": [],
+                "WebKitCssMatrix": [
+                    "DomMatrix",
+                    "DomMatrixReadOnly"
+                ],
+                "WebSocket": [
+                    "EventTarget"
+                ],
+                "WebSocketDict": [],
+                "WebSocketElement": [],
+                "WebglColorBufferFloat": [],
+                "WebglCompressedTextureAstc": [],
+                "WebglCompressedTextureAtc": [],
+                "WebglCompressedTextureEtc": [],
+                "WebglCompressedTextureEtc1": [],
+                "WebglCompressedTexturePvrtc": [],
+                "WebglCompressedTextureS3tc": [],
+                "WebglCompressedTextureS3tcSrgb": [],
+                "WebglDebugRendererInfo": [],
+                "WebglDebugShaders": [],
+                "WebglDepthTexture": [],
+                "WebglDrawBuffers": [],
+                "WebglLoseContext": [],
+                "WebglMultiDraw": [],
+                "WebrtcGlobalStatisticsReport": [],
+                "WheelEvent": [
+                    "Event",
+                    "MouseEvent",
+                    "UiEvent"
+                ],
+                "WheelEventInit": [],
+                "WidevineCdmManifest": [],
+                "Window": [
+                    "EventTarget"
+                ],
+                "WindowClient": [
+                    "Client"
+                ],
+                "Worker": [
+                    "EventTarget"
+                ],
+                "WorkerDebuggerGlobalScope": [
+                    "EventTarget"
+                ],
+                "WorkerGlobalScope": [
+                    "EventTarget"
+                ],
+                "WorkerLocation": [],
+                "WorkerNavigator": [],
+                "WorkerOptions": [],
+                "WorkerType": [],
+                "Worklet": [],
+                "WorkletGlobalScope": [],
+                "WorkletOptions": [],
+                "WritableStream": [],
+                "WritableStreamDefaultController": [],
+                "WritableStreamDefaultWriter": [],
+                "XPathExpression": [],
+                "XPathNsResolver": [],
+                "XPathResult": [],
+                "XmlDocument": [
+                    "Document",
+                    "EventTarget",
+                    "Node"
+                ],
+                "XmlHttpRequest": [
+                    "EventTarget",
+                    "XmlHttpRequestEventTarget"
+                ],
+                "XmlHttpRequestEventTarget": [
+                    "EventTarget"
+                ],
+                "XmlHttpRequestResponseType": [],
+                "XmlHttpRequestUpload": [
+                    "EventTarget",
+                    "XmlHttpRequestEventTarget"
+                ],
+                "XmlSerializer": [],
+                "XrBoundedReferenceSpace": [
+                    "EventTarget",
+                    "XrReferenceSpace",
+                    "XrSpace"
+                ],
+                "XrEye": [],
+                "XrFrame": [],
+                "XrHandedness": [],
+                "XrInputSource": [],
+                "XrInputSourceArray": [],
+                "XrInputSourceEvent": [
+                    "Event"
+                ],
+                "XrInputSourceEventInit": [],
+                "XrInputSourcesChangeEvent": [
+                    "Event"
+                ],
+                "XrInputSourcesChangeEventInit": [],
+                "XrLayer": [
+                    "EventTarget"
+                ],
+                "XrPermissionDescriptor": [],
+                "XrPermissionStatus": [
+                    "EventTarget",
+                    "PermissionStatus"
+                ],
+                "XrPose": [],
+                "XrReferenceSpace": [
+                    "EventTarget",
+                    "XrSpace"
+                ],
+                "XrReferenceSpaceEvent": [
+                    "Event"
+                ],
+                "XrReferenceSpaceEventInit": [],
+                "XrReferenceSpaceType": [],
+                "XrRenderState": [],
+                "XrRenderStateInit": [],
+                "XrRigidTransform": [],
+                "XrSession": [
+                    "EventTarget"
+                ],
+                "XrSessionEvent": [
+                    "Event"
+                ],
+                "XrSessionEventInit": [],
+                "XrSessionInit": [],
+                "XrSessionMode": [],
+                "XrSessionSupportedPermissionDescriptor": [],
+                "XrSpace": [
+                    "EventTarget"
+                ],
+                "XrSystem": [
+                    "EventTarget"
+                ],
+                "XrTargetRayMode": [],
+                "XrView": [],
+                "XrViewerPose": [
+                    "XrPose"
+                ],
+                "XrViewport": [],
+                "XrVisibilityState": [],
+                "XrWebGlLayer": [
+                    "EventTarget",
+                    "XrLayer"
+                ],
+                "XrWebGlLayerInit": [],
+                "XsltProcessor": [],
+                "console": [],
+                "css": [],
+                "gpu_buffer_usage": [],
+                "gpu_color_write": [],
+                "gpu_map_mode": [],
+                "gpu_shader_stage": [],
+                "gpu_texture_usage": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/web-sys-0.3.60/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg=web_sys_unstable_apis"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "./README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/web-sys/index.html",
+            "documentation": "https://rustwasm.github.io/wasm-bindgen/api/web_sys/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wgpu",
+            "version": "0.14.0",
+            "id": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Rusty WebGPU API wrapper",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arrayvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "clone"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.11, <0.13",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "raw-window-handle",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "static_assertions",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgt",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bytemuck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ddsfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "futures-intrusive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "glam",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.21.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "wgsl-in"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "nanorand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "wyrand"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "noise",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "obj",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "png",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.17",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winit",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.27.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(not(target_arch = \"wasm32\"), target_os = \"emscripten\"))",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgc",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "raw-window-handle"
+                    ],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "async-executor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "pollster",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "wgsl-out"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.11, <0.13",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.33",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Document",
+                        "Navigator",
+                        "Node",
+                        "NodeList",
+                        "Gpu",
+                        "GpuAdapter",
+                        "GpuAddressMode",
+                        "GpuAutoLayoutMode",
+                        "GpuBindGroup",
+                        "GpuBindGroupDescriptor",
+                        "GpuBindGroupEntry",
+                        "GpuBindGroupLayout",
+                        "GpuBindGroupLayoutDescriptor",
+                        "GpuBindGroupLayoutEntry",
+                        "GpuBlendComponent",
+                        "GpuBlendFactor",
+                        "GpuBlendOperation",
+                        "GpuBlendState",
+                        "GpuBuffer",
+                        "GpuBufferBinding",
+                        "GpuBufferBindingLayout",
+                        "GpuBufferBindingType",
+                        "GpuBufferDescriptor",
+                        "GpuCanvasAlphaMode",
+                        "GpuCanvasContext",
+                        "GpuCanvasConfiguration",
+                        "GpuColorDict",
+                        "GpuColorTargetState",
+                        "GpuCommandBuffer",
+                        "GpuCommandBufferDescriptor",
+                        "GpuCommandEncoder",
+                        "GpuCommandEncoderDescriptor",
+                        "GpuCompareFunction",
+                        "GpuCompilationInfo",
+                        "GpuCompilationMessage",
+                        "GpuCompilationMessageType",
+                        "GpuComputePassDescriptor",
+                        "GpuComputePassEncoder",
+                        "GpuComputePipeline",
+                        "GpuComputePipelineDescriptor",
+                        "GpuCullMode",
+                        "GpuDepthStencilState",
+                        "GpuDevice",
+                        "GpuDeviceDescriptor",
+                        "GpuDeviceLostInfo",
+                        "GpuDeviceLostReason",
+                        "GpuError",
+                        "GpuErrorFilter",
+                        "GpuExtent3dDict",
+                        "GpuFeatureName",
+                        "GpuFilterMode",
+                        "GpuFragmentState",
+                        "GpuFrontFace",
+                        "GpuImageCopyBuffer",
+                        "GpuImageCopyExternalImage",
+                        "GpuImageCopyTexture",
+                        "GpuImageCopyTextureTagged",
+                        "GpuImageDataLayout",
+                        "GpuIndexFormat",
+                        "GpuLoadOp",
+                        "gpu_map_mode",
+                        "GpuMipmapFilterMode",
+                        "GpuMultisampleState",
+                        "GpuObjectDescriptorBase",
+                        "GpuOrigin2dDict",
+                        "GpuOrigin3dDict",
+                        "GpuOutOfMemoryError",
+                        "GpuPipelineDescriptorBase",
+                        "GpuPipelineLayout",
+                        "GpuPipelineLayoutDescriptor",
+                        "GpuPowerPreference",
+                        "GpuPrimitiveState",
+                        "GpuPrimitiveTopology",
+                        "GpuProgrammableStage",
+                        "GpuQuerySet",
+                        "GpuQuerySetDescriptor",
+                        "GpuQueryType",
+                        "GpuQueue",
+                        "GpuRenderBundle",
+                        "GpuRenderBundleDescriptor",
+                        "GpuRenderBundleEncoder",
+                        "GpuRenderBundleEncoderDescriptor",
+                        "GpuRenderPassColorAttachment",
+                        "GpuRenderPassDepthStencilAttachment",
+                        "GpuRenderPassDescriptor",
+                        "GpuRenderPassEncoder",
+                        "GpuRenderPipeline",
+                        "GpuRenderPipelineDescriptor",
+                        "GpuRequestAdapterOptions",
+                        "GpuSampler",
+                        "GpuSamplerBindingLayout",
+                        "GpuSamplerBindingType",
+                        "GpuSamplerDescriptor",
+                        "GpuShaderModule",
+                        "GpuShaderModuleDescriptor",
+                        "GpuStencilFaceState",
+                        "GpuStencilOperation",
+                        "GpuStorageTextureAccess",
+                        "GpuStorageTextureBindingLayout",
+                        "GpuStoreOp",
+                        "GpuSupportedFeatures",
+                        "GpuSupportedLimits",
+                        "GpuTexture",
+                        "GpuTextureAspect",
+                        "GpuTextureBindingLayout",
+                        "GpuTextureDescriptor",
+                        "GpuTextureDimension",
+                        "GpuTextureFormat",
+                        "GpuTextureSampleType",
+                        "GpuTextureView",
+                        "GpuTextureViewDescriptor",
+                        "GpuTextureViewDimension",
+                        "GpuUncapturedErrorEvent",
+                        "GpuUncapturedErrorEventInit",
+                        "GpuValidationError",
+                        "GpuVertexAttribute",
+                        "GpuVertexBufferLayout",
+                        "GpuVertexFormat",
+                        "GpuVertexState",
+                        "GpuVertexStepMode",
+                        "HtmlCanvasElement",
+                        "OffscreenCanvas",
+                        "ImageBitmap",
+                        "ImageBitmapRenderingContext",
+                        "Window"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgc",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "raw-window-handle"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "console_error_panic_hook",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "console_log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Location",
+                        "Blob",
+                        "RequestInit",
+                        "RequestMode",
+                        "Request",
+                        "Response"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wgpu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "boids",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/boids/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bunnymark",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/bunnymark/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "conservative-raster",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/conservative-raster/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cube",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/cube/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hello-compute",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/hello-compute/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "mipmap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/mipmap/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "msaa-line",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/msaa-line/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "shadow",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/shadow/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "skybox",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/skybox/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "texture-arrays",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/texture-arrays/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "water",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/water/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "framework",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/framework.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "capture",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/capture/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hello-windows",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/hello-windows/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hello",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/hello/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hello-triangle",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/hello-triangle/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wgpu-tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/tests/root.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "angle": [
+                    "wgc/angle"
+                ],
+                "default": [],
+                "emscripten": [
+                    "webgl"
+                ],
+                "glsl": [
+                    "naga/glsl-in"
+                ],
+                "naga": [
+                    "dep:naga"
+                ],
+                "replay": [
+                    "serde",
+                    "wgc/replay"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "spirv": [
+                    "naga/spv-in"
+                ],
+                "trace": [
+                    "serde",
+                    "wgc/trace"
+                ],
+                "vulkan-portability": [
+                    "wgc/vulkan-portability"
+                ],
+                "webgl": [
+                    "wgc"
+                ],
+                "wgc": [
+                    "dep:wgc"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "wgpu developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "graphics"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/wgpu/tree/v0.13",
+            "homepage": "https://wgpu.rs/",
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wgpu-core",
+            "version": "0.14.0",
+            "id": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "WebGPU core logic on wgpu-hal",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arrayvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bit-vec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "codespan-reporting",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "clone",
+                        "span",
+                        "validate",
+                        "wgsl-in"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.11, <0.13",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "profiling",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "raw-window-handle",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ron",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "serde_derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thiserror",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgt",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cfg_aliases",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "metal"
+                    ],
+                    "target": "cfg(all(not(target_arch = \"wasm32\"), any(target_os = \"ios\", target_os = \"macos\")))",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "vulkan",
+                        "gles",
+                        "renderdoc"
+                    ],
+                    "target": "cfg(all(not(target_arch = \"wasm32\"), unix, not(target_os = \"ios\"), not(target_os = \"macos\")))",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "vulkan",
+                        "dx12",
+                        "dx11",
+                        "renderdoc"
+                    ],
+                    "target": "cfg(all(not(target_arch = \"wasm32\"), windows))",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "HtmlCanvasElement",
+                        "OffscreenCanvas"
+                    ],
+                    "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "gles"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "emscripten"
+                    ],
+                    "target": "cfg(target_os = \"emscripten\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wgpu-core",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-core-0.14.0/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-core-0.14.0/build.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "angle": [
+                    "hal/gles"
+                ],
+                "default": [],
+                "id32": [],
+                "raw-window-handle": [
+                    "dep:raw-window-handle"
+                ],
+                "replay": [
+                    "serde",
+                    "wgt/replay",
+                    "arrayvec/serde",
+                    "naga/deserialize"
+                ],
+                "ron": [
+                    "dep:ron"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serial-pass": [
+                    "serde",
+                    "wgt/serde",
+                    "arrayvec/serde"
+                ],
+                "strict_asserts": [],
+                "trace": [
+                    "ron",
+                    "serde",
+                    "wgt/trace",
+                    "arrayvec/serde",
+                    "naga/serialize"
+                ],
+                "vulkan-portability": [
+                    "hal/vulkan"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-core-0.14.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "wgpu developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "graphics"
+            ],
+            "readme": null,
+            "repository": "https://github.com/gfx-rs/wgpu",
+            "homepage": "https://github.com/gfx-rs/wgpu",
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wgpu-hal",
+            "version": "0.14.1",
+            "id": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "WebGPU hardware abstraction layer",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arrayvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.37",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bit-set",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "block",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "foreign-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "glow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gpu-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gpu-descriptor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "clone"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.11, <0.13",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "profiling",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "range-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "raw-window-handle",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "renderdoc-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "union"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thiserror",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgt",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winit",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.27.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Window",
+                        "HtmlCanvasElement",
+                        "WebGl2RenderingContext",
+                        "OffscreenCanvas"
+                    ],
+                    "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))",
+                    "registry": null
+                },
+                {
+                    "name": "core-graphics-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))",
+                    "registry": null
+                },
+                {
+                    "name": "metal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.24.0",
+                    "kind": null,
+                    "rename": "mtl",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))",
+                    "registry": null
+                },
+                {
+                    "name": "objc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))",
+                    "registry": null
+                },
+                {
+                    "name": "khronos-egl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^4.1",
+                    "kind": null,
+                    "rename": "egl",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "dynamic"
+                    ],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "glutin",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.29.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "android_system_properties",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"android\")",
+                    "registry": null
+                },
+                {
+                    "name": "khronos-egl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^4.1",
+                    "kind": null,
+                    "rename": "egl",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "static",
+                        "no-pkg-config"
+                    ],
+                    "target": "cfg(target_os = \"emscripten\")",
+                    "registry": null
+                },
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"emscripten\")",
+                    "registry": null
+                },
+                {
+                    "name": "d3d12",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5.0",
+                    "kind": null,
+                    "rename": "native",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "libloading"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                },
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "libloaderapi",
+                        "windef",
+                        "winuser",
+                        "dcomp"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wgpu-hal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.14.1/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "halmark",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.14.1/examples/halmark/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "raw-gles",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.14.1/examples/raw-gles.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "gles"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "ash": [
+                    "dep:ash"
+                ],
+                "bit-set": [
+                    "dep:bit-set"
+                ],
+                "block": [
+                    "dep:block"
+                ],
+                "default": [],
+                "dx11": [
+                    "naga/hlsl-out",
+                    "native",
+                    "libloading",
+                    "winapi/d3d11",
+                    "winapi/d3d11_1",
+                    "winapi/d3d11_2",
+                    "winapi/d3d11sdklayers",
+                    "winapi/dxgi1_6"
+                ],
+                "dx12": [
+                    "naga/hlsl-out",
+                    "native",
+                    "bit-set",
+                    "range-alloc",
+                    "winapi/d3d12",
+                    "winapi/d3d12shader",
+                    "winapi/d3d12sdklayers",
+                    "winapi/dxgi1_6"
+                ],
+                "egl": [
+                    "dep:egl"
+                ],
+                "emscripten": [
+                    "gles"
+                ],
+                "foreign-types": [
+                    "dep:foreign-types"
+                ],
+                "gles": [
+                    "naga/glsl-out",
+                    "glow",
+                    "egl",
+                    "libloading"
+                ],
+                "glow": [
+                    "dep:glow"
+                ],
+                "gpu-alloc": [
+                    "dep:gpu-alloc"
+                ],
+                "gpu-descriptor": [
+                    "dep:gpu-descriptor"
+                ],
+                "libloading": [
+                    "dep:libloading"
+                ],
+                "metal": [
+                    "naga/msl-out",
+                    "block",
+                    "foreign-types"
+                ],
+                "native": [
+                    "dep:native"
+                ],
+                "range-alloc": [
+                    "dep:range-alloc"
+                ],
+                "renderdoc": [
+                    "libloading",
+                    "renderdoc-sys"
+                ],
+                "renderdoc-sys": [
+                    "dep:renderdoc-sys"
+                ],
+                "smallvec": [
+                    "dep:smallvec"
+                ],
+                "vulkan": [
+                    "naga/spv-out",
+                    "ash",
+                    "gpu-alloc",
+                    "gpu-descriptor",
+                    "libloading",
+                    "smallvec"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.14.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "wgpu developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "graphics"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/wgpu",
+            "homepage": "https://github.com/gfx-rs/wgpu",
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.59"
+        },
+        {
+            "name": "wgpu-types",
+            "version": "0.14.1",
+            "id": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "WebGPU types",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags_serde_shim",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "serde_derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.85",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wgpu-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-types-0.14.1/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "bitflags_serde_shim": [
+                    "dep:bitflags_serde_shim"
+                ],
+                "replay": [
+                    "serde",
+                    "bitflags_serde_shim"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "trace": [
+                    "serde",
+                    "bitflags_serde_shim"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-types-0.14.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "wgpu developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "graphics"
+            ],
+            "readme": null,
+            "repository": "https://github.com/gfx-rs/wgpu",
+            "homepage": "https://github.com/gfx-rs/wgpu",
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi",
+            "version": "0.3.9",
+            "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Raw FFI bindings for all of Windows API.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "winapi-i686-pc-windows-gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "winapi-x86_64-pc-windows-gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnu",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "accctrl": [],
+                "aclapi": [],
+                "activation": [],
+                "adhoc": [],
+                "appmgmt": [],
+                "audioclient": [],
+                "audiosessiontypes": [],
+                "avrt": [],
+                "basetsd": [],
+                "bcrypt": [],
+                "bits": [],
+                "bits10_1": [],
+                "bits1_5": [],
+                "bits2_0": [],
+                "bits2_5": [],
+                "bits3_0": [],
+                "bits4_0": [],
+                "bits5_0": [],
+                "bitscfg": [],
+                "bitsmsg": [],
+                "bluetoothapis": [],
+                "bluetoothleapis": [],
+                "bthdef": [],
+                "bthioctl": [],
+                "bthledef": [],
+                "bthsdpdef": [],
+                "bugcodes": [],
+                "cderr": [],
+                "cfg": [],
+                "cfgmgr32": [],
+                "cguid": [],
+                "combaseapi": [],
+                "coml2api": [],
+                "commapi": [],
+                "commctrl": [],
+                "commdlg": [],
+                "commoncontrols": [],
+                "consoleapi": [],
+                "corecrt": [],
+                "corsym": [],
+                "d2d1": [],
+                "d2d1_1": [],
+                "d2d1_2": [],
+                "d2d1_3": [],
+                "d2d1effectauthor": [],
+                "d2d1effects": [],
+                "d2d1effects_1": [],
+                "d2d1effects_2": [],
+                "d2d1svg": [],
+                "d2dbasetypes": [],
+                "d3d": [],
+                "d3d10": [],
+                "d3d10_1": [],
+                "d3d10_1shader": [],
+                "d3d10effect": [],
+                "d3d10misc": [],
+                "d3d10sdklayers": [],
+                "d3d10shader": [],
+                "d3d11": [],
+                "d3d11_1": [],
+                "d3d11_2": [],
+                "d3d11_3": [],
+                "d3d11_4": [],
+                "d3d11on12": [],
+                "d3d11sdklayers": [],
+                "d3d11shader": [],
+                "d3d11tokenizedprogramformat": [],
+                "d3d12": [],
+                "d3d12sdklayers": [],
+                "d3d12shader": [],
+                "d3d9": [],
+                "d3d9caps": [],
+                "d3d9types": [],
+                "d3dcommon": [],
+                "d3dcompiler": [],
+                "d3dcsx": [],
+                "d3dkmdt": [],
+                "d3dkmthk": [],
+                "d3dukmdt": [],
+                "d3dx10core": [],
+                "d3dx10math": [],
+                "d3dx10mesh": [],
+                "datetimeapi": [],
+                "davclnt": [],
+                "dbghelp": [],
+                "dbt": [],
+                "dcommon": [],
+                "dcomp": [],
+                "dcompanimation": [],
+                "dcomptypes": [],
+                "dde": [],
+                "ddraw": [],
+                "ddrawi": [],
+                "ddrawint": [],
+                "debug": [
+                    "impl-debug"
+                ],
+                "debugapi": [],
+                "devguid": [],
+                "devicetopology": [],
+                "devpkey": [],
+                "devpropdef": [],
+                "dinput": [],
+                "dinputd": [],
+                "dispex": [],
+                "dmksctl": [],
+                "dmusicc": [],
+                "docobj": [],
+                "documenttarget": [],
+                "dot1x": [],
+                "dpa_dsa": [],
+                "dpapi": [],
+                "dsgetdc": [],
+                "dsound": [],
+                "dsrole": [],
+                "dvp": [],
+                "dwmapi": [],
+                "dwrite": [],
+                "dwrite_1": [],
+                "dwrite_2": [],
+                "dwrite_3": [],
+                "dxdiag": [],
+                "dxfile": [],
+                "dxgi": [],
+                "dxgi1_2": [],
+                "dxgi1_3": [],
+                "dxgi1_4": [],
+                "dxgi1_5": [],
+                "dxgi1_6": [],
+                "dxgidebug": [],
+                "dxgiformat": [],
+                "dxgitype": [],
+                "dxva2api": [],
+                "dxvahd": [],
+                "eaptypes": [],
+                "enclaveapi": [],
+                "endpointvolume": [],
+                "errhandlingapi": [],
+                "everything": [],
+                "evntcons": [],
+                "evntprov": [],
+                "evntrace": [],
+                "excpt": [],
+                "exdisp": [],
+                "fibersapi": [],
+                "fileapi": [],
+                "functiondiscoverykeys_devpkey": [],
+                "gl-gl": [],
+                "guiddef": [],
+                "handleapi": [],
+                "heapapi": [],
+                "hidclass": [],
+                "hidpi": [],
+                "hidsdi": [],
+                "hidusage": [],
+                "highlevelmonitorconfigurationapi": [],
+                "hstring": [],
+                "http": [],
+                "ifdef": [],
+                "ifmib": [],
+                "imm": [],
+                "impl-debug": [],
+                "impl-default": [],
+                "in6addr": [],
+                "inaddr": [],
+                "inspectable": [],
+                "interlockedapi": [],
+                "intsafe": [],
+                "ioapiset": [],
+                "ipexport": [],
+                "iphlpapi": [],
+                "ipifcons": [],
+                "ipmib": [],
+                "iprtrmib": [],
+                "iptypes": [],
+                "jobapi": [],
+                "jobapi2": [],
+                "knownfolders": [],
+                "ks": [],
+                "ksmedia": [],
+                "ktmtypes": [],
+                "ktmw32": [],
+                "l2cmn": [],
+                "libloaderapi": [],
+                "limits": [],
+                "lmaccess": [],
+                "lmalert": [],
+                "lmapibuf": [],
+                "lmat": [],
+                "lmcons": [],
+                "lmdfs": [],
+                "lmerrlog": [],
+                "lmjoin": [],
+                "lmmsg": [],
+                "lmremutl": [],
+                "lmrepl": [],
+                "lmserver": [],
+                "lmshare": [],
+                "lmstats": [],
+                "lmsvc": [],
+                "lmuse": [],
+                "lmwksta": [],
+                "lowlevelmonitorconfigurationapi": [],
+                "lsalookup": [],
+                "memoryapi": [],
+                "minschannel": [],
+                "minwinbase": [],
+                "minwindef": [],
+                "mmdeviceapi": [],
+                "mmeapi": [],
+                "mmreg": [],
+                "mmsystem": [],
+                "mprapidef": [],
+                "msaatext": [],
+                "mscat": [],
+                "mschapp": [],
+                "mssip": [],
+                "mstcpip": [],
+                "mswsock": [],
+                "mswsockdef": [],
+                "namedpipeapi": [],
+                "namespaceapi": [],
+                "nb30": [],
+                "ncrypt": [],
+                "netioapi": [],
+                "nldef": [],
+                "ntddndis": [],
+                "ntddscsi": [],
+                "ntddser": [],
+                "ntdef": [],
+                "ntlsa": [],
+                "ntsecapi": [],
+                "ntstatus": [],
+                "oaidl": [],
+                "objbase": [],
+                "objidl": [],
+                "objidlbase": [],
+                "ocidl": [],
+                "ole2": [],
+                "oleauto": [],
+                "olectl": [],
+                "oleidl": [],
+                "opmapi": [],
+                "pdh": [],
+                "perflib": [],
+                "physicalmonitorenumerationapi": [],
+                "playsoundapi": [],
+                "portabledevice": [],
+                "portabledeviceapi": [],
+                "portabledevicetypes": [],
+                "powerbase": [],
+                "powersetting": [],
+                "powrprof": [],
+                "processenv": [],
+                "processsnapshot": [],
+                "processthreadsapi": [],
+                "processtopologyapi": [],
+                "profileapi": [],
+                "propidl": [],
+                "propkey": [],
+                "propkeydef": [],
+                "propsys": [],
+                "prsht": [],
+                "psapi": [],
+                "qos": [],
+                "realtimeapiset": [],
+                "reason": [],
+                "restartmanager": [],
+                "restrictederrorinfo": [],
+                "rmxfguid": [],
+                "roapi": [],
+                "robuffer": [],
+                "roerrorapi": [],
+                "rpc": [],
+                "rpcdce": [],
+                "rpcndr": [],
+                "rtinfo": [],
+                "sapi": [],
+                "sapi51": [],
+                "sapi53": [],
+                "sapiddk": [],
+                "sapiddk51": [],
+                "schannel": [],
+                "sddl": [],
+                "securityappcontainer": [],
+                "securitybaseapi": [],
+                "servprov": [],
+                "setupapi": [],
+                "shellapi": [],
+                "shellscalingapi": [],
+                "shlobj": [],
+                "shobjidl": [],
+                "shobjidl_core": [],
+                "shtypes": [],
+                "softpub": [],
+                "spapidef": [],
+                "spellcheck": [],
+                "sporder": [],
+                "sql": [],
+                "sqlext": [],
+                "sqltypes": [],
+                "sqlucode": [],
+                "sspi": [],
+                "std": [],
+                "stralign": [],
+                "stringapiset": [],
+                "strmif": [],
+                "subauth": [],
+                "synchapi": [],
+                "sysinfoapi": [],
+                "systemtopologyapi": [],
+                "taskschd": [],
+                "tcpestats": [],
+                "tcpmib": [],
+                "textstor": [],
+                "threadpoolapiset": [],
+                "threadpoollegacyapiset": [],
+                "timeapi": [],
+                "timezoneapi": [],
+                "tlhelp32": [],
+                "transportsettingcommon": [],
+                "tvout": [],
+                "udpmib": [],
+                "unknwnbase": [],
+                "urlhist": [],
+                "urlmon": [],
+                "usb": [],
+                "usbioctl": [],
+                "usbiodef": [],
+                "usbscan": [],
+                "usbspec": [],
+                "userenv": [],
+                "usp10": [],
+                "utilapiset": [],
+                "uxtheme": [],
+                "vadefs": [],
+                "vcruntime": [],
+                "vsbackup": [],
+                "vss": [],
+                "vsserror": [],
+                "vswriter": [],
+                "wbemads": [],
+                "wbemcli": [],
+                "wbemdisp": [],
+                "wbemprov": [],
+                "wbemtran": [],
+                "wct": [],
+                "werapi": [],
+                "winbase": [],
+                "wincodec": [],
+                "wincodecsdk": [],
+                "wincon": [],
+                "wincontypes": [],
+                "wincred": [],
+                "wincrypt": [],
+                "windef": [],
+                "windot11": [],
+                "windowsceip": [],
+                "windowsx": [],
+                "winefs": [],
+                "winerror": [],
+                "winevt": [],
+                "wingdi": [],
+                "winhttp": [],
+                "wininet": [],
+                "winineti": [],
+                "winioctl": [],
+                "winnetwk": [],
+                "winnls": [],
+                "winnt": [],
+                "winreg": [],
+                "winsafer": [],
+                "winscard": [],
+                "winsmcrd": [],
+                "winsock2": [],
+                "winspool": [],
+                "winstring": [],
+                "winsvc": [],
+                "wintrust": [],
+                "winusb": [],
+                "winusbio": [],
+                "winuser": [],
+                "winver": [],
+                "wlanapi": [],
+                "wlanihv": [],
+                "wlanihvtypes": [],
+                "wlantypes": [],
+                "wlclient": [],
+                "wmistr": [],
+                "wnnc": [],
+                "wow64apiset": [],
+                "wpdmtpextensions": [],
+                "ws2bth": [],
+                "ws2def": [],
+                "ws2ipdef": [],
+                "ws2spi": [],
+                "ws2tcpip": [],
+                "wtsapi32": [],
+                "wtypes": [],
+                "wtypesbase": [],
+                "xinput": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "features": [
+                            "everything",
+                            "impl-debug",
+                            "impl-default"
+                        ],
+                        "targets": [
+                            "aarch64-pc-windows-msvc",
+                            "i686-pc-windows-msvc",
+                            "x86_64-pc-windows-msvc"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Peter Atashian <retep998@gmail.com>"
+            ],
+            "categories": [
+                "external-ffi-bindings",
+                "no-std",
+                "os::windows-apis"
+            ],
+            "keywords": [
+                "windows",
+                "ffi",
+                "win32",
+                "com",
+                "directx"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/retep998/winapi-rs",
+            "homepage": null,
+            "documentation": "https://docs.rs/winapi/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi-i686-pc-windows-gnu",
+            "version": "0.4.0",
+            "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi-i686-pc-windows-gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Peter Atashian <retep998@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windows"
+            ],
+            "readme": null,
+            "repository": "https://github.com/retep998/winapi-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi-util",
+            "version": "0.1.5",
+            "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense/MIT",
+            "license_file": null,
+            "description": "A dumping ground for high level safe wrappers over winapi.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "std",
+                        "consoleapi",
+                        "errhandlingapi",
+                        "fileapi",
+                        "minwindef",
+                        "processenv",
+                        "winbase",
+                        "wincon",
+                        "winerror",
+                        "winnt"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi-util",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-util-0.1.5/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-util-0.1.5/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-pc-windows-msvc"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [
+                "os::windows-apis",
+                "external-ffi-bindings"
+            ],
+            "keywords": [
+                "windows",
+                "winapi",
+                "util",
+                "win"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/winapi-util",
+            "homepage": "https://github.com/BurntSushi/winapi-util",
+            "documentation": "https://docs.rs/winapi-util",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi-x86_64-pc-windows-gnu",
+            "version": "0.4.0",
+            "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi-x86_64-pc-windows-gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Peter Atashian <retep998@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windows"
+            ],
+            "readme": null,
+            "repository": "https://github.com/retep998/winapi-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows-sys",
+            "version": "0.42.0",
+            "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Rust for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "windows_aarch64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-msvc",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "Win32": [],
+                "Win32_AI": [
+                    "Win32"
+                ],
+                "Win32_AI_MachineLearning": [
+                    "Win32_AI"
+                ],
+                "Win32_AI_MachineLearning_DirectML": [
+                    "Win32_AI_MachineLearning"
+                ],
+                "Win32_AI_MachineLearning_WinML": [
+                    "Win32_AI_MachineLearning"
+                ],
+                "Win32_Data": [
+                    "Win32"
+                ],
+                "Win32_Data_HtmlHelp": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_RightsManagement": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml_MsXml": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Data_Xml_XmlLite": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Devices": [
+                    "Win32"
+                ],
+                "Win32_Devices_AllJoyn": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_BiometricFramework": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Bluetooth": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Communication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAccess": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAndDriverInstallation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceQuery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Display": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration_Pnp": [
+                    "Win32_Devices_Enumeration"
+                ],
+                "Win32_Devices_Fax": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_FunctionDiscovery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Geolocation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_HumanInterfaceDevice": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_ImageAcquisition": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_PortableDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Properties": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Pwm": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Sensors": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_SerialCommunication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Tapi": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Usb": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_WebServicesOnDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Foundation": [
+                    "Win32"
+                ],
+                "Win32_Gaming": [
+                    "Win32"
+                ],
+                "Win32_Globalization": [
+                    "Win32"
+                ],
+                "Win32_Graphics": [
+                    "Win32"
+                ],
+                "Win32_Graphics_CompositionSwapchain": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DXCore": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct2D": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct2D_Common": [
+                    "Win32_Graphics_Direct2D"
+                ],
+                "Win32_Graphics_Direct3D": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D10": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D11": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D11on12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D9": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D9on12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D_Dxc": [
+                    "Win32_Graphics_Direct3D"
+                ],
+                "Win32_Graphics_Direct3D_Fxc": [
+                    "Win32_Graphics_Direct3D"
+                ],
+                "Win32_Graphics_DirectComposition": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectDraw": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectManipulation": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectWrite": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dwm": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dxgi": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dxgi_Common": [
+                    "Win32_Graphics_Dxgi"
+                ],
+                "Win32_Graphics_Gdi": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Hlsl": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Imaging": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Imaging_D2D": [
+                    "Win32_Graphics_Imaging"
+                ],
+                "Win32_Graphics_OpenGL": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing_PrintTicket": [
+                    "Win32_Graphics_Printing"
+                ],
+                "Win32_Management": [
+                    "Win32"
+                ],
+                "Win32_Management_MobileDeviceManagementRegistration": [
+                    "Win32_Management"
+                ],
+                "Win32_Media": [
+                    "Win32"
+                ],
+                "Win32_Media_Audio": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Audio_Apo": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_DirectMusic": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_DirectSound": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_Endpoints": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_XAudio2": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_DeviceManager": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_DirectShow": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_DirectShow_Xml": [
+                    "Win32_Media_DirectShow"
+                ],
+                "Win32_Media_DxMediaObjects": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_KernelStreaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_LibrarySharingServices": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_MediaFoundation": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_MediaPlayer": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Multimedia": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_PictureAcquisition": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Speech": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Streaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_WindowsMediaFormat": [
+                    "Win32_Media"
+                ],
+                "Win32_NetworkManagement": [
+                    "Win32"
+                ],
+                "Win32_NetworkManagement_Dhcp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Dns": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_InternetConnectionWizard": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_IpHelper": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_MobileBroadband": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Multicast": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Ndis": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetBios": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetManagement": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetShell": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkDiagnosticsFramework": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkPolicyServer": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_P2P": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_QoS": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Rras": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Snmp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WNet": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WebDav": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WiFi": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectNow": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectionManager": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFilteringPlatform": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFirewall": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsNetworkVirtualization": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_Networking": [
+                    "Win32"
+                ],
+                "Win32_Networking_ActiveDirectory": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_BackgroundIntelligentTransferService": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Clustering": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_HttpServer": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Ldap": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_NetworkListManager": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_RemoteDifferentialCompression": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WebSocket": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinHttp": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinInet": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinSock": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WindowsWebServices": [
+                    "Win32_Networking"
+                ],
+                "Win32_Security": [
+                    "Win32"
+                ],
+                "Win32_Security_AppLocker": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication_Identity": [
+                    "Win32_Security_Authentication"
+                ],
+                "Win32_Security_Authentication_Identity_Provider": [
+                    "Win32_Security_Authentication_Identity"
+                ],
+                "Win32_Security_Authorization": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authorization_UI": [
+                    "Win32_Security_Authorization"
+                ],
+                "Win32_Security_ConfigurationSnapin": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Credentials": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography_Catalog": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Certificates": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Sip": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_UI": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_DiagnosticDataQuery": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_DirectoryServices": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_EnterpriseData": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_ExtensibleAuthenticationProtocol": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Isolation": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_LicenseProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_NetworkAccessProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Tpm": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinTrust": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinWlx": [
+                    "Win32_Security"
+                ],
+                "Win32_Storage": [
+                    "Win32"
+                ],
+                "Win32_Storage_Cabinets": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_CloudFilters": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Compression": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DataDeduplication": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DistributedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_EnhancedStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileHistory": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileServerResourceManager": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Imapi": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IndexServer": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_InstallableFileSystems": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IscsiDisc": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Jet": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OfflineFiles": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OperationRecorder": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging_Appx": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_Packaging_Opc": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_ProjectedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_StructuredStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vhd": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_VirtualDiskService": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vss": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps_Printing": [
+                    "Win32_Storage_Xps"
+                ],
+                "Win32_System": [
+                    "Win32"
+                ],
+                "Win32_System_AddressBook": [
+                    "Win32_System"
+                ],
+                "Win32_System_Antimalware": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationInstallationAndServicing": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationVerifier": [
+                    "Win32_System"
+                ],
+                "Win32_System_AssessmentTool": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com_CallObj": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_ChannelCredentials": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Events": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Marshal": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_StructuredStorage": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_UI": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Urlmon": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_ComponentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_Console": [
+                    "Win32_System"
+                ],
+                "Win32_System_Contacts": [
+                    "Win32_System"
+                ],
+                "Win32_System_CorrelationVector": [
+                    "Win32_System"
+                ],
+                "Win32_System_DataExchange": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeploymentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_DesktopSharing": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeveloperLicensing": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics_Ceip": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Debug": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Etw": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ProcessSnapshotting": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ToolHelp": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_DistributedTransactionCoordinator": [
+                    "Win32_System"
+                ],
+                "Win32_System_Environment": [
+                    "Win32_System"
+                ],
+                "Win32_System_ErrorReporting": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventCollector": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventLog": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventNotificationService": [
+                    "Win32_System"
+                ],
+                "Win32_System_GroupPolicy": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostCompute": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeNetwork": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeSystem": [
+                    "Win32_System"
+                ],
+                "Win32_System_Hypervisor": [
+                    "Win32_System"
+                ],
+                "Win32_System_IO": [
+                    "Win32_System"
+                ],
+                "Win32_System_Iis": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ioctl": [
+                    "Win32_System"
+                ],
+                "Win32_System_JobObjects": [
+                    "Win32_System"
+                ],
+                "Win32_System_Js": [
+                    "Win32_System"
+                ],
+                "Win32_System_Kernel": [
+                    "Win32_System"
+                ],
+                "Win32_System_LibraryLoader": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mailslots": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mapi": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory_NonVolatile": [
+                    "Win32_System_Memory"
+                ],
+                "Win32_System_MessageQueuing": [
+                    "Win32_System"
+                ],
+                "Win32_System_MixedReality": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mmc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ole": [
+                    "Win32_System"
+                ],
+                "Win32_System_ParentalControls": [
+                    "Win32_System"
+                ],
+                "Win32_System_PasswordManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance_HardwareCounterProfiling": [
+                    "Win32_System_Performance"
+                ],
+                "Win32_System_Pipes": [
+                    "Win32_System"
+                ],
+                "Win32_System_Power": [
+                    "Win32_System"
+                ],
+                "Win32_System_ProcessStatus": [
+                    "Win32_System"
+                ],
+                "Win32_System_RealTimeCommunications": [
+                    "Win32_System"
+                ],
+                "Win32_System_Recovery": [
+                    "Win32_System"
+                ],
+                "Win32_System_Registry": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteAssistance": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteDesktop": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_RestartManager": [
+                    "Win32_System"
+                ],
+                "Win32_System_Restore": [
+                    "Win32_System"
+                ],
+                "Win32_System_Rpc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search_Common": [
+                    "Win32_System_Search"
+                ],
+                "Win32_System_SecurityCenter": [
+                    "Win32_System"
+                ],
+                "Win32_System_ServerBackup": [
+                    "Win32_System"
+                ],
+                "Win32_System_Services": [
+                    "Win32_System"
+                ],
+                "Win32_System_SettingsManagementInfrastructure": [
+                    "Win32_System"
+                ],
+                "Win32_System_SetupAndMigration": [
+                    "Win32_System"
+                ],
+                "Win32_System_Shutdown": [
+                    "Win32_System"
+                ],
+                "Win32_System_SideShow": [
+                    "Win32_System"
+                ],
+                "Win32_System_StationsAndDesktops": [
+                    "Win32_System"
+                ],
+                "Win32_System_SubsystemForLinux": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemInformation": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_TaskScheduler": [
+                    "Win32_System"
+                ],
+                "Win32_System_Threading": [
+                    "Win32_System"
+                ],
+                "Win32_System_Time": [
+                    "Win32_System"
+                ],
+                "Win32_System_TpmBaseServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_TransactionServer": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAgent": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAssessment": [
+                    "Win32_System"
+                ],
+                "Win32_System_UserAccessLogging": [
+                    "Win32_System"
+                ],
+                "Win32_System_VirtualDosMachines": [
+                    "Win32_System"
+                ],
+                "Win32_System_WinRT": [
+                    "Win32_System"
+                ],
+                "Win32_System_WinRT_AllJoyn": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Composition": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_CoreInputView": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Direct3D11": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Display": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Graphics": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Graphics_Capture": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Graphics_Direct2D": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Graphics_Imaging": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Holographic": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Isolation": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_ML": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Media": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Pdf": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Printing": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Shell": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Storage": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WindowsProgramming": [
+                    "Win32_System"
+                ],
+                "Win32_System_WindowsSync": [
+                    "Win32_System"
+                ],
+                "Win32_System_Wmi": [
+                    "Win32_System"
+                ],
+                "Win32_UI": [
+                    "Win32"
+                ],
+                "Win32_UI_Accessibility": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Animation": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_ColorSystem": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls_Dialogs": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_Controls_RichEdit": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_HiDpi": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input_Ime": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Ink": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_KeyboardAndMouse": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Pointer": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Radial": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Touch": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_XboxController": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_InteractionContext": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_LegacyWindowsEnvironmentFeatures": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Magnification": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Notifications": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Ribbon": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell_Common": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_Shell_PropertiesSystem": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_TabletPC": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_TextServices": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_WindowsAndMessaging": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Wpf": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Xaml": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Xaml_Diagnostics": [
+                    "Win32_UI_Xaml"
+                ],
+                "default": [],
+                "deprecated": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "readme.md",
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.49"
+        },
+        {
+            "name": "windows_aarch64_gnullvm",
+            "version": "0.42.0",
+            "id": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_aarch64_gnullvm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_aarch64_msvc",
+            "version": "0.42.0",
+            "id": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_aarch64_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_i686_gnu",
+            "version": "0.42.0",
+            "id": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_i686_gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_i686_msvc",
+            "version": "0.42.0",
+            "id": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_i686_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_x86_64_gnu",
+            "version": "0.42.0",
+            "id": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_x86_64_gnullvm",
+            "version": "0.42.0",
+            "id": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_gnullvm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_x86_64_msvc",
+            "version": "0.42.0",
+            "id": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        }
+    ],
+    "workspace_members": [
+        "target_features 0.1.0 (path+file://{TEMP_DIR}/target_features)"
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "id": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "getrandom",
+                        "pkg": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "once_cell",
+                        "pkg": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "version_check",
+                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libloading",
+                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "debug",
+                    "default",
+                    "libloading",
+                    "loaded"
+                ]
+            },
+            {
+                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bit_vec",
+                        "pkg": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "termcolor",
+                        "pkg": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_width",
+                        "pkg": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "core_foundation_sys",
+                        "pkg": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "core_foundation",
+                        "pkg": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "foreign_types",
+                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libloading",
+                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "libloading"
+                ]
+            },
+            {
+                "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "foreign_types_shared",
+                        "pkg": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "byteorder",
+                        "pkg": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasi",
+                        "pkg": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"wasi\")"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "slotmap",
+                        "pkg": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "gpu_alloc_types",
+                        "pkg": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "gpu_descriptor_types",
+                        "pkg": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hashbrown",
+                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "ahash",
+                        "pkg": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "ahash",
+                    "default",
+                    "inline-more",
+                    "raw"
+                ]
+            },
+            {
+                "id": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "autocfg",
+                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hashbrown",
+                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "std"
+                ]
+            },
+            {
+                "id": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libloading",
+                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "pkg_config",
+                        "pkg": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "1_0",
+                    "1_1",
+                    "1_2",
+                    "1_3",
+                    "1_4",
+                    "1_5",
+                    "default",
+                    "dynamic",
+                    "libloading",
+                    "no-pkg-config",
+                    "pkg-config",
+                    "static"
+                ]
+            },
+            {
+                "id": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "autocfg",
+                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "scopeguard",
+                        "pkg": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "block",
+                        "pkg": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "core_graphics_types",
+                        "pkg": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "foreign_types",
+                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "objc",
+                        "pkg": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bit_set",
+                        "pkg": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codespan_reporting",
+                        "pkg": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hexf_parse",
+                        "pkg": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "indexmap",
+                        "pkg": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "num_traits",
+                        "pkg": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rustc_hash",
+                        "pkg": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "spirv",
+                        "pkg": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "termcolor",
+                        "pkg": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "thiserror",
+                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_xid",
+                        "pkg": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "clone",
+                    "codespan-reporting",
+                    "default",
+                    "glsl-out",
+                    "hexf-parse",
+                    "hlsl-out",
+                    "msl-out",
+                    "span",
+                    "spirv",
+                    "spv-out",
+                    "termcolor",
+                    "unicode-xid",
+                    "validate",
+                    "wgsl-in",
+                    "wgsl-out"
+                ]
+            },
+            {
+                "id": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "autocfg",
+                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "malloc_buf",
+                        "pkg": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "objc_exception",
+                        "pkg": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "objc_exception"
+                ]
+            },
+            {
+                "id": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cc",
+                        "pkg": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "alloc",
+                    "default",
+                    "race",
+                    "std"
+                ]
+            },
+            {
+                "id": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "lock_api",
+                        "pkg": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "parking_lot_core",
+                        "pkg": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syscall",
+                        "pkg": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"redox\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "smallvec",
+                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_sys",
+                        "pkg": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "unicode_ident",
+                        "pkg": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ]
+            },
+            {
+                "id": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ]
+            },
+            {
+                "id": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cty",
+                        "pkg": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "version_check",
+                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "union"
+                ]
+            },
+            {
+                "id": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "num_traits",
+                        "pkg": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_ident",
+                        "pkg": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "clone-impls",
+                    "default",
+                    "derive",
+                    "full",
+                    "parsing",
+                    "printing",
+                    "proc-macro",
+                    "quote",
+                    "visit"
+                ]
+            },
+            {
+                "id": "target_features 0.1.0 (path+file://{TEMP_DIR}/target_features)",
+                "dependencies": [
+                    "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "wgpu",
+                        "pkg": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi_util",
+                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "thiserror_impl",
+                        "pkg": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_macro",
+                        "pkg": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "spans",
+                    "std"
+                ]
+            },
+            {
+                "id": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bumpalo",
+                        "pkg": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "once_cell",
+                        "pkg": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_shared",
+                        "pkg": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "spans"
+                ]
+            },
+            {
+                "id": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_feature = \"atomics\")"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_macro_support",
+                        "pkg": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "spans"
+                ]
+            },
+            {
+                "id": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_backend",
+                        "pkg": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_shared",
+                        "pkg": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "spans"
+                ]
+            },
+            {
+                "id": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "AngleInstancedArrays",
+                    "Document",
+                    "Element",
+                    "Event",
+                    "EventTarget",
+                    "ExtBlendMinmax",
+                    "ExtColorBufferFloat",
+                    "ExtColorBufferHalfFloat",
+                    "ExtDisjointTimerQuery",
+                    "ExtFragDepth",
+                    "ExtSRgb",
+                    "ExtShaderTextureLod",
+                    "ExtTextureFilterAnisotropic",
+                    "Gpu",
+                    "GpuAdapter",
+                    "GpuAddressMode",
+                    "GpuAutoLayoutMode",
+                    "GpuBindGroup",
+                    "GpuBindGroupDescriptor",
+                    "GpuBindGroupEntry",
+                    "GpuBindGroupLayout",
+                    "GpuBindGroupLayoutDescriptor",
+                    "GpuBindGroupLayoutEntry",
+                    "GpuBlendComponent",
+                    "GpuBlendFactor",
+                    "GpuBlendOperation",
+                    "GpuBlendState",
+                    "GpuBuffer",
+                    "GpuBufferBinding",
+                    "GpuBufferBindingLayout",
+                    "GpuBufferBindingType",
+                    "GpuBufferDescriptor",
+                    "GpuCanvasAlphaMode",
+                    "GpuCanvasConfiguration",
+                    "GpuCanvasContext",
+                    "GpuColorDict",
+                    "GpuColorTargetState",
+                    "GpuCommandBuffer",
+                    "GpuCommandBufferDescriptor",
+                    "GpuCommandEncoder",
+                    "GpuCommandEncoderDescriptor",
+                    "GpuCompareFunction",
+                    "GpuCompilationInfo",
+                    "GpuCompilationMessage",
+                    "GpuCompilationMessageType",
+                    "GpuComputePassDescriptor",
+                    "GpuComputePassEncoder",
+                    "GpuComputePipeline",
+                    "GpuComputePipelineDescriptor",
+                    "GpuCullMode",
+                    "GpuDepthStencilState",
+                    "GpuDevice",
+                    "GpuDeviceDescriptor",
+                    "GpuDeviceLostInfo",
+                    "GpuDeviceLostReason",
+                    "GpuError",
+                    "GpuErrorFilter",
+                    "GpuExtent3dDict",
+                    "GpuFeatureName",
+                    "GpuFilterMode",
+                    "GpuFragmentState",
+                    "GpuFrontFace",
+                    "GpuImageCopyBuffer",
+                    "GpuImageCopyExternalImage",
+                    "GpuImageCopyTexture",
+                    "GpuImageCopyTextureTagged",
+                    "GpuImageDataLayout",
+                    "GpuIndexFormat",
+                    "GpuLoadOp",
+                    "GpuMipmapFilterMode",
+                    "GpuMultisampleState",
+                    "GpuObjectDescriptorBase",
+                    "GpuOrigin2dDict",
+                    "GpuOrigin3dDict",
+                    "GpuOutOfMemoryError",
+                    "GpuPipelineDescriptorBase",
+                    "GpuPipelineLayout",
+                    "GpuPipelineLayoutDescriptor",
+                    "GpuPowerPreference",
+                    "GpuPrimitiveState",
+                    "GpuPrimitiveTopology",
+                    "GpuProgrammableStage",
+                    "GpuQuerySet",
+                    "GpuQuerySetDescriptor",
+                    "GpuQueryType",
+                    "GpuQueue",
+                    "GpuRenderBundle",
+                    "GpuRenderBundleDescriptor",
+                    "GpuRenderBundleEncoder",
+                    "GpuRenderBundleEncoderDescriptor",
+                    "GpuRenderPassColorAttachment",
+                    "GpuRenderPassDepthStencilAttachment",
+                    "GpuRenderPassDescriptor",
+                    "GpuRenderPassEncoder",
+                    "GpuRenderPipeline",
+                    "GpuRenderPipelineDescriptor",
+                    "GpuRequestAdapterOptions",
+                    "GpuSampler",
+                    "GpuSamplerBindingLayout",
+                    "GpuSamplerBindingType",
+                    "GpuSamplerDescriptor",
+                    "GpuShaderModule",
+                    "GpuShaderModuleDescriptor",
+                    "GpuStencilFaceState",
+                    "GpuStencilOperation",
+                    "GpuStorageTextureAccess",
+                    "GpuStorageTextureBindingLayout",
+                    "GpuStoreOp",
+                    "GpuSupportedFeatures",
+                    "GpuSupportedLimits",
+                    "GpuTexture",
+                    "GpuTextureAspect",
+                    "GpuTextureBindingLayout",
+                    "GpuTextureDescriptor",
+                    "GpuTextureDimension",
+                    "GpuTextureFormat",
+                    "GpuTextureSampleType",
+                    "GpuTextureView",
+                    "GpuTextureViewDescriptor",
+                    "GpuTextureViewDimension",
+                    "GpuUncapturedErrorEvent",
+                    "GpuUncapturedErrorEventInit",
+                    "GpuValidationError",
+                    "GpuVertexAttribute",
+                    "GpuVertexBufferLayout",
+                    "GpuVertexFormat",
+                    "GpuVertexState",
+                    "GpuVertexStepMode",
+                    "HtmlCanvasElement",
+                    "HtmlElement",
+                    "HtmlImageElement",
+                    "ImageBitmap",
+                    "ImageBitmapRenderingContext",
+                    "MessageEvent",
+                    "Navigator",
+                    "Node",
+                    "NodeList",
+                    "OesElementIndexUint",
+                    "OesStandardDerivatives",
+                    "OesTextureFloat",
+                    "OesTextureFloatLinear",
+                    "OesTextureHalfFloat",
+                    "OesTextureHalfFloatLinear",
+                    "OesVertexArrayObject",
+                    "OffscreenCanvas",
+                    "WebGl2RenderingContext",
+                    "WebGlActiveInfo",
+                    "WebGlBuffer",
+                    "WebGlFramebuffer",
+                    "WebGlProgram",
+                    "WebGlQuery",
+                    "WebGlRenderbuffer",
+                    "WebGlRenderingContext",
+                    "WebGlSampler",
+                    "WebGlShader",
+                    "WebGlSync",
+                    "WebGlTexture",
+                    "WebGlTransformFeedback",
+                    "WebGlUniformLocation",
+                    "WebGlVertexArrayObject",
+                    "WebglColorBufferFloat",
+                    "WebglCompressedTextureAstc",
+                    "WebglCompressedTextureEtc",
+                    "WebglCompressedTextureEtc1",
+                    "WebglCompressedTexturePvrtc",
+                    "WebglCompressedTextureS3tc",
+                    "WebglCompressedTextureS3tcSrgb",
+                    "WebglDebugRendererInfo",
+                    "WebglDebugShaders",
+                    "WebglDepthTexture",
+                    "WebglDrawBuffers",
+                    "WebglLoseContext",
+                    "Window",
+                    "Worker",
+                    "gpu_map_mode"
+                ]
+            },
+            {
+                "id": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "arrayvec",
+                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "naga",
+                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "parking_lot",
+                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "raw_window_handle",
+                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "smallvec",
+                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "static_assertions",
+                        "pkg": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_futures",
+                        "pkg": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wgc",
+                        "pkg": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(target_arch = \"wasm32\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hal",
+                        "pkg": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(not(target_arch = \"wasm32\"), target_os = \"emscripten\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wgt",
+                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "arrayvec",
+                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bit_vec",
+                        "pkg": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "cfg_aliases",
+                        "pkg": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codespan_reporting",
+                        "pkg": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "fxhash",
+                        "pkg": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "naga",
+                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "parking_lot",
+                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "profiling",
+                        "pkg": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "raw_window_handle",
+                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "smallvec",
+                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "thiserror",
+                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hal",
+                        "pkg": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(all(not(target_arch = \"wasm32\"), any(target_os = \"ios\", target_os = \"macos\")))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(all(not(target_arch = \"wasm32\"), unix, not(target_os = \"ios\"), not(target_os = \"macos\")))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(all(not(target_arch = \"wasm32\"), windows))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"emscripten\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wgt",
+                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "raw-window-handle"
+                ]
+            },
+            {
+                "id": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "android_system_properties",
+                        "pkg": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"android\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "arrayvec",
+                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ash",
+                        "pkg": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bit_set",
+                        "pkg": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "block",
+                        "pkg": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "core_graphics_types",
+                        "pkg": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "native",
+                        "pkg": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "foreign_types",
+                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "fxhash",
+                        "pkg": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "glow",
+                        "pkg": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "gpu_alloc",
+                        "pkg": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "gpu_descriptor",
+                        "pkg": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "egl",
+                        "pkg": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(target_arch = \"wasm32\"))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"emscripten\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libloading",
+                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(target_arch = \"wasm32\"))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"emscripten\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "mtl",
+                        "pkg": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "naga",
+                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "objc",
+                        "pkg": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "parking_lot",
+                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "profiling",
+                        "pkg": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "range_alloc",
+                        "pkg": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "raw_window_handle",
+                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "renderdoc_sys",
+                        "pkg": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "smallvec",
+                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "thiserror",
+                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wgt",
+                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "ash",
+                    "bit-set",
+                    "block",
+                    "default",
+                    "dx11",
+                    "dx12",
+                    "egl",
+                    "emscripten",
+                    "foreign-types",
+                    "gles",
+                    "glow",
+                    "gpu-alloc",
+                    "gpu-descriptor",
+                    "libloading",
+                    "metal",
+                    "native",
+                    "range-alloc",
+                    "renderdoc",
+                    "renderdoc-sys",
+                    "smallvec",
+                    "vulkan"
+                ]
+            },
+            {
+                "id": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi_i686_pc_windows_gnu",
+                        "pkg": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi_x86_64_pc_windows_gnu",
+                        "pkg": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnu"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "consoleapi",
+                    "d3d11",
+                    "d3d11_1",
+                    "d3d11_2",
+                    "d3d11sdklayers",
+                    "d3d12",
+                    "d3d12sdklayers",
+                    "d3d12shader",
+                    "d3dcommon",
+                    "d3dcompiler",
+                    "dcomp",
+                    "dxgi1_2",
+                    "dxgi1_3",
+                    "dxgi1_4",
+                    "dxgi1_5",
+                    "dxgi1_6",
+                    "dxgidebug",
+                    "dxgiformat",
+                    "errhandlingapi",
+                    "fileapi",
+                    "libloaderapi",
+                    "minwindef",
+                    "processenv",
+                    "std",
+                    "synchapi",
+                    "winbase",
+                    "wincon",
+                    "windef",
+                    "winerror",
+                    "winnt",
+                    "winuser"
+                ]
+            },
+            {
+                "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "windows_aarch64_gnullvm",
+                        "pkg": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_aarch64_msvc",
+                        "pkg": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "aarch64-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_gnu",
+                        "pkg": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_msvc",
+                        "pkg": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnu",
+                        "pkg": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnullvm",
+                        "pkg": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_msvc",
+                        "pkg": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-msvc"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "Win32",
+                    "Win32_Foundation",
+                    "Win32_System",
+                    "Win32_System_LibraryLoader",
+                    "Win32_System_SystemServices",
+                    "Win32_System_WindowsProgramming",
+                    "default"
+                ]
+            },
+            {
+                "id": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            }
+        ],
+        "root": "target_features 0.1.0 (path+file://{TEMP_DIR}/target_features)"
+    },
+    "target_directory": "{TEMP_DIR}/target_features/target",
+    "version": 1,
+    "workspace_root": "{TEMP_DIR}/target_features",
+    "metadata": null
+}

--- a/crate_universe/test_data/metadata/workspace/metadata.json
+++ b/crate_universe/test_data/metadata/workspace/metadata.json
@@ -1,0 +1,22030 @@
+{
+    "packages": [
+        {
+            "name": "ahash",
+            "version": "0.7.6",
+            "id": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A non-cryptographic hash function using AES-NI for high performance",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "hex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "no-panic",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "seahash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^4.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.59",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "version_check",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "const-random",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "getrandom",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.117",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))",
+                    "registry": null
+                },
+                {
+                    "name": "once_cell",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "alloc"
+                    ],
+                    "target": "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))",
+                    "registry": null
+                },
+                {
+                    "name": "const-random",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\")))",
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.117",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\")))",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "ahash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "nopanic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/nopanic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "map_tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/map_tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "ahash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "map",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/tests/map_tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/./build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "compile-time-rng": [
+                    "const-random"
+                ],
+                "const-random": [
+                    "dep:const-random"
+                ],
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ahash-0.7.6/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std"
+                        ],
+                        "rustc-args": [
+                            "-C",
+                            "target-feature=+aes"
+                        ],
+                        "rustdoc-args": [
+                            "-C",
+                            "target-feature=+aes"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Tom Kaitchuck <Tom.Kaitchuck@gmail.com>"
+            ],
+            "categories": [
+                "algorithms",
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "hash",
+                "hasher",
+                "hashmap",
+                "aes",
+                "no-std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/tkaitchuck/ahash",
+            "homepage": null,
+            "documentation": "https://docs.rs/ahash",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "android_system_properties",
+            "version": "0.1.5",
+            "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Minimal Android system properties wrapper",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.126",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "android_system_properties",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/android_system_properties-0.1.5/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "time_zone",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/android_system_properties-0.1.5/examples/time_zone.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/android_system_properties-0.1.5/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "arm-linux-androideabi",
+                            "armv7-linux-androideabi",
+                            "aarch64-linux-android",
+                            "i686-linux-android",
+                            "x86_64-linux-android",
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Nicolas Silva <nical@fastmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "android"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/nical/android_system_properties",
+            "homepage": "https://github.com/nical/android_system_properties",
+            "documentation": "https://docs.rs/android_system_properties",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "arrayvec",
+            "version": "0.7.2",
+            "id": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A vector with fixed capacity, backed by an array (it can be stored on the stack too). Implements fixed capacity ArrayVec and ArrayString.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bencher",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "matches",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "arrayvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "serde",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/tests/serde.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/tests/tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "extend",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/benches/extend.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "arraystring",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/benches/arraystring.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/arrayvec-0.7.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "serde"
+                        ]
+                    }
+                },
+                "release": {
+                    "no-dev-version": true,
+                    "tag-name": "{{version}}"
+                }
+            },
+            "publish": null,
+            "authors": [
+                "bluss"
+            ],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "stack",
+                "vector",
+                "array",
+                "data-structure",
+                "no_std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bluss/arrayvec",
+            "homepage": null,
+            "documentation": "https://docs.rs/arrayvec/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "ash",
+            "version": "0.37.1+1.3.235",
+            "id": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Vulkan bindings for Rust",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "ash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "display",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/tests/display.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "constant_size_arrays",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/tests/constant_size_arrays.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "debug": [],
+                "default": [
+                    "loaded",
+                    "debug"
+                ],
+                "libloading": [
+                    "dep:libloading"
+                ],
+                "linked": [],
+                "loaded": [
+                    "libloading"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/ash-0.37.1+1.3.235/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                },
+                "release": {
+                    "no-dev-version": true
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Maik Klein <maikklein@googlemail.com>",
+                "Benjamin Saunders <ben.e.saunders@gmail.com>",
+                "Marijn Suijten <marijn@traverseresearch.nl>"
+            ],
+            "categories": [],
+            "keywords": [
+                "vulkan",
+                "graphic"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/MaikKlein/ash",
+            "homepage": null,
+            "documentation": "https://docs.rs/ash",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.59.0"
+        },
+        {
+            "name": "autocfg",
+            "version": "1.1.0",
+            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "Automatic cfg for Rust compiler features",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "autocfg",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "integers",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/integers.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "paths",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/paths.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "versions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/versions.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "traits",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/examples/traits.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rustflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/tests/rustflags.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/autocfg-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Josh Stone <cuviper@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::build-utils"
+            ],
+            "keywords": [
+                "rustc",
+                "build",
+                "autoconf"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/cuviper/autocfg",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "bit-set",
+            "version": "0.5.3",
+            "id": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A set of bits",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bit-vec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bit-set",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-set-0.5.3/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "std": [
+                    "bit-vec/std"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-set-0.5.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alexis Beingessner <a.beingessner@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "data-structures",
+                "bitset"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/contain-rs/bit-set",
+            "homepage": "https://github.com/contain-rs/bit-set",
+            "documentation": "https://contain-rs.github.io/bit-set/bit_set",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "bit-vec",
+            "version": "0.6.3",
+            "id": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A vector of bits",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand_xorshift",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bit-vec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-vec-0.6.3/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-vec-0.6.3/benches/bench.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serde_no_std": [
+                    "serde/alloc"
+                ],
+                "serde_std": [
+                    "std",
+                    "serde/std"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bit-vec-0.6.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alexis Beingessner <a.beingessner@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "data-structures",
+                "bitvec",
+                "bitmask",
+                "bitmap",
+                "bit"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/contain-rs/bit-vec",
+            "homepage": "https://github.com/contain-rs/bit-vec",
+            "documentation": "https://contain-rs.github.io/bit-vec/bit_vec",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "bitflags",
+            "version": "1.3.2",
+            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A macro to generate structures which behave like bitflags.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "walkdir",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bitflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compile",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/tests/compile.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "basic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/tests/basic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [],
+                "example_generated": [],
+                "rustc-dep-of-std": [
+                    "core",
+                    "compiler_builtins"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bitflags-1.3.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "example_generated"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "no-std"
+            ],
+            "keywords": [
+                "bit",
+                "bitmask",
+                "bitflags",
+                "flags"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bitflags/bitflags",
+            "homepage": "https://github.com/bitflags/bitflags",
+            "documentation": "https://docs.rs/bitflags",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "block",
+            "version": "0.1.6",
+            "id": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Rust interface for Apple's C language extension of blocks.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "objc_test_utils",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "block",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/block-0.1.6/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/block-0.1.6/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Sheldon"
+            ],
+            "categories": [],
+            "keywords": [
+                "blocks",
+                "osx",
+                "ios",
+                "objective-c"
+            ],
+            "readme": "README.md",
+            "repository": "http://github.com/SSheldon/rust-block",
+            "homepage": null,
+            "documentation": "http://ssheldon.github.io/rust-objc/block/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "bumpalo",
+            "version": "3.11.1",
+            "id": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A fast bump allocation arena for Rust.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "bumpalo",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.1/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "try_alloc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.1/tests/try_alloc.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "benches",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.1/benches/benches.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "collections"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "allocator_api": [],
+                "boxed": [],
+                "collections": [],
+                "default": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/bumpalo-3.11.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Nick Fitzgerald <fitzgen@gmail.com>"
+            ],
+            "categories": [
+                "memory-management",
+                "rust-patterns",
+                "no-std"
+            ],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/fitzgen/bumpalo",
+            "homepage": null,
+            "documentation": "https://docs.rs/bumpalo",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "byteorder",
+            "version": "1.4.3",
+            "id": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense OR MIT",
+            "license_file": null,
+            "description": "Library for reading/writing numbers in big-endian and little-endian.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "byteorder",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/byteorder-1.4.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/byteorder-1.4.3/benches/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "i128": [],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/byteorder-1.4.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [
+                "encoding",
+                "parsing",
+                "no-std"
+            ],
+            "keywords": [
+                "byte",
+                "endian",
+                "big-endian",
+                "little-endian",
+                "binary"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/byteorder",
+            "homepage": "https://github.com/BurntSushi/byteorder",
+            "documentation": "https://docs.rs/byteorder",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cc",
+            "version": "1.0.77",
+            "id": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A build-time dependency for Cargo build scripts to assist in invoking the native\nC compiler to compile native C code into a static archive to be linked into Rust\ncode.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "jobserver",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.16",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tempfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bin"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "gcc-shim",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/src/bin/gcc-shim.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cxxflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/tests/cxxflags.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cflags",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/tests/cflags.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cc_env",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/tests/cc_env.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "jobserver": [
+                    "dep:jobserver"
+                ],
+                "parallel": [
+                    "jobserver"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cc-1.0.77/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "development-tools::build-utils"
+            ],
+            "keywords": [
+                "build-dependencies"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/cc-rs",
+            "homepage": "https://github.com/rust-lang/cc-rs",
+            "documentation": "https://docs.rs/cc",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cfg-if",
+            "version": "1.0.0",
+            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A macro to ergonomically define an item depending on a large number of #[cfg]\nparameters. Structured like an if-else chain, the first matching branch is the\nitem that gets emitted.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cfg-if",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xcrate",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/tests/xcrate.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "rustc-dep-of-std": [
+                    "core",
+                    "compiler_builtins"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg-if-1.0.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/alexcrichton/cfg-if",
+            "homepage": "https://github.com/alexcrichton/cfg-if",
+            "documentation": "https://docs.rs/cfg-if",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cfg_aliases",
+            "version": "0.1.1",
+            "id": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cfg_aliases",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg_aliases-0.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cfg_aliases-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zicklag <zicklag@katharostech.com>"
+            ],
+            "categories": [
+                "development-tools",
+                "development-tools::build-utils"
+            ],
+            "keywords": [
+                "cfg",
+                "alias",
+                "conditional",
+                "compilation",
+                "build"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/katharostech/cfg_aliases",
+            "homepage": "https://github.com/katharostech/cfg_aliases",
+            "documentation": "https://docs.rs/cfg_aliases",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "child",
+            "version": "0.1.0",
+            "id": "child 0.1.0 (path+file://{TEMP_DIR}/workspace/child)",
+            "license": null,
+            "license_file": null,
+            "description": null,
+            "source": null,
+            "dependencies": [
+                {
+                    "name": "wgpu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.14.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "child",
+                    "src_path": "{TEMP_DIR}/workspace/child/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{TEMP_DIR}/workspace/child/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "codespan-reporting",
+            "version": "0.11.1",
+            "id": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0",
+            "license_file": null,
+            "description": "Beautiful diagnostic reporting for text-based programming languages",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-width",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "insta",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.6.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "peg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustyline",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "structopt",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unindent",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "codespan-reporting",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "term",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/term.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "custom_files",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/custom_files.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "peg_calculator",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/peg_calculator.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "reusable_diagnostic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/reusable_diagnostic.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "readme_preview",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/examples/readme_preview.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "term",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/tests/term.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "ascii-only": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serialization": [
+                    "serde",
+                    "serde/rc"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/codespan-reporting-0.11.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Brendan Zabarauskas <bjzaba@yahoo.com.au>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "../README.md",
+            "repository": "https://github.com/brendanzab/codespan",
+            "homepage": "https://github.com/brendanzab/codespan",
+            "documentation": "https://docs.rs/codespan-reporting",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "core-foundation",
+            "version": "0.9.3",
+            "id": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT / Apache-2.0",
+            "license_file": null,
+            "description": "Bindings to Core Foundation for macOS",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "chrono",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "core-foundation-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "uuid",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "core-foundation",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-0.9.3/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "use_macro_outside_crate",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-0.9.3/tests/use_macro_outside_crate.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "chrono": [
+                    "dep:chrono"
+                ],
+                "mac_os_10_7_support": [
+                    "core-foundation-sys/mac_os_10_7_support"
+                ],
+                "mac_os_10_8_features": [
+                    "core-foundation-sys/mac_os_10_8_features"
+                ],
+                "uuid": [
+                    "dep:uuid"
+                ],
+                "with-chrono": [
+                    "chrono"
+                ],
+                "with-uuid": [
+                    "uuid"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-0.9.3/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-apple-darwin"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [
+                "os::macos-apis"
+            ],
+            "keywords": [
+                "macos",
+                "framework",
+                "objc"
+            ],
+            "readme": null,
+            "repository": "https://github.com/servo/core-foundation-rs",
+            "homepage": "https://github.com/servo/core-foundation-rs",
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "core-foundation-sys",
+            "version": "0.8.3",
+            "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT / Apache-2.0",
+            "license_file": null,
+            "description": "Bindings to Core Foundation for macOS",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "core-foundation-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-sys-0.8.3/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-sys-0.8.3/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "mac_os_10_7_support": [],
+                "mac_os_10_8_features": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-foundation-sys-0.8.3/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-apple-darwin"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/core-foundation-rs",
+            "homepage": "https://github.com/servo/core-foundation-rs",
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "core-graphics-types",
+            "version": "0.1.1",
+            "id": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT / Apache-2.0",
+            "license_file": null,
+            "description": "Bindings for some fundamental Core Graphics types",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "core-foundation",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "foreign-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "core-graphics-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-graphics-types-0.1.1/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/core-graphics-types-0.1.1/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-apple-darwin"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/servo/core-foundation-rs",
+            "homepage": "https://github.com/servo/core-foundation-rs",
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "cty",
+            "version": "0.2.2",
+            "id": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Type aliases to C types like c_int for use with bindgen",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "cty",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cty-0.2.2/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/cty-0.2.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Jorge Aparicio <jorge@japaric.io>"
+            ],
+            "categories": [
+                "embedded",
+                "external-ffi-bindings",
+                "no-std"
+            ],
+            "keywords": [
+                "c",
+                "types",
+                "bindgen",
+                "ffi"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/japaric/cty",
+            "homepage": null,
+            "documentation": "https://docs.rs/cty",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "d3d12",
+            "version": "0.5.0",
+            "id": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Low level D3D12 API wrapper",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "dxgi1_2",
+                        "dxgi1_3",
+                        "dxgi1_4",
+                        "dxgi1_5",
+                        "dxgi1_6",
+                        "dxgidebug",
+                        "d3d12",
+                        "d3d12sdklayers",
+                        "d3dcommon",
+                        "d3dcompiler",
+                        "dxgiformat",
+                        "synchapi",
+                        "winerror"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "d3d12",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/d3d12-0.5.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "implicit-link": [],
+                "libloading": [
+                    "dep:libloading"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/d3d12-0.5.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "gfx-rs developers"
+            ],
+            "categories": [
+                "api-bindings",
+                "graphics",
+                "memory-management",
+                "os::windows-apis"
+            ],
+            "keywords": [
+                "windows",
+                "graphics"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/d3d12-rs",
+            "homepage": null,
+            "documentation": "https://docs.rs/d3d12",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "foreign-types",
+            "version": "0.3.2",
+            "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A framework for Rust wrappers over C APIs",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "foreign-types-shared",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "foreign-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/foreign-types-0.3.2/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/foreign-types-0.3.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Fackler <sfackler@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/sfackler/foreign-types",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "foreign-types-shared",
+            "version": "0.1.1",
+            "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "An internal crate used by foreign-types",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "foreign-types-shared",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/foreign-types-shared-0.1.1/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/foreign-types-shared-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Fackler <sfackler@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/sfackler/foreign-types",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "fxhash",
+            "version": "0.2.1",
+            "id": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0/MIT",
+            "license_file": null,
+            "description": "A fast, non-secure, hashing algorithm derived from an internal hasher used in FireFox and Rustc.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "byteorder",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "seahash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.0.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "fxhash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/fxhash-0.2.1/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fxhash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/fxhash-0.2.1/bench.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/fxhash-0.2.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "cbreeden <github@u.breeden.cc>"
+            ],
+            "categories": [
+                "algorithms"
+            ],
+            "keywords": [
+                "hash"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/cbreeden/fxhash",
+            "homepage": null,
+            "documentation": "https://docs.rs/fxhash",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "getrandom",
+            "version": "0.2.8",
+            "id": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A small cross-platform library for retrieving random data from system source",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.62",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.18",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "registry": null
+                },
+                {
+                    "name": "wasi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"wasi\")",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.120",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "getrandom",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "normal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/tests/normal.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "custom",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/tests/custom.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rdrand",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/tests/rdrand.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "mod",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/benches/mod.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "custom": [],
+                "js": [
+                    "wasm-bindgen",
+                    "js-sys"
+                ],
+                "js-sys": [
+                    "dep:js-sys"
+                ],
+                "rdrand": [],
+                "rustc-dep-of-std": [
+                    "compiler_builtins",
+                    "core",
+                    "libc/rustc-dep-of-std",
+                    "wasi/rustc-dep-of-std"
+                ],
+                "std": [],
+                "test-in-browser": [],
+                "wasm-bindgen": [
+                    "dep:wasm-bindgen"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.8/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std",
+                            "custom"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rand Project Developers"
+            ],
+            "categories": [
+                "os",
+                "no-std"
+            ],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-random/getrandom",
+            "homepage": null,
+            "documentation": "https://docs.rs/getrandom",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "glow",
+            "version": "0.11.2",
+            "id": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "GL on Whatever: a set of bindings to run GL (Open GL, OpenGL ES, and WebGL) anywhere, and avoid target-specific code.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "~0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "slotmap",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "~0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "~0.3.37",
+                    "kind": null,
+                    "rename": "web_sys",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Document",
+                        "Element",
+                        "HtmlCanvasElement",
+                        "HtmlImageElement",
+                        "ImageBitmap",
+                        "WebGlActiveInfo",
+                        "WebGlBuffer",
+                        "WebGlFramebuffer",
+                        "WebGlProgram",
+                        "WebGlQuery",
+                        "WebGlRenderbuffer",
+                        "WebGlRenderingContext",
+                        "WebGl2RenderingContext",
+                        "WebGlSampler",
+                        "WebGlShader",
+                        "WebGlSync",
+                        "WebGlTexture",
+                        "WebGlTransformFeedback",
+                        "WebGlUniformLocation",
+                        "WebGlVertexArrayObject",
+                        "Window",
+                        "AngleInstancedArrays",
+                        "ExtBlendMinmax",
+                        "ExtColorBufferFloat",
+                        "ExtColorBufferHalfFloat",
+                        "ExtDisjointTimerQuery",
+                        "ExtFragDepth",
+                        "ExtShaderTextureLod",
+                        "ExtSRgb",
+                        "ExtTextureFilterAnisotropic",
+                        "OesElementIndexUint",
+                        "OesStandardDerivatives",
+                        "OesTextureFloat",
+                        "OesTextureFloatLinear",
+                        "OesTextureHalfFloat",
+                        "OesTextureHalfFloatLinear",
+                        "OesVertexArrayObject",
+                        "WebglColorBufferFloat",
+                        "WebglCompressedTextureAstc",
+                        "WebglCompressedTextureEtc",
+                        "WebglCompressedTextureEtc1",
+                        "WebglCompressedTexturePvrtc",
+                        "WebglCompressedTextureS3tc",
+                        "WebglCompressedTextureS3tcSrgb",
+                        "WebglDebugRendererInfo",
+                        "WebglDebugShaders",
+                        "WebglDepthTexture",
+                        "WebglDrawBuffers",
+                        "WebglLoseContext"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "glow",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/glow-0.11.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/glow-0.11.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-unknown-linux-gnu",
+                        "targets": [
+                            "x86_64-unknown-linux-gnu",
+                            "x86_64-apple-darwin",
+                            "x86_64-pc-windows-msvc",
+                            "i686-unknown-linux-gnu",
+                            "i686-pc-windows-msvc",
+                            "wasm32-unknown-unknown"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Joshua Groves <josh@joshgroves.com>",
+                "Dzmitry Malyshau <kvarkus@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/grovesNL/glow",
+            "homepage": "https://github.com/grovesNL/glow.git",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "gpu-alloc",
+            "version": "0.5.3",
+            "id": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Implementation agnostic memory allocator for Vulkan like APIs",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gpu-alloc-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.27",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "attributes"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "gpu-alloc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-alloc-0.5.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "tracing": [
+                    "dep:tracing"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-alloc-0.5.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zakarum <zakarumych@ya.ru>"
+            ],
+            "categories": [
+                "graphics",
+                "memory-management",
+                "no-std",
+                "game-development"
+            ],
+            "keywords": [
+                "gpu",
+                "vulkan",
+                "allocation",
+                "no-std"
+            ],
+            "readme": "../README.md",
+            "repository": "https://github.com/zakarumych/gpu-alloc",
+            "homepage": "https://github.com/zakarumych/gpu-alloc",
+            "documentation": "https://docs.rs/gpu-alloc-types",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "gpu-alloc-types",
+            "version": "0.2.0",
+            "id": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Core types of gpu-alloc crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "gpu-alloc-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-alloc-types-0.2.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-alloc-types-0.2.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zakarum <zakarumych@ya.ru>"
+            ],
+            "categories": [],
+            "keywords": [
+                "gpu",
+                "vulkan",
+                "allocation",
+                "no-std"
+            ],
+            "readme": null,
+            "repository": "https://github.com/zakarumych/gpu-alloc",
+            "homepage": "https://github.com/zakarumych/gpu-alloc",
+            "documentation": "https://docs.rs/gpu-alloc-types/0.2.0",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "gpu-descriptor",
+            "version": "0.2.3",
+            "id": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Implementation agnostic descriptor allocator for Vulkan like APIs",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gpu-descriptor-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "hashbrown",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "gpu-descriptor",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-descriptor-0.2.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "tracing": [
+                    "dep:tracing"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-descriptor-0.2.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zakarum <zakarumych@ya.ru>"
+            ],
+            "categories": [],
+            "keywords": [
+                "gpu",
+                "vulkan",
+                "no-std"
+            ],
+            "readme": "../README.md",
+            "repository": "https://github.com/zakarumych/gpu-descriptor",
+            "homepage": "https://github.com/zakarumych/gpu-descriptor",
+            "documentation": "https://docs.rs/gpu-descriptor",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "gpu-descriptor-types",
+            "version": "0.1.1",
+            "id": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Core types of gpu-descriptor crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "gpu-descriptor-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-descriptor-types-0.1.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/gpu-descriptor-types-0.1.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Zakarum <zakarumych@ya.ru>"
+            ],
+            "categories": [],
+            "keywords": [
+                "gpu",
+                "vulkan",
+                "allocation",
+                "no-std"
+            ],
+            "readme": null,
+            "repository": "https://github.com/zakarumych/gpu-descriptor",
+            "homepage": "https://github.com/zakarumych/gpu-descriptor",
+            "documentation": "https://docs.rs/gpu-descriptor-types/0.1.0",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "hashbrown",
+            "version": "0.12.3",
+            "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A Rust port of Google's SwissTable hash map",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "ahash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "alloc",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bumpalo",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.5.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.25",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "doc-comment",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "hashbrown",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "serde",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/serde.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rayon",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/rayon.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "set",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/set.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hasher",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/tests/hasher.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "insert_unique_unchecked",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/benches/insert_unique_unchecked.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/benches/bench.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "ahash": [
+                    "dep:ahash"
+                ],
+                "ahash-compile-time-rng": [
+                    "ahash/compile-time-rng"
+                ],
+                "alloc": [
+                    "dep:alloc"
+                ],
+                "bumpalo": [
+                    "dep:bumpalo"
+                ],
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [
+                    "ahash",
+                    "inline-more"
+                ],
+                "inline-more": [],
+                "nightly": [],
+                "raw": [],
+                "rayon": [
+                    "dep:rayon"
+                ],
+                "rustc-dep-of-std": [
+                    "nightly",
+                    "core",
+                    "compiler_builtins",
+                    "alloc",
+                    "rustc-internal-api"
+                ],
+                "rustc-internal-api": [],
+                "serde": [
+                    "dep:serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.12.3/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "nightly",
+                            "rayon",
+                            "serde",
+                            "raw"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Amanieu d'Antras <amanieu@gmail.com>"
+            ],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "hash",
+                "no_std",
+                "hashmap",
+                "swisstable"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/hashbrown",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56.0"
+        },
+        {
+            "name": "hexf-parse",
+            "version": "0.2.1",
+            "id": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "CC0-1.0",
+            "license_file": null,
+            "description": "Parses hexadecimal floats (see also hexf)",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "hexf-parse",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hexf-parse-0.2.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/hexf-parse-0.2.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Kang Seonghoon <public+rust@mearie.org>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/lifthrasiir/hexf",
+            "homepage": "https://github.com/lifthrasiir/hexf",
+            "documentation": "https://docs.rs/hexf-parse/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "indexmap",
+            "version": "1.9.2",
+            "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "A hash table with consistent order and fast iteration.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arbitrary",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "hashbrown",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "raw"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fnv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "itertools",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "autocfg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "indexmap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "quick",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/quick.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros_full_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/macros_full_path.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "equivalent_trait",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/equivalent_trait.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/tests/tests.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "faststring",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/benches/faststring.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/benches/bench.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/build.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "arbitrary": [
+                    "dep:arbitrary"
+                ],
+                "quickcheck": [
+                    "dep:quickcheck"
+                ],
+                "rayon": [
+                    "dep:rayon"
+                ],
+                "rustc-rayon": [
+                    "dep:rustc-rayon"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serde-1": [
+                    "serde"
+                ],
+                "std": [],
+                "test_debug": [],
+                "test_low_transition_point": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/indexmap-1.9.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "arbitrary",
+                            "quickcheck",
+                            "serde-1",
+                            "rayon"
+                        ]
+                    }
+                },
+                "release": {
+                    "no-dev-version": true,
+                    "tag-name": "{{version}}"
+                }
+            },
+            "publish": null,
+            "authors": [],
+            "categories": [
+                "data-structures",
+                "no-std"
+            ],
+            "keywords": [
+                "hashmap",
+                "no_std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bluss/indexmap",
+            "homepage": null,
+            "documentation": "https://docs.rs/indexmap/",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "js-sys",
+            "version": "0.3.60",
+            "id": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Bindings for all JS global objects and functions in all JS environments like\nNode.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.3.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Headers",
+                        "Response",
+                        "ResponseInit"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "js-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js-sys-0.3.60/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wasm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js-sys-0.3.60/tests/wasm/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "headless",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js-sys-0.3.60/tests/headless.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/js-sys-0.3.60/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [
+                "wasm"
+            ],
+            "keywords": [],
+            "readme": "./README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/js-sys",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "khronos-egl",
+            "version": "4.1.0",
+            "id": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Rust bindings for EGL",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wayland-client",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.28",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wayland-egl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.28",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wayland-protocols",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.28",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "client"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pkg-config",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "khronos-egl",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wayland-static",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/examples/wayland-static.rs",
+                    "edition": "2015",
+                    "required-features": [
+                        "static"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wayland-dynamic",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/examples/wayland-dynamic.rs",
+                    "edition": "2015",
+                    "required-features": [
+                        "dynamic"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "load-minimal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/examples/load-minimal.rs",
+                    "edition": "2015",
+                    "required-features": [
+                        "dynamic",
+                        "1_4"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "1_0": [],
+                "1_1": [
+                    "1_0"
+                ],
+                "1_2": [
+                    "1_1"
+                ],
+                "1_3": [
+                    "1_2"
+                ],
+                "1_4": [
+                    "1_3"
+                ],
+                "1_5": [
+                    "1_4"
+                ],
+                "default": [
+                    "1_5"
+                ],
+                "dynamic": [
+                    "libloading"
+                ],
+                "libloading": [
+                    "dep:libloading"
+                ],
+                "no-pkg-config": [],
+                "pkg-config": [
+                    "dep:pkg-config"
+                ],
+                "static": [
+                    "pkg-config"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/khronos-egl-4.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Timoth\u00e9e Haudebourg <author@haudebourg.net>",
+                "Sean Kerr <sean@metatomic.io>"
+            ],
+            "categories": [],
+            "keywords": [
+                "egl",
+                "gl",
+                "khronos",
+                "opengl"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/timothee-haudebourg/khronos-egl",
+            "homepage": null,
+            "documentation": "https://docs.rs/khronos-egl",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "libc",
+            "version": "0.2.137",
+            "id": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Raw FFI bindings to platform libraries like libc.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "libc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "const_fn",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/tests/const_fn.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "align": [],
+                "const-extern-fn": [],
+                "default": [
+                    "std"
+                ],
+                "extra_traits": [],
+                "rustc-dep-of-std": [
+                    "align",
+                    "rustc-std-workspace-core"
+                ],
+                "rustc-std-workspace-core": [
+                    "dep:rustc-std-workspace-core"
+                ],
+                "std": [],
+                "use_std": [
+                    "std"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libc-0.2.137/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "const-extern-fn",
+                            "extra_traits"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "external-ffi-bindings",
+                "no-std",
+                "os"
+            ],
+            "keywords": [
+                "libc",
+                "ffi",
+                "bindings",
+                "operating",
+                "system"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/libc",
+            "homepage": "https://github.com/rust-lang/libc",
+            "documentation": "https://docs.rs/libc/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "libloading",
+            "version": "0.7.4",
+            "id": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "ISC",
+            "license_file": null,
+            "description": "Bindings around the platform's dynamic library loading primitives with greatly improved memory safety.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "static_assertions",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "errhandlingapi",
+                        "libloaderapi"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "libloading",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "constants",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/constants.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "functions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/functions.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "library_filename",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/library_filename.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "windows",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/windows.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "markers",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/tests/markers.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/libloading-0.7.4/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "libloading_docs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Simonas Kazlauskas <libloading@kazlauskas.me>"
+            ],
+            "categories": [
+                "api-bindings"
+            ],
+            "keywords": [
+                "dlopen",
+                "load",
+                "shared",
+                "dylib"
+            ],
+            "readme": "README.mkd",
+            "repository": "https://github.com/nagisa/rust_libloading/",
+            "homepage": null,
+            "documentation": "https://docs.rs/libloading/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.40.0"
+        },
+        {
+            "name": "lock_api",
+            "version": "0.4.9",
+            "id": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Wrappers to create fully-featured Mutex and RwLock types. Compatible with no_std.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "owning_ref",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "scopeguard",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.126",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "autocfg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "lock_api",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.9/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.9/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "arc_lock": [],
+                "nightly": [],
+                "owning_ref": [
+                    "dep:owning_ref"
+                ],
+                "serde": [
+                    "dep:serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.9/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Amanieu d'Antras <amanieu@gmail.com>"
+            ],
+            "categories": [
+                "concurrency",
+                "no-std"
+            ],
+            "keywords": [
+                "mutex",
+                "rwlock",
+                "lock",
+                "no_std"
+            ],
+            "readme": null,
+            "repository": "https://github.com/Amanieu/parking_lot",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "log",
+            "version": "0.4.17",
+            "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A lightweight logging facade for Rust\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sval",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "value-bag",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.9",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sval",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "value-bag",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.0-alpha.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "test"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "log",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "filters",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/filters.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macros",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/tests/macros.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "value",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/benches/value.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "kv_unstable": [
+                    "value-bag"
+                ],
+                "kv_unstable_serde": [
+                    "kv_unstable_std",
+                    "value-bag/serde",
+                    "serde"
+                ],
+                "kv_unstable_std": [
+                    "std",
+                    "kv_unstable",
+                    "value-bag/error"
+                ],
+                "kv_unstable_sval": [
+                    "kv_unstable",
+                    "value-bag/sval",
+                    "sval"
+                ],
+                "max_level_debug": [],
+                "max_level_error": [],
+                "max_level_info": [],
+                "max_level_off": [],
+                "max_level_trace": [],
+                "max_level_warn": [],
+                "release_max_level_debug": [],
+                "release_max_level_error": [],
+                "release_max_level_info": [],
+                "release_max_level_off": [],
+                "release_max_level_trace": [],
+                "release_max_level_warn": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "sval": [
+                    "dep:sval"
+                ],
+                "value-bag": [
+                    "dep:value-bag"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/log-0.4.17/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std",
+                            "serde",
+                            "kv_unstable_std",
+                            "kv_unstable_sval",
+                            "kv_unstable_serde"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "development-tools::debugging"
+            ],
+            "keywords": [
+                "logging"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/log",
+            "homepage": null,
+            "documentation": "https://docs.rs/log",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "malloc_buf",
+            "version": "0.0.6",
+            "id": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Structs for handling malloc'd memory passed to Rust.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.1, <0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "malloc_buf",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/malloc_buf-0.0.6/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/malloc_buf-0.0.6/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Sheldon"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/SSheldon/malloc_buf",
+            "homepage": null,
+            "documentation": "http://ssheldon.github.io/malloc_buf/malloc_buf/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "metal",
+            "version": "0.24.0",
+            "id": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Rust bindings for Metal",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "block",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "core-graphics-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "dispatch",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "foreign-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "objc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "objc_exception"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cocoa",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.24.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cty",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "png",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.16",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "sema",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winit",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.24",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "metal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "window",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/window/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "headless-render",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/headless-render/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "library",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/library/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "reflection",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/reflection/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "caps",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/caps/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "argument-buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/argument-buffer/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bindless",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/bindless/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "circle",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/circle/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compute",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/compute/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "mps",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/mps/main.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "mps"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "embedded-lib",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/compute/embedded-lib.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compute-argument-buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/compute/compute-argument-buffer.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bind",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/bind/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "events",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/events/main.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "dispatch"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "fence",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/fence/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "shader-dylib",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/examples/shader-dylib/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [],
+                "dispatch": [
+                    "dep:dispatch"
+                ],
+                "mps": [],
+                "private": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/metal-0.24.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-apple-darwin"
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "GFX Developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "metal",
+                "graphics",
+                "bindings"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/metal-rs",
+            "homepage": "https://github.com/gfx-rs/metal-rs",
+            "documentation": "https://docs.rs/crate/metal",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "naga",
+            "version": "0.10.0",
+            "id": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Shader translation infrastructure",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arbitrary",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bit-set",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "codespan-reporting",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "hexf-parse",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "indexmap",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "std"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "num-traits",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "petgraph",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "pp-rs",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-hash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.103",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "spirv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thiserror",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.21",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-xid",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bincode",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "diff",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ron",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "~0.7.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rspirv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "spirv",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "deserialize"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "naga",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/naga-0.10.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "criterion",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/naga-0.10.0/benches/criterion.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "arbitrary": [
+                    "dep:arbitrary"
+                ],
+                "clone": [],
+                "codespan-reporting": [
+                    "dep:codespan-reporting"
+                ],
+                "default": [],
+                "deserialize": [
+                    "serde",
+                    "indexmap/serde-1"
+                ],
+                "dot-out": [],
+                "glsl-in": [
+                    "pp-rs"
+                ],
+                "glsl-out": [],
+                "hexf-parse": [
+                    "dep:hexf-parse"
+                ],
+                "hlsl-out": [],
+                "msl-out": [],
+                "petgraph": [
+                    "dep:petgraph"
+                ],
+                "pp-rs": [
+                    "dep:pp-rs"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serialize": [
+                    "serde",
+                    "indexmap/serde-1"
+                ],
+                "span": [
+                    "codespan-reporting",
+                    "termcolor"
+                ],
+                "spirv": [
+                    "dep:spirv"
+                ],
+                "spv-in": [
+                    "petgraph",
+                    "spirv"
+                ],
+                "spv-out": [
+                    "spirv"
+                ],
+                "termcolor": [
+                    "dep:termcolor"
+                ],
+                "unicode-xid": [
+                    "dep:unicode-xid"
+                ],
+                "validate": [],
+                "wgsl-in": [
+                    "codespan-reporting",
+                    "hexf-parse",
+                    "termcolor",
+                    "unicode-xid"
+                ],
+                "wgsl-out": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/naga-0.10.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Naga Developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "shader",
+                "SPIR-V",
+                "GLSL",
+                "MSL"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/naga/tree/v0.9",
+            "homepage": "https://github.com/gfx-rs/naga",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "num-traits",
+            "version": "0.2.15",
+            "id": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Numeric traits for generic mathematics",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "libm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "autocfg",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "num-traits",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.15/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cast",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.15/tests/cast.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.15/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "i128": [],
+                "libm": [
+                    "dep:libm"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.15/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "std"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [
+                "algorithms",
+                "science",
+                "no-std"
+            ],
+            "keywords": [
+                "mathematics",
+                "numerics"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-num/num-traits",
+            "homepage": "https://github.com/rust-num/num-traits",
+            "documentation": "https://docs.rs/num-traits",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "objc",
+            "version": "0.2.7",
+            "id": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Objective-C Runtime bindings and wrapper for Rust.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "malloc_buf",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "objc_exception",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "objc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc-0.2.7/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "example",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc-0.2.7/examples/example.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "exception": [
+                    "objc_exception"
+                ],
+                "objc_exception": [
+                    "dep:objc_exception"
+                ],
+                "verify_message": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc-0.2.7/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Sheldon"
+            ],
+            "categories": [],
+            "keywords": [
+                "objective-c",
+                "osx",
+                "ios",
+                "cocoa",
+                "uikit"
+            ],
+            "readme": "README.md",
+            "repository": "http://github.com/SSheldon/rust-objc",
+            "homepage": null,
+            "documentation": "http://ssheldon.github.io/rust-objc/objc/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "objc_exception",
+            "version": "0.1.2",
+            "id": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "Rust interface for Objective-C's throw and try/catch statements.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "objc_exception",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc_exception-0.1.2/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc_exception-0.1.2/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/objc_exception-0.1.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Steven Sheldon"
+            ],
+            "categories": [],
+            "keywords": [
+                "objective-c",
+                "osx",
+                "ios"
+            ],
+            "readme": null,
+            "repository": "http://github.com/SSheldon/rust-objc-exception",
+            "homepage": null,
+            "documentation": "http://ssheldon.github.io/rust-objc/objc_exception/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "once_cell",
+            "version": "1.16.0",
+            "id": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Single assignment cells and lazy values.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "atomic-polyfill",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": "atomic_polyfill",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "critical-section",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": "critical_section",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot_core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "critical-section",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.1",
+                    "kind": "dev",
+                    "rename": "critical_section",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "std"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "crossbeam-utils",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "regex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.2.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "once_cell",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/bench.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench_acquire",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/bench_acquire.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench_vs_lazy_static",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/bench_vs_lazy_static.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "lazy_static",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/lazy_static.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "reentrant_init_deadlocks",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/reentrant_init_deadlocks.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "regex",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/regex.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_synchronization",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/examples/test_synchronization.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "std"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "it",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/tests/it.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "alloc": [
+                    "race"
+                ],
+                "atomic-polyfill": [
+                    "critical-section"
+                ],
+                "atomic_polyfill": [
+                    "dep:atomic_polyfill"
+                ],
+                "critical-section": [
+                    "critical_section",
+                    "atomic_polyfill"
+                ],
+                "critical_section": [
+                    "dep:critical_section"
+                ],
+                "default": [
+                    "std"
+                ],
+                "parking_lot": [
+                    "parking_lot_core"
+                ],
+                "parking_lot_core": [
+                    "dep:parking_lot_core"
+                ],
+                "race": [],
+                "std": [
+                    "alloc"
+                ],
+                "unstable": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/once_cell-1.16.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Aleksey Kladov <aleksey.kladov@gmail.com>"
+            ],
+            "categories": [
+                "rust-patterns",
+                "memory-management"
+            ],
+            "keywords": [
+                "lazy",
+                "static"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/matklad/once_cell",
+            "homepage": null,
+            "documentation": "https://docs.rs/once_cell",
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.56"
+        },
+        {
+            "name": "parent",
+            "version": "0.1.0",
+            "id": "parent 0.1.0 (path+file://{TEMP_DIR}/workspace)",
+            "license": null,
+            "license_file": null,
+            "description": null,
+            "source": null,
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "parent",
+                    "src_path": "{TEMP_DIR}/workspace/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{TEMP_DIR}/workspace/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": null,
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "parking_lot",
+            "version": "0.12.1",
+            "id": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "More compact and efficient implementations of the standard synchronization primitives.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "lock_api",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot_core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bincode",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "parking_lot",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.12.1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "issue_203",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.12.1/tests/issue_203.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "arc_lock": [
+                    "lock_api/arc_lock"
+                ],
+                "deadlock_detection": [
+                    "parking_lot_core/deadlock_detection"
+                ],
+                "default": [],
+                "hardware-lock-elision": [],
+                "nightly": [
+                    "parking_lot_core/nightly",
+                    "lock_api/nightly"
+                ],
+                "owning_ref": [
+                    "lock_api/owning_ref"
+                ],
+                "send_guard": [],
+                "serde": [
+                    "lock_api/serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.12.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Amanieu d'Antras <amanieu@gmail.com>"
+            ],
+            "categories": [
+                "concurrency"
+            ],
+            "keywords": [
+                "mutex",
+                "condvar",
+                "rwlock",
+                "once",
+                "thread"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/Amanieu/parking_lot",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "parking_lot_core",
+            "version": "0.9.4",
+            "id": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "An advanced API for creating custom synchronization primitives.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "backtrace",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "petgraph",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.6.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thread-id",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^4.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "redox_syscall",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"redox\")",
+                    "registry": null
+                },
+                {
+                    "name": "libc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.95",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(unix)",
+                    "registry": null
+                },
+                {
+                    "name": "windows-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Win32_Foundation",
+                        "Win32_System_LibraryLoader",
+                        "Win32_System_SystemServices",
+                        "Win32_System_WindowsProgramming"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "parking_lot_core",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.4/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.4/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "backtrace": [
+                    "dep:backtrace"
+                ],
+                "deadlock_detection": [
+                    "petgraph",
+                    "thread-id",
+                    "backtrace"
+                ],
+                "nightly": [],
+                "petgraph": [
+                    "dep:petgraph"
+                ],
+                "thread-id": [
+                    "dep:thread-id"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/parking_lot_core-0.9.4/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Amanieu d'Antras <amanieu@gmail.com>"
+            ],
+            "categories": [
+                "concurrency"
+            ],
+            "keywords": [
+                "mutex",
+                "condvar",
+                "rwlock",
+                "once",
+                "thread"
+            ],
+            "readme": null,
+            "repository": "https://github.com/Amanieu/parking_lot",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "pkg-config",
+            "version": "0.3.26",
+            "id": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A library to run the pkg-config system tool at build time in order to be used in\nCargo build scripts.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "pkg-config",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pkg-config-0.3.26/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pkg-config-0.3.26/tests/test.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/pkg-config-0.3.26/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "build-dependencies"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang/pkg-config-rs",
+            "homepage": null,
+            "documentation": "https://docs.rs/pkg-config",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "proc-macro2",
+            "version": "1.0.47",
+            "id": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "unicode-ident",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "proc-macro2",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "features",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/features.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_fmt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/test_fmt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "comments",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/comments.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "marker",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/tests/marker.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "nightly": [],
+                "proc-macro": [],
+                "span-locations": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.47/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt",
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "span-locations"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>",
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/proc-macro2",
+            "homepage": null,
+            "documentation": "https://docs.rs/proc-macro2",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "profiling",
+            "version": "1.0.7",
+            "id": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "This crate provides a very thin abstraction over other profiler crates.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "optick",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "profiling-procmacros",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "puffin",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.12.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "superluminal-perf",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracy-client",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bincode",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.3.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "glam",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8.6",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "imgui",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "imgui-winit-support",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "lazy_static",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "puffin-imgui",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.15.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rafx",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.0.14",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "rafx-vulkan",
+                        "framework"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing-subscriber",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tracing-tracy",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winit",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.25",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "profiling",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/profiling-1.0.7/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "puffin",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/profiling-1.0.7/examples/puffin/puffin.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "profile-with-puffin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "simple",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/profiling-1.0.7/examples/simple.rs",
+                    "edition": "2018",
+                    "required-features": [],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "procmacros"
+                ],
+                "optick": [
+                    "dep:optick"
+                ],
+                "procmacros": [
+                    "profiling-procmacros"
+                ],
+                "profile-with-optick": [
+                    "optick",
+                    "profiling-procmacros/profile-with-optick"
+                ],
+                "profile-with-puffin": [
+                    "puffin",
+                    "profiling-procmacros/profile-with-puffin"
+                ],
+                "profile-with-superluminal": [
+                    "superluminal-perf",
+                    "profiling-procmacros/profile-with-superluminal"
+                ],
+                "profile-with-tracing": [
+                    "tracing",
+                    "profiling-procmacros/profile-with-tracing"
+                ],
+                "profile-with-tracy": [
+                    "tracy-client",
+                    "profiling-procmacros/profile-with-tracy"
+                ],
+                "profiling-procmacros": [
+                    "dep:profiling-procmacros"
+                ],
+                "puffin": [
+                    "dep:puffin"
+                ],
+                "superluminal-perf": [
+                    "dep:superluminal-perf"
+                ],
+                "tracing": [
+                    "dep:tracing"
+                ],
+                "tracy-client": [
+                    "dep:tracy-client"
+                ],
+                "type-check": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/profiling-1.0.7/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Philip Degarmo <aclysma@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::profiling"
+            ],
+            "keywords": [
+                "performance",
+                "profiling"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/aclysma/profiling",
+            "homepage": "https://github.com/aclysma/profiling",
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "quote",
+            "version": "1.0.21",
+            "id": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Quasi-quoting macro quote!(...)",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.40",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.52",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "diff"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "quote",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/tests/test.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/quote-1.0.21/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/quote",
+            "homepage": null,
+            "documentation": "https://docs.rs/quote/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "range-alloc",
+            "version": "0.1.2",
+            "id": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Generic range allocator used by gfx-rs backends",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "range_alloc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/range-alloc-0.1.2/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/range-alloc-0.1.2/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The Gfx-rs Developers"
+            ],
+            "categories": [
+                "memory-management"
+            ],
+            "keywords": [
+                "allocator"
+            ],
+            "readme": null,
+            "repository": "https://github.com/gfx-rs/gfx",
+            "homepage": "https://github.com/gfx-rs/gfx",
+            "documentation": "https://docs.rs/range-alloc",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "raw-window-handle",
+            "version": "0.5.0",
+            "id": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0 OR Zlib",
+            "license_file": null,
+            "description": "Interoperability library for Rust Windowing applications.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cty",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "raw-window-handle",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/raw-window-handle-0.5.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "alloc": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/raw-window-handle-0.5.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Osspial <osspial@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windowing"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-windowing/raw-window-handle",
+            "homepage": null,
+            "documentation": "https://docs.rs/raw-window-handle",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "redox_syscall",
+            "version": "0.2.16",
+            "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT",
+            "license_file": null,
+            "description": "A Rust library to access raw Redox system calls",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "syscall",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/redox_syscall-0.2.16/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/redox_syscall-0.2.16/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Jeremy Soller <jackpot51@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://gitlab.redox-os.org/redox-os/syscall",
+            "homepage": null,
+            "documentation": "https://docs.rs/redox_syscall",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "renderdoc-sys",
+            "version": "0.7.1",
+            "id": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Raw FFI bindings to the RenderDoc API",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "renderdoc-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/renderdoc-sys-0.7.1/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/renderdoc-sys-0.7.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Eyal Kalderon <ebkalderon@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "ffi",
+                "renderdoc"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/ebkalderon/renderdoc-rs",
+            "homepage": "https://github.com/ebkalderon/renderdoc-rs/tree/master/renderdoc-sys",
+            "documentation": "https://docs.rs/renderdoc-sys/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "rustc-hash",
+            "version": "1.1.0",
+            "id": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0/MIT",
+            "license_file": null,
+            "description": "speed, non-cryptographic hash used in rustc",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "rustc-hash",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/rustc-hash-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/rustc-hash-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The Rust Project Developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "hash",
+                "fxhash",
+                "rustc"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/rust-lang-nursery/rustc-hash",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "scopeguard",
+            "version": "1.1.0",
+            "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "A RAII scope guard that will run a given closure when it goes out of scope,\neven if the code between panics (assuming unwinding panic).\n\nDefines the macros `defer!`, `defer_on_unwind!`, `defer_on_success!` as\nshorthands for guards with one of the implemented strategies.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "scopeguard",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/scopeguard-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "readme",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/scopeguard-1.1.0/examples/readme.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "use_std"
+                ],
+                "use_std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/scopeguard-1.1.0/Cargo.toml",
+            "metadata": {
+                "release": {
+                    "no-dev-version": true
+                }
+            },
+            "publish": null,
+            "authors": [
+                "bluss"
+            ],
+            "categories": [
+                "rust-patterns",
+                "no-std"
+            ],
+            "keywords": [
+                "scope-guard",
+                "defer",
+                "panic",
+                "unwind"
+            ],
+            "readme": null,
+            "repository": "https://github.com/bluss/scopeguard",
+            "homepage": null,
+            "documentation": "https://docs.rs/scopeguard/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "slotmap",
+            "version": "1.0.6",
+            "id": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Zlib",
+            "license_file": null,
+            "description": "Slotmap data structure",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [
+                        "derive",
+                        "alloc"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quickcheck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "version_check",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "slotmap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rand_meld_heap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/examples/rand_meld_heap.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "doubly_linked_list",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/examples/doubly_linked_list.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "std": [],
+                "unstable": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/slotmap-1.0.6/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Orson Peters <orsonpeters@gmail.com>"
+            ],
+            "categories": [
+                "data-structures",
+                "memory-management",
+                "caching"
+            ],
+            "keywords": [
+                "slotmap",
+                "storage",
+                "allocator",
+                "arena",
+                "reference"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/orlp/slotmap",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "smallvec",
+            "version": "1.10.0",
+            "id": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "'Small vector' optimization: store up to a small number of items on the stack",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arbitrary",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bincode",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "debugger_test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "debugger_test_parser",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "smallvec",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "debugger_visualizer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/tests/debugger_visualizer.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "debugger_visualizer"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "macro",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/tests/macro.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/benches/bench.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "arbitrary": [
+                    "dep:arbitrary"
+                ],
+                "const_generics": [],
+                "const_new": [
+                    "const_generics"
+                ],
+                "debugger_visualizer": [],
+                "may_dangle": [],
+                "serde": [
+                    "dep:serde"
+                ],
+                "specialization": [],
+                "union": [],
+                "write": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/smallvec-1.10.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The Servo Project Developers"
+            ],
+            "categories": [
+                "data-structures"
+            ],
+            "keywords": [
+                "small",
+                "vec",
+                "vector",
+                "stack",
+                "no_std"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/servo/rust-smallvec",
+            "homepage": null,
+            "documentation": "https://docs.rs/smallvec/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "spirv",
+            "version": "0.2.0+1.5.4",
+            "id": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0",
+            "license_file": null,
+            "description": "Rust definition of SPIR-V structs and enums",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "num-traits",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "spirv",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/spirv-0.2.0+1.5.4/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "deserialize": [
+                    "serde"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serialize": [
+                    "serde"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/spirv-0.2.0+1.5.4/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Lei Zhang <antiagainst@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "spirv",
+                "definition",
+                "struct",
+                "enum"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/rspirv",
+            "homepage": null,
+            "documentation": "https://docs.rs/spirv",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "static_assertions",
+            "version": "1.1.0",
+            "id": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Compile-time assertions to ensure that invariants are met.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "static_assertions",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/static_assertions-1.1.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "nightly": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/static_assertions-1.1.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Nikolai Vazquez"
+            ],
+            "categories": [
+                "no-std",
+                "rust-patterns",
+                "development-tools::testing"
+            ],
+            "keywords": [
+                "assert",
+                "static",
+                "testing"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/nvzqz/static-assertions-rs",
+            "homepage": "https://github.com/nvzqz/static-assertions-rs",
+            "documentation": "https://docs.rs/static_assertions/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "syn",
+            "version": "1.0.104",
+            "id": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Parser for Rust source code",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.46",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-ident",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "automod",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "flate2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "insta",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rayon",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ref-cast",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "regex",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "reqwest",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "blocking"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn-test-suite",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "tar",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.16",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "termcolor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "walkdir",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^2.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "syn",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_should_parse",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_should_parse.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_visibility",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_visibility.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_stmt",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_stmt.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_round_trip",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_round_trip.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_size.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_shebang",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_shebang.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_pat",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_pat.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_receiver",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_receiver.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_precedence",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_precedence.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_lit",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_lit.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "regression",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/regression.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_parse_stream.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_grouping",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_grouping.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ident",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_ident.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_iterators",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_iterators.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_parse_buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_parse_buffer.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_asyncness",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_asyncness.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_token_trees",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_token_trees.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_ty",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_ty.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "zzz_stable",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/zzz_stable.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_meta",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_meta.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_expr.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_item",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_item.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_path.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_derive_input",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_derive_input.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_generics.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_attribute",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/tests/test_attribute.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "rust",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/benches/rust.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "file",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/benches/file.rs",
+                    "edition": "2018",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "clone-impls": [],
+                "default": [
+                    "derive",
+                    "parsing",
+                    "printing",
+                    "clone-impls",
+                    "proc-macro"
+                ],
+                "derive": [],
+                "extra-traits": [],
+                "fold": [],
+                "full": [],
+                "parsing": [],
+                "printing": [
+                    "quote"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro",
+                    "quote/proc-macro"
+                ],
+                "quote": [
+                    "dep:quote"
+                ],
+                "test": [
+                    "syn-test-suite/all-features"
+                ],
+                "visit": [],
+                "visit-mut": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/syn-1.0.104/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "doc_cfg"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "full",
+                        "visit",
+                        "visit-mut",
+                        "fold",
+                        "extra-traits"
+                    ]
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "parser-implementations"
+            ],
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/syn",
+            "homepage": null,
+            "documentation": "https://docs.rs/syn",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "termcolor",
+            "version": "1.1.3",
+            "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense OR MIT",
+            "license_file": null,
+            "description": "A simple cross platform library for writing colored text to a terminal.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "winapi-util",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "termcolor",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/termcolor-1.1.3/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/termcolor-1.1.3/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windows",
+                "win",
+                "color",
+                "ansi",
+                "console"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/termcolor",
+            "homepage": "https://github.com/BurntSushi/termcolor",
+            "documentation": "https://docs.rs/termcolor",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "thiserror",
+            "version": "1.0.37",
+            "id": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "derive(Error)",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "thiserror-impl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=1.0.37",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "anyhow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.65",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ref-cast",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustversion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.49",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "diff"
+                    ],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "thiserror",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_source",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_source.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_backtrace",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_backtrace.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_display",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_display.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_lints",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_lints.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_transparent",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_transparent.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/compiletest.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_from",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_from.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_expr.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_path.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_error",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_error.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_generics.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_option",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_option.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "test_deprecated",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/tests/test_deprecated.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-1.0.37/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "rust-patterns"
+            ],
+            "keywords": [
+                "error",
+                "error-handling",
+                "derive"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/thiserror",
+            "homepage": null,
+            "documentation": "https://docs.rs/thiserror",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "thiserror-impl",
+            "version": "1.0.37",
+            "id": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Implementation detail of the `thiserror` crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.45",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "name": "thiserror-impl",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-impl-1.0.37/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/thiserror-impl-1.0.37/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/dtolnay/thiserror",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "unicode-ident",
+            "version": "1.0.5",
+            "id": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
+            "license_file": null,
+            "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fst",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "small_rng"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "roaring",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ucd-trie",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "unicode-xid",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-ident",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "static_size",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/tests/static_size.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "compare",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/tests/compare.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xid",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/benches/xid.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-ident-1.0.5/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "no-std"
+            ],
+            "keywords": [
+                "unicode",
+                "xid"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/unicode-ident",
+            "homepage": null,
+            "documentation": "https://docs.rs/unicode-ident",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.31"
+        },
+        {
+            "name": "unicode-width",
+            "version": "0.1.10",
+            "id": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Determine displayed width of `char` and `str` types\naccording to Unicode Standard Annex #11 rules.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-std",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": "std",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-width",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-width-0.1.10/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "bench": [],
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [],
+                "no_std": [],
+                "rustc-dep-of-std": [
+                    "std",
+                    "core",
+                    "compiler_builtins"
+                ],
+                "std": [
+                    "dep:std"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-width-0.1.10/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "kwantam <kwantam@gmail.com>",
+                "Manish Goregaokar <manishsmail@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "text",
+                "width",
+                "unicode"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/unicode-rs/unicode-width",
+            "homepage": "https://github.com/unicode-rs/unicode-width",
+            "documentation": "https://unicode-rs.github.io/unicode-width",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "unicode-xid",
+            "version": "0.2.4",
+            "id": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Determine whether characters have the XID_Start\nor XID_Continue properties according to\nUnicode Standard Annex #31.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "criterion",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "unicode-xid",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.4/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "exhaustive_tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.4/tests/exhaustive_tests.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "bench"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "xid",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.4/benches/xid.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "bench": [],
+                "default": [],
+                "no_std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/unicode-xid-0.2.4/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "erick.tryzelaar <erick.tryzelaar@gmail.com>",
+                "kwantam <kwantam@gmail.com>",
+                "Manish Goregaokar <manishsmail@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "text",
+                "unicode",
+                "xid"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/unicode-rs/unicode-xid",
+            "homepage": "https://github.com/unicode-rs/unicode-xid",
+            "documentation": "https://unicode-rs.github.io/unicode-xid",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.17"
+        },
+        {
+            "name": "version_check",
+            "version": "0.9.4",
+            "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Tiny crate to check the version of the installed/running rustc.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "version_check",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/version_check-0.9.4/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/version_check-0.9.4/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Sergio Benitez <sb@sergio.bz>"
+            ],
+            "categories": [],
+            "keywords": [
+                "version",
+                "rustc",
+                "minimum",
+                "check"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/SergioBenitez/version_check",
+            "homepage": null,
+            "documentation": "https://docs.rs/version_check/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasi",
+            "version": "0.11.0+wasi-snapshot-preview1",
+            "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+            "license_file": null,
+            "description": "Experimental WASI API bindings for Rust",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "compiler_builtins",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": "core",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "rustc-std-workspace-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasi",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasi-0.11.0+wasi-snapshot-preview1/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "compiler_builtins": [
+                    "dep:compiler_builtins"
+                ],
+                "core": [
+                    "dep:core"
+                ],
+                "default": [
+                    "std"
+                ],
+                "rustc-dep-of-std": [
+                    "compiler_builtins",
+                    "core",
+                    "rustc-std-workspace-alloc"
+                ],
+                "rustc-std-workspace-alloc": [
+                    "dep:rustc-std-workspace-alloc"
+                ],
+                "std": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasi-0.11.0+wasi-snapshot-preview1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The Cranelift Project Developers"
+            ],
+            "categories": [
+                "no-std",
+                "wasm"
+            ],
+            "keywords": [
+                "webassembly",
+                "wasm"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/bytecodealliance/wasi",
+            "homepage": null,
+            "documentation": "https://docs.rs/wasi",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen",
+            "version": "0.2.83",
+            "id": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Easy support for interacting between JS and Rust.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-macro",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "serde_derive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.4.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.3.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test-crate-a",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test-crate-b",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wasm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/wasm/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "non_wasm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/non_wasm.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "std-crate-no-std-dep",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/std-crate-no-std-dep.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "must_use",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/must_use.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "headless",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/headless/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "unwrap_throw",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/tests/unwrap_throw.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "default": [
+                    "spans",
+                    "std"
+                ],
+                "enable-interning": [
+                    "std"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serde-serialize": [
+                    "serde",
+                    "serde_json",
+                    "std"
+                ],
+                "serde_json": [
+                    "dep:serde_json"
+                ],
+                "spans": [
+                    "wasm-bindgen-macro/spans"
+                ],
+                "std": [],
+                "strict-macro": [
+                    "wasm-bindgen-macro/strict-macro"
+                ],
+                "xxx_debug_only_print_generated_code": [
+                    "wasm-bindgen-macro/xxx_debug_only_print_generated_code"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-0.2.83/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "features": [
+                            "serde-serialize"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [
+                "wasm"
+            ],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen",
+            "homepage": "https://rustwasm.github.io/",
+            "documentation": "https://docs.rs/wasm-bindgen",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-backend",
+            "version": "0.2.83",
+            "id": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Backend code generation of the wasm-bindgen tool\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bumpalo",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^3.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "once_cell",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.12",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "full"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-shared",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen-backend",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-backend-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "extra-traits": [
+                    "syn/extra-traits"
+                ],
+                "spans": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-backend-0.2.83/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen-backend",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-futures",
+            "version": "0.4.33",
+            "id": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Bridging the gap between Rust Futures and JavaScript Promises",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "cfg-if",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "futures-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "futures-channel-preview",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.0-alpha.18",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "futures-lite",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.11.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.24",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "MessageEvent",
+                        "Worker"
+                    ],
+                    "target": "cfg(target_feature = \"atomics\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen-futures",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-futures-0.4.33/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-futures-0.4.33/tests/tests.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "futures-core": [
+                    "dep:futures-core"
+                ],
+                "futures-core-03-stream": [
+                    "futures-core"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-futures-0.4.33/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "./README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen-futures",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-macro",
+            "version": "0.2.83",
+            "id": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Definition of the `#[wasm_bindgen]` attribute, an internal dependency\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-macro-support",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "trybuild",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "name": "wasm-bindgen-macro",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "ui",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-0.2.83/tests/ui.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "spans": [
+                    "wasm-bindgen-macro-support/spans"
+                ],
+                "strict-macro": [
+                    "wasm-bindgen-macro-support/strict-macro"
+                ],
+                "xxx_debug_only_print_generated_code": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-0.2.83/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-macro-support",
+            "version": "0.2.83",
+            "id": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "The part of the implementation of the `#[wasm_bindgen]` attribute that is not in the shared backend crate\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "proc-macro2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "quote",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "syn",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.67",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "visit",
+                        "full"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-backend",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-shared",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "=0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen-macro-support",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-support-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "extra-traits": [
+                    "syn/extra-traits"
+                ],
+                "spans": [
+                    "wasm-bindgen-backend/spans"
+                ],
+                "strict-macro": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-support-0.2.83/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wasm-bindgen-shared",
+            "version": "0.2.83",
+            "id": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Shared support between wasm-bindgen and wasm-bindgen cli, an internal\ndependency.\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wasm-bindgen-shared",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-shared-0.2.83/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-shared-0.2.83/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-shared-0.2.83/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/",
+            "documentation": "https://docs.rs/wasm-bindgen-shared",
+            "edition": "2018",
+            "links": "wasm_bindgen",
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "web-sys",
+            "version": "0.3.60",
+            "id": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Bindings for all Web APIs, a procedurally generated crate from WebIDL\n",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-test",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.33",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "web-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/web-sys-0.3.60/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wasm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/web-sys-0.3.60/tests/wasm/main.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "AbortController": [],
+                "AbortSignal": [
+                    "EventTarget"
+                ],
+                "AddEventListenerOptions": [],
+                "AesCbcParams": [],
+                "AesCtrParams": [],
+                "AesDerivedKeyParams": [],
+                "AesGcmParams": [],
+                "AesKeyAlgorithm": [],
+                "AesKeyGenParams": [],
+                "Algorithm": [],
+                "AlignSetting": [],
+                "AllowedBluetoothDevice": [],
+                "AllowedUsbDevice": [],
+                "AlphaOption": [],
+                "AnalyserNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "AnalyserOptions": [],
+                "AngleInstancedArrays": [],
+                "Animation": [
+                    "EventTarget"
+                ],
+                "AnimationEffect": [],
+                "AnimationEvent": [
+                    "Event"
+                ],
+                "AnimationEventInit": [],
+                "AnimationPlayState": [],
+                "AnimationPlaybackEvent": [
+                    "Event"
+                ],
+                "AnimationPlaybackEventInit": [],
+                "AnimationPropertyDetails": [],
+                "AnimationPropertyValueDetails": [],
+                "AnimationTimeline": [],
+                "AssignedNodesOptions": [],
+                "AttestationConveyancePreference": [],
+                "Attr": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "AttributeNameValue": [],
+                "AudioBuffer": [],
+                "AudioBufferOptions": [],
+                "AudioBufferSourceNode": [
+                    "AudioNode",
+                    "AudioScheduledSourceNode",
+                    "EventTarget"
+                ],
+                "AudioBufferSourceOptions": [],
+                "AudioConfiguration": [],
+                "AudioContext": [
+                    "BaseAudioContext",
+                    "EventTarget"
+                ],
+                "AudioContextOptions": [],
+                "AudioContextState": [],
+                "AudioData": [],
+                "AudioDataCopyToOptions": [],
+                "AudioDataInit": [],
+                "AudioDecoder": [],
+                "AudioDecoderConfig": [],
+                "AudioDecoderInit": [],
+                "AudioDecoderSupport": [],
+                "AudioDestinationNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "AudioEncoder": [],
+                "AudioEncoderConfig": [],
+                "AudioEncoderInit": [],
+                "AudioEncoderSupport": [],
+                "AudioListener": [],
+                "AudioNode": [
+                    "EventTarget"
+                ],
+                "AudioNodeOptions": [],
+                "AudioParam": [],
+                "AudioParamMap": [],
+                "AudioProcessingEvent": [
+                    "Event"
+                ],
+                "AudioSampleFormat": [],
+                "AudioScheduledSourceNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "AudioStreamTrack": [
+                    "EventTarget",
+                    "MediaStreamTrack"
+                ],
+                "AudioTrack": [],
+                "AudioTrackList": [
+                    "EventTarget"
+                ],
+                "AudioWorklet": [
+                    "Worklet"
+                ],
+                "AudioWorkletGlobalScope": [
+                    "WorkletGlobalScope"
+                ],
+                "AudioWorkletNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "AudioWorkletNodeOptions": [],
+                "AudioWorkletProcessor": [],
+                "AuthenticationExtensionsClientInputs": [],
+                "AuthenticationExtensionsClientOutputs": [],
+                "AuthenticatorAssertionResponse": [
+                    "AuthenticatorResponse"
+                ],
+                "AuthenticatorAttachment": [],
+                "AuthenticatorAttestationResponse": [
+                    "AuthenticatorResponse"
+                ],
+                "AuthenticatorResponse": [],
+                "AuthenticatorSelectionCriteria": [],
+                "AuthenticatorTransport": [],
+                "AutoKeyword": [],
+                "AutocompleteInfo": [],
+                "BarProp": [],
+                "BaseAudioContext": [
+                    "EventTarget"
+                ],
+                "BaseComputedKeyframe": [],
+                "BaseKeyframe": [],
+                "BasePropertyIndexedKeyframe": [],
+                "BasicCardRequest": [],
+                "BasicCardResponse": [],
+                "BasicCardType": [],
+                "BatteryManager": [
+                    "EventTarget"
+                ],
+                "BeforeUnloadEvent": [
+                    "Event"
+                ],
+                "BinaryType": [],
+                "BiquadFilterNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "BiquadFilterOptions": [],
+                "BiquadFilterType": [],
+                "Blob": [],
+                "BlobEvent": [
+                    "Event"
+                ],
+                "BlobEventInit": [],
+                "BlobPropertyBag": [],
+                "BlockParsingOptions": [],
+                "Bluetooth": [
+                    "EventTarget"
+                ],
+                "BluetoothAdvertisingEvent": [
+                    "Event"
+                ],
+                "BluetoothAdvertisingEventInit": [],
+                "BluetoothCharacteristicProperties": [],
+                "BluetoothDataFilterInit": [],
+                "BluetoothDevice": [
+                    "EventTarget"
+                ],
+                "BluetoothLeScanFilterInit": [],
+                "BluetoothManufacturerDataMap": [],
+                "BluetoothPermissionDescriptor": [],
+                "BluetoothPermissionResult": [
+                    "EventTarget",
+                    "PermissionStatus"
+                ],
+                "BluetoothPermissionStorage": [],
+                "BluetoothRemoteGattCharacteristic": [
+                    "EventTarget"
+                ],
+                "BluetoothRemoteGattDescriptor": [],
+                "BluetoothRemoteGattServer": [],
+                "BluetoothRemoteGattService": [
+                    "EventTarget"
+                ],
+                "BluetoothServiceDataMap": [],
+                "BluetoothUuid": [],
+                "BoxQuadOptions": [],
+                "BroadcastChannel": [
+                    "EventTarget"
+                ],
+                "BrowserElementDownloadOptions": [],
+                "BrowserElementExecuteScriptOptions": [],
+                "BrowserFeedWriter": [],
+                "BrowserFindCaseSensitivity": [],
+                "BrowserFindDirection": [],
+                "ByteLengthQueuingStrategy": [],
+                "Cache": [],
+                "CacheBatchOperation": [],
+                "CacheQueryOptions": [],
+                "CacheStorage": [],
+                "CacheStorageNamespace": [],
+                "CanvasCaptureMediaStream": [
+                    "EventTarget",
+                    "MediaStream"
+                ],
+                "CanvasGradient": [],
+                "CanvasPattern": [],
+                "CanvasRenderingContext2d": [],
+                "CanvasWindingRule": [],
+                "CaretChangedReason": [],
+                "CaretPosition": [],
+                "CaretStateChangedEventInit": [],
+                "CdataSection": [
+                    "CharacterData",
+                    "EventTarget",
+                    "Node",
+                    "Text"
+                ],
+                "ChannelCountMode": [],
+                "ChannelInterpretation": [],
+                "ChannelMergerNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "ChannelMergerOptions": [],
+                "ChannelPixelLayout": [],
+                "ChannelPixelLayoutDataType": [],
+                "ChannelSplitterNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "ChannelSplitterOptions": [],
+                "CharacterData": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "CheckerboardReason": [],
+                "CheckerboardReport": [],
+                "CheckerboardReportService": [],
+                "ChromeFilePropertyBag": [],
+                "ChromeWorker": [
+                    "EventTarget",
+                    "Worker"
+                ],
+                "Client": [],
+                "ClientQueryOptions": [],
+                "ClientRectsAndTexts": [],
+                "ClientType": [],
+                "Clients": [],
+                "Clipboard": [
+                    "EventTarget"
+                ],
+                "ClipboardEvent": [
+                    "Event"
+                ],
+                "ClipboardEventInit": [],
+                "ClipboardItem": [],
+                "ClipboardItemOptions": [],
+                "ClipboardPermissionDescriptor": [],
+                "CloseEvent": [
+                    "Event"
+                ],
+                "CloseEventInit": [],
+                "CodecState": [],
+                "CollectedClientData": [],
+                "Comment": [
+                    "CharacterData",
+                    "EventTarget",
+                    "Node"
+                ],
+                "CompositeOperation": [],
+                "CompositionEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "CompositionEventInit": [],
+                "ComputedEffectTiming": [],
+                "ConnStatusDict": [],
+                "ConnectionType": [],
+                "ConsoleCounter": [],
+                "ConsoleCounterError": [],
+                "ConsoleEvent": [],
+                "ConsoleInstance": [],
+                "ConsoleInstanceOptions": [],
+                "ConsoleLevel": [],
+                "ConsoleLogLevel": [],
+                "ConsoleProfileEvent": [],
+                "ConsoleStackEntry": [],
+                "ConsoleTimerError": [],
+                "ConsoleTimerLogOrEnd": [],
+                "ConsoleTimerStart": [],
+                "ConstantSourceNode": [
+                    "AudioNode",
+                    "AudioScheduledSourceNode",
+                    "EventTarget"
+                ],
+                "ConstantSourceOptions": [],
+                "ConstrainBooleanParameters": [],
+                "ConstrainDomStringParameters": [],
+                "ConstrainDoubleRange": [],
+                "ConstrainLongRange": [],
+                "ContextAttributes2d": [],
+                "ConvertCoordinateOptions": [],
+                "ConvolverNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "ConvolverOptions": [],
+                "Coordinates": [],
+                "CountQueuingStrategy": [],
+                "Credential": [],
+                "CredentialCreationOptions": [],
+                "CredentialRequestOptions": [],
+                "CredentialsContainer": [],
+                "Crypto": [],
+                "CryptoKey": [],
+                "CryptoKeyPair": [],
+                "Csp": [],
+                "CspPolicies": [],
+                "CspReport": [],
+                "CspReportProperties": [],
+                "CssAnimation": [
+                    "Animation",
+                    "EventTarget"
+                ],
+                "CssBoxType": [],
+                "CssConditionRule": [
+                    "CssGroupingRule",
+                    "CssRule"
+                ],
+                "CssCounterStyleRule": [
+                    "CssRule"
+                ],
+                "CssFontFaceRule": [
+                    "CssRule"
+                ],
+                "CssFontFeatureValuesRule": [
+                    "CssRule"
+                ],
+                "CssGroupingRule": [
+                    "CssRule"
+                ],
+                "CssImportRule": [
+                    "CssRule"
+                ],
+                "CssKeyframeRule": [
+                    "CssRule"
+                ],
+                "CssKeyframesRule": [
+                    "CssRule"
+                ],
+                "CssMediaRule": [
+                    "CssConditionRule",
+                    "CssGroupingRule",
+                    "CssRule"
+                ],
+                "CssNamespaceRule": [
+                    "CssRule"
+                ],
+                "CssPageRule": [
+                    "CssRule"
+                ],
+                "CssPseudoElement": [],
+                "CssRule": [],
+                "CssRuleList": [],
+                "CssStyleDeclaration": [],
+                "CssStyleRule": [
+                    "CssRule"
+                ],
+                "CssStyleSheet": [
+                    "StyleSheet"
+                ],
+                "CssStyleSheetParsingMode": [],
+                "CssSupportsRule": [
+                    "CssConditionRule",
+                    "CssGroupingRule",
+                    "CssRule"
+                ],
+                "CssTransition": [
+                    "Animation",
+                    "EventTarget"
+                ],
+                "CustomElementRegistry": [],
+                "CustomEvent": [
+                    "Event"
+                ],
+                "CustomEventInit": [],
+                "DataTransfer": [],
+                "DataTransferItem": [],
+                "DataTransferItemList": [],
+                "DateTimeValue": [],
+                "DecoderDoctorNotification": [],
+                "DecoderDoctorNotificationType": [],
+                "DedicatedWorkerGlobalScope": [
+                    "EventTarget",
+                    "WorkerGlobalScope"
+                ],
+                "DelayNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "DelayOptions": [],
+                "DeviceAcceleration": [],
+                "DeviceAccelerationInit": [],
+                "DeviceLightEvent": [
+                    "Event"
+                ],
+                "DeviceLightEventInit": [],
+                "DeviceMotionEvent": [
+                    "Event"
+                ],
+                "DeviceMotionEventInit": [],
+                "DeviceOrientationEvent": [
+                    "Event"
+                ],
+                "DeviceOrientationEventInit": [],
+                "DeviceProximityEvent": [
+                    "Event"
+                ],
+                "DeviceProximityEventInit": [],
+                "DeviceRotationRate": [],
+                "DeviceRotationRateInit": [],
+                "DhKeyDeriveParams": [],
+                "DirectionSetting": [],
+                "Directory": [],
+                "DisplayMediaStreamConstraints": [],
+                "DisplayNameOptions": [],
+                "DisplayNameResult": [],
+                "DistanceModelType": [],
+                "DnsCacheDict": [],
+                "DnsCacheEntry": [],
+                "DnsLookupDict": [],
+                "Document": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "DocumentFragment": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "DocumentTimeline": [
+                    "AnimationTimeline"
+                ],
+                "DocumentTimelineOptions": [],
+                "DocumentType": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "DomError": [],
+                "DomException": [],
+                "DomImplementation": [],
+                "DomMatrix": [
+                    "DomMatrixReadOnly"
+                ],
+                "DomMatrixReadOnly": [],
+                "DomParser": [],
+                "DomPoint": [
+                    "DomPointReadOnly"
+                ],
+                "DomPointInit": [],
+                "DomPointReadOnly": [],
+                "DomQuad": [],
+                "DomQuadInit": [],
+                "DomQuadJson": [],
+                "DomRect": [
+                    "DomRectReadOnly"
+                ],
+                "DomRectInit": [],
+                "DomRectList": [],
+                "DomRectReadOnly": [],
+                "DomRequest": [
+                    "EventTarget"
+                ],
+                "DomRequestReadyState": [],
+                "DomStringList": [],
+                "DomStringMap": [],
+                "DomTokenList": [],
+                "DomWindowResizeEventDetail": [],
+                "DragEvent": [
+                    "Event",
+                    "MouseEvent",
+                    "UiEvent"
+                ],
+                "DragEventInit": [],
+                "DynamicsCompressorNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "DynamicsCompressorOptions": [],
+                "EcKeyAlgorithm": [],
+                "EcKeyGenParams": [],
+                "EcKeyImportParams": [],
+                "EcdhKeyDeriveParams": [],
+                "EcdsaParams": [],
+                "EffectTiming": [],
+                "Element": [
+                    "EventTarget",
+                    "Node"
+                ],
+                "ElementCreationOptions": [],
+                "ElementDefinitionOptions": [],
+                "EncodedAudioChunk": [],
+                "EncodedAudioChunkInit": [],
+                "EncodedAudioChunkMetadata": [],
+                "EncodedAudioChunkType": [],
+                "EncodedVideoChunk": [],
+                "EncodedVideoChunkInit": [],
+                "EncodedVideoChunkMetadata": [],
+                "EncodedVideoChunkType": [],
+                "EndingTypes": [],
+                "ErrorCallback": [],
+                "ErrorEvent": [
+                    "Event"
+                ],
+                "ErrorEventInit": [],
+                "Event": [],
+                "EventInit": [],
+                "EventListener": [],
+                "EventListenerOptions": [],
+                "EventModifierInit": [],
+                "EventSource": [
+                    "EventTarget"
+                ],
+                "EventSourceInit": [],
+                "EventTarget": [],
+                "Exception": [],
+                "ExtBlendMinmax": [],
+                "ExtColorBufferFloat": [],
+                "ExtColorBufferHalfFloat": [],
+                "ExtDisjointTimerQuery": [],
+                "ExtFragDepth": [],
+                "ExtSRgb": [],
+                "ExtShaderTextureLod": [],
+                "ExtTextureFilterAnisotropic": [],
+                "ExtendableEvent": [
+                    "Event"
+                ],
+                "ExtendableEventInit": [],
+                "ExtendableMessageEvent": [
+                    "Event",
+                    "ExtendableEvent"
+                ],
+                "ExtendableMessageEventInit": [],
+                "External": [],
+                "FakePluginMimeEntry": [],
+                "FakePluginTagInit": [],
+                "FetchEvent": [
+                    "Event",
+                    "ExtendableEvent"
+                ],
+                "FetchEventInit": [],
+                "FetchObserver": [
+                    "EventTarget"
+                ],
+                "FetchReadableStreamReadDataArray": [],
+                "FetchReadableStreamReadDataDone": [],
+                "FetchState": [],
+                "File": [
+                    "Blob"
+                ],
+                "FileCallback": [],
+                "FileList": [],
+                "FilePropertyBag": [],
+                "FileReader": [
+                    "EventTarget"
+                ],
+                "FileReaderSync": [],
+                "FileSystem": [],
+                "FileSystemDirectoryEntry": [
+                    "FileSystemEntry"
+                ],
+                "FileSystemDirectoryReader": [],
+                "FileSystemEntriesCallback": [],
+                "FileSystemEntry": [],
+                "FileSystemEntryCallback": [],
+                "FileSystemFileEntry": [
+                    "FileSystemEntry"
+                ],
+                "FileSystemFlags": [],
+                "FillMode": [],
+                "FlashClassification": [],
+                "FlexLineGrowthState": [],
+                "FocusEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "FocusEventInit": [],
+                "FontFace": [],
+                "FontFaceDescriptors": [],
+                "FontFaceLoadStatus": [],
+                "FontFaceSet": [
+                    "EventTarget"
+                ],
+                "FontFaceSetIterator": [],
+                "FontFaceSetIteratorResult": [],
+                "FontFaceSetLoadEvent": [
+                    "Event"
+                ],
+                "FontFaceSetLoadEventInit": [],
+                "FontFaceSetLoadStatus": [],
+                "FormData": [],
+                "FrameType": [],
+                "FuzzingFunctions": [],
+                "GainNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "GainOptions": [],
+                "Gamepad": [],
+                "GamepadAxisMoveEvent": [
+                    "Event",
+                    "GamepadEvent"
+                ],
+                "GamepadAxisMoveEventInit": [],
+                "GamepadButton": [],
+                "GamepadButtonEvent": [
+                    "Event",
+                    "GamepadEvent"
+                ],
+                "GamepadButtonEventInit": [],
+                "GamepadEvent": [
+                    "Event"
+                ],
+                "GamepadEventInit": [],
+                "GamepadHand": [],
+                "GamepadHapticActuator": [],
+                "GamepadHapticActuatorType": [],
+                "GamepadMappingType": [],
+                "GamepadPose": [],
+                "GamepadServiceTest": [],
+                "Geolocation": [],
+                "GetNotificationOptions": [],
+                "GetRootNodeOptions": [],
+                "GetUserMediaRequest": [],
+                "Gpu": [],
+                "GpuAdapter": [],
+                "GpuAdapterInfo": [],
+                "GpuAddressMode": [],
+                "GpuAutoLayoutMode": [],
+                "GpuBindGroup": [],
+                "GpuBindGroupDescriptor": [],
+                "GpuBindGroupEntry": [],
+                "GpuBindGroupLayout": [],
+                "GpuBindGroupLayoutDescriptor": [],
+                "GpuBindGroupLayoutEntry": [],
+                "GpuBlendComponent": [],
+                "GpuBlendFactor": [],
+                "GpuBlendOperation": [],
+                "GpuBlendState": [],
+                "GpuBuffer": [],
+                "GpuBufferBinding": [],
+                "GpuBufferBindingLayout": [],
+                "GpuBufferBindingType": [],
+                "GpuBufferDescriptor": [],
+                "GpuCanvasAlphaMode": [],
+                "GpuCanvasConfiguration": [],
+                "GpuCanvasContext": [],
+                "GpuColorDict": [],
+                "GpuColorTargetState": [],
+                "GpuCommandBuffer": [],
+                "GpuCommandBufferDescriptor": [],
+                "GpuCommandEncoder": [],
+                "GpuCommandEncoderDescriptor": [],
+                "GpuCompareFunction": [],
+                "GpuCompilationInfo": [],
+                "GpuCompilationMessage": [],
+                "GpuCompilationMessageType": [],
+                "GpuComputePassDescriptor": [],
+                "GpuComputePassEncoder": [],
+                "GpuComputePassTimestampLocation": [],
+                "GpuComputePassTimestampWrite": [],
+                "GpuComputePipeline": [],
+                "GpuComputePipelineDescriptor": [],
+                "GpuCullMode": [],
+                "GpuDepthStencilState": [],
+                "GpuDevice": [
+                    "EventTarget"
+                ],
+                "GpuDeviceDescriptor": [],
+                "GpuDeviceLostInfo": [],
+                "GpuDeviceLostReason": [],
+                "GpuError": [],
+                "GpuErrorFilter": [],
+                "GpuExtent3dDict": [],
+                "GpuExternalTexture": [],
+                "GpuExternalTextureBindingLayout": [],
+                "GpuExternalTextureDescriptor": [],
+                "GpuFeatureName": [],
+                "GpuFilterMode": [],
+                "GpuFragmentState": [],
+                "GpuFrontFace": [],
+                "GpuImageCopyBuffer": [],
+                "GpuImageCopyExternalImage": [],
+                "GpuImageCopyTexture": [],
+                "GpuImageCopyTextureTagged": [],
+                "GpuImageDataLayout": [],
+                "GpuIndexFormat": [],
+                "GpuLoadOp": [],
+                "GpuMipmapFilterMode": [],
+                "GpuMultisampleState": [],
+                "GpuObjectDescriptorBase": [],
+                "GpuOrigin2dDict": [],
+                "GpuOrigin3dDict": [],
+                "GpuOutOfMemoryError": [
+                    "GpuError"
+                ],
+                "GpuPipelineDescriptorBase": [],
+                "GpuPipelineLayout": [],
+                "GpuPipelineLayoutDescriptor": [],
+                "GpuPowerPreference": [],
+                "GpuPrimitiveState": [],
+                "GpuPrimitiveTopology": [],
+                "GpuProgrammableStage": [],
+                "GpuQuerySet": [],
+                "GpuQuerySetDescriptor": [],
+                "GpuQueryType": [],
+                "GpuQueue": [],
+                "GpuQueueDescriptor": [],
+                "GpuRenderBundle": [],
+                "GpuRenderBundleDescriptor": [],
+                "GpuRenderBundleEncoder": [],
+                "GpuRenderBundleEncoderDescriptor": [],
+                "GpuRenderPassColorAttachment": [],
+                "GpuRenderPassDepthStencilAttachment": [],
+                "GpuRenderPassDescriptor": [],
+                "GpuRenderPassEncoder": [],
+                "GpuRenderPassLayout": [],
+                "GpuRenderPassTimestampLocation": [],
+                "GpuRenderPassTimestampWrite": [],
+                "GpuRenderPipeline": [],
+                "GpuRenderPipelineDescriptor": [],
+                "GpuRequestAdapterOptions": [],
+                "GpuSampler": [],
+                "GpuSamplerBindingLayout": [],
+                "GpuSamplerBindingType": [],
+                "GpuSamplerDescriptor": [],
+                "GpuShaderModule": [],
+                "GpuShaderModuleCompilationHint": [],
+                "GpuShaderModuleDescriptor": [],
+                "GpuStencilFaceState": [],
+                "GpuStencilOperation": [],
+                "GpuStorageTextureAccess": [],
+                "GpuStorageTextureBindingLayout": [],
+                "GpuStoreOp": [],
+                "GpuSupportedFeatures": [],
+                "GpuSupportedLimits": [],
+                "GpuTexture": [],
+                "GpuTextureAspect": [],
+                "GpuTextureBindingLayout": [],
+                "GpuTextureDescriptor": [],
+                "GpuTextureDimension": [],
+                "GpuTextureFormat": [],
+                "GpuTextureSampleType": [],
+                "GpuTextureView": [],
+                "GpuTextureViewDescriptor": [],
+                "GpuTextureViewDimension": [],
+                "GpuUncapturedErrorEvent": [
+                    "Event"
+                ],
+                "GpuUncapturedErrorEventInit": [],
+                "GpuValidationError": [
+                    "GpuError"
+                ],
+                "GpuVertexAttribute": [],
+                "GpuVertexBufferLayout": [],
+                "GpuVertexFormat": [],
+                "GpuVertexState": [],
+                "GpuVertexStepMode": [],
+                "GridDeclaration": [],
+                "GridTrackState": [],
+                "GroupedHistoryEventInit": [],
+                "HalfOpenInfoDict": [],
+                "HardwareAcceleration": [],
+                "HashChangeEvent": [
+                    "Event"
+                ],
+                "HashChangeEventInit": [],
+                "Headers": [],
+                "HeadersGuardEnum": [],
+                "Hid": [
+                    "EventTarget"
+                ],
+                "HidCollectionInfo": [],
+                "HidConnectionEvent": [
+                    "Event"
+                ],
+                "HidConnectionEventInit": [],
+                "HidDevice": [
+                    "EventTarget"
+                ],
+                "HidDeviceFilter": [],
+                "HidDeviceRequestOptions": [],
+                "HidInputReportEvent": [
+                    "Event"
+                ],
+                "HidInputReportEventInit": [],
+                "HidReportInfo": [],
+                "HidReportItem": [],
+                "HidUnitSystem": [],
+                "HiddenPluginEventInit": [],
+                "History": [],
+                "HitRegionOptions": [],
+                "HkdfParams": [],
+                "HmacDerivedKeyParams": [],
+                "HmacImportParams": [],
+                "HmacKeyAlgorithm": [],
+                "HmacKeyGenParams": [],
+                "HtmlAllCollection": [],
+                "HtmlAnchorElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlAreaElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlAudioElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "HtmlMediaElement",
+                    "Node"
+                ],
+                "HtmlBaseElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlBodyElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlBrElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlButtonElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlCanvasElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlCollection": [],
+                "HtmlDListElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDataElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDataListElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDetailsElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDialogElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDirectoryElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDivElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlDocument": [
+                    "Document",
+                    "EventTarget",
+                    "Node"
+                ],
+                "HtmlElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node"
+                ],
+                "HtmlEmbedElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFieldSetElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFontElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFormControlsCollection": [
+                    "HtmlCollection"
+                ],
+                "HtmlFormElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFrameElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlFrameSetElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlHeadElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlHeadingElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlHrElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlHtmlElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlIFrameElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlImageElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlInputElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlLabelElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlLegendElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlLiElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlLinkElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMapElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMediaElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMenuElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMenuItemElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMetaElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlMeterElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlModElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlOListElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlObjectElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlOptGroupElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlOptionElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlOptionsCollection": [
+                    "HtmlCollection"
+                ],
+                "HtmlOutputElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlParagraphElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlParamElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlPictureElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlPreElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlProgressElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlQuoteElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlScriptElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlSelectElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlSlotElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlSourceElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlSpanElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlStyleElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableCaptionElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableCellElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableColElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableRowElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTableSectionElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTemplateElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTextAreaElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTimeElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTitleElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlTrackElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlUListElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlUnknownElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "Node"
+                ],
+                "HtmlVideoElement": [
+                    "Element",
+                    "EventTarget",
+                    "HtmlElement",
+                    "HtmlMediaElement",
+                    "Node"
+                ],
+                "HttpConnDict": [],
+                "HttpConnInfo": [],
+                "HttpConnectionElement": [],
+                "IdbCursor": [],
+                "IdbCursorDirection": [],
+                "IdbCursorWithValue": [
+                    "IdbCursor"
+                ],
+                "IdbDatabase": [
+                    "EventTarget"
+                ],
+                "IdbFactory": [],
+                "IdbFileHandle": [
+                    "EventTarget"
+                ],
+                "IdbFileMetadataParameters": [],
+                "IdbFileRequest": [
+                    "DomRequest",
+                    "EventTarget"
+                ],
+                "IdbIndex": [],
+                "IdbIndexParameters": [],
+                "IdbKeyRange": [],
+                "IdbLocaleAwareKeyRange": [
+                    "IdbKeyRange"
+                ],
+                "IdbMutableFile": [
+                    "EventTarget"
+                ],
+                "IdbObjectStore": [],
+                "IdbObjectStoreParameters": [],
+                "IdbOpenDbOptions": [],
+                "IdbOpenDbRequest": [
+                    "EventTarget",
+                    "IdbRequest"
+                ],
+                "IdbRequest": [
+                    "EventTarget"
+                ],
+                "IdbRequestReadyState": [],
+                "IdbTransaction": [
+                    "EventTarget"
+                ],
+                "IdbTransactionMode": [],
+                "IdbVersionChangeEvent": [
+                    "Event"
+                ],
+                "IdbVersionChangeEventInit": [],
+                "IdleDeadline": [],
+                "IdleRequestOptions": [],
+                "IirFilterNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "IirFilterOptions": [],
+                "ImageBitmap": [],
+                "ImageBitmapFormat": [],
+                "ImageBitmapRenderingContext": [],
+                "ImageCapture": [],
+                "ImageCaptureError": [],
+                "ImageCaptureErrorEvent": [
+                    "Event"
+                ],
+                "ImageCaptureErrorEventInit": [],
+                "ImageData": [],
+                "ImageDecodeOptions": [],
+                "ImageDecodeResult": [],
+                "ImageDecoder": [],
+                "ImageDecoderInit": [],
+                "ImageTrack": [
+                    "EventTarget"
+                ],
+                "ImageTrackList": [],
+                "InputEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "InputEventInit": [],
+                "InstallTriggerData": [],
+                "IntersectionObserver": [],
+                "IntersectionObserverEntry": [],
+                "IntersectionObserverEntryInit": [],
+                "IntersectionObserverInit": [],
+                "IntlUtils": [],
+                "IterableKeyAndValueResult": [],
+                "IterableKeyOrValueResult": [],
+                "IterationCompositeOperation": [],
+                "JsonWebKey": [],
+                "KeyAlgorithm": [],
+                "KeyEvent": [],
+                "KeyIdsInitData": [],
+                "KeyboardEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "KeyboardEventInit": [],
+                "KeyframeEffect": [
+                    "AnimationEffect"
+                ],
+                "KeyframeEffectOptions": [],
+                "L10nElement": [],
+                "L10nValue": [],
+                "LatencyMode": [],
+                "LifecycleCallbacks": [],
+                "LineAlignSetting": [],
+                "ListBoxObject": [],
+                "LocalMediaStream": [
+                    "EventTarget",
+                    "MediaStream"
+                ],
+                "LocaleInfo": [],
+                "Location": [],
+                "MediaCapabilities": [],
+                "MediaCapabilitiesInfo": [],
+                "MediaConfiguration": [],
+                "MediaDecodingConfiguration": [],
+                "MediaDecodingType": [],
+                "MediaDeviceInfo": [],
+                "MediaDeviceKind": [],
+                "MediaDevices": [
+                    "EventTarget"
+                ],
+                "MediaElementAudioSourceNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "MediaElementAudioSourceOptions": [],
+                "MediaEncodingConfiguration": [],
+                "MediaEncodingType": [],
+                "MediaEncryptedEvent": [
+                    "Event"
+                ],
+                "MediaError": [],
+                "MediaImage": [],
+                "MediaKeyError": [
+                    "Event"
+                ],
+                "MediaKeyMessageEvent": [
+                    "Event"
+                ],
+                "MediaKeyMessageEventInit": [],
+                "MediaKeyMessageType": [],
+                "MediaKeyNeededEventInit": [],
+                "MediaKeySession": [
+                    "EventTarget"
+                ],
+                "MediaKeySessionType": [],
+                "MediaKeyStatus": [],
+                "MediaKeyStatusMap": [],
+                "MediaKeySystemAccess": [],
+                "MediaKeySystemConfiguration": [],
+                "MediaKeySystemMediaCapability": [],
+                "MediaKeySystemStatus": [],
+                "MediaKeys": [],
+                "MediaKeysPolicy": [],
+                "MediaKeysRequirement": [],
+                "MediaList": [],
+                "MediaMetadata": [],
+                "MediaMetadataInit": [],
+                "MediaPositionState": [],
+                "MediaQueryList": [
+                    "EventTarget"
+                ],
+                "MediaQueryListEvent": [
+                    "Event"
+                ],
+                "MediaQueryListEventInit": [],
+                "MediaRecorder": [
+                    "EventTarget"
+                ],
+                "MediaRecorderErrorEvent": [
+                    "Event"
+                ],
+                "MediaRecorderErrorEventInit": [],
+                "MediaRecorderOptions": [],
+                "MediaSession": [],
+                "MediaSessionAction": [],
+                "MediaSessionActionDetails": [],
+                "MediaSessionPlaybackState": [],
+                "MediaSource": [
+                    "EventTarget"
+                ],
+                "MediaSourceEndOfStreamError": [],
+                "MediaSourceEnum": [],
+                "MediaSourceReadyState": [],
+                "MediaStream": [
+                    "EventTarget"
+                ],
+                "MediaStreamAudioDestinationNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "MediaStreamAudioSourceNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "MediaStreamAudioSourceOptions": [],
+                "MediaStreamConstraints": [],
+                "MediaStreamError": [],
+                "MediaStreamEvent": [
+                    "Event"
+                ],
+                "MediaStreamEventInit": [],
+                "MediaStreamTrack": [
+                    "EventTarget"
+                ],
+                "MediaStreamTrackEvent": [
+                    "Event"
+                ],
+                "MediaStreamTrackEventInit": [],
+                "MediaStreamTrackGenerator": [
+                    "EventTarget",
+                    "MediaStreamTrack"
+                ],
+                "MediaStreamTrackGeneratorInit": [],
+                "MediaStreamTrackProcessor": [],
+                "MediaStreamTrackProcessorInit": [],
+                "MediaStreamTrackState": [],
+                "MediaTrackConstraintSet": [],
+                "MediaTrackConstraints": [],
+                "MediaTrackSettings": [],
+                "MediaTrackSupportedConstraints": [],
+                "MessageChannel": [],
+                "MessageEvent": [
+                    "Event"
+                ],
+                "MessageEventInit": [],
+                "MessagePort": [
+                    "EventTarget"
+                ],
+                "MidiAccess": [
+                    "EventTarget"
+                ],
+                "MidiConnectionEvent": [
+                    "Event"
+                ],
+                "MidiConnectionEventInit": [],
+                "MidiInput": [
+                    "EventTarget",
+                    "MidiPort"
+                ],
+                "MidiInputMap": [],
+                "MidiMessageEvent": [
+                    "Event"
+                ],
+                "MidiMessageEventInit": [],
+                "MidiOptions": [],
+                "MidiOutput": [
+                    "EventTarget",
+                    "MidiPort"
+                ],
+                "MidiOutputMap": [],
+                "MidiPort": [
+                    "EventTarget"
+                ],
+                "MidiPortConnectionState": [],
+                "MidiPortDeviceState": [],
+                "MidiPortType": [],
+                "MimeType": [],
+                "MimeTypeArray": [],
+                "MouseEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "MouseEventInit": [],
+                "MouseScrollEvent": [
+                    "Event",
+                    "MouseEvent",
+                    "UiEvent"
+                ],
+                "MozDebug": [],
+                "MutationEvent": [
+                    "Event"
+                ],
+                "MutationObserver": [],
+                "MutationObserverInit": [],
+                "MutationObservingInfo": [],
+                "MutationRecord": [],
+                "NamedNodeMap": [],
+                "NativeOsFileReadOptions": [],
+                "NativeOsFileWriteAtomicOptions": [],
+                "NavigationType": [],
+                "Navigator": [],
+                "NavigatorAutomationInformation": [],
+                "NetworkCommandOptions": [],
+                "NetworkInformation": [
+                    "EventTarget"
+                ],
+                "NetworkResultOptions": [],
+                "Node": [
+                    "EventTarget"
+                ],
+                "NodeFilter": [],
+                "NodeIterator": [],
+                "NodeList": [],
+                "Notification": [
+                    "EventTarget"
+                ],
+                "NotificationBehavior": [],
+                "NotificationDirection": [],
+                "NotificationEvent": [
+                    "Event",
+                    "ExtendableEvent"
+                ],
+                "NotificationEventInit": [],
+                "NotificationOptions": [],
+                "NotificationPermission": [],
+                "ObserverCallback": [],
+                "OesElementIndexUint": [],
+                "OesStandardDerivatives": [],
+                "OesTextureFloat": [],
+                "OesTextureFloatLinear": [],
+                "OesTextureHalfFloat": [],
+                "OesTextureHalfFloatLinear": [],
+                "OesVertexArrayObject": [],
+                "OfflineAudioCompletionEvent": [
+                    "Event"
+                ],
+                "OfflineAudioCompletionEventInit": [],
+                "OfflineAudioContext": [
+                    "BaseAudioContext",
+                    "EventTarget"
+                ],
+                "OfflineAudioContextOptions": [],
+                "OfflineResourceList": [
+                    "EventTarget"
+                ],
+                "OffscreenCanvas": [
+                    "EventTarget"
+                ],
+                "OpenWindowEventDetail": [],
+                "OptionalEffectTiming": [],
+                "OrientationLockType": [],
+                "OrientationType": [],
+                "OscillatorNode": [
+                    "AudioNode",
+                    "AudioScheduledSourceNode",
+                    "EventTarget"
+                ],
+                "OscillatorOptions": [],
+                "OscillatorType": [],
+                "OverSampleType": [],
+                "OvrMultiview2": [],
+                "PageTransitionEvent": [
+                    "Event"
+                ],
+                "PageTransitionEventInit": [],
+                "PaintRequest": [],
+                "PaintRequestList": [],
+                "PaintWorkletGlobalScope": [
+                    "WorkletGlobalScope"
+                ],
+                "PannerNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "PannerOptions": [],
+                "PanningModelType": [],
+                "Path2d": [],
+                "PaymentAddress": [],
+                "PaymentComplete": [],
+                "PaymentMethodChangeEvent": [
+                    "Event",
+                    "PaymentRequestUpdateEvent"
+                ],
+                "PaymentMethodChangeEventInit": [],
+                "PaymentRequestUpdateEvent": [
+                    "Event"
+                ],
+                "PaymentRequestUpdateEventInit": [],
+                "PaymentResponse": [],
+                "Pbkdf2Params": [],
+                "PcImplIceConnectionState": [],
+                "PcImplIceGatheringState": [],
+                "PcImplSignalingState": [],
+                "PcObserverStateType": [],
+                "Performance": [
+                    "EventTarget"
+                ],
+                "PerformanceEntry": [],
+                "PerformanceEntryEventInit": [],
+                "PerformanceEntryFilterOptions": [],
+                "PerformanceMark": [
+                    "PerformanceEntry"
+                ],
+                "PerformanceMeasure": [
+                    "PerformanceEntry"
+                ],
+                "PerformanceNavigation": [],
+                "PerformanceNavigationTiming": [
+                    "PerformanceEntry",
+                    "PerformanceResourceTiming"
+                ],
+                "PerformanceObserver": [],
+                "PerformanceObserverEntryList": [],
+                "PerformanceObserverInit": [],
+                "PerformanceResourceTiming": [
+                    "PerformanceEntry"
+                ],
+                "PerformanceServerTiming": [],
+                "PerformanceTiming": [],
+                "PeriodicWave": [],
+                "PeriodicWaveConstraints": [],
+                "PeriodicWaveOptions": [],
+                "PermissionDescriptor": [],
+                "PermissionName": [],
+                "PermissionState": [],
+                "PermissionStatus": [
+                    "EventTarget"
+                ],
+                "Permissions": [],
+                "PlaneLayout": [],
+                "PlaybackDirection": [],
+                "Plugin": [],
+                "PluginArray": [],
+                "PluginCrashedEventInit": [],
+                "PointerEvent": [
+                    "Event",
+                    "MouseEvent",
+                    "UiEvent"
+                ],
+                "PointerEventInit": [],
+                "PopStateEvent": [
+                    "Event"
+                ],
+                "PopStateEventInit": [],
+                "PopupBlockedEvent": [
+                    "Event"
+                ],
+                "PopupBlockedEventInit": [],
+                "Position": [],
+                "PositionAlignSetting": [],
+                "PositionError": [],
+                "PositionOptions": [],
+                "Presentation": [],
+                "PresentationAvailability": [
+                    "EventTarget"
+                ],
+                "PresentationConnection": [
+                    "EventTarget"
+                ],
+                "PresentationConnectionAvailableEvent": [
+                    "Event"
+                ],
+                "PresentationConnectionAvailableEventInit": [],
+                "PresentationConnectionBinaryType": [],
+                "PresentationConnectionCloseEvent": [
+                    "Event"
+                ],
+                "PresentationConnectionCloseEventInit": [],
+                "PresentationConnectionClosedReason": [],
+                "PresentationConnectionList": [
+                    "EventTarget"
+                ],
+                "PresentationConnectionState": [],
+                "PresentationReceiver": [],
+                "PresentationRequest": [
+                    "EventTarget"
+                ],
+                "PresentationStyle": [],
+                "ProcessingInstruction": [
+                    "CharacterData",
+                    "EventTarget",
+                    "Node"
+                ],
+                "ProfileTimelineLayerRect": [],
+                "ProfileTimelineMarker": [],
+                "ProfileTimelineMessagePortOperationType": [],
+                "ProfileTimelineStackFrame": [],
+                "ProfileTimelineWorkerOperationType": [],
+                "ProgressEvent": [
+                    "Event"
+                ],
+                "ProgressEventInit": [],
+                "PromiseNativeHandler": [],
+                "PromiseRejectionEvent": [
+                    "Event"
+                ],
+                "PromiseRejectionEventInit": [],
+                "PublicKeyCredential": [
+                    "Credential"
+                ],
+                "PublicKeyCredentialCreationOptions": [],
+                "PublicKeyCredentialDescriptor": [],
+                "PublicKeyCredentialEntity": [],
+                "PublicKeyCredentialParameters": [],
+                "PublicKeyCredentialRequestOptions": [],
+                "PublicKeyCredentialRpEntity": [],
+                "PublicKeyCredentialType": [],
+                "PublicKeyCredentialUserEntity": [],
+                "PushEncryptionKeyName": [],
+                "PushEvent": [
+                    "Event",
+                    "ExtendableEvent"
+                ],
+                "PushEventInit": [],
+                "PushManager": [],
+                "PushMessageData": [],
+                "PushPermissionState": [],
+                "PushSubscription": [],
+                "PushSubscriptionInit": [],
+                "PushSubscriptionJson": [],
+                "PushSubscriptionKeys": [],
+                "PushSubscriptionOptions": [],
+                "PushSubscriptionOptionsInit": [],
+                "QueuingStrategy": [],
+                "QueuingStrategyInit": [],
+                "RadioNodeList": [
+                    "NodeList"
+                ],
+                "Range": [],
+                "RcwnPerfStats": [],
+                "RcwnStatus": [],
+                "ReadableByteStreamController": [],
+                "ReadableStream": [],
+                "ReadableStreamByobReader": [],
+                "ReadableStreamByobRequest": [],
+                "ReadableStreamDefaultController": [],
+                "ReadableStreamDefaultReader": [],
+                "ReadableStreamGetReaderOptions": [],
+                "ReadableStreamIteratorOptions": [],
+                "ReadableStreamReadResult": [],
+                "ReadableStreamReaderMode": [],
+                "ReadableStreamType": [],
+                "ReadableWritablePair": [],
+                "RecordingState": [],
+                "ReferrerPolicy": [],
+                "RegisterRequest": [],
+                "RegisterResponse": [],
+                "RegisteredKey": [],
+                "RegistrationOptions": [],
+                "Request": [],
+                "RequestCache": [],
+                "RequestCredentials": [],
+                "RequestDestination": [],
+                "RequestDeviceOptions": [],
+                "RequestInit": [],
+                "RequestMediaKeySystemAccessNotification": [],
+                "RequestMode": [],
+                "RequestRedirect": [],
+                "ResizeObserver": [],
+                "ResizeObserverBoxOptions": [],
+                "ResizeObserverEntry": [],
+                "ResizeObserverOptions": [],
+                "ResizeObserverSize": [],
+                "Response": [],
+                "ResponseInit": [],
+                "ResponseType": [],
+                "RsaHashedImportParams": [],
+                "RsaOaepParams": [],
+                "RsaOtherPrimesInfo": [],
+                "RsaPssParams": [],
+                "RtcAnswerOptions": [],
+                "RtcBundlePolicy": [],
+                "RtcCertificate": [],
+                "RtcCertificateExpiration": [],
+                "RtcCodecStats": [],
+                "RtcConfiguration": [],
+                "RtcDataChannel": [
+                    "EventTarget"
+                ],
+                "RtcDataChannelEvent": [
+                    "Event"
+                ],
+                "RtcDataChannelEventInit": [],
+                "RtcDataChannelInit": [],
+                "RtcDataChannelState": [],
+                "RtcDataChannelType": [],
+                "RtcDegradationPreference": [],
+                "RtcFecParameters": [],
+                "RtcIceCandidate": [],
+                "RtcIceCandidateInit": [],
+                "RtcIceCandidatePairStats": [],
+                "RtcIceCandidateStats": [],
+                "RtcIceComponentStats": [],
+                "RtcIceConnectionState": [],
+                "RtcIceCredentialType": [],
+                "RtcIceGatheringState": [],
+                "RtcIceServer": [],
+                "RtcIceTransportPolicy": [],
+                "RtcIdentityAssertion": [],
+                "RtcIdentityAssertionResult": [],
+                "RtcIdentityProvider": [],
+                "RtcIdentityProviderDetails": [],
+                "RtcIdentityProviderOptions": [],
+                "RtcIdentityProviderRegistrar": [],
+                "RtcIdentityValidationResult": [],
+                "RtcInboundRtpStreamStats": [],
+                "RtcLifecycleEvent": [],
+                "RtcMediaStreamStats": [],
+                "RtcMediaStreamTrackStats": [],
+                "RtcOfferAnswerOptions": [],
+                "RtcOfferOptions": [],
+                "RtcOutboundRtpStreamStats": [],
+                "RtcPeerConnection": [
+                    "EventTarget"
+                ],
+                "RtcPeerConnectionIceEvent": [
+                    "Event"
+                ],
+                "RtcPeerConnectionIceEventInit": [],
+                "RtcPriorityType": [],
+                "RtcRtcpParameters": [],
+                "RtcRtpCodecParameters": [],
+                "RtcRtpContributingSource": [],
+                "RtcRtpEncodingParameters": [],
+                "RtcRtpHeaderExtensionParameters": [],
+                "RtcRtpParameters": [],
+                "RtcRtpReceiver": [],
+                "RtcRtpSender": [],
+                "RtcRtpSourceEntry": [],
+                "RtcRtpSourceEntryType": [],
+                "RtcRtpSynchronizationSource": [],
+                "RtcRtpTransceiver": [],
+                "RtcRtpTransceiverDirection": [],
+                "RtcRtpTransceiverInit": [],
+                "RtcRtxParameters": [],
+                "RtcSdpType": [],
+                "RtcSessionDescription": [],
+                "RtcSessionDescriptionInit": [],
+                "RtcSignalingState": [],
+                "RtcStats": [],
+                "RtcStatsIceCandidatePairState": [],
+                "RtcStatsIceCandidateType": [],
+                "RtcStatsReport": [],
+                "RtcStatsReportInternal": [],
+                "RtcStatsType": [],
+                "RtcTrackEvent": [
+                    "Event"
+                ],
+                "RtcTrackEventInit": [],
+                "RtcTransportStats": [],
+                "RtcdtmfSender": [
+                    "EventTarget"
+                ],
+                "RtcdtmfToneChangeEvent": [
+                    "Event"
+                ],
+                "RtcdtmfToneChangeEventInit": [],
+                "RtcrtpContributingSourceStats": [],
+                "RtcrtpStreamStats": [],
+                "Screen": [
+                    "EventTarget"
+                ],
+                "ScreenColorGamut": [],
+                "ScreenLuminance": [],
+                "ScreenOrientation": [
+                    "EventTarget"
+                ],
+                "ScriptProcessorNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "ScrollAreaEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "ScrollBehavior": [],
+                "ScrollBoxObject": [],
+                "ScrollIntoViewOptions": [],
+                "ScrollLogicalPosition": [],
+                "ScrollOptions": [],
+                "ScrollRestoration": [],
+                "ScrollSetting": [],
+                "ScrollState": [],
+                "ScrollToOptions": [],
+                "ScrollViewChangeEventInit": [],
+                "SecurityPolicyViolationEvent": [
+                    "Event"
+                ],
+                "SecurityPolicyViolationEventDisposition": [],
+                "SecurityPolicyViolationEventInit": [],
+                "Selection": [],
+                "ServerSocketOptions": [],
+                "ServiceWorker": [
+                    "EventTarget"
+                ],
+                "ServiceWorkerContainer": [
+                    "EventTarget"
+                ],
+                "ServiceWorkerGlobalScope": [
+                    "EventTarget",
+                    "WorkerGlobalScope"
+                ],
+                "ServiceWorkerRegistration": [
+                    "EventTarget"
+                ],
+                "ServiceWorkerState": [],
+                "ServiceWorkerUpdateViaCache": [],
+                "ShadowRoot": [
+                    "DocumentFragment",
+                    "EventTarget",
+                    "Node"
+                ],
+                "ShadowRootInit": [],
+                "ShadowRootMode": [],
+                "ShareData": [],
+                "SharedWorker": [
+                    "EventTarget"
+                ],
+                "SharedWorkerGlobalScope": [
+                    "EventTarget",
+                    "WorkerGlobalScope"
+                ],
+                "SignResponse": [],
+                "SocketElement": [],
+                "SocketOptions": [],
+                "SocketReadyState": [],
+                "SocketsDict": [],
+                "SourceBuffer": [
+                    "EventTarget"
+                ],
+                "SourceBufferAppendMode": [],
+                "SourceBufferList": [
+                    "EventTarget"
+                ],
+                "SpeechGrammar": [],
+                "SpeechGrammarList": [],
+                "SpeechRecognition": [
+                    "EventTarget"
+                ],
+                "SpeechRecognitionAlternative": [],
+                "SpeechRecognitionError": [
+                    "Event"
+                ],
+                "SpeechRecognitionErrorCode": [],
+                "SpeechRecognitionErrorInit": [],
+                "SpeechRecognitionEvent": [
+                    "Event"
+                ],
+                "SpeechRecognitionEventInit": [],
+                "SpeechRecognitionResult": [],
+                "SpeechRecognitionResultList": [],
+                "SpeechSynthesis": [
+                    "EventTarget"
+                ],
+                "SpeechSynthesisErrorCode": [],
+                "SpeechSynthesisErrorEvent": [
+                    "Event",
+                    "SpeechSynthesisEvent"
+                ],
+                "SpeechSynthesisErrorEventInit": [],
+                "SpeechSynthesisEvent": [
+                    "Event"
+                ],
+                "SpeechSynthesisEventInit": [],
+                "SpeechSynthesisUtterance": [
+                    "EventTarget"
+                ],
+                "SpeechSynthesisVoice": [],
+                "StereoPannerNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "StereoPannerOptions": [],
+                "Storage": [],
+                "StorageEstimate": [],
+                "StorageEvent": [
+                    "Event"
+                ],
+                "StorageEventInit": [],
+                "StorageManager": [],
+                "StorageType": [],
+                "StreamPipeOptions": [],
+                "StyleRuleChangeEventInit": [],
+                "StyleSheet": [],
+                "StyleSheetApplicableStateChangeEventInit": [],
+                "StyleSheetChangeEventInit": [],
+                "StyleSheetList": [],
+                "SubmitEvent": [
+                    "Event"
+                ],
+                "SubmitEventInit": [],
+                "SubtleCrypto": [],
+                "SupportedType": [],
+                "SvcOutputMetadata": [],
+                "SvgAngle": [],
+                "SvgAnimateElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgAnimationElement",
+                    "SvgElement"
+                ],
+                "SvgAnimateMotionElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgAnimationElement",
+                    "SvgElement"
+                ],
+                "SvgAnimateTransformElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgAnimationElement",
+                    "SvgElement"
+                ],
+                "SvgAnimatedAngle": [],
+                "SvgAnimatedBoolean": [],
+                "SvgAnimatedEnumeration": [],
+                "SvgAnimatedInteger": [],
+                "SvgAnimatedLength": [],
+                "SvgAnimatedLengthList": [],
+                "SvgAnimatedNumber": [],
+                "SvgAnimatedNumberList": [],
+                "SvgAnimatedPreserveAspectRatio": [],
+                "SvgAnimatedRect": [],
+                "SvgAnimatedString": [],
+                "SvgAnimatedTransformList": [],
+                "SvgAnimationElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgBoundingBoxOptions": [],
+                "SvgCircleElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgClipPathElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgComponentTransferFunctionElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgDefsElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgDescElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node"
+                ],
+                "SvgEllipseElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgFilterElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgForeignObjectElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgGeometryElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgGradientElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgGraphicsElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgImageElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgLength": [],
+                "SvgLengthList": [],
+                "SvgLineElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgLinearGradientElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGradientElement"
+                ],
+                "SvgMarkerElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgMaskElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgMatrix": [],
+                "SvgMetadataElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgNumber": [],
+                "SvgNumberList": [],
+                "SvgPathElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgPathSeg": [],
+                "SvgPathSegArcAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegArcRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegClosePath": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoCubicAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoCubicRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoCubicSmoothAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoCubicSmoothRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoQuadraticAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoQuadraticRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoQuadraticSmoothAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegCurvetoQuadraticSmoothRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoHorizontalAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoHorizontalRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoVerticalAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegLinetoVerticalRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegList": [],
+                "SvgPathSegMovetoAbs": [
+                    "SvgPathSeg"
+                ],
+                "SvgPathSegMovetoRel": [
+                    "SvgPathSeg"
+                ],
+                "SvgPatternElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgPoint": [],
+                "SvgPointList": [],
+                "SvgPolygonElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgPolylineElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgPreserveAspectRatio": [],
+                "SvgRadialGradientElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGradientElement"
+                ],
+                "SvgRect": [],
+                "SvgRectElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGeometryElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgScriptElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgSetElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgAnimationElement",
+                    "SvgElement"
+                ],
+                "SvgStopElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgStringList": [],
+                "SvgStyleElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgSwitchElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgSymbolElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgTextContentElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgTextElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement",
+                    "SvgTextContentElement",
+                    "SvgTextPositioningElement"
+                ],
+                "SvgTextPathElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement",
+                    "SvgTextContentElement"
+                ],
+                "SvgTextPositioningElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement",
+                    "SvgTextContentElement"
+                ],
+                "SvgTitleElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgTransform": [],
+                "SvgTransformList": [],
+                "SvgUnitTypes": [],
+                "SvgUseElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgViewElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgZoomAndPan": [],
+                "SvgaElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgfeBlendElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeColorMatrixElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeComponentTransferElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeCompositeElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeConvolveMatrixElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeDiffuseLightingElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeDisplacementMapElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeDistantLightElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeDropShadowElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeFloodElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeFuncAElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgComponentTransferFunctionElement",
+                    "SvgElement"
+                ],
+                "SvgfeFuncBElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgComponentTransferFunctionElement",
+                    "SvgElement"
+                ],
+                "SvgfeFuncGElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgComponentTransferFunctionElement",
+                    "SvgElement"
+                ],
+                "SvgfeFuncRElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgComponentTransferFunctionElement",
+                    "SvgElement"
+                ],
+                "SvgfeGaussianBlurElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeImageElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeMergeElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeMergeNodeElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeMorphologyElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeOffsetElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfePointLightElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeSpecularLightingElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeSpotLightElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeTileElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgfeTurbulenceElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvggElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgmPathElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement"
+                ],
+                "SvgsvgElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement"
+                ],
+                "SvgtSpanElement": [
+                    "Element",
+                    "EventTarget",
+                    "Node",
+                    "SvgElement",
+                    "SvgGraphicsElement",
+                    "SvgTextContentElement",
+                    "SvgTextPositioningElement"
+                ],
+                "TcpReadyState": [],
+                "TcpServerSocket": [
+                    "EventTarget"
+                ],
+                "TcpServerSocketEvent": [
+                    "Event"
+                ],
+                "TcpServerSocketEventInit": [],
+                "TcpSocket": [
+                    "EventTarget"
+                ],
+                "TcpSocketBinaryType": [],
+                "TcpSocketErrorEvent": [
+                    "Event"
+                ],
+                "TcpSocketErrorEventInit": [],
+                "TcpSocketEvent": [
+                    "Event"
+                ],
+                "TcpSocketEventInit": [],
+                "Text": [
+                    "CharacterData",
+                    "EventTarget",
+                    "Node"
+                ],
+                "TextDecodeOptions": [],
+                "TextDecoder": [],
+                "TextDecoderOptions": [],
+                "TextEncoder": [],
+                "TextMetrics": [],
+                "TextTrack": [
+                    "EventTarget"
+                ],
+                "TextTrackCue": [
+                    "EventTarget"
+                ],
+                "TextTrackCueList": [],
+                "TextTrackKind": [],
+                "TextTrackList": [
+                    "EventTarget"
+                ],
+                "TextTrackMode": [],
+                "TimeEvent": [
+                    "Event"
+                ],
+                "TimeRanges": [],
+                "Touch": [],
+                "TouchEvent": [
+                    "Event",
+                    "UiEvent"
+                ],
+                "TouchEventInit": [],
+                "TouchInit": [],
+                "TouchList": [],
+                "TrackEvent": [
+                    "Event"
+                ],
+                "TrackEventInit": [],
+                "TransformStream": [],
+                "TransformStreamDefaultController": [],
+                "Transformer": [],
+                "TransitionEvent": [
+                    "Event"
+                ],
+                "TransitionEventInit": [],
+                "Transport": [],
+                "TreeBoxObject": [],
+                "TreeCellInfo": [],
+                "TreeView": [],
+                "TreeWalker": [],
+                "U2f": [],
+                "U2fClientData": [],
+                "UdpMessageEventInit": [],
+                "UdpOptions": [],
+                "UiEvent": [
+                    "Event"
+                ],
+                "UiEventInit": [],
+                "UnderlyingSink": [],
+                "UnderlyingSource": [],
+                "Url": [],
+                "UrlSearchParams": [],
+                "Usb": [
+                    "EventTarget"
+                ],
+                "UsbAlternateInterface": [],
+                "UsbConfiguration": [],
+                "UsbConnectionEvent": [
+                    "Event"
+                ],
+                "UsbConnectionEventInit": [],
+                "UsbControlTransferParameters": [],
+                "UsbDevice": [],
+                "UsbDeviceFilter": [],
+                "UsbDeviceRequestOptions": [],
+                "UsbDirection": [],
+                "UsbEndpoint": [],
+                "UsbEndpointType": [],
+                "UsbInTransferResult": [],
+                "UsbInterface": [],
+                "UsbIsochronousInTransferPacket": [],
+                "UsbIsochronousInTransferResult": [],
+                "UsbIsochronousOutTransferPacket": [],
+                "UsbIsochronousOutTransferResult": [],
+                "UsbOutTransferResult": [],
+                "UsbPermissionDescriptor": [],
+                "UsbPermissionResult": [
+                    "EventTarget",
+                    "PermissionStatus"
+                ],
+                "UsbPermissionStorage": [],
+                "UsbRecipient": [],
+                "UsbRequestType": [],
+                "UsbTransferStatus": [],
+                "UserProximityEvent": [
+                    "Event"
+                ],
+                "UserProximityEventInit": [],
+                "UserVerificationRequirement": [],
+                "ValidityState": [],
+                "ValueEvent": [
+                    "Event"
+                ],
+                "ValueEventInit": [],
+                "VideoColorPrimaries": [],
+                "VideoColorSpace": [],
+                "VideoColorSpaceInit": [],
+                "VideoConfiguration": [],
+                "VideoDecoder": [],
+                "VideoDecoderConfig": [],
+                "VideoDecoderInit": [],
+                "VideoDecoderSupport": [],
+                "VideoEncoder": [],
+                "VideoEncoderConfig": [],
+                "VideoEncoderEncodeOptions": [],
+                "VideoEncoderInit": [],
+                "VideoEncoderSupport": [],
+                "VideoFacingModeEnum": [],
+                "VideoFrame": [],
+                "VideoFrameBufferInit": [],
+                "VideoFrameCopyToOptions": [],
+                "VideoFrameInit": [],
+                "VideoMatrixCoefficients": [],
+                "VideoPixelFormat": [],
+                "VideoPlaybackQuality": [],
+                "VideoStreamTrack": [
+                    "EventTarget",
+                    "MediaStreamTrack"
+                ],
+                "VideoTrack": [],
+                "VideoTrackList": [
+                    "EventTarget"
+                ],
+                "VideoTransferCharacteristics": [],
+                "VisibilityState": [],
+                "VoidCallback": [],
+                "VrDisplay": [
+                    "EventTarget"
+                ],
+                "VrDisplayCapabilities": [],
+                "VrEye": [],
+                "VrEyeParameters": [],
+                "VrFieldOfView": [],
+                "VrFrameData": [],
+                "VrLayer": [],
+                "VrMockController": [],
+                "VrMockDisplay": [],
+                "VrPose": [],
+                "VrServiceTest": [],
+                "VrStageParameters": [],
+                "VrSubmitFrameResult": [],
+                "VttCue": [
+                    "EventTarget",
+                    "TextTrackCue"
+                ],
+                "VttRegion": [],
+                "WakeLock": [],
+                "WakeLockSentinel": [
+                    "EventTarget"
+                ],
+                "WakeLockType": [],
+                "WatchAdvertisementsOptions": [],
+                "WaveShaperNode": [
+                    "AudioNode",
+                    "EventTarget"
+                ],
+                "WaveShaperOptions": [],
+                "WebGl2RenderingContext": [],
+                "WebGlActiveInfo": [],
+                "WebGlBuffer": [],
+                "WebGlContextAttributes": [],
+                "WebGlContextEvent": [
+                    "Event"
+                ],
+                "WebGlContextEventInit": [],
+                "WebGlFramebuffer": [],
+                "WebGlPowerPreference": [],
+                "WebGlProgram": [],
+                "WebGlQuery": [],
+                "WebGlRenderbuffer": [],
+                "WebGlRenderingContext": [],
+                "WebGlSampler": [],
+                "WebGlShader": [],
+                "WebGlShaderPrecisionFormat": [],
+                "WebGlSync": [],
+                "WebGlTexture": [],
+                "WebGlTransformFeedback": [],
+                "WebGlUniformLocation": [],
+                "WebGlVertexArrayObject": [],
+                "WebKitCssMatrix": [
+                    "DomMatrix",
+                    "DomMatrixReadOnly"
+                ],
+                "WebSocket": [
+                    "EventTarget"
+                ],
+                "WebSocketDict": [],
+                "WebSocketElement": [],
+                "WebglColorBufferFloat": [],
+                "WebglCompressedTextureAstc": [],
+                "WebglCompressedTextureAtc": [],
+                "WebglCompressedTextureEtc": [],
+                "WebglCompressedTextureEtc1": [],
+                "WebglCompressedTexturePvrtc": [],
+                "WebglCompressedTextureS3tc": [],
+                "WebglCompressedTextureS3tcSrgb": [],
+                "WebglDebugRendererInfo": [],
+                "WebglDebugShaders": [],
+                "WebglDepthTexture": [],
+                "WebglDrawBuffers": [],
+                "WebglLoseContext": [],
+                "WebglMultiDraw": [],
+                "WebrtcGlobalStatisticsReport": [],
+                "WheelEvent": [
+                    "Event",
+                    "MouseEvent",
+                    "UiEvent"
+                ],
+                "WheelEventInit": [],
+                "WidevineCdmManifest": [],
+                "Window": [
+                    "EventTarget"
+                ],
+                "WindowClient": [
+                    "Client"
+                ],
+                "Worker": [
+                    "EventTarget"
+                ],
+                "WorkerDebuggerGlobalScope": [
+                    "EventTarget"
+                ],
+                "WorkerGlobalScope": [
+                    "EventTarget"
+                ],
+                "WorkerLocation": [],
+                "WorkerNavigator": [],
+                "WorkerOptions": [],
+                "WorkerType": [],
+                "Worklet": [],
+                "WorkletGlobalScope": [],
+                "WorkletOptions": [],
+                "WritableStream": [],
+                "WritableStreamDefaultController": [],
+                "WritableStreamDefaultWriter": [],
+                "XPathExpression": [],
+                "XPathNsResolver": [],
+                "XPathResult": [],
+                "XmlDocument": [
+                    "Document",
+                    "EventTarget",
+                    "Node"
+                ],
+                "XmlHttpRequest": [
+                    "EventTarget",
+                    "XmlHttpRequestEventTarget"
+                ],
+                "XmlHttpRequestEventTarget": [
+                    "EventTarget"
+                ],
+                "XmlHttpRequestResponseType": [],
+                "XmlHttpRequestUpload": [
+                    "EventTarget",
+                    "XmlHttpRequestEventTarget"
+                ],
+                "XmlSerializer": [],
+                "XrBoundedReferenceSpace": [
+                    "EventTarget",
+                    "XrReferenceSpace",
+                    "XrSpace"
+                ],
+                "XrEye": [],
+                "XrFrame": [],
+                "XrHandedness": [],
+                "XrInputSource": [],
+                "XrInputSourceArray": [],
+                "XrInputSourceEvent": [
+                    "Event"
+                ],
+                "XrInputSourceEventInit": [],
+                "XrInputSourcesChangeEvent": [
+                    "Event"
+                ],
+                "XrInputSourcesChangeEventInit": [],
+                "XrLayer": [
+                    "EventTarget"
+                ],
+                "XrPermissionDescriptor": [],
+                "XrPermissionStatus": [
+                    "EventTarget",
+                    "PermissionStatus"
+                ],
+                "XrPose": [],
+                "XrReferenceSpace": [
+                    "EventTarget",
+                    "XrSpace"
+                ],
+                "XrReferenceSpaceEvent": [
+                    "Event"
+                ],
+                "XrReferenceSpaceEventInit": [],
+                "XrReferenceSpaceType": [],
+                "XrRenderState": [],
+                "XrRenderStateInit": [],
+                "XrRigidTransform": [],
+                "XrSession": [
+                    "EventTarget"
+                ],
+                "XrSessionEvent": [
+                    "Event"
+                ],
+                "XrSessionEventInit": [],
+                "XrSessionInit": [],
+                "XrSessionMode": [],
+                "XrSessionSupportedPermissionDescriptor": [],
+                "XrSpace": [
+                    "EventTarget"
+                ],
+                "XrSystem": [
+                    "EventTarget"
+                ],
+                "XrTargetRayMode": [],
+                "XrView": [],
+                "XrViewerPose": [
+                    "XrPose"
+                ],
+                "XrViewport": [],
+                "XrVisibilityState": [],
+                "XrWebGlLayer": [
+                    "EventTarget",
+                    "XrLayer"
+                ],
+                "XrWebGlLayerInit": [],
+                "XsltProcessor": [],
+                "console": [],
+                "css": [],
+                "gpu_buffer_usage": [],
+                "gpu_color_write": [],
+                "gpu_map_mode": [],
+                "gpu_shader_stage": [],
+                "gpu_texture_usage": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/web-sys-0.3.60/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg=web_sys_unstable_apis"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "The wasm-bindgen Developers"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "./README.md",
+            "repository": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys",
+            "homepage": "https://rustwasm.github.io/wasm-bindgen/web-sys/index.html",
+            "documentation": "https://rustwasm.github.io/wasm-bindgen/api/web_sys/",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wgpu",
+            "version": "0.14.0",
+            "id": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Rusty WebGPU API wrapper",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arrayvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "clone"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.11, <0.13",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "raw-window-handle",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "static_assertions",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgt",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bytemuck",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ddsfile",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "futures-intrusive",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "glam",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.21.3",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "wgsl-in"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "nanorand",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [
+                        "wyrand"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "noise",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "obj",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "png",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.17",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winit",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.27.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(not(target_arch = \"wasm32\"), target_os = \"emscripten\"))",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgc",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "raw-window-handle"
+                    ],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "async-executor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "pollster",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "wgsl-out"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.11, <0.13",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.83",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen-futures",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.33",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Document",
+                        "Navigator",
+                        "Node",
+                        "NodeList",
+                        "Gpu",
+                        "GpuAdapter",
+                        "GpuAddressMode",
+                        "GpuAutoLayoutMode",
+                        "GpuBindGroup",
+                        "GpuBindGroupDescriptor",
+                        "GpuBindGroupEntry",
+                        "GpuBindGroupLayout",
+                        "GpuBindGroupLayoutDescriptor",
+                        "GpuBindGroupLayoutEntry",
+                        "GpuBlendComponent",
+                        "GpuBlendFactor",
+                        "GpuBlendOperation",
+                        "GpuBlendState",
+                        "GpuBuffer",
+                        "GpuBufferBinding",
+                        "GpuBufferBindingLayout",
+                        "GpuBufferBindingType",
+                        "GpuBufferDescriptor",
+                        "GpuCanvasAlphaMode",
+                        "GpuCanvasContext",
+                        "GpuCanvasConfiguration",
+                        "GpuColorDict",
+                        "GpuColorTargetState",
+                        "GpuCommandBuffer",
+                        "GpuCommandBufferDescriptor",
+                        "GpuCommandEncoder",
+                        "GpuCommandEncoderDescriptor",
+                        "GpuCompareFunction",
+                        "GpuCompilationInfo",
+                        "GpuCompilationMessage",
+                        "GpuCompilationMessageType",
+                        "GpuComputePassDescriptor",
+                        "GpuComputePassEncoder",
+                        "GpuComputePipeline",
+                        "GpuComputePipelineDescriptor",
+                        "GpuCullMode",
+                        "GpuDepthStencilState",
+                        "GpuDevice",
+                        "GpuDeviceDescriptor",
+                        "GpuDeviceLostInfo",
+                        "GpuDeviceLostReason",
+                        "GpuError",
+                        "GpuErrorFilter",
+                        "GpuExtent3dDict",
+                        "GpuFeatureName",
+                        "GpuFilterMode",
+                        "GpuFragmentState",
+                        "GpuFrontFace",
+                        "GpuImageCopyBuffer",
+                        "GpuImageCopyExternalImage",
+                        "GpuImageCopyTexture",
+                        "GpuImageCopyTextureTagged",
+                        "GpuImageDataLayout",
+                        "GpuIndexFormat",
+                        "GpuLoadOp",
+                        "gpu_map_mode",
+                        "GpuMipmapFilterMode",
+                        "GpuMultisampleState",
+                        "GpuObjectDescriptorBase",
+                        "GpuOrigin2dDict",
+                        "GpuOrigin3dDict",
+                        "GpuOutOfMemoryError",
+                        "GpuPipelineDescriptorBase",
+                        "GpuPipelineLayout",
+                        "GpuPipelineLayoutDescriptor",
+                        "GpuPowerPreference",
+                        "GpuPrimitiveState",
+                        "GpuPrimitiveTopology",
+                        "GpuProgrammableStage",
+                        "GpuQuerySet",
+                        "GpuQuerySetDescriptor",
+                        "GpuQueryType",
+                        "GpuQueue",
+                        "GpuRenderBundle",
+                        "GpuRenderBundleDescriptor",
+                        "GpuRenderBundleEncoder",
+                        "GpuRenderBundleEncoderDescriptor",
+                        "GpuRenderPassColorAttachment",
+                        "GpuRenderPassDepthStencilAttachment",
+                        "GpuRenderPassDescriptor",
+                        "GpuRenderPassEncoder",
+                        "GpuRenderPipeline",
+                        "GpuRenderPipelineDescriptor",
+                        "GpuRequestAdapterOptions",
+                        "GpuSampler",
+                        "GpuSamplerBindingLayout",
+                        "GpuSamplerBindingType",
+                        "GpuSamplerDescriptor",
+                        "GpuShaderModule",
+                        "GpuShaderModuleDescriptor",
+                        "GpuStencilFaceState",
+                        "GpuStencilOperation",
+                        "GpuStorageTextureAccess",
+                        "GpuStorageTextureBindingLayout",
+                        "GpuStoreOp",
+                        "GpuSupportedFeatures",
+                        "GpuSupportedLimits",
+                        "GpuTexture",
+                        "GpuTextureAspect",
+                        "GpuTextureBindingLayout",
+                        "GpuTextureDescriptor",
+                        "GpuTextureDimension",
+                        "GpuTextureFormat",
+                        "GpuTextureSampleType",
+                        "GpuTextureView",
+                        "GpuTextureViewDescriptor",
+                        "GpuTextureViewDimension",
+                        "GpuUncapturedErrorEvent",
+                        "GpuUncapturedErrorEventInit",
+                        "GpuValidationError",
+                        "GpuVertexAttribute",
+                        "GpuVertexBufferLayout",
+                        "GpuVertexFormat",
+                        "GpuVertexState",
+                        "GpuVertexStepMode",
+                        "HtmlCanvasElement",
+                        "OffscreenCanvas",
+                        "ImageBitmap",
+                        "ImageBitmapRenderingContext",
+                        "Window"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-core",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgc",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "raw-window-handle"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "console_error_panic_hook",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.7",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "console_log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3.60",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Location",
+                        "Blob",
+                        "RequestInit",
+                        "RequestMode",
+                        "Request",
+                        "Response"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wgpu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "boids",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/boids/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "bunnymark",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/bunnymark/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "conservative-raster",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/conservative-raster/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "cube",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/cube/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hello-compute",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/hello-compute/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "mipmap",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/mipmap/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "msaa-line",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/msaa-line/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "shadow",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/shadow/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "skybox",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/skybox/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "texture-arrays",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/texture-arrays/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "water",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/water/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "framework",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/framework.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "capture",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/capture/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hello-windows",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/hello-windows/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hello",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/hello/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "hello-triangle",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/examples/hello-triangle/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "test"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "wgpu-tests",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/tests/root.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": true
+                }
+            ],
+            "features": {
+                "angle": [
+                    "wgc/angle"
+                ],
+                "default": [],
+                "emscripten": [
+                    "webgl"
+                ],
+                "glsl": [
+                    "naga/glsl-in"
+                ],
+                "naga": [
+                    "dep:naga"
+                ],
+                "replay": [
+                    "serde",
+                    "wgc/replay"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "spirv": [
+                    "naga/spv-in"
+                ],
+                "trace": [
+                    "serde",
+                    "wgc/trace"
+                ],
+                "vulkan-portability": [
+                    "wgc/vulkan-portability"
+                ],
+                "webgl": [
+                    "wgc"
+                ],
+                "wgc": [
+                    "dep:wgc"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "docsrs"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "wgpu developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "graphics"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/wgpu/tree/v0.13",
+            "homepage": "https://wgpu.rs/",
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wgpu-core",
+            "version": "0.14.0",
+            "id": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "WebGPU core logic on wgpu-hal",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arrayvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bit-vec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "codespan-reporting",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "clone",
+                        "span",
+                        "validate",
+                        "wgsl-in"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.11, <0.13",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "profiling",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "raw-window-handle",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ron",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.8",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "serde_derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thiserror",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgt",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "cfg_aliases",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": "build",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "metal"
+                    ],
+                    "target": "cfg(all(not(target_arch = \"wasm32\"), any(target_os = \"ios\", target_os = \"macos\")))",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "vulkan",
+                        "gles",
+                        "renderdoc"
+                    ],
+                    "target": "cfg(all(not(target_arch = \"wasm32\"), unix, not(target_os = \"ios\"), not(target_os = \"macos\")))",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "vulkan",
+                        "dx12",
+                        "dx11",
+                        "renderdoc"
+                    ],
+                    "target": "cfg(all(not(target_arch = \"wasm32\"), windows))",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "HtmlCanvasElement",
+                        "OffscreenCanvas"
+                    ],
+                    "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "gles"
+                    ],
+                    "target": "cfg(target_arch = \"wasm32\")",
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-hal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "hal",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "emscripten"
+                    ],
+                    "target": "cfg(target_os = \"emscripten\")",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wgpu-core",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-core-0.14.0/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-core-0.14.0/build.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "angle": [
+                    "hal/gles"
+                ],
+                "default": [],
+                "id32": [],
+                "raw-window-handle": [
+                    "dep:raw-window-handle"
+                ],
+                "replay": [
+                    "serde",
+                    "wgt/replay",
+                    "arrayvec/serde",
+                    "naga/deserialize"
+                ],
+                "ron": [
+                    "dep:ron"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "serial-pass": [
+                    "serde",
+                    "wgt/serde",
+                    "arrayvec/serde"
+                ],
+                "strict_asserts": [],
+                "trace": [
+                    "ron",
+                    "serde",
+                    "wgt/trace",
+                    "arrayvec/serde",
+                    "naga/serialize"
+                ],
+                "vulkan-portability": [
+                    "hal/vulkan"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-core-0.14.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "wgpu developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "graphics"
+            ],
+            "readme": null,
+            "repository": "https://github.com/gfx-rs/wgpu",
+            "homepage": "https://github.com/gfx-rs/wgpu",
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "wgpu-hal",
+            "version": "0.14.1",
+            "id": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "WebGPU hardware abstraction layer",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "arrayvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "ash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.37",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bit-set",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "block",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "foreign-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "fxhash",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "glow",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.11.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gpu-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "gpu-descriptor",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "naga",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.10",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "clone"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "parking_lot",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": ">=0.11, <0.13",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "profiling",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "range-alloc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "raw-window-handle",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "renderdoc-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "smallvec",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "union"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "thiserror",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "wgpu-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.14",
+                    "kind": null,
+                    "rename": "wgt",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.9",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "winit",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.27.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "js-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))",
+                    "registry": null
+                },
+                {
+                    "name": "wasm-bindgen",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))",
+                    "registry": null
+                },
+                {
+                    "name": "web-sys",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "Window",
+                        "HtmlCanvasElement",
+                        "WebGl2RenderingContext",
+                        "OffscreenCanvas"
+                    ],
+                    "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))",
+                    "registry": null
+                },
+                {
+                    "name": "core-graphics-types",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))",
+                    "registry": null
+                },
+                {
+                    "name": "metal",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.24.0",
+                    "kind": null,
+                    "rename": "mtl",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))",
+                    "registry": null
+                },
+                {
+                    "name": "objc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.5",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))",
+                    "registry": null
+                },
+                {
+                    "name": "khronos-egl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^4.1",
+                    "kind": null,
+                    "rename": "egl",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "dynamic"
+                    ],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "glutin",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.29.1",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(not(target_arch = \"wasm32\"))",
+                    "registry": null
+                },
+                {
+                    "name": "android_system_properties",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.1.1",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"android\")",
+                    "registry": null
+                },
+                {
+                    "name": "khronos-egl",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^4.1",
+                    "kind": null,
+                    "rename": "egl",
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "static",
+                        "no-pkg-config"
+                    ],
+                    "target": "cfg(target_os = \"emscripten\")",
+                    "registry": null
+                },
+                {
+                    "name": "libloading",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "cfg(target_os = \"emscripten\")",
+                    "registry": null
+                },
+                {
+                    "name": "d3d12",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.5.0",
+                    "kind": null,
+                    "rename": "native",
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "libloading"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                },
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "libloaderapi",
+                        "windef",
+                        "winuser",
+                        "dcomp"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wgpu-hal",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.14.1/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "halmark",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.14.1/examples/halmark/main.rs",
+                    "edition": "2021",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "raw-gles",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.14.1/examples/raw-gles.rs",
+                    "edition": "2021",
+                    "required-features": [
+                        "gles"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "ash": [
+                    "dep:ash"
+                ],
+                "bit-set": [
+                    "dep:bit-set"
+                ],
+                "block": [
+                    "dep:block"
+                ],
+                "default": [],
+                "dx11": [
+                    "naga/hlsl-out",
+                    "native",
+                    "libloading",
+                    "winapi/d3d11",
+                    "winapi/d3d11_1",
+                    "winapi/d3d11_2",
+                    "winapi/d3d11sdklayers",
+                    "winapi/dxgi1_6"
+                ],
+                "dx12": [
+                    "naga/hlsl-out",
+                    "native",
+                    "bit-set",
+                    "range-alloc",
+                    "winapi/d3d12",
+                    "winapi/d3d12shader",
+                    "winapi/d3d12sdklayers",
+                    "winapi/dxgi1_6"
+                ],
+                "egl": [
+                    "dep:egl"
+                ],
+                "emscripten": [
+                    "gles"
+                ],
+                "foreign-types": [
+                    "dep:foreign-types"
+                ],
+                "gles": [
+                    "naga/glsl-out",
+                    "glow",
+                    "egl",
+                    "libloading"
+                ],
+                "glow": [
+                    "dep:glow"
+                ],
+                "gpu-alloc": [
+                    "dep:gpu-alloc"
+                ],
+                "gpu-descriptor": [
+                    "dep:gpu-descriptor"
+                ],
+                "libloading": [
+                    "dep:libloading"
+                ],
+                "metal": [
+                    "naga/msl-out",
+                    "block",
+                    "foreign-types"
+                ],
+                "native": [
+                    "dep:native"
+                ],
+                "range-alloc": [
+                    "dep:range-alloc"
+                ],
+                "renderdoc": [
+                    "libloading",
+                    "renderdoc-sys"
+                ],
+                "renderdoc-sys": [
+                    "dep:renderdoc-sys"
+                ],
+                "smallvec": [
+                    "dep:smallvec"
+                ],
+                "vulkan": [
+                    "naga/spv-out",
+                    "ash",
+                    "gpu-alloc",
+                    "gpu-descriptor",
+                    "libloading",
+                    "smallvec"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.14.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "wgpu developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "graphics"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/gfx-rs/wgpu",
+            "homepage": "https://github.com/gfx-rs/wgpu",
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.59"
+        },
+        {
+            "name": "wgpu-types",
+            "version": "0.14.1",
+            "id": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "WebGPU types",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "bitflags",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "bitflags_serde_shim",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": true,
+                    "uses_default_features": true,
+                    "features": [
+                        "serde_derive"
+                    ],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "serde_json",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^1.0.85",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "wgpu-types",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-types-0.14.1/src/lib.rs",
+                    "edition": "2021",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "bitflags_serde_shim": [
+                    "dep:bitflags_serde_shim"
+                ],
+                "replay": [
+                    "serde",
+                    "bitflags_serde_shim"
+                ],
+                "serde": [
+                    "dep:serde"
+                ],
+                "trace": [
+                    "serde",
+                    "bitflags_serde_shim"
+                ]
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/wgpu-types-0.14.1/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "wgpu developers"
+            ],
+            "categories": [],
+            "keywords": [
+                "graphics"
+            ],
+            "readme": null,
+            "repository": "https://github.com/gfx-rs/wgpu",
+            "homepage": "https://github.com/gfx-rs/wgpu",
+            "documentation": null,
+            "edition": "2021",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi",
+            "version": "0.3.9",
+            "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Raw FFI bindings for all of Windows API.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "winapi-i686-pc-windows-gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "winapi-x86_64-pc-windows-gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnu",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {
+                "accctrl": [],
+                "aclapi": [],
+                "activation": [],
+                "adhoc": [],
+                "appmgmt": [],
+                "audioclient": [],
+                "audiosessiontypes": [],
+                "avrt": [],
+                "basetsd": [],
+                "bcrypt": [],
+                "bits": [],
+                "bits10_1": [],
+                "bits1_5": [],
+                "bits2_0": [],
+                "bits2_5": [],
+                "bits3_0": [],
+                "bits4_0": [],
+                "bits5_0": [],
+                "bitscfg": [],
+                "bitsmsg": [],
+                "bluetoothapis": [],
+                "bluetoothleapis": [],
+                "bthdef": [],
+                "bthioctl": [],
+                "bthledef": [],
+                "bthsdpdef": [],
+                "bugcodes": [],
+                "cderr": [],
+                "cfg": [],
+                "cfgmgr32": [],
+                "cguid": [],
+                "combaseapi": [],
+                "coml2api": [],
+                "commapi": [],
+                "commctrl": [],
+                "commdlg": [],
+                "commoncontrols": [],
+                "consoleapi": [],
+                "corecrt": [],
+                "corsym": [],
+                "d2d1": [],
+                "d2d1_1": [],
+                "d2d1_2": [],
+                "d2d1_3": [],
+                "d2d1effectauthor": [],
+                "d2d1effects": [],
+                "d2d1effects_1": [],
+                "d2d1effects_2": [],
+                "d2d1svg": [],
+                "d2dbasetypes": [],
+                "d3d": [],
+                "d3d10": [],
+                "d3d10_1": [],
+                "d3d10_1shader": [],
+                "d3d10effect": [],
+                "d3d10misc": [],
+                "d3d10sdklayers": [],
+                "d3d10shader": [],
+                "d3d11": [],
+                "d3d11_1": [],
+                "d3d11_2": [],
+                "d3d11_3": [],
+                "d3d11_4": [],
+                "d3d11on12": [],
+                "d3d11sdklayers": [],
+                "d3d11shader": [],
+                "d3d11tokenizedprogramformat": [],
+                "d3d12": [],
+                "d3d12sdklayers": [],
+                "d3d12shader": [],
+                "d3d9": [],
+                "d3d9caps": [],
+                "d3d9types": [],
+                "d3dcommon": [],
+                "d3dcompiler": [],
+                "d3dcsx": [],
+                "d3dkmdt": [],
+                "d3dkmthk": [],
+                "d3dukmdt": [],
+                "d3dx10core": [],
+                "d3dx10math": [],
+                "d3dx10mesh": [],
+                "datetimeapi": [],
+                "davclnt": [],
+                "dbghelp": [],
+                "dbt": [],
+                "dcommon": [],
+                "dcomp": [],
+                "dcompanimation": [],
+                "dcomptypes": [],
+                "dde": [],
+                "ddraw": [],
+                "ddrawi": [],
+                "ddrawint": [],
+                "debug": [
+                    "impl-debug"
+                ],
+                "debugapi": [],
+                "devguid": [],
+                "devicetopology": [],
+                "devpkey": [],
+                "devpropdef": [],
+                "dinput": [],
+                "dinputd": [],
+                "dispex": [],
+                "dmksctl": [],
+                "dmusicc": [],
+                "docobj": [],
+                "documenttarget": [],
+                "dot1x": [],
+                "dpa_dsa": [],
+                "dpapi": [],
+                "dsgetdc": [],
+                "dsound": [],
+                "dsrole": [],
+                "dvp": [],
+                "dwmapi": [],
+                "dwrite": [],
+                "dwrite_1": [],
+                "dwrite_2": [],
+                "dwrite_3": [],
+                "dxdiag": [],
+                "dxfile": [],
+                "dxgi": [],
+                "dxgi1_2": [],
+                "dxgi1_3": [],
+                "dxgi1_4": [],
+                "dxgi1_5": [],
+                "dxgi1_6": [],
+                "dxgidebug": [],
+                "dxgiformat": [],
+                "dxgitype": [],
+                "dxva2api": [],
+                "dxvahd": [],
+                "eaptypes": [],
+                "enclaveapi": [],
+                "endpointvolume": [],
+                "errhandlingapi": [],
+                "everything": [],
+                "evntcons": [],
+                "evntprov": [],
+                "evntrace": [],
+                "excpt": [],
+                "exdisp": [],
+                "fibersapi": [],
+                "fileapi": [],
+                "functiondiscoverykeys_devpkey": [],
+                "gl-gl": [],
+                "guiddef": [],
+                "handleapi": [],
+                "heapapi": [],
+                "hidclass": [],
+                "hidpi": [],
+                "hidsdi": [],
+                "hidusage": [],
+                "highlevelmonitorconfigurationapi": [],
+                "hstring": [],
+                "http": [],
+                "ifdef": [],
+                "ifmib": [],
+                "imm": [],
+                "impl-debug": [],
+                "impl-default": [],
+                "in6addr": [],
+                "inaddr": [],
+                "inspectable": [],
+                "interlockedapi": [],
+                "intsafe": [],
+                "ioapiset": [],
+                "ipexport": [],
+                "iphlpapi": [],
+                "ipifcons": [],
+                "ipmib": [],
+                "iprtrmib": [],
+                "iptypes": [],
+                "jobapi": [],
+                "jobapi2": [],
+                "knownfolders": [],
+                "ks": [],
+                "ksmedia": [],
+                "ktmtypes": [],
+                "ktmw32": [],
+                "l2cmn": [],
+                "libloaderapi": [],
+                "limits": [],
+                "lmaccess": [],
+                "lmalert": [],
+                "lmapibuf": [],
+                "lmat": [],
+                "lmcons": [],
+                "lmdfs": [],
+                "lmerrlog": [],
+                "lmjoin": [],
+                "lmmsg": [],
+                "lmremutl": [],
+                "lmrepl": [],
+                "lmserver": [],
+                "lmshare": [],
+                "lmstats": [],
+                "lmsvc": [],
+                "lmuse": [],
+                "lmwksta": [],
+                "lowlevelmonitorconfigurationapi": [],
+                "lsalookup": [],
+                "memoryapi": [],
+                "minschannel": [],
+                "minwinbase": [],
+                "minwindef": [],
+                "mmdeviceapi": [],
+                "mmeapi": [],
+                "mmreg": [],
+                "mmsystem": [],
+                "mprapidef": [],
+                "msaatext": [],
+                "mscat": [],
+                "mschapp": [],
+                "mssip": [],
+                "mstcpip": [],
+                "mswsock": [],
+                "mswsockdef": [],
+                "namedpipeapi": [],
+                "namespaceapi": [],
+                "nb30": [],
+                "ncrypt": [],
+                "netioapi": [],
+                "nldef": [],
+                "ntddndis": [],
+                "ntddscsi": [],
+                "ntddser": [],
+                "ntdef": [],
+                "ntlsa": [],
+                "ntsecapi": [],
+                "ntstatus": [],
+                "oaidl": [],
+                "objbase": [],
+                "objidl": [],
+                "objidlbase": [],
+                "ocidl": [],
+                "ole2": [],
+                "oleauto": [],
+                "olectl": [],
+                "oleidl": [],
+                "opmapi": [],
+                "pdh": [],
+                "perflib": [],
+                "physicalmonitorenumerationapi": [],
+                "playsoundapi": [],
+                "portabledevice": [],
+                "portabledeviceapi": [],
+                "portabledevicetypes": [],
+                "powerbase": [],
+                "powersetting": [],
+                "powrprof": [],
+                "processenv": [],
+                "processsnapshot": [],
+                "processthreadsapi": [],
+                "processtopologyapi": [],
+                "profileapi": [],
+                "propidl": [],
+                "propkey": [],
+                "propkeydef": [],
+                "propsys": [],
+                "prsht": [],
+                "psapi": [],
+                "qos": [],
+                "realtimeapiset": [],
+                "reason": [],
+                "restartmanager": [],
+                "restrictederrorinfo": [],
+                "rmxfguid": [],
+                "roapi": [],
+                "robuffer": [],
+                "roerrorapi": [],
+                "rpc": [],
+                "rpcdce": [],
+                "rpcndr": [],
+                "rtinfo": [],
+                "sapi": [],
+                "sapi51": [],
+                "sapi53": [],
+                "sapiddk": [],
+                "sapiddk51": [],
+                "schannel": [],
+                "sddl": [],
+                "securityappcontainer": [],
+                "securitybaseapi": [],
+                "servprov": [],
+                "setupapi": [],
+                "shellapi": [],
+                "shellscalingapi": [],
+                "shlobj": [],
+                "shobjidl": [],
+                "shobjidl_core": [],
+                "shtypes": [],
+                "softpub": [],
+                "spapidef": [],
+                "spellcheck": [],
+                "sporder": [],
+                "sql": [],
+                "sqlext": [],
+                "sqltypes": [],
+                "sqlucode": [],
+                "sspi": [],
+                "std": [],
+                "stralign": [],
+                "stringapiset": [],
+                "strmif": [],
+                "subauth": [],
+                "synchapi": [],
+                "sysinfoapi": [],
+                "systemtopologyapi": [],
+                "taskschd": [],
+                "tcpestats": [],
+                "tcpmib": [],
+                "textstor": [],
+                "threadpoolapiset": [],
+                "threadpoollegacyapiset": [],
+                "timeapi": [],
+                "timezoneapi": [],
+                "tlhelp32": [],
+                "transportsettingcommon": [],
+                "tvout": [],
+                "udpmib": [],
+                "unknwnbase": [],
+                "urlhist": [],
+                "urlmon": [],
+                "usb": [],
+                "usbioctl": [],
+                "usbiodef": [],
+                "usbscan": [],
+                "usbspec": [],
+                "userenv": [],
+                "usp10": [],
+                "utilapiset": [],
+                "uxtheme": [],
+                "vadefs": [],
+                "vcruntime": [],
+                "vsbackup": [],
+                "vss": [],
+                "vsserror": [],
+                "vswriter": [],
+                "wbemads": [],
+                "wbemcli": [],
+                "wbemdisp": [],
+                "wbemprov": [],
+                "wbemtran": [],
+                "wct": [],
+                "werapi": [],
+                "winbase": [],
+                "wincodec": [],
+                "wincodecsdk": [],
+                "wincon": [],
+                "wincontypes": [],
+                "wincred": [],
+                "wincrypt": [],
+                "windef": [],
+                "windot11": [],
+                "windowsceip": [],
+                "windowsx": [],
+                "winefs": [],
+                "winerror": [],
+                "winevt": [],
+                "wingdi": [],
+                "winhttp": [],
+                "wininet": [],
+                "winineti": [],
+                "winioctl": [],
+                "winnetwk": [],
+                "winnls": [],
+                "winnt": [],
+                "winreg": [],
+                "winsafer": [],
+                "winscard": [],
+                "winsmcrd": [],
+                "winsock2": [],
+                "winspool": [],
+                "winstring": [],
+                "winsvc": [],
+                "wintrust": [],
+                "winusb": [],
+                "winusbio": [],
+                "winuser": [],
+                "winver": [],
+                "wlanapi": [],
+                "wlanihv": [],
+                "wlanihvtypes": [],
+                "wlantypes": [],
+                "wlclient": [],
+                "wmistr": [],
+                "wnnc": [],
+                "wow64apiset": [],
+                "wpdmtpextensions": [],
+                "ws2bth": [],
+                "ws2def": [],
+                "ws2ipdef": [],
+                "ws2spi": [],
+                "ws2tcpip": [],
+                "wtsapi32": [],
+                "wtypes": [],
+                "wtypesbase": [],
+                "xinput": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-0.3.9/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "features": [
+                            "everything",
+                            "impl-debug",
+                            "impl-default"
+                        ],
+                        "targets": [
+                            "aarch64-pc-windows-msvc",
+                            "i686-pc-windows-msvc",
+                            "x86_64-pc-windows-msvc"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Peter Atashian <retep998@gmail.com>"
+            ],
+            "categories": [
+                "external-ffi-bindings",
+                "no-std",
+                "os::windows-apis"
+            ],
+            "keywords": [
+                "windows",
+                "ffi",
+                "win32",
+                "com",
+                "directx"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/retep998/winapi-rs",
+            "homepage": null,
+            "documentation": "https://docs.rs/winapi/",
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi-i686-pc-windows-gnu",
+            "version": "0.4.0",
+            "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi-i686-pc-windows-gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-i686-pc-windows-gnu-0.4.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Peter Atashian <retep998@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windows"
+            ],
+            "readme": null,
+            "repository": "https://github.com/retep998/winapi-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi-util",
+            "version": "0.1.5",
+            "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "Unlicense/MIT",
+            "license_file": null,
+            "description": "A dumping ground for high level safe wrappers over winapi.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "winapi",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.3",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [
+                        "std",
+                        "consoleapi",
+                        "errhandlingapi",
+                        "fileapi",
+                        "minwindef",
+                        "processenv",
+                        "winbase",
+                        "wincon",
+                        "winerror",
+                        "winnt"
+                    ],
+                    "target": "cfg(windows)",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi-util",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-util-0.1.5/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-util-0.1.5/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "targets": [
+                            "x86_64-pc-windows-msvc"
+                        ]
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Andrew Gallant <jamslam@gmail.com>"
+            ],
+            "categories": [
+                "os::windows-apis",
+                "external-ffi-bindings"
+            ],
+            "keywords": [
+                "windows",
+                "winapi",
+                "util",
+                "win"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/BurntSushi/winapi-util",
+            "homepage": "https://github.com/BurntSushi/winapi-util",
+            "documentation": "https://docs.rs/winapi-util",
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "winapi-x86_64-pc-windows-gnu",
+            "version": "0.4.0",
+            "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT/Apache-2.0",
+            "license_file": null,
+            "description": "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "winapi-x86_64-pc-windows-gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/src/lib.rs",
+                    "edition": "2015",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/build.rs",
+                    "edition": "2015",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/winapi-x86_64-pc-windows-gnu-0.4.0/Cargo.toml",
+            "metadata": null,
+            "publish": null,
+            "authors": [
+                "Peter Atashian <retep998@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [
+                "windows"
+            ],
+            "readme": null,
+            "repository": "https://github.com/retep998/winapi-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2015",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows-sys",
+            "version": "0.42.0",
+            "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Rust for Windows",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "windows_aarch64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_aarch64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "aarch64-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_i686_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "i686-uwp-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnullvm",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-gnullvm",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-pc-windows-msvc",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_gnu",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-gnu",
+                    "registry": null
+                },
+                {
+                    "name": "windows_x86_64_msvc",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.42.0",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": "x86_64-uwp-windows-msvc",
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows-sys",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                }
+            ],
+            "features": {
+                "Win32": [],
+                "Win32_AI": [
+                    "Win32"
+                ],
+                "Win32_AI_MachineLearning": [
+                    "Win32_AI"
+                ],
+                "Win32_AI_MachineLearning_DirectML": [
+                    "Win32_AI_MachineLearning"
+                ],
+                "Win32_AI_MachineLearning_WinML": [
+                    "Win32_AI_MachineLearning"
+                ],
+                "Win32_Data": [
+                    "Win32"
+                ],
+                "Win32_Data_HtmlHelp": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_RightsManagement": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml": [
+                    "Win32_Data"
+                ],
+                "Win32_Data_Xml_MsXml": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Data_Xml_XmlLite": [
+                    "Win32_Data_Xml"
+                ],
+                "Win32_Devices": [
+                    "Win32"
+                ],
+                "Win32_Devices_AllJoyn": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_BiometricFramework": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Bluetooth": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Communication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAccess": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceAndDriverInstallation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_DeviceQuery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Display": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Enumeration_Pnp": [
+                    "Win32_Devices_Enumeration"
+                ],
+                "Win32_Devices_Fax": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_FunctionDiscovery": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Geolocation": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_HumanInterfaceDevice": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_ImageAcquisition": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_PortableDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Properties": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Pwm": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Sensors": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_SerialCommunication": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Tapi": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_Usb": [
+                    "Win32_Devices"
+                ],
+                "Win32_Devices_WebServicesOnDevices": [
+                    "Win32_Devices"
+                ],
+                "Win32_Foundation": [
+                    "Win32"
+                ],
+                "Win32_Gaming": [
+                    "Win32"
+                ],
+                "Win32_Globalization": [
+                    "Win32"
+                ],
+                "Win32_Graphics": [
+                    "Win32"
+                ],
+                "Win32_Graphics_CompositionSwapchain": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DXCore": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct2D": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct2D_Common": [
+                    "Win32_Graphics_Direct2D"
+                ],
+                "Win32_Graphics_Direct3D": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D10": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D11": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D11on12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D9": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D9on12": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Direct3D_Dxc": [
+                    "Win32_Graphics_Direct3D"
+                ],
+                "Win32_Graphics_Direct3D_Fxc": [
+                    "Win32_Graphics_Direct3D"
+                ],
+                "Win32_Graphics_DirectComposition": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectDraw": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectManipulation": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_DirectWrite": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dwm": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dxgi": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Dxgi_Common": [
+                    "Win32_Graphics_Dxgi"
+                ],
+                "Win32_Graphics_Gdi": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Hlsl": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Imaging": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Imaging_D2D": [
+                    "Win32_Graphics_Imaging"
+                ],
+                "Win32_Graphics_OpenGL": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing": [
+                    "Win32_Graphics"
+                ],
+                "Win32_Graphics_Printing_PrintTicket": [
+                    "Win32_Graphics_Printing"
+                ],
+                "Win32_Management": [
+                    "Win32"
+                ],
+                "Win32_Management_MobileDeviceManagementRegistration": [
+                    "Win32_Management"
+                ],
+                "Win32_Media": [
+                    "Win32"
+                ],
+                "Win32_Media_Audio": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Audio_Apo": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_DirectMusic": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_DirectSound": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_Endpoints": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_Audio_XAudio2": [
+                    "Win32_Media_Audio"
+                ],
+                "Win32_Media_DeviceManager": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_DirectShow": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_DirectShow_Xml": [
+                    "Win32_Media_DirectShow"
+                ],
+                "Win32_Media_DxMediaObjects": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_KernelStreaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_LibrarySharingServices": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_MediaFoundation": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_MediaPlayer": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Multimedia": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_PictureAcquisition": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Speech": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_Streaming": [
+                    "Win32_Media"
+                ],
+                "Win32_Media_WindowsMediaFormat": [
+                    "Win32_Media"
+                ],
+                "Win32_NetworkManagement": [
+                    "Win32"
+                ],
+                "Win32_NetworkManagement_Dhcp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Dns": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_InternetConnectionWizard": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_IpHelper": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_MobileBroadband": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Multicast": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Ndis": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetBios": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetManagement": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetShell": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkDiagnosticsFramework": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_NetworkPolicyServer": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_P2P": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_QoS": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Rras": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_Snmp": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WNet": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WebDav": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WiFi": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectNow": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsConnectionManager": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFilteringPlatform": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsFirewall": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_NetworkManagement_WindowsNetworkVirtualization": [
+                    "Win32_NetworkManagement"
+                ],
+                "Win32_Networking": [
+                    "Win32"
+                ],
+                "Win32_Networking_ActiveDirectory": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_BackgroundIntelligentTransferService": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Clustering": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_HttpServer": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_Ldap": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_NetworkListManager": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_RemoteDifferentialCompression": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WebSocket": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinHttp": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinInet": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WinSock": [
+                    "Win32_Networking"
+                ],
+                "Win32_Networking_WindowsWebServices": [
+                    "Win32_Networking"
+                ],
+                "Win32_Security": [
+                    "Win32"
+                ],
+                "Win32_Security_AppLocker": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authentication_Identity": [
+                    "Win32_Security_Authentication"
+                ],
+                "Win32_Security_Authentication_Identity_Provider": [
+                    "Win32_Security_Authentication_Identity"
+                ],
+                "Win32_Security_Authorization": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Authorization_UI": [
+                    "Win32_Security_Authorization"
+                ],
+                "Win32_Security_ConfigurationSnapin": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Credentials": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Cryptography_Catalog": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Certificates": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_Sip": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_Cryptography_UI": [
+                    "Win32_Security_Cryptography"
+                ],
+                "Win32_Security_DiagnosticDataQuery": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_DirectoryServices": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_EnterpriseData": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_ExtensibleAuthenticationProtocol": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Isolation": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_LicenseProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_NetworkAccessProtection": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_Tpm": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinTrust": [
+                    "Win32_Security"
+                ],
+                "Win32_Security_WinWlx": [
+                    "Win32_Security"
+                ],
+                "Win32_Storage": [
+                    "Win32"
+                ],
+                "Win32_Storage_Cabinets": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_CloudFilters": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Compression": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DataDeduplication": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_DistributedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_EnhancedStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileHistory": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileServerResourceManager": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_FileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Imapi": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IndexServer": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_InstallableFileSystems": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_IscsiDisc": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Jet": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OfflineFiles": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_OperationRecorder": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Packaging_Appx": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_Packaging_Opc": [
+                    "Win32_Storage_Packaging"
+                ],
+                "Win32_Storage_ProjectedFileSystem": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_StructuredStorage": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vhd": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_VirtualDiskService": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Vss": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps": [
+                    "Win32_Storage"
+                ],
+                "Win32_Storage_Xps_Printing": [
+                    "Win32_Storage_Xps"
+                ],
+                "Win32_System": [
+                    "Win32"
+                ],
+                "Win32_System_AddressBook": [
+                    "Win32_System"
+                ],
+                "Win32_System_Antimalware": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationInstallationAndServicing": [
+                    "Win32_System"
+                ],
+                "Win32_System_ApplicationVerifier": [
+                    "Win32_System"
+                ],
+                "Win32_System_AssessmentTool": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com": [
+                    "Win32_System"
+                ],
+                "Win32_System_Com_CallObj": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_ChannelCredentials": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Events": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Marshal": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_StructuredStorage": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_UI": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_Com_Urlmon": [
+                    "Win32_System_Com"
+                ],
+                "Win32_System_ComponentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_Console": [
+                    "Win32_System"
+                ],
+                "Win32_System_Contacts": [
+                    "Win32_System"
+                ],
+                "Win32_System_CorrelationVector": [
+                    "Win32_System"
+                ],
+                "Win32_System_DataExchange": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeploymentServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_DesktopSharing": [
+                    "Win32_System"
+                ],
+                "Win32_System_DeveloperLicensing": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics": [
+                    "Win32_System"
+                ],
+                "Win32_System_Diagnostics_Ceip": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Debug": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_Etw": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ProcessSnapshotting": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_Diagnostics_ToolHelp": [
+                    "Win32_System_Diagnostics"
+                ],
+                "Win32_System_DistributedTransactionCoordinator": [
+                    "Win32_System"
+                ],
+                "Win32_System_Environment": [
+                    "Win32_System"
+                ],
+                "Win32_System_ErrorReporting": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventCollector": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventLog": [
+                    "Win32_System"
+                ],
+                "Win32_System_EventNotificationService": [
+                    "Win32_System"
+                ],
+                "Win32_System_GroupPolicy": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostCompute": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeNetwork": [
+                    "Win32_System"
+                ],
+                "Win32_System_HostComputeSystem": [
+                    "Win32_System"
+                ],
+                "Win32_System_Hypervisor": [
+                    "Win32_System"
+                ],
+                "Win32_System_IO": [
+                    "Win32_System"
+                ],
+                "Win32_System_Iis": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ioctl": [
+                    "Win32_System"
+                ],
+                "Win32_System_JobObjects": [
+                    "Win32_System"
+                ],
+                "Win32_System_Js": [
+                    "Win32_System"
+                ],
+                "Win32_System_Kernel": [
+                    "Win32_System"
+                ],
+                "Win32_System_LibraryLoader": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mailslots": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mapi": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory": [
+                    "Win32_System"
+                ],
+                "Win32_System_Memory_NonVolatile": [
+                    "Win32_System_Memory"
+                ],
+                "Win32_System_MessageQueuing": [
+                    "Win32_System"
+                ],
+                "Win32_System_MixedReality": [
+                    "Win32_System"
+                ],
+                "Win32_System_Mmc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Ole": [
+                    "Win32_System"
+                ],
+                "Win32_System_ParentalControls": [
+                    "Win32_System"
+                ],
+                "Win32_System_PasswordManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance": [
+                    "Win32_System"
+                ],
+                "Win32_System_Performance_HardwareCounterProfiling": [
+                    "Win32_System_Performance"
+                ],
+                "Win32_System_Pipes": [
+                    "Win32_System"
+                ],
+                "Win32_System_Power": [
+                    "Win32_System"
+                ],
+                "Win32_System_ProcessStatus": [
+                    "Win32_System"
+                ],
+                "Win32_System_RealTimeCommunications": [
+                    "Win32_System"
+                ],
+                "Win32_System_Recovery": [
+                    "Win32_System"
+                ],
+                "Win32_System_Registry": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteAssistance": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteDesktop": [
+                    "Win32_System"
+                ],
+                "Win32_System_RemoteManagement": [
+                    "Win32_System"
+                ],
+                "Win32_System_RestartManager": [
+                    "Win32_System"
+                ],
+                "Win32_System_Restore": [
+                    "Win32_System"
+                ],
+                "Win32_System_Rpc": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search": [
+                    "Win32_System"
+                ],
+                "Win32_System_Search_Common": [
+                    "Win32_System_Search"
+                ],
+                "Win32_System_SecurityCenter": [
+                    "Win32_System"
+                ],
+                "Win32_System_ServerBackup": [
+                    "Win32_System"
+                ],
+                "Win32_System_Services": [
+                    "Win32_System"
+                ],
+                "Win32_System_SettingsManagementInfrastructure": [
+                    "Win32_System"
+                ],
+                "Win32_System_SetupAndMigration": [
+                    "Win32_System"
+                ],
+                "Win32_System_Shutdown": [
+                    "Win32_System"
+                ],
+                "Win32_System_SideShow": [
+                    "Win32_System"
+                ],
+                "Win32_System_StationsAndDesktops": [
+                    "Win32_System"
+                ],
+                "Win32_System_SubsystemForLinux": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemInformation": [
+                    "Win32_System"
+                ],
+                "Win32_System_SystemServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_TaskScheduler": [
+                    "Win32_System"
+                ],
+                "Win32_System_Threading": [
+                    "Win32_System"
+                ],
+                "Win32_System_Time": [
+                    "Win32_System"
+                ],
+                "Win32_System_TpmBaseServices": [
+                    "Win32_System"
+                ],
+                "Win32_System_TransactionServer": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAgent": [
+                    "Win32_System"
+                ],
+                "Win32_System_UpdateAssessment": [
+                    "Win32_System"
+                ],
+                "Win32_System_UserAccessLogging": [
+                    "Win32_System"
+                ],
+                "Win32_System_VirtualDosMachines": [
+                    "Win32_System"
+                ],
+                "Win32_System_WinRT": [
+                    "Win32_System"
+                ],
+                "Win32_System_WinRT_AllJoyn": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Composition": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_CoreInputView": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Direct3D11": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Display": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Graphics": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Graphics_Capture": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Graphics_Direct2D": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Graphics_Imaging": [
+                    "Win32_System_WinRT_Graphics"
+                ],
+                "Win32_System_WinRT_Holographic": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Isolation": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_ML": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Media": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Pdf": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Printing": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Shell": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WinRT_Storage": [
+                    "Win32_System_WinRT"
+                ],
+                "Win32_System_WindowsProgramming": [
+                    "Win32_System"
+                ],
+                "Win32_System_WindowsSync": [
+                    "Win32_System"
+                ],
+                "Win32_System_Wmi": [
+                    "Win32_System"
+                ],
+                "Win32_UI": [
+                    "Win32"
+                ],
+                "Win32_UI_Accessibility": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Animation": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_ColorSystem": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Controls_Dialogs": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_Controls_RichEdit": [
+                    "Win32_UI_Controls"
+                ],
+                "Win32_UI_HiDpi": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Input_Ime": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Ink": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_KeyboardAndMouse": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Pointer": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Radial": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_Touch": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_Input_XboxController": [
+                    "Win32_UI_Input"
+                ],
+                "Win32_UI_InteractionContext": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_LegacyWindowsEnvironmentFeatures": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Magnification": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Notifications": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Ribbon": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Shell_Common": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_Shell_PropertiesSystem": [
+                    "Win32_UI_Shell"
+                ],
+                "Win32_UI_TabletPC": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_TextServices": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_WindowsAndMessaging": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Wpf": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Xaml": [
+                    "Win32_UI"
+                ],
+                "Win32_UI_Xaml_Diagnostics": [
+                    "Win32_UI_Xaml"
+                ],
+                "default": [],
+                "deprecated": []
+            },
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows-sys-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": "readme.md",
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": "1.49"
+        },
+        {
+            "name": "windows_aarch64_gnullvm",
+            "version": "0.42.0",
+            "id": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_aarch64_gnullvm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_gnullvm-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_aarch64_msvc",
+            "version": "0.42.0",
+            "id": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_aarch64_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_aarch64_msvc-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_i686_gnu",
+            "version": "0.42.0",
+            "id": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_i686_gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_i686_msvc",
+            "version": "0.42.0",
+            "id": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_i686_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_i686_msvc-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_x86_64_gnu",
+            "version": "0.42.0",
+            "id": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_gnu",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnu-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_x86_64_gnullvm",
+            "version": "0.42.0",
+            "id": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_gnullvm",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_gnullvm-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        },
+        {
+            "name": "windows_x86_64_msvc",
+            "version": "0.42.0",
+            "id": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "description": "Code gen support for the windows crate",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "windows_x86_64_msvc",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.0/src/lib.rs",
+                    "edition": "2018",
+                    "doc": true,
+                    "doctest": true,
+                    "test": true
+                },
+                {
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.0/build.rs",
+                    "edition": "2018",
+                    "doc": false,
+                    "doctest": false,
+                    "test": false
+                }
+            ],
+            "features": {},
+            "manifest_path": "{CARGO_HOME}/registry/src/github.com-1ecc6299db9ec823/windows_x86_64_msvc-0.42.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "default-target": "x86_64-pc-windows-msvc",
+                        "targets": []
+                    }
+                }
+            },
+            "publish": null,
+            "authors": [
+                "Microsoft"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/microsoft/windows-rs",
+            "homepage": null,
+            "documentation": null,
+            "edition": "2018",
+            "links": null,
+            "default_run": null,
+            "rust_version": null
+        }
+    ],
+    "workspace_members": [
+        "child 0.1.0 (path+file://{TEMP_DIR}/workspace/child)",
+        "parent 0.1.0 (path+file://{TEMP_DIR}/workspace)"
+    ],
+    "resolve": {
+        "nodes": [
+            {
+                "id": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "getrandom",
+                        "pkg": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "once_cell",
+                        "pkg": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "version_check",
+                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libloading",
+                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "debug",
+                    "default",
+                    "libloading",
+                    "loaded"
+                ]
+            },
+            {
+                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bit_vec",
+                        "pkg": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "child 0.1.0 (path+file://{TEMP_DIR}/workspace/child)",
+                "dependencies": [
+                    "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "wgpu",
+                        "pkg": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "termcolor",
+                        "pkg": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_width",
+                        "pkg": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "core_foundation_sys",
+                        "pkg": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "core_foundation",
+                        "pkg": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "foreign_types",
+                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libloading",
+                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "libloading"
+                ]
+            },
+            {
+                "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "foreign_types_shared",
+                        "pkg": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "byteorder",
+                        "pkg": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasi",
+                        "pkg": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"wasi\")"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "slotmap",
+                        "pkg": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "gpu_alloc_types",
+                        "pkg": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "gpu_descriptor_types",
+                        "pkg": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hashbrown",
+                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "ahash",
+                        "pkg": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "ahash",
+                    "default",
+                    "inline-more",
+                    "raw"
+                ]
+            },
+            {
+                "id": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "autocfg",
+                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hashbrown",
+                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "std"
+                ]
+            },
+            {
+                "id": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libloading",
+                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "pkg_config",
+                        "pkg": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "1_0",
+                    "1_1",
+                    "1_2",
+                    "1_3",
+                    "1_4",
+                    "1_5",
+                    "default",
+                    "dynamic",
+                    "libloading",
+                    "no-pkg-config",
+                    "pkg-config",
+                    "static"
+                ]
+            },
+            {
+                "id": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "autocfg",
+                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "scopeguard",
+                        "pkg": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "block",
+                        "pkg": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "core_graphics_types",
+                        "pkg": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "foreign_types",
+                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "objc",
+                        "pkg": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bit_set",
+                        "pkg": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codespan_reporting",
+                        "pkg": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hexf_parse",
+                        "pkg": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "indexmap",
+                        "pkg": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "num_traits",
+                        "pkg": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "rustc_hash",
+                        "pkg": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "spirv",
+                        "pkg": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "termcolor",
+                        "pkg": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "thiserror",
+                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_xid",
+                        "pkg": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "clone",
+                    "codespan-reporting",
+                    "default",
+                    "glsl-out",
+                    "hexf-parse",
+                    "hlsl-out",
+                    "msl-out",
+                    "span",
+                    "spirv",
+                    "spv-out",
+                    "termcolor",
+                    "unicode-xid",
+                    "validate",
+                    "wgsl-in",
+                    "wgsl-out"
+                ]
+            },
+            {
+                "id": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "autocfg",
+                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "malloc_buf",
+                        "pkg": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "objc_exception",
+                        "pkg": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "objc_exception"
+                ]
+            },
+            {
+                "id": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cc",
+                        "pkg": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "alloc",
+                    "default",
+                    "race",
+                    "std"
+                ]
+            },
+            {
+                "id": "parent 0.1.0 (path+file://{TEMP_DIR}/workspace)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "lock_api",
+                        "pkg": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "parking_lot_core",
+                        "pkg": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libc",
+                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(unix)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syscall",
+                        "pkg": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"redox\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "smallvec",
+                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_sys",
+                        "pkg": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "unicode_ident",
+                        "pkg": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ]
+            },
+            {
+                "id": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ]
+            },
+            {
+                "id": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cty",
+                        "pkg": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "version_check",
+                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "union"
+                ]
+            },
+            {
+                "id": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "num_traits",
+                        "pkg": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "unicode_ident",
+                        "pkg": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "clone-impls",
+                    "default",
+                    "derive",
+                    "full",
+                    "parsing",
+                    "printing",
+                    "proc-macro",
+                    "quote",
+                    "visit"
+                ]
+            },
+            {
+                "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi_util",
+                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "thiserror_impl",
+                        "pkg": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "default",
+                    "std"
+                ]
+            },
+            {
+                "id": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_macro",
+                        "pkg": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "spans",
+                    "std"
+                ]
+            },
+            {
+                "id": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bumpalo",
+                        "pkg": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "once_cell",
+                        "pkg": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_shared",
+                        "pkg": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "spans"
+                ]
+            },
+            {
+                "id": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "cfg_if",
+                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_feature = \"atomics\")"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_macro_support",
+                        "pkg": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "spans"
+                ]
+            },
+            {
+                "id": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "proc_macro2",
+                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "quote",
+                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "syn",
+                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_backend",
+                        "pkg": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_shared",
+                        "pkg": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "spans"
+                ]
+            },
+            {
+                "id": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "AngleInstancedArrays",
+                    "Document",
+                    "Element",
+                    "Event",
+                    "EventTarget",
+                    "ExtBlendMinmax",
+                    "ExtColorBufferFloat",
+                    "ExtColorBufferHalfFloat",
+                    "ExtDisjointTimerQuery",
+                    "ExtFragDepth",
+                    "ExtSRgb",
+                    "ExtShaderTextureLod",
+                    "ExtTextureFilterAnisotropic",
+                    "Gpu",
+                    "GpuAdapter",
+                    "GpuAddressMode",
+                    "GpuAutoLayoutMode",
+                    "GpuBindGroup",
+                    "GpuBindGroupDescriptor",
+                    "GpuBindGroupEntry",
+                    "GpuBindGroupLayout",
+                    "GpuBindGroupLayoutDescriptor",
+                    "GpuBindGroupLayoutEntry",
+                    "GpuBlendComponent",
+                    "GpuBlendFactor",
+                    "GpuBlendOperation",
+                    "GpuBlendState",
+                    "GpuBuffer",
+                    "GpuBufferBinding",
+                    "GpuBufferBindingLayout",
+                    "GpuBufferBindingType",
+                    "GpuBufferDescriptor",
+                    "GpuCanvasAlphaMode",
+                    "GpuCanvasConfiguration",
+                    "GpuCanvasContext",
+                    "GpuColorDict",
+                    "GpuColorTargetState",
+                    "GpuCommandBuffer",
+                    "GpuCommandBufferDescriptor",
+                    "GpuCommandEncoder",
+                    "GpuCommandEncoderDescriptor",
+                    "GpuCompareFunction",
+                    "GpuCompilationInfo",
+                    "GpuCompilationMessage",
+                    "GpuCompilationMessageType",
+                    "GpuComputePassDescriptor",
+                    "GpuComputePassEncoder",
+                    "GpuComputePipeline",
+                    "GpuComputePipelineDescriptor",
+                    "GpuCullMode",
+                    "GpuDepthStencilState",
+                    "GpuDevice",
+                    "GpuDeviceDescriptor",
+                    "GpuDeviceLostInfo",
+                    "GpuDeviceLostReason",
+                    "GpuError",
+                    "GpuErrorFilter",
+                    "GpuExtent3dDict",
+                    "GpuFeatureName",
+                    "GpuFilterMode",
+                    "GpuFragmentState",
+                    "GpuFrontFace",
+                    "GpuImageCopyBuffer",
+                    "GpuImageCopyExternalImage",
+                    "GpuImageCopyTexture",
+                    "GpuImageCopyTextureTagged",
+                    "GpuImageDataLayout",
+                    "GpuIndexFormat",
+                    "GpuLoadOp",
+                    "GpuMipmapFilterMode",
+                    "GpuMultisampleState",
+                    "GpuObjectDescriptorBase",
+                    "GpuOrigin2dDict",
+                    "GpuOrigin3dDict",
+                    "GpuOutOfMemoryError",
+                    "GpuPipelineDescriptorBase",
+                    "GpuPipelineLayout",
+                    "GpuPipelineLayoutDescriptor",
+                    "GpuPowerPreference",
+                    "GpuPrimitiveState",
+                    "GpuPrimitiveTopology",
+                    "GpuProgrammableStage",
+                    "GpuQuerySet",
+                    "GpuQuerySetDescriptor",
+                    "GpuQueryType",
+                    "GpuQueue",
+                    "GpuRenderBundle",
+                    "GpuRenderBundleDescriptor",
+                    "GpuRenderBundleEncoder",
+                    "GpuRenderBundleEncoderDescriptor",
+                    "GpuRenderPassColorAttachment",
+                    "GpuRenderPassDepthStencilAttachment",
+                    "GpuRenderPassDescriptor",
+                    "GpuRenderPassEncoder",
+                    "GpuRenderPipeline",
+                    "GpuRenderPipelineDescriptor",
+                    "GpuRequestAdapterOptions",
+                    "GpuSampler",
+                    "GpuSamplerBindingLayout",
+                    "GpuSamplerBindingType",
+                    "GpuSamplerDescriptor",
+                    "GpuShaderModule",
+                    "GpuShaderModuleDescriptor",
+                    "GpuStencilFaceState",
+                    "GpuStencilOperation",
+                    "GpuStorageTextureAccess",
+                    "GpuStorageTextureBindingLayout",
+                    "GpuStoreOp",
+                    "GpuSupportedFeatures",
+                    "GpuSupportedLimits",
+                    "GpuTexture",
+                    "GpuTextureAspect",
+                    "GpuTextureBindingLayout",
+                    "GpuTextureDescriptor",
+                    "GpuTextureDimension",
+                    "GpuTextureFormat",
+                    "GpuTextureSampleType",
+                    "GpuTextureView",
+                    "GpuTextureViewDescriptor",
+                    "GpuTextureViewDimension",
+                    "GpuUncapturedErrorEvent",
+                    "GpuUncapturedErrorEventInit",
+                    "GpuValidationError",
+                    "GpuVertexAttribute",
+                    "GpuVertexBufferLayout",
+                    "GpuVertexFormat",
+                    "GpuVertexState",
+                    "GpuVertexStepMode",
+                    "HtmlCanvasElement",
+                    "HtmlElement",
+                    "HtmlImageElement",
+                    "ImageBitmap",
+                    "ImageBitmapRenderingContext",
+                    "MessageEvent",
+                    "Navigator",
+                    "Node",
+                    "NodeList",
+                    "OesElementIndexUint",
+                    "OesStandardDerivatives",
+                    "OesTextureFloat",
+                    "OesTextureFloatLinear",
+                    "OesTextureHalfFloat",
+                    "OesTextureHalfFloatLinear",
+                    "OesVertexArrayObject",
+                    "OffscreenCanvas",
+                    "WebGl2RenderingContext",
+                    "WebGlActiveInfo",
+                    "WebGlBuffer",
+                    "WebGlFramebuffer",
+                    "WebGlProgram",
+                    "WebGlQuery",
+                    "WebGlRenderbuffer",
+                    "WebGlRenderingContext",
+                    "WebGlSampler",
+                    "WebGlShader",
+                    "WebGlSync",
+                    "WebGlTexture",
+                    "WebGlTransformFeedback",
+                    "WebGlUniformLocation",
+                    "WebGlVertexArrayObject",
+                    "WebglColorBufferFloat",
+                    "WebglCompressedTextureAstc",
+                    "WebglCompressedTextureEtc",
+                    "WebglCompressedTextureEtc1",
+                    "WebglCompressedTexturePvrtc",
+                    "WebglCompressedTextureS3tc",
+                    "WebglCompressedTextureS3tcSrgb",
+                    "WebglDebugRendererInfo",
+                    "WebglDebugShaders",
+                    "WebglDepthTexture",
+                    "WebglDrawBuffers",
+                    "WebglLoseContext",
+                    "Window",
+                    "Worker",
+                    "gpu_map_mode"
+                ]
+            },
+            {
+                "id": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "arrayvec",
+                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "naga",
+                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "parking_lot",
+                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "raw_window_handle",
+                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "smallvec",
+                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "static_assertions",
+                        "pkg": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen_futures",
+                        "pkg": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wgc",
+                        "pkg": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(target_arch = \"wasm32\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hal",
+                        "pkg": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(not(target_arch = \"wasm32\"), target_os = \"emscripten\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wgt",
+                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default"
+                ]
+            },
+            {
+                "id": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "arrayvec",
+                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bit_vec",
+                        "pkg": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "cfg_aliases",
+                        "pkg": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": "build",
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codespan_reporting",
+                        "pkg": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "fxhash",
+                        "pkg": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "naga",
+                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "parking_lot",
+                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "profiling",
+                        "pkg": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "raw_window_handle",
+                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "smallvec",
+                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "thiserror",
+                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "hal",
+                        "pkg": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(all(not(target_arch = \"wasm32\"), any(target_os = \"ios\", target_os = \"macos\")))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(all(not(target_arch = \"wasm32\"), unix, not(target_os = \"ios\"), not(target_os = \"macos\")))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(all(not(target_arch = \"wasm32\"), windows))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_arch = \"wasm32\")"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"emscripten\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wgt",
+                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "default",
+                    "raw-window-handle"
+                ]
+            },
+            {
+                "id": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "android_system_properties",
+                        "pkg": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"android\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "arrayvec",
+                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ash",
+                        "pkg": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bit_set",
+                        "pkg": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "block",
+                        "pkg": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "core_graphics_types",
+                        "pkg": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "native",
+                        "pkg": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "foreign_types",
+                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "fxhash",
+                        "pkg": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "glow",
+                        "pkg": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "gpu_alloc",
+                        "pkg": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "gpu_descriptor",
+                        "pkg": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "js_sys",
+                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "egl",
+                        "pkg": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(target_arch = \"wasm32\"))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"emscripten\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "libloading",
+                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(not(target_arch = \"wasm32\"))"
+                            },
+                            {
+                                "kind": null,
+                                "target": "cfg(target_os = \"emscripten\")"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "log",
+                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "mtl",
+                        "pkg": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "naga",
+                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "objc",
+                        "pkg": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(any(target_os = \"macos\", target_os = \"ios\"))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "parking_lot",
+                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "profiling",
+                        "pkg": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "range_alloc",
+                        "pkg": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "raw_window_handle",
+                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "renderdoc_sys",
+                        "pkg": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "smallvec",
+                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "thiserror",
+                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wasm_bindgen",
+                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "web_sys",
+                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "wgt",
+                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "ash",
+                    "bit-set",
+                    "block",
+                    "default",
+                    "dx11",
+                    "dx12",
+                    "egl",
+                    "emscripten",
+                    "foreign-types",
+                    "gles",
+                    "glow",
+                    "gpu-alloc",
+                    "gpu-descriptor",
+                    "libloading",
+                    "metal",
+                    "native",
+                    "range-alloc",
+                    "renderdoc",
+                    "renderdoc-sys",
+                    "smallvec",
+                    "vulkan"
+                ]
+            },
+            {
+                "id": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "bitflags",
+                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi_i686_pc_windows_gnu",
+                        "pkg": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "winapi_x86_64_pc_windows_gnu",
+                        "pkg": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnu"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "consoleapi",
+                    "d3d11",
+                    "d3d11_1",
+                    "d3d11_2",
+                    "d3d11sdklayers",
+                    "d3d12",
+                    "d3d12sdklayers",
+                    "d3d12shader",
+                    "d3dcommon",
+                    "d3dcompiler",
+                    "dcomp",
+                    "dxgi1_2",
+                    "dxgi1_3",
+                    "dxgi1_4",
+                    "dxgi1_5",
+                    "dxgi1_6",
+                    "dxgidebug",
+                    "dxgiformat",
+                    "errhandlingapi",
+                    "fileapi",
+                    "libloaderapi",
+                    "minwindef",
+                    "processenv",
+                    "std",
+                    "synchapi",
+                    "winbase",
+                    "wincon",
+                    "windef",
+                    "winerror",
+                    "winnt",
+                    "winuser"
+                ]
+            },
+            {
+                "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "winapi",
+                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "cfg(windows)"
+                            }
+                        ]
+                    }
+                ],
+                "features": []
+            },
+            {
+                "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [
+                    "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                    "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                ],
+                "deps": [
+                    {
+                        "name": "windows_aarch64_gnullvm",
+                        "pkg": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_aarch64_msvc",
+                        "pkg": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "aarch64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "aarch64-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_gnu",
+                        "pkg": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_i686_msvc",
+                        "pkg": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "i686-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "i686-uwp-windows-msvc"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnu",
+                        "pkg": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnu"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-gnu"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_gnullvm",
+                        "pkg": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-gnullvm"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "windows_x86_64_msvc",
+                        "pkg": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": "x86_64-pc-windows-msvc"
+                            },
+                            {
+                                "kind": null,
+                                "target": "x86_64-uwp-windows-msvc"
+                            }
+                        ]
+                    }
+                ],
+                "features": [
+                    "Win32",
+                    "Win32_Foundation",
+                    "Win32_System",
+                    "Win32_System_LibraryLoader",
+                    "Win32_System_SystemServices",
+                    "Win32_System_WindowsProgramming",
+                    "default"
+                ]
+            },
+            {
+                "id": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            },
+            {
+                "id": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                "dependencies": [],
+                "deps": [],
+                "features": []
+            }
+        ],
+        "root": "parent 0.1.0 (path+file://{TEMP_DIR}/workspace)"
+    },
+    "target_directory": "{TEMP_DIR}/workspace/target",
+    "version": 1,
+    "workspace_root": "{TEMP_DIR}/workspace",
+    "metadata": null
+}

--- a/crate_universe/test_data/private/metadata_generator.py
+++ b/crate_universe/test_data/private/metadata_generator.py
@@ -45,20 +45,23 @@ if __name__ == "__main__":
 
             # Copy the test directory into a temp directory (and out from under a Cargo workspace)
             manifest_dir = temp_dir_path / test_dir.name
-            # manifest_dir.mkdir(parents=True, exist_ok=True)
             shutil.copytree(test_dir, manifest_dir)
 
             manifest = manifest_dir / "Cargo.toml"
-
-            # Generate Lockfile
-            proc = run_subprocess([cargo, "generate-lockfile", "--manifest-path", str(manifest)])
             lockfile = manifest_dir / "Cargo.lock"
-            if not lockfile.exists():
-                print("Faield to generate lockfile")
-                print("Args:", proc.args, file=sys.stderr)
-                print("stderr:", proc.stderr.decode("utf-8"), file=sys.stderr)
-                print("stdout:", proc.stdout.decode("utf-8"), file=sys.stderr)
-                exit(1)
+
+            if lockfile.exists():
+                proc = run_subprocess([cargo, "update", "--manifest-path", str(manifest), "--workspace"])
+            else:
+                # Generate Lockfile
+                proc = run_subprocess([cargo, "generate-lockfile", "--manifest-path", str(manifest)])
+            
+                if not lockfile.exists():
+                    print("Faield to generate lockfile")
+                    print("Args:", proc.args, file=sys.stderr)
+                    print("stderr:", proc.stderr.decode("utf-8"), file=sys.stderr)
+                    print("stdout:", proc.stdout.decode("utf-8"), file=sys.stderr)
+                    exit(1)
 
             shutil.copy2(str(lockfile), str(test_dir / "Cargo.lock"))
 


### PR DESCRIPTION
This change updates test metadata and adds a test to check the expected behavior for parsing [build dependencies](https://doc.rust-lang.org/cargo/reference/build-scripts.html#build-dependencies) from targets.