### PR TITLE
Fix typo in crate_universe-generated defs.bzl comment

### DIFF
--- a/bindgen/3rdparty/crates/defs.bzl
+++ b/bindgen/3rdparty/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/crate_universe/3rdparty/crates/defs.bzl
+++ b/crate_universe/3rdparty/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/crate_universe/src/metadata/dependency.rs
+++ b/crate_universe/src/metadata/dependency.rs
@@ -266,7 +266,7 @@ fn get_library_target_name(package: &Package, potential_name: &str) -> Result<St
 /// for targets where packages (packages[#].targets[#].name) uses crate names. In order to
 /// determine whether or not a dependency is aliased, we compare it with all available targets
 /// on it's package. Note that target names are not guaranteed to be module names where Node
-/// dependnecies are, so we need to do a conversion to check for this
+/// dependencies are, so we need to do a conversion to check for this
 fn get_target_alias(target_name: &str, package: &Package) -> Option<String> {
     match package
         .targets

--- a/crate_universe/src/rendering/templates/module_bzl.j2
+++ b/crate_universe/src/rendering/templates/module_bzl.j2
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/crate_universe/vendor_external/crates/defs.bzl
+++ b/examples/crate_universe/vendor_external/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/crate_universe/vendor_local_manifests/crates/defs.bzl
+++ b/examples/crate_universe/vendor_local_manifests/crates/defs.bzl
@@ -35,7 +35,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/crate_universe/vendor_local_pkgs/crates/defs.bzl
+++ b/examples/crate_universe/vendor_local_pkgs/crates/defs.bzl
@@ -35,7 +35,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/crate_universe/vendor_remote_manifests/crates/defs.bzl
+++ b/examples/crate_universe/vendor_remote_manifests/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/crate_universe/vendor_remote_pkgs/crates/defs.bzl
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/defs.bzl
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/defs.bzl
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/ios_build/3rdparty/crates/defs.bzl
+++ b/examples/ios_build/3rdparty/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/sys/basic/3rdparty/crates/defs.bzl
+++ b/examples/sys/basic/3rdparty/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/examples/sys/complex/3rdparty/crates/defs.bzl
+++ b/examples/sys/complex/3rdparty/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/proto/3rdparty/crates/defs.bzl
+++ b/proto/3rdparty/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/tools/rust_analyzer/3rdparty/crates/defs.bzl
+++ b/tools/rust_analyzer/3rdparty/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/util/import/3rdparty/crates/defs.bzl
+++ b/util/import/3rdparty/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {

--- a/wasm_bindgen/3rdparty/crates/defs.bzl
+++ b/wasm_bindgen/3rdparty/crates/defs.bzl
@@ -37,7 +37,7 @@ def _flatten_dependency_maps(all_dependency_maps):
         # name of the workspace this file is defined in.
         "workspace_member_package": {
 
-            # Not all dependnecies are supported for all platforms.
+            # Not all dependencies are supported for all platforms.
             # the condition key is the condition required to be true
             # on the host platform.
             "condition": {


### PR DESCRIPTION
```diff
        vv
- dependnecies
+ dependencies
        ^^
```

This typo ends up in the caller's repo after they run crates_vendor, so it's worth fixing to keep from tripping a spell checker they might run on their repo.