### PR TITLE
Fixes crates_vendor workspace name detection when using bzlmod

### DIFF
--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -136,7 +136,7 @@ def _write_config_file(ctx):
     output_pkg = _get_output_package(ctx)
 
     workspace_name = ctx.workspace_name
-    if ctx.workspace_name == "__main__":
+    if ctx.workspace_name == "__main__" or ctx.workspace_name == "_main":
         workspace_name = ""
 
     if ctx.attr.mode == "local":


### PR DESCRIPTION
This fixes a similar issue to #1514, fixed by #1575.

When using Bzlmod, the main default repository name is now `_main`, instead of `__main__`. This PR extends detection of this use case to both scenarios.