### PR TITLE
Don't use startup:windows

### DIFF
--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -3,7 +3,7 @@
 
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable rustfmt for all targets in the workspace

--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -1,6 +1,6 @@
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 build --fat_apk_cpu=arm64-v8a

--- a/examples/bzlmod/hello_world/.bazelrc
+++ b/examples/bzlmod/hello_world/.bazelrc
@@ -1,6 +1,6 @@
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 build --experimental_enable_bzlmod

--- a/examples/crate_universe/.bazelrc
+++ b/examples/crate_universe/.bazelrc
@@ -3,7 +3,7 @@
 
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable rustfmt for all targets in the workspace

--- a/examples/crate_universe/cargo_aliases/.bazelrc
+++ b/examples/crate_universe/cargo_aliases/.bazelrc
@@ -2,7 +2,7 @@
 
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable rustfmt

--- a/examples/crate_universe/cargo_remote/.bazelrc
+++ b/examples/crate_universe/cargo_remote/.bazelrc
@@ -2,7 +2,7 @@
 
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable rustfmt

--- a/examples/crate_universe/cargo_workspace/.bazelrc
+++ b/examples/crate_universe/cargo_workspace/.bazelrc
@@ -2,7 +2,7 @@
 
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable rustfmt

--- a/examples/crate_universe/multi_package/.bazelrc
+++ b/examples/crate_universe/multi_package/.bazelrc
@@ -2,7 +2,7 @@
 
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable rustfmt

--- a/examples/crate_universe/no_cargo_manifests/.bazelrc
+++ b/examples/crate_universe/no_cargo_manifests/.bazelrc
@@ -2,7 +2,7 @@
 
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable rustfmt

--- a/examples/crate_universe_unnamed/.bazelrc
+++ b/examples/crate_universe_unnamed/.bazelrc
@@ -3,7 +3,7 @@
 
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable rustfmt for all targets in the workspace

--- a/examples/ios/.bazelrc
+++ b/examples/ios/.bazelrc
@@ -1,6 +1,6 @@
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable CC toolchain that supports iOS from https://github.com/bazelbuild/apple_support

--- a/examples/ios_build/.bazelrc
+++ b/examples/ios_build/.bazelrc
@@ -1,6 +1,6 @@
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 # Enable CC toolchain that supports iOS from https://github.com/bazelbuild/apple_support

--- a/examples/zig_cross_compiling/.bazelrc
+++ b/examples/zig_cross_compiling/.bazelrc
@@ -1,6 +1,6 @@
 # Required on windows
 common --enable_platform_specific_config
-startup:windows --windows_enable_symlinks
+startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 build --incompatible_enable_cc_toolchain_resolution


### PR DESCRIPTION
It looks like startup doesn't support platform-specific config, but the only thing we use it for is windows-only anyway
(`--windows_enable_symlinks`).