### PR TITLE
Crate Universe: enable all features when generating metadata

### DIFF
--- a/crate_universe/src/metadata.rs
+++ b/crate_universe/src/metadata.rs
@@ -77,6 +77,7 @@ impl MetadataGenerator for Generator {
         let metadata = self
             .cargo_bin
             .metadata_command()?
+            .features(cargo_metadata::CargoOpt::AllFeatures)
             .current_dir(manifest_dir)
             .manifest_path(manifest_path.as_ref())
             .other_options(["--locked".to_owned()])


### PR DESCRIPTION
Closes https://github.com/bazelbuild/rules_rust/issues/1939

Enabling "all features" in the metadata-generateion, will add all the dependencies to metadata. Later this metadata is used to create bazel packages and fetch dependencies.

this fixes the my problem, described in https://github.com/bazelbuild/rules_rust/issues/1939

Tests seem to pass.

Open questions:
 - where is a good place to add test for this functionality?
 - are there undesired side-effects of this change? If yes probably we need tests for them as well?