### PR TITLE
Set windows flags in platform-specific bazelrc

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -60,10 +60,6 @@ tasks:
     test_targets: *default_macos_targets
     coverage_targets: *default_macos_targets
   windows:
-    build_flags:
-      - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts
-    test_flags:
-      - "--enable_runfiles"
     build_targets: *default_windows_targets
     test_targets: *default_windows_targets
   ubuntu2004_opt:
@@ -88,10 +84,8 @@ tasks:
     name: Opt Mode
     platform: windows
     build_flags:
-      - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts
       - "--compilation_mode=opt"
     test_flags:
-      - "--enable_runfiles"
       - "--compilation_mode=opt"
     build_targets: *default_windows_targets
     test_targets: *default_windows_targets
@@ -151,22 +145,16 @@ tasks:
     name: With Aspects
     platform: windows
     build_flags:
-      - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts
       - "--config=rustfmt"
       - "--config=clippy"
-    test_flags:
-      - "--enable_runfiles"
     build_targets: *default_windows_targets
     test_targets: *default_windows_targets
   windows_rolling_with_aspects:
     name: "Windows Rolling Bazel Version With Aspects"
     platform: windows
     build_flags:
-      - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts
       - "--config=rustfmt"
       - "--config=clippy"
-    test_flags:
-      - "--enable_runfiles"
     build_targets: *default_windows_targets
     test_targets: *default_windows_targets
     soft_fail: yes
@@ -385,11 +373,8 @@ tasks:
     platform: windows
     working_directory: examples
     build_flags:
-      - "--enable_runfiles" # this is not enabled by default on windows and is necessary for the cargo build scripts
       - "--config=rustfmt"
       - "--config=clippy"
-    test_flags:
-      - "--enable_runfiles"
     windows_targets: &windows_targets
       - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
       - "//..."
@@ -472,9 +457,6 @@ tasks:
     name: Crate Universe Examples
     platform: windows
     working_directory: examples/crate_universe
-    batch_commands:
-      - echo startup --windows_enable_symlinks >> user.bazelrc
-      - echo build --enable_runfiles >> user.bazelrc  # this is not enabled by default on windows and is necessary for the cargo build scripts
     run_targets: *crate_universe_vendor_example_targets
     build_flags: *aspects_flags
     build_targets:
@@ -485,9 +467,6 @@ tasks:
     name: Crate Universe Unnamed Examples
     platform: windows
     working_directory: examples/crate_universe_unnamed
-    batch_commands:
-      - echo startup --windows_enable_symlinks >> user.bazelrc
-      - echo build --enable_runfiles >> user.bazelrc  # this is not enabled by default on windows and is necessary for the cargo build scripts
     run_targets: *crate_universe_unnamed_vendor_example_targets
     build_flags: *aspects_flags
     build_targets:

--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,11 @@
 # https://bazel.build/docs/windows#symlink
 startup --windows_enable_symlinks
 
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 ###############################################################################
 ## Unique configuration groups
 ###############################################################################

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,6 +1,11 @@
 # `.bazelrc` is a Bazel configuration file.
 # https://bazel.build/docs/best-practices#bazelrc-file
 
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable rustfmt for all targets in the workspace
 build:rustfmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:rustfmt --output_groups=+rustfmt_checks

--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -1,1 +1,6 @@
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 build --fat_apk_cpu=arm64-v8a

--- a/examples/bzlmod/hello_world/.bazelrc
+++ b/examples/bzlmod/hello_world/.bazelrc
@@ -1,1 +1,6 @@
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 build --experimental_enable_bzlmod

--- a/examples/crate_universe/.bazelrc
+++ b/examples/crate_universe/.bazelrc
@@ -1,6 +1,11 @@
 # `.bazelrc` is a Bazel configuration file.
 # https://bazel.build/docs/best-practices#bazelrc-file
 
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable rustfmt for all targets in the workspace
 build:rustfmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:rustfmt --output_groups=+rustfmt_checks

--- a/examples/crate_universe/cargo_aliases/.bazelrc
+++ b/examples/crate_universe/cargo_aliases/.bazelrc
@@ -1,5 +1,10 @@
 # A config file containing Bazel settings
 
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable rustfmt
 build:strict --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:strict --output_groups=+rustfmt_checks

--- a/examples/crate_universe/cargo_remote/.bazelrc
+++ b/examples/crate_universe/cargo_remote/.bazelrc
@@ -1,5 +1,10 @@
 # A config file containing Bazel settings
 
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable rustfmt
 build:strict --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:strict --output_groups=+rustfmt_checks

--- a/examples/crate_universe/cargo_workspace/.bazelrc
+++ b/examples/crate_universe/cargo_workspace/.bazelrc
@@ -1,5 +1,10 @@
 # A config file containing Bazel settings
 
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable rustfmt
 build:strict --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:strict --output_groups=+rustfmt_checks

--- a/examples/crate_universe/multi_package/.bazelrc
+++ b/examples/crate_universe/multi_package/.bazelrc
@@ -1,5 +1,10 @@
 # A config file containing Bazel settings
 
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable rustfmt
 build:strict --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:strict --output_groups=+rustfmt_checks

--- a/examples/crate_universe/no_cargo_manifests/.bazelrc
+++ b/examples/crate_universe/no_cargo_manifests/.bazelrc
@@ -1,5 +1,10 @@
 # A config file containing Bazel settings
 
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable rustfmt
 build:strict --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:strict --output_groups=+rustfmt_checks

--- a/examples/crate_universe_unnamed/.bazelrc
+++ b/examples/crate_universe_unnamed/.bazelrc
@@ -1,6 +1,11 @@
 # `.bazelrc` is a Bazel configuration file.
 # https://bazel.build/docs/best-practices#bazelrc-file
 
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable rustfmt for all targets in the workspace
 build:rustfmt --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:rustfmt --output_groups=+rustfmt_checks

--- a/examples/ios/.bazelrc
+++ b/examples/ios/.bazelrc
@@ -1,3 +1,8 @@
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable CC toolchain that supports iOS from https://github.com/bazelbuild/apple_support
 build --apple_crosstool_top=@local_config_apple_cc//:toolchain
 build --crosstool_top=@local_config_apple_cc//:toolchain

--- a/examples/ios_build/.bazelrc
+++ b/examples/ios_build/.bazelrc
@@ -1,3 +1,8 @@
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 # Enable CC toolchain that supports iOS from https://github.com/bazelbuild/apple_support
 build --apple_crosstool_top=@local_config_apple_cc//:toolchain
 build --crosstool_top=@local_config_apple_cc//:toolchain

--- a/examples/zig_cross_compiling/.bazelrc
+++ b/examples/zig_cross_compiling/.bazelrc
@@ -1,1 +1,6 @@
+# Required on windows
+common --enable_platform_specific_config
+startup:windows --windows_enable_symlinks
+build:windows --enable_runfiles
+
 build --incompatible_enable_cc_toolchain_resolution


### PR DESCRIPTION
Rather than writing them in .bazelci yaml blocks.

This makes running the examples on Windows more likely to work out of the box.