### PR TITLE
Shorten build script target names

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -352,6 +352,8 @@ def name_to_pkg_name(name):
     """
     if name.endswith("_build_script"):
         return name[:-len("_build_script")]
+    if name.endswith("_bs"):
+        return name[:-len("_bs")]
     return name
 
 def _cargo_dep_env_implementation(ctx):

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -321,7 +321,7 @@ impl Renderer {
             // on having certain Cargo environment variables set.
             //
             // Do not change this name to "cargo_build_script".
-            name: format!("{}_build_script", krate.name),
+            name: format!("{}_bs", krate.name),
             aliases: self
                 .make_aliases(krate, true, false)
                 .remap_configurations(platforms),
@@ -839,7 +839,7 @@ mod test {
         assert!(build_file_content.contains("\"crate-name=mock_crate\""));
 
         // Ensure `cargo_build_script` requirements are met
-        assert!(build_file_content.contains("name = \"mock_crate_build_script\""));
+        assert!(build_file_content.contains("name = \"mock_crate_bs\""));
     }
 
     #[test]


### PR DESCRIPTION
I don't love this, but it helps with the windows path length limits, saving 10 characters.