### PR TITLE
feature: `target_compatible_with` added to `CommonAttrs`

### DIFF
--- a/crate_universe/private/crates_repository.bzl
+++ b/crate_universe/private/crates_repository.bzl
@@ -227,6 +227,13 @@ CARGO_BAZEL_REPIN=1 CARGO_BAZEL_REPIN_ONLY=crate_index bazel sync --only=crate_i
             ),
             default = True,
         ),
+        "generate_target_compatible_with": attr.bool(
+            doc = (
+                "Whether to generate `target_compatible_with` annotations on the generated BUILD files.  This catches a `target_triple` " +
+                "being targeted that isn't declared in `supported_platform_triples."
+            ),
+            default = True,
+        ),
         "generator": attr.string(
             doc = (
                 "The absolute label of a generator. Eg. `@cargo_bazel_bootstrap//:cargo-bazel`. " +

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -178,6 +178,7 @@ def _write_config_file(ctx):
         crate_annotations = ctx.attr.annotations,
         generate_binaries = ctx.attr.generate_binaries,
         generate_build_scripts = ctx.attr.generate_build_scripts,
+        generate_target_compatible_with = ctx.attr.generate_target_compatible_with,
         cargo_config = None,
         render_config = rendering_config,
         supported_platform_triples = ctx.attr.supported_platform_triples,
@@ -290,7 +291,7 @@ This rule is useful for users whose workspaces are expected to be consumed in ot
 rendered `BUILD` files reduce the number of workspace dependencies, allowing for easier loads. This rule
 handles all the same [workflows](#workflows) `crate_universe` rules do.
 
-Example: 
+Example:
 
 Given the following workspace structure:
 
@@ -402,6 +403,13 @@ call against the generated workspace. The following table describes how to contr
             doc = (
                 "Whether or not to generate " +
                 "[cargo build scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html) by default."
+            ),
+            default = True,
+        ),
+        "generate_target_compatible_with": attr.bool(
+            doc = (
+                "Whether to generate `target_compatible_with` annotations on the generated BUILD files.  This catches a `target_triple` " +
+                "being targeted that isn't declared in `supported_platform_triples."
             ),
             default = True,
         ),

--- a/crate_universe/private/generate_utils.bzl
+++ b/crate_universe/private/generate_utils.bzl
@@ -213,6 +213,7 @@ def compile_config(
         crate_annotations,
         generate_binaries,
         generate_build_scripts,
+        generate_target_compatible_with,
         cargo_config,
         render_config,
         supported_platform_triples,
@@ -227,6 +228,7 @@ def compile_config(
             `crates_repository.annotations` or `crates_vendor.annotations`.
         generate_binaries (bool): Whether to generate `rust_binary` targets for all bins.
         generate_build_scripts (bool): Whether or not to globally disable build scripts.
+        generate_target_compatible_with (bool): Whether to emit `target_compatible_with` on generated rules
         cargo_config (str): The optional contents of a [Cargo config][cargo_config].
         render_config (dict): The deserialized dict of the `render_config` function.
         supported_platform_triples (list): A list of platform triples
@@ -259,6 +261,7 @@ def compile_config(
     config = struct(
         generate_binaries = generate_binaries,
         generate_build_scripts = generate_build_scripts,
+        generate_target_compatible_with = generate_target_compatible_with,
         annotations = annotations,
         cargo_config = cargo_config,
         rendering = _update_render_config(
@@ -284,6 +287,7 @@ def generate_config(repository_ctx):
         crate_annotations = repository_ctx.attr.annotations,
         generate_binaries = repository_ctx.attr.generate_binaries,
         generate_build_scripts = repository_ctx.attr.generate_build_scripts,
+        generate_target_compatible_with = repository_ctx.attr.generate_target_compatible_with,
         cargo_config = _read_cargo_config(repository_ctx),
         render_config = _get_render_config(repository_ctx),
         supported_platform_triples = repository_ctx.attr.supported_platform_triples,

--- a/crate_universe/private/srcs.bzl
+++ b/crate_universe/private/srcs.bzl
@@ -38,4 +38,5 @@ CARGO_BAZEL_SRCS = [
     Label("//crate_universe:src/utils/starlark/label.rs"),
     Label("//crate_universe:src/utils/starlark/select.rs"),
     Label("//crate_universe:src/utils/starlark/serialize.rs"),
+    Label("//crate_universe:src/utils/starlark/target_compatible_with.rs"),
 ]

--- a/crate_universe/src/cli/generate.rs
+++ b/crate_universe/src/cli/generate.rs
@@ -73,7 +73,8 @@ pub fn generate(opt: GenerateOptions) -> Result<()> {
             let context = Context::try_from_path(lockfile)?;
 
             // Render build files
-            let outputs = Renderer::new(config.rendering).render(&context)?;
+            let outputs = Renderer::new(config.rendering, config.supported_platform_triples)
+                .render(&context)?;
 
             // Write the outputs to disk
             write_outputs(outputs, &opt.repository_dir, opt.dry_run)?;
@@ -101,9 +102,6 @@ pub fn generate(opt: GenerateOptions) -> Result<()> {
     // Load Metadata and Lockfile
     let (cargo_metadata, cargo_lockfile) = load_metadata(metadata_path)?;
 
-    // Copy the rendering config for later use
-    let render_config = config.rendering.clone();
-
     // Annotate metadata
     let annotations = Annotations::new(cargo_metadata, cargo_lockfile.clone(), config.clone())?;
 
@@ -111,7 +109,11 @@ pub fn generate(opt: GenerateOptions) -> Result<()> {
     let context = Context::new(annotations)?;
 
     // Render build files
-    let outputs = Renderer::new(render_config).render(&context)?;
+    let outputs = Renderer::new(
+        config.rendering.clone(),
+        config.supported_platform_triples.clone(),
+    )
+    .render(&context)?;
 
     // Write outputs
     write_outputs(outputs, &opt.repository_dir, opt.dry_run)?;

--- a/crate_universe/src/cli/generate.rs
+++ b/crate_universe/src/cli/generate.rs
@@ -73,8 +73,12 @@ pub fn generate(opt: GenerateOptions) -> Result<()> {
             let context = Context::try_from_path(lockfile)?;
 
             // Render build files
-            let outputs = Renderer::new(config.rendering, config.supported_platform_triples)
-                .render(&context)?;
+            let outputs = Renderer::new(
+                config.rendering,
+                config.supported_platform_triples,
+                config.generate_target_compatible_with,
+            )
+            .render(&context)?;
 
             // Write the outputs to disk
             write_outputs(outputs, &opt.repository_dir, opt.dry_run)?;
@@ -112,6 +116,7 @@ pub fn generate(opt: GenerateOptions) -> Result<()> {
     let outputs = Renderer::new(
         config.rendering.clone(),
         config.supported_platform_triples.clone(),
+        config.generate_target_compatible_with,
     )
     .render(&context)?;
 

--- a/crate_universe/src/cli/vendor.rs
+++ b/crate_universe/src/cli/vendor.rs
@@ -174,6 +174,7 @@ pub fn vendor(opt: VendorOptions) -> Result<()> {
     let outputs = Renderer::new(
         config.rendering.clone(),
         config.supported_platform_triples.clone(),
+        config.generate_target_compatible_with,
     )
     .render(&context)?;
 

--- a/crate_universe/src/cli/vendor.rs
+++ b/crate_universe/src/cli/vendor.rs
@@ -171,7 +171,11 @@ pub fn vendor(opt: VendorOptions) -> Result<()> {
     let context = Context::new(annotations)?;
 
     // Render build files
-    let outputs = Renderer::new(config.rendering.clone()).render(&context)?;
+    let outputs = Renderer::new(
+        config.rendering.clone(),
+        config.supported_platform_triples.clone(),
+    )
+    .render(&context)?;
 
     // Cache the file names for potential use with buildifier
     let file_names: BTreeSet<PathBuf> = outputs.keys().cloned().collect();

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -508,6 +508,13 @@ pub struct Config {
     /// Whether or not to generate Cargo build scripts by default
     pub generate_build_scripts: bool,
 
+    /// A set of platform triples to use in generated select statements
+    #[serde(
+        default = "default_generate_target_compatible_with",
+        skip_serializing_if = "skip_generate_target_compatible_with"
+    )]
+    pub generate_target_compatible_with: bool,
+
     /// Additional settings to apply to generated crates
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub annotations: BTreeMap<CrateId, CrateAnnotations>,
@@ -528,6 +535,13 @@ impl Config {
         let data = fs::read_to_string(path)?;
         Ok(serde_json::from_str(&data)?)
     }
+}
+
+fn default_generate_target_compatible_with() -> bool {
+    true
+}
+fn skip_generate_target_compatible_with(value: &bool) -> bool {
+    *value
 }
 
 #[cfg(test)]

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -38,7 +38,7 @@ impl std::fmt::Display for VendorMode {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct RenderConfig {
     /// The name of the repository being rendered
@@ -77,8 +77,27 @@ pub struct RenderConfig {
     /// The command to use for regenerating generated files.
     pub regen_command: String,
 
-    /// An optional configuration for rendirng content to be rendered into repositories.
+    /// An optional configuration for rendering content to be rendered into repositories.
     pub vendor_mode: Option<VendorMode>,
+}
+
+// Default is manually implemented so that the default values match the default
+// values when deserializing, which involves calling the vairous `default_x()`
+// functions specified in `#[serde(default = "default_x")]`.
+impl Default for RenderConfig {
+    fn default() -> Self {
+        RenderConfig {
+            repository_name: String::default(),
+            build_file_template: default_build_file_template(),
+            crate_label_template: default_crate_label_template(),
+            crates_module_template: default_crates_module_template(),
+            crate_repository_template: default_crate_repository_template(),
+            default_package_name: Option::default(),
+            platforms_template: default_platforms_template(),
+            regen_command: String::default(),
+            vendor_mode: Option::default(),
+        }
+    }
 }
 
 fn default_build_file_template() -> String {

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -211,7 +211,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("7b4142c24aff865f158da49840f7f23a6921c65f28999dd03fdd4bc83eb3fcb1".to_owned())
+            Digest("fcca6635448d70091bffb6409f5edb153a46fcf7e889e39a33a9b9ff6e345ca0".to_owned())
         );
     }
 
@@ -256,7 +256,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("c8cffedeccfa9262d8d69d15210c2b9322d40486c1f73da652a92c7f2efef9d7".to_owned())
+            Digest("c90e7e5a98e49884c9962f99aea5cf20d5a32df243dbb549001c50badf0a02d3".to_owned())
         );
     }
 
@@ -287,7 +287,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("fab65a87a9b8e008c68842cde1a62ca1c1196b835affeb8525cae0bfc890f1c2".to_owned())
+            Digest("e199dd859bd5b75d6b152f364f8cc6ad6c3a2a68ae777dfb8b250c2d90e35f28".to_owned())
         );
     }
 
@@ -336,7 +336,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("302a5f2e564ecb8002838a1e7865cf2b97ce776cb55f06c7d3efab8b73eee922".to_owned())
+            Digest("0222be160f1031346cc209a8732c678bf32acb08f891fdfa0e9965d0ad22a33a".to_owned())
         );
     }
 }

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -211,7 +211,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("7be4f323ac6a4d0a45d9d430a8056967eb248ca7c86bdba44af33ad90392cb4a".to_owned())
+            Digest("7b4142c24aff865f158da49840f7f23a6921c65f28999dd03fdd4bc83eb3fcb1".to_owned())
         );
     }
 
@@ -256,7 +256,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("0485e1ac3d5a868679b2ee4b59443eec3f8b54e1f4824f7c251b20031542f64c".to_owned())
+            Digest("c8cffedeccfa9262d8d69d15210c2b9322d40486c1f73da652a92c7f2efef9d7".to_owned())
         );
     }
 
@@ -287,7 +287,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("c343bd2a351184bec7abad0016d45e1f4a89ec2fdf3f63d86e414206814ae483".to_owned())
+            Digest("fab65a87a9b8e008c68842cde1a62ca1c1196b835affeb8525cae0bfc890f1c2".to_owned())
         );
     }
 
