### PR TITLE
rustdoc_test: Apply prefix stripping to proc_macro dependencies.

### DIFF
--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -67,7 +67,7 @@ def _construct_writer_arguments(ctx, test_runner, opt_test_params, action, crate
     root = crate_info.output.root.path
     if not root in roots:
         roots.append(root)
-    for dep in crate_info.deps.to_list():
+    for dep in crate_info.deps.to_list() + crate_info.proc_macro_deps.to_list():
         dep_crate_info = getattr(dep, "crate_info", None)
         dep_dep_info = getattr(dep, "dep_info", None)
         if dep_crate_info:

--- a/test/unit/rustdoc/procmacro_in_rustdoc.rs
+++ b/test/unit/rustdoc/procmacro_in_rustdoc.rs
@@ -1,0 +1,9 @@
+/// A different answer that only exists if using procmacros.
+/// ```
+/// use rustdoc_proc_macro::make_answer;
+/// make_answer!();
+/// assert_eq!(answer(), 42);
+/// ```
+pub fn procmacro_answer() -> u32 {
+    24
+}

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -74,6 +74,14 @@ def _rustdoc_for_lib_with_proc_macro_test_impl(ctx):
 
     return analysistest.end(env)
 
+def _rustdoc_for_lib_with_proc_macro_in_docs_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+
+    _common_rustdoc_checks(env, tut)
+
+    return analysistest.end(env)
+
 def _rustdoc_for_bin_with_transitive_proc_macro_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
@@ -145,6 +153,7 @@ rustdoc_for_bin_with_cc_lib_test = analysistest.make(_rustdoc_for_bin_with_cc_li
 rustdoc_for_bin_with_transitive_cc_lib_test = analysistest.make(_rustdoc_for_bin_with_transitive_cc_lib_test_impl)
 rustdoc_for_proc_macro_test = analysistest.make(_rustdoc_for_proc_macro_test_impl)
 rustdoc_for_lib_with_proc_macro_test = analysistest.make(_rustdoc_for_lib_with_proc_macro_test_impl)
+rustdoc_for_lib_with_proc_macro_in_docs_test = analysistest.make(_rustdoc_for_lib_with_proc_macro_in_docs_test_impl)
 rustdoc_for_bin_with_transitive_proc_macro_test = analysistest.make(_rustdoc_for_bin_with_transitive_proc_macro_test_impl)
 rustdoc_for_lib_with_cc_lib_test = analysistest.make(_rustdoc_for_lib_with_cc_lib_test_impl)
 rustdoc_with_args_test = analysistest.make(_rustdoc_with_args_test_impl)
@@ -232,6 +241,13 @@ def _define_targets():
         rustdoc_deps = [":adder"],
         proc_macro_deps = [":rustdoc_proc_macro"],
         crate_features = ["with_proc_macro"],
+    )
+
+    _target_maker(
+        rust_library,
+        name = "lib_with_proc_macro_in_docs",
+        srcs = ["procmacro_in_rustdoc.rs"],
+        proc_macro_deps = [":rustdoc_proc_macro"],
     )
 
     _target_maker(
@@ -371,6 +387,11 @@ def rustdoc_test_suite(name):
         target_under_test = ":rustdoc_proc_macro_doc",
     )
 
+    rustdoc_for_lib_with_proc_macro_in_docs_test(
+        name = "rustdoc_for_lib_with_proc_macro_in_docs_test",
+        target_under_test = ":lib_with_proc_macro_in_docs_doc",
+    )
+
     rustdoc_for_lib_with_proc_macro_test(
         name = "rustdoc_for_lib_with_proc_macro_test",
         target_under_test = ":lib_with_proc_macro_doc",
@@ -414,6 +435,7 @@ def rustdoc_test_suite(name):
             ":rustdoc_for_bin_with_cc_lib_test",
             ":rustdoc_for_bin_with_transitive_cc_lib_test",
             ":rustdoc_for_proc_macro_test",
+            ":rustdoc_for_lib_with_proc_macro_in_docs_test",
             ":rustdoc_for_lib_with_proc_macro_test",
             ":rustdoc_for_lib_with_cc_lib_test",
             ":rustdoc_with_args_test",


### PR DESCRIPTION
Without stripping the prefix, rustdoc can not find the proc macro shared library.

It's not entirely clear to me why `//test/unit/rustdoc:lib_with_proc_macro` passes without this. When I run `bazel test //test/unit/rustdoc:rustdoc_test_suite     --subcommands` I don't see any "action 'Generating Rustdoc test runner for.." lines so perhaps that path is not tested?