### PR TITLE
Update `rust_test` to produce outputs with predictable names.

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1357,6 +1357,7 @@ def rustc_compile_action(
             target_file = executable,
             is_executable = True,
         )
+        runfiles = runfiles.merge(ctx.runfiles(files=outputs))
         executable = predictable_output
 
     providers = [


### PR DESCRIPTION
A followup to https://github.com/bazelbuild/rules_rust/pull/1600