@@ -336,7 +336,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("16dc7c9c8d2e1f50e070ae10b7a06a42c962c2afa9a60a73043eb74c5fb6cd82".to_owned())
+            Digest("302a5f2e564ecb8002838a1e7865cf2b97ce776cb55f06c7d3efab8b73eee922".to_owned())
         );
     }
 }

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -19,7 +19,7 @@ use crate::splicing::default_splicing_package_crate_id;
 use crate::utils::starlark::{
     self, Alias, CargoBuildScript, CommonAttrs, Data, ExportsFiles, Filegroup, Glob, Label, Load,
     Package, RustBinary, RustLibrary, RustProcMacro, Select, SelectDict, SelectList, SelectMap,
-    Starlark,
+    Starlark, TargetCompatibleWith,
 };
 use crate::utils::{self, sanitize_repository_name};
 
@@ -29,13 +29,18 @@ type Platforms = BTreeMap<String, BTreeSet<String>>;
 
 pub struct Renderer {
     config: RenderConfig,
+    supported_platform_triples: BTreeSet<String>,
     engine: TemplateEngine,
 }
 
 impl Renderer {
-    pub fn new(config: RenderConfig) -> Self {
+    pub fn new(config: RenderConfig, supported_platform_triples: BTreeSet<String>) -> Self {
         let engine = TemplateEngine::new(&config);
-        Self { config, engine }
+        Self {
+            config,
+            supported_platform_triples,
+            engine,
+        }
     }
 
     pub fn render(&self, context: &Context) -> Result<BTreeMap<PathBuf, String>> {
@@ -525,6 +530,14 @@ impl Renderer {
                 tags.insert(format!("crate-name={}", krate.name));
                 tags
             },
+            target_compatible_with: TargetCompatibleWith::new(
+                self.supported_platform_triples
+                    .iter()
+                    .map(|triple| {
+                        render_platform_constraint_label(&self.config.platforms_template, triple)
+                    })
+                    .collect(),
+            ),
             version: krate.common_attrs.version.clone(),
         })
     }
