### PR TITLE
Add T2 support for thumbv7em-none-eabi

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -36,6 +36,7 @@ SUPPORTED_T2_PLATFORM_TRIPLES = [
     "riscv32imc-unknown-none-elf",
     "riscv64gc-unknown-none-elf",
     "s390x-unknown-linux-gnu",
+    "thumbv7em-none-eabi",
     "wasm32-unknown-unknown",
     "wasm32-wasi",
     "x86_64-apple-ios",


### PR DESCRIPTION
We have been using this patch internally for several months without
any issues.

Signed-off-by: Curt Brune <curt@enfabrica.net>