@@ -740,20 +753,48 @@ mod test {
     use crate::test;
     use crate::utils::starlark::SelectList;
 
-    fn mock_render_config() -> RenderConfig {
-        serde_json::from_value(serde_json::json!({
-            "repository_name": "test_rendering",
-            "regen_command": "cargo_bazel_regen_command",
-        }))
-        .unwrap()
-    }
-
     fn mock_target_attributes() -> TargetAttributes {
         TargetAttributes {
             crate_name: "mock_crate".to_owned(),
             crate_root: Some("src/root.rs".to_owned()),
             ..TargetAttributes::default()
         }
+    }
+
+    fn mock_render_config(vendor_mode: Option<VendorMode>) -> RenderConfig {
+        RenderConfig {
+            repository_name: "test_rendering".to_owned(),
+            regen_command: "cargo_bazel_regen_command".to_owned(),
+            vendor_mode,
+            ..RenderConfig::default()
+        }
+    }
+
+    fn mock_supported_platform_triples() -> BTreeSet<String> {
+        BTreeSet::from([
+            "aarch64-apple-darwin".to_owned(),
+            "aarch64-apple-ios".to_owned(),
+            "aarch64-linux-android".to_owned(),
+            "aarch64-pc-windows-msvc".to_owned(),
+            "aarch64-unknown-linux-gnu".to_owned(),
+            "arm-unknown-linux-gnueabi".to_owned(),
+            "armv7-unknown-linux-gnueabi".to_owned(),
+            "i686-apple-darwin".to_owned(),
+            "i686-linux-android".to_owned(),
+            "i686-pc-windows-msvc".to_owned(),
+            "i686-unknown-freebsd".to_owned(),
+            "i686-unknown-linux-gnu".to_owned(),
+            "powerpc-unknown-linux-gnu".to_owned(),
+            "s390x-unknown-linux-gnu".to_owned(),
+            "wasm32-unknown-unknown".to_owned(),
+            "wasm32-wasi".to_owned(),
+            "x86_64-apple-darwin".to_owned(),
+            "x86_64-apple-ios".to_owned(),
+            "x86_64-linux-android".to_owned(),
+            "x86_64-pc-windows-msvc".to_owned(),
+            "x86_64-unknown-freebsd".to_owned(),
+            "x86_64-unknown-linux-gnu".to_owned(),
+        ])
     }
 
     #[test]
@@ -770,7 +811,7 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -797,7 +838,7 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -827,7 +868,7 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -856,7 +897,7 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -882,7 +923,7 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -911,7 +952,7 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -931,7 +972,7 @@ mod test {
             Annotations::new(test::metadata::alias(), test::lockfile::alias(), config).unwrap();
         let context = Context::new(annotations).unwrap();
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output.get(&PathBuf::from("BUILD.bazel")).unwrap();
@@ -954,7 +995,7 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let defs_module = output.get(&PathBuf::from("defs.bzl")).unwrap();
@@ -977,12 +1018,10 @@ mod test {
         );
 
         // Enable remote vendor mode
-        let config = RenderConfig {
-            vendor_mode: Some(VendorMode::Remote),
-            ..mock_render_config()
-        };
-
-        let renderer = Renderer::new(config);
+        let renderer = Renderer::new(
+            mock_render_config(Some(VendorMode::Remote)),
+            mock_supported_platform_triples(),
+        );
         let output = renderer.render(&context).unwrap();
 
         let defs_module = output.get(&PathBuf::from("defs.bzl")).unwrap();
@@ -1007,12 +1046,10 @@ mod test {
         );
 
         // Enable local vendor mode
-        let config = RenderConfig {
-            vendor_mode: Some(VendorMode::Local),
-            ..mock_render_config()
-        };
-
-        let renderer = Renderer::new(config);
+        let renderer = Renderer::new(
+            mock_render_config(Some(VendorMode::Local)),
+            mock_supported_platform_triples(),
+        );
         let output = renderer.render(&context).unwrap();
 
         // Local vendoring does not produce a `crate_repositories` macro
@@ -1050,12 +1087,10 @@ mod test {
         );
 
         // Enable local vendor mode
-        let config = RenderConfig {
-            vendor_mode: Some(VendorMode::Local),
-            ..mock_render_config()
-        };
-
-        let renderer = Renderer::new(config);
+        let renderer = Renderer::new(
+            mock_render_config(Some(VendorMode::Local)),
+            mock_supported_platform_triples(),
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -1096,7 +1131,7 @@ mod test {
         let annotations = Annotations::new(metadata, lockfile, config.clone()).unwrap();
         let context = Context::new(annotations).unwrap();
 
-        let renderer = Renderer::new(config.rendering);
+        let renderer = Renderer::new(config.rendering, config.supported_platform_triples);
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -1145,7 +1180,7 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -1180,7 +1215,7 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config());
+        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -30,15 +30,21 @@ type Platforms = BTreeMap<String, BTreeSet<String>>;
 pub struct Renderer {
     config: RenderConfig,
     supported_platform_triples: BTreeSet<String>,
+    generate_target_compatible_with: bool,
     engine: TemplateEngine,
 }
 
 impl Renderer {
-    pub fn new(config: RenderConfig, supported_platform_triples: BTreeSet<String>) -> Self {
+    pub fn new(
+        config: RenderConfig,
+        supported_platform_triples: BTreeSet<String>,
+        generate_target_compatible_with: bool,
+    ) -> Self {
         let engine = TemplateEngine::new(&config);
         Self {
             config,
             supported_platform_triples,
+            generate_target_compatible_with,
             engine,
         }
     }
@@ -530,14 +536,19 @@ impl Renderer {
                 tags.insert(format!("crate-name={}", krate.name));
                 tags
             },
-            target_compatible_with: TargetCompatibleWith::new(
-                self.supported_platform_triples
-                    .iter()
-                    .map(|triple| {
-                        render_platform_constraint_label(&self.config.platforms_template, triple)
-                    })
-                    .collect(),
-            ),
+            target_compatible_with: self.generate_target_compatible_with.then(|| {
+                TargetCompatibleWith::new(
+                    self.supported_platform_triples
+                        .iter()
+                        .map(|triple| {
+                            render_platform_constraint_label(
+                                &self.config.platforms_template,
+                                triple,
+                            )
+                        })
+                        .collect(),
+                )
+            }),
             version: krate.common_attrs.version.clone(),
         })
     }
@@ -811,7 +822,11 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -838,7 +853,11 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -868,7 +887,11 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -897,7 +920,11 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -923,7 +950,11 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -952,7 +983,11 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -972,7 +1007,11 @@ mod test {
             Annotations::new(test::metadata::alias(), test::lockfile::alias(), config).unwrap();
         let context = Context::new(annotations).unwrap();
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output.get(&PathBuf::from("BUILD.bazel")).unwrap();
@@ -995,7 +1034,11 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let defs_module = output.get(&PathBuf::from("defs.bzl")).unwrap();
@@ -1021,6 +1064,7 @@ mod test {
         let renderer = Renderer::new(
             mock_render_config(Some(VendorMode::Remote)),
             mock_supported_platform_triples(),
+            true,
         );
         let output = renderer.render(&context).unwrap();
 
@@ -1049,6 +1093,7 @@ mod test {
         let renderer = Renderer::new(
             mock_render_config(Some(VendorMode::Local)),
             mock_supported_platform_triples(),
+            true,
         );
         let output = renderer.render(&context).unwrap();
 
@@ -1090,6 +1135,7 @@ mod test {
         let renderer = Renderer::new(
             mock_render_config(Some(VendorMode::Local)),
             mock_supported_platform_triples(),
+            true,
         );
         let output = renderer.render(&context).unwrap();
 
@@ -1131,7 +1177,7 @@ mod test {
         let annotations = Annotations::new(metadata, lockfile, config.clone()).unwrap();
         let context = Context::new(annotations).unwrap();
 
-        let renderer = Renderer::new(config.rendering, config.supported_platform_triples);
+        let renderer = Renderer::new(config.rendering, config.supported_platform_triples, true);
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -1180,7 +1226,11 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output
@@ -1215,7 +1265,11 @@ mod test {
             },
         );
 
-        let renderer = Renderer::new(mock_render_config(None), mock_supported_platform_triples());
+        let renderer = Renderer::new(
+            mock_render_config(None),
+            mock_supported_platform_triples(),
+            true,
+        );
         let output = renderer.render(&context).unwrap();
 
         let build_file_content = output

--- a/crate_universe/src/utils/starlark.rs
+++ b/crate_universe/src/utils/starlark.rs
@@ -4,6 +4,7 @@ mod glob;
 mod label;
 mod select;
 mod serialize;
+mod target_compatible_with;
 
 use std::collections::BTreeSet as Set;
 
@@ -13,6 +14,7 @@ use serde_starlark::Error as StarlarkError;
 pub use glob::*;
 pub use label::*;
 pub use select::*;
+pub use target_compatible_with::*;
 
 pub type SelectStringList = SelectList<String>;
 pub type SelectStringDict = SelectDict<String>;
@@ -235,6 +237,8 @@ pub struct CommonAttrs {
     pub srcs: Glob,
     #[serde(skip_serializing_if = "Set::is_empty")]
     pub tags: Set<String>,
+    #[serde(serialize_with = "TargetCompatibleWith::serialize_starlark")]
+    pub target_compatible_with: TargetCompatibleWith,
     pub version: String,
 }
 

--- a/crate_universe/src/utils/starlark/target_compatible_with.rs
+++ b/crate_universe/src/utils/starlark/target_compatible_with.rs
@@ -1,0 +1,92 @@
+use std::collections::BTreeSet;
+
+use serde::ser::{SerializeMap, SerializeTupleStruct, Serializer};
+use serde::{Deserialize, Serialize};
+use serde_starlark::{FunctionCall, MULTILINE};
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone)]
+pub struct TargetCompatibleWith {
+    target_triples: BTreeSet<String>,
+}
+
+impl TargetCompatibleWith {
+    pub fn new(target_triples: BTreeSet<String>) -> Self {
+        TargetCompatibleWith { target_triples }
+    }
+
+    pub fn serialize_starlark<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Output looks like:
+        //
+        //     select({
+        //         "configuration": [],
+        //         "//conditions:default": ["@platforms//:incompatible"],
+        //     })
+
+        let mut plus = serializer.serialize_tuple_struct("+", MULTILINE)?;
+
+        struct SelectInner<'a>(&'a BTreeSet<String>);
+
+        impl<'a> Serialize for SelectInner<'a> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let mut map = serializer.serialize_map(Some(MULTILINE))?;
+                for cfg in self.0 {
+                    map.serialize_entry(cfg, &[] as &[String])?;
+                }
+                map.serialize_entry(
+                    "//conditions:default",
+                    &["@platforms//:incompatible".to_owned()] as &[String],
+                )?;
+                map.end()
+            }
+        }
+
+        plus.serialize_field(&FunctionCall::new(
+            "select",
+            [SelectInner(&self.target_triples)],
+        ))?;
+
+        plus.end()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use indoc::indoc;
+
+    #[test]
+    fn target_compatible_with() {
+        let target_compatible_with = TargetCompatibleWith::new(BTreeSet::from([
+            "@rules_rust//rust/platform:wasm32-unknown-unknown".to_owned(),
+            "@rules_rust//rust/platform:wasm32-wasi".to_owned(),
+            "@rules_rust//rust/platform:x86_64-apple-darwin".to_owned(),
+            "@rules_rust//rust/platform:x86_64-pc-windows-msvc".to_owned(),
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu".to_owned(),
+        ]));
+
+        let expected_starlark = indoc! {r#"
+            select({
+                "@rules_rust//rust/platform:wasm32-unknown-unknown": [],
+                "@rules_rust//rust/platform:wasm32-wasi": [],
+                "@rules_rust//rust/platform:x86_64-apple-darwin": [],
+                "@rules_rust//rust/platform:x86_64-pc-windows-msvc": [],
+                "@rules_rust//rust/platform:x86_64-unknown-linux-gnu": [],
+                "//conditions:default": ["@platforms//:incompatible"],
+            })
+        "#};
+
+        assert_eq!(
+            target_compatible_with
+                .serialize_starlark(serde_starlark::Serializer)
+                .unwrap(),
+            expected_starlark,
+        );
+    }
+}

--- a/crate_universe/test_data/serialized_configs/BUILD.bazel
+++ b/crate_universe/test_data/serialized_configs/BUILD.bazel
@@ -21,6 +21,7 @@ write_file(
             },
             generate_binaries = False,
             generate_build_scripts = False,
+            generate_target_compatible_with = True,
             render_config = json.decode(render_config(
                 platforms_template = "//custom/platform:{triple}",
                 regen_command = "cargo_bazel_regen_command",

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -265,10 +265,11 @@ convenient accessors to larger sections of the dependency graph.
 
 <pre>
 crates_repository(<a href="#crates_repository-name">name</a>, <a href="#crates_repository-annotations">annotations</a>, <a href="#crates_repository-cargo_config">cargo_config</a>, <a href="#crates_repository-cargo_lockfile">cargo_lockfile</a>, <a href="#crates_repository-generate_binaries">generate_binaries</a>,
-                  <a href="#crates_repository-generate_build_scripts">generate_build_scripts</a>, <a href="#crates_repository-generator">generator</a>, <a href="#crates_repository-generator_sha256s">generator_sha256s</a>, <a href="#crates_repository-generator_urls">generator_urls</a>, <a href="#crates_repository-isolated">isolated</a>,
-                  <a href="#crates_repository-lockfile">lockfile</a>, <a href="#crates_repository-manifests">manifests</a>, <a href="#crates_repository-packages">packages</a>, <a href="#crates_repository-quiet">quiet</a>, <a href="#crates_repository-render_config">render_config</a>, <a href="#crates_repository-repo_mapping">repo_mapping</a>,
-                  <a href="#crates_repository-rust_toolchain_cargo_template">rust_toolchain_cargo_template</a>, <a href="#crates_repository-rust_toolchain_rustc_template">rust_toolchain_rustc_template</a>, <a href="#crates_repository-rust_version">rust_version</a>,
-                  <a href="#crates_repository-splicing_config">splicing_config</a>, <a href="#crates_repository-supported_platform_triples">supported_platform_triples</a>)
+                  <a href="#crates_repository-generate_build_scripts">generate_build_scripts</a>, <a href="#crates_repository-generate_target_compatible_with">generate_target_compatible_with</a>, <a href="#crates_repository-generator">generator</a>,
+                  <a href="#crates_repository-generator_sha256s">generator_sha256s</a>, <a href="#crates_repository-generator_urls">generator_urls</a>, <a href="#crates_repository-isolated">isolated</a>, <a href="#crates_repository-lockfile">lockfile</a>, <a href="#crates_repository-manifests">manifests</a>, <a href="#crates_repository-packages">packages</a>, <a href="#crates_repository-quiet">quiet</a>,
+                  <a href="#crates_repository-render_config">render_config</a>, <a href="#crates_repository-repo_mapping">repo_mapping</a>, <a href="#crates_repository-rust_toolchain_cargo_template">rust_toolchain_cargo_template</a>,
+                  <a href="#crates_repository-rust_toolchain_rustc_template">rust_toolchain_rustc_template</a>, <a href="#crates_repository-rust_version">rust_version</a>, <a href="#crates_repository-splicing_config">splicing_config</a>,
+                  <a href="#crates_repository-supported_platform_triples">supported_platform_triples</a>)
 </pre>
 
 A rule for defining and downloading Rust dependencies (crates). This rule
@@ -372,6 +373,7 @@ CARGO_BAZEL_REPIN=1 CARGO_BAZEL_REPIN_ONLY=crate_index bazel sync --only=crate_i
 | <a id="crates_repository-cargo_lockfile"></a>cargo_lockfile |  The path used to store the <code>crates_repository</code> specific [Cargo.lock](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html) file. In the case that your <code>crates_repository</code> corresponds directly with an existing <code>Cargo.toml</code> file which has a paired <code>Cargo.lock</code> file, that <code>Cargo.lock</code> file should be used here, which will keep the versions used by cargo and bazel in sync.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="crates_repository-generate_binaries"></a>generate_binaries |  Whether to generate <code>rust_binary</code> targets for all the binary crates in every package. By default only the <code>rust_library</code> targets are generated.   | Boolean | optional | <code>False</code> |
 | <a id="crates_repository-generate_build_scripts"></a>generate_build_scripts |  Whether or not to generate [cargo build scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html) by default.   | Boolean | optional | <code>True</code> |
+| <a id="crates_repository-generate_target_compatible_with"></a>generate_target_compatible_with |  Whether to generate <code>target_compatible_with</code> annotations on the generated BUILD files.  This catches a <code>target_triple</code> being targeted that isn't declared in <code>supported_platform_triples.   | Boolean | optional | <code>True</code> |
 | <a id="crates_repository-generator"></a>generator |  The absolute label of a generator. Eg. <code>@cargo_bazel_bootstrap//:cargo-bazel</code>. This is typically used when bootstrapping   | String | optional | <code>""</code> |
 | <a id="crates_repository-generator_sha256s"></a>generator_sha256s |  Dictionary of <code>host_triple</code> -&gt; <code>sha256</code> for a <code>cargo-bazel</code> binary.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
 | <a id="crates_repository-generator_urls"></a>generator_urls |  URL template from which to download the <code>cargo-bazel</code> binary. <code>{host_triple}</code> and will be filled in according to the host platform.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
@@ -395,8 +397,9 @@ CARGO_BAZEL_REPIN=1 CARGO_BAZEL_REPIN_ONLY=crate_index bazel sync --only=crate_i
 
 <pre>
 crates_vendor(<a href="#crates_vendor-name">name</a>, <a href="#crates_vendor-annotations">annotations</a>, <a href="#crates_vendor-bazel">bazel</a>, <a href="#crates_vendor-buildifier">buildifier</a>, <a href="#crates_vendor-cargo_bazel">cargo_bazel</a>, <a href="#crates_vendor-cargo_config">cargo_config</a>, <a href="#crates_vendor-cargo_lockfile">cargo_lockfile</a>,
-              <a href="#crates_vendor-generate_binaries">generate_binaries</a>, <a href="#crates_vendor-generate_build_scripts">generate_build_scripts</a>, <a href="#crates_vendor-manifests">manifests</a>, <a href="#crates_vendor-mode">mode</a>, <a href="#crates_vendor-packages">packages</a>, <a href="#crates_vendor-render_config">render_config</a>,
-              <a href="#crates_vendor-repository_name">repository_name</a>, <a href="#crates_vendor-splicing_config">splicing_config</a>, <a href="#crates_vendor-supported_platform_triples">supported_platform_triples</a>, <a href="#crates_vendor-vendor_path">vendor_path</a>)
+              <a href="#crates_vendor-generate_binaries">generate_binaries</a>, <a href="#crates_vendor-generate_build_scripts">generate_build_scripts</a>, <a href="#crates_vendor-generate_target_compatible_with">generate_target_compatible_with</a>, <a href="#crates_vendor-manifests">manifests</a>,
+              <a href="#crates_vendor-mode">mode</a>, <a href="#crates_vendor-packages">packages</a>, <a href="#crates_vendor-render_config">render_config</a>, <a href="#crates_vendor-repository_name">repository_name</a>, <a href="#crates_vendor-splicing_config">splicing_config</a>,
+              <a href="#crates_vendor-supported_platform_triples">supported_platform_triples</a>, <a href="#crates_vendor-vendor_path">vendor_path</a>)
 </pre>
 
 A rule for defining Rust dependencies (crates) and writing targets for them to the current workspace.
@@ -404,7 +407,7 @@ This rule is useful for users whose workspaces are expected to be consumed in ot
 rendered `BUILD` files reduce the number of workspace dependencies, allowing for easier loads. This rule
 handles all the same [workflows](#workflows) `crate_universe` rules do.
 
-Example: 
+Example:
 
 Given the following workspace structure:
 
@@ -485,6 +488,7 @@ call against the generated workspace. The following table describes how to contr
 | <a id="crates_vendor-cargo_lockfile"></a>cargo_lockfile |  The path to an existing <code>Cargo.lock</code> file   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="crates_vendor-generate_binaries"></a>generate_binaries |  Whether to generate <code>rust_binary</code> targets for all the binary crates in every package. By default only the <code>rust_library</code> targets are generated.   | Boolean | optional | <code>False</code> |
 | <a id="crates_vendor-generate_build_scripts"></a>generate_build_scripts |  Whether or not to generate [cargo build scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html) by default.   | Boolean | optional | <code>True</code> |
+| <a id="crates_vendor-generate_target_compatible_with"></a>generate_target_compatible_with |  Whether to generate <code>target_compatible_with</code> annotations on the generated BUILD files.  This catches a <code>target_triple</code> being targeted that isn't declared in <code>supported_platform_triples.   | Boolean | optional | <code>True</code> |
 | <a id="crates_vendor-manifests"></a>manifests |  A list of Cargo manifests (<code>Cargo.toml</code> files).   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="crates_vendor-mode"></a>mode |  Flags determining how crates should be vendored. <code>local</code> is where crate source and BUILD files are written to the repository. <code>remote</code> is where only BUILD files are written and repository rules used to fetch source code.   | String | optional | <code>"remote"</code> |
 | <a id="crates_vendor-packages"></a>packages |  A set of crates (packages) specifications to depend on. See [crate.spec](#crate.spec).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |


### PR DESCRIPTION
This should resolve the problem where a platform is targeted that isn't listed in `supported_platform_triples` (in `crates_repository()`) and no error manifests until a missing dependency (or some similar error due to an omitted branch in a `select()`) is encountered.