### PR TITLE
Update `rust_library_group` to use `DepVariantInfo`

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -49,6 +49,7 @@ PAGES = dict([
         symbols = [
             "rust_binary",
             "rust_library",
+            "rust_library_group",
             "rust_static_library",
             "rust_shared_library",
             "rust_proc_macro",

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -3,6 +3,7 @@
 
 * [rust_binary](#rust_binary)
 * [rust_library](#rust_library)
+* [rust_library_group](#rust_library_group)
 * [rust_static_library](#rust_static_library)
 * [rust_shared_library](#rust_shared_library)
 * [rust_proc_macro](#rust_proc_macro)
@@ -306,6 +307,57 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="rust_library-stamp"></a>stamp |  Whether to encode build information into the <code>Rustc</code> action. Possible values:<br><br>- <code>stamp = 1</code>: Always stamp the build information into the <code>Rustc</code> action, even in             [--nostamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) builds.             This setting should be avoided, since it potentially kills remote caching for the target and             any downstream actions that depend on it.<br><br>- <code>stamp = 0</code>: Always replace build information by constant values. This gives good build result caching.<br><br>- <code>stamp = -1</code>: Embedding of build information is controlled by the             [--[no]stamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) flag.<br><br>Stamped targets are not rebuilt unless their dependencies change.<br><br>For example if a <code>rust_library</code> is stamped, and a <code>rust_binary</code> depends on that library, the stamped library won't be rebuilt when we change sources of the <code>rust_binary</code>. This is different from how [<code>cc_library.linkstamps</code>](https://docs.bazel.build/versions/main/be/c-cpp.html#cc_library.linkstamp) behaves.   | Integer | optional | <code>0</code> |
 | <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | <code>"0.0.0"</code> |
+
+
+<a id="rust_library_group"></a>
+
+## rust_library_group
+
+<pre>
+rust_library_group(<a href="#rust_library_group-name">name</a>, <a href="#rust_library_group-deps">deps</a>)
+</pre>
+
+Functions as an alias for a set of dependencies.
+
+Specifically, the following are equivalent:
+
+```starlark
+rust_library_group(
+    name = "crate_group",
+    deps = [
+        ":crate1",
+        ":crate2",
+    ],
+)
+
+rust_library(
+    name = "foobar",
+    deps = [":crate_group"],
+    ...
+)
+```
+
+and
+
+```starlark
+rust_library(
+    name = "foobar",
+    deps = [
+        ":crate1",
+        ":crate2",
+    ],
+    ...
+)
+```
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_library_group-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="rust_library_group-deps"></a>deps |  Other dependencies to forward through this crate group.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 
 
 <a id="rust_proc_macro"></a>

--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -29,6 +29,7 @@
 * [rust_doc_test](#rust_doc_test)
 * [rust_grpc_library](#rust_grpc_library)
 * [rust_library](#rust_library)
+* [rust_library_group](#rust_library_group)
 * [rust_proc_macro](#rust_proc_macro)
 * [rust_proto_library](#rust_proto_library)
 * [rust_proto_repositories](#rust_proto_repositories)
@@ -729,6 +730,57 @@ INFO: Elapsed time: 1.245s, Critical Path: 1.01s
 | <a id="rust_library-srcs"></a>srcs |  List of Rust <code>.rs</code> source files used to build the library.<br><br>If <code>srcs</code> contains more than one file, then there must be a file either named <code>lib.rs</code>. Otherwise, <code>crate_root</code> must be set to the source file that is the root of the crate to be passed to rustc to build this crate.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="rust_library-stamp"></a>stamp |  Whether to encode build information into the <code>Rustc</code> action. Possible values:<br><br>- <code>stamp = 1</code>: Always stamp the build information into the <code>Rustc</code> action, even in             [--nostamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) builds.             This setting should be avoided, since it potentially kills remote caching for the target and             any downstream actions that depend on it.<br><br>- <code>stamp = 0</code>: Always replace build information by constant values. This gives good build result caching.<br><br>- <code>stamp = -1</code>: Embedding of build information is controlled by the             [--[no]stamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) flag.<br><br>Stamped targets are not rebuilt unless their dependencies change.<br><br>For example if a <code>rust_library</code> is stamped, and a <code>rust_binary</code> depends on that library, the stamped library won't be rebuilt when we change sources of the <code>rust_binary</code>. This is different from how [<code>cc_library.linkstamps</code>](https://docs.bazel.build/versions/main/be/c-cpp.html#cc_library.linkstamp) behaves.   | Integer | optional | <code>0</code> |
 | <a id="rust_library-version"></a>version |  A version to inject in the cargo environment variable.   | String | optional | <code>"0.0.0"</code> |
+
+
+<a id="rust_library_group"></a>
+
+## rust_library_group
+
+<pre>
+rust_library_group(<a href="#rust_library_group-name">name</a>, <a href="#rust_library_group-deps">deps</a>)
+</pre>
+
+Functions as an alias for a set of dependencies.
+
+Specifically, the following are equivalent:
+
+```starlark
+rust_library_group(
+    name = "crate_group",
+    deps = [
+        ":crate1",
+        ":crate2",
+    ],
+)
+
+rust_library(
+    name = "foobar",
+    deps = [":crate_group"],
+    ...
+)
+```
+
+and
+
+```starlark
+rust_library(
+    name = "foobar",
+    deps = [
+        ":crate1",
+        ":crate2",
+    ],
+    ...
+)
+```
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_library_group-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="rust_library_group-deps"></a>deps |  Other dependencies to forward through this crate group.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 
 
 <a id="rust_proc_macro"></a>

--- a/docs/symbols.bzl
+++ b/docs/symbols.bzl
@@ -57,6 +57,7 @@ load(
     _rust_doc = "rust_doc",
     _rust_doc_test = "rust_doc_test",
     _rust_library = "rust_library",
+    _rust_library_group = "rust_library_group",
     _rust_proc_macro = "rust_proc_macro",
     _rust_shared_library = "rust_shared_library",
     _rust_static_library = "rust_static_library",
@@ -112,6 +113,7 @@ load(
 
 rust_binary = _rust_binary
 rust_library = _rust_library
+rust_library_group = _rust_library_group
 rust_static_library = _rust_static_library
 rust_shared_library = _rust_shared_library
 rust_proc_macro = _rust_proc_macro

--- a/rust/private/common.bzl
+++ b/rust/private/common.bzl
@@ -23,7 +23,7 @@ which exports the `rust_common` struct.
 In the Bazel lingo, `rust_common` gives the access to the Rust Sandwich API.
 """
 
-load(":providers.bzl", "CrateGroupInfo", "CrateInfo", "DepInfo", "StdLibInfo", "TestCrateInfo")
+load(":providers.bzl", "CrateGroupInfo", "CrateInfo", "DepInfo", "DepVariantInfo", "StdLibInfo", "TestCrateInfo")
 
 # This constant only represents the default value for attributes and macros
 # defined in `rules_rust`. Like any attribute public attribute, it can be
@@ -59,6 +59,7 @@ rust_common = struct(
     create_crate_info = _create_crate_info,
     crate_info = CrateInfo,
     dep_info = DepInfo,
+    dep_variant_info = DepVariantInfo,
     stdlib_info = StdLibInfo,
     test_crate_info = TestCrateInfo,
     crate_group_info = CrateGroupInfo,

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -60,8 +60,7 @@ DepInfo = provider(
 CrateGroupInfo = provider(
     doc = "A provider containing a group of crates.",
     fields = {
-        "crate_infos": "List[CrateInfo]",
-        "dep_infos": "List[DepInfo]",
+        "dep_variant_infos": "depset[DepVariantInfo]: Dependency information from all crates in the group.",
     },
 )
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -231,12 +231,10 @@ def collect_deps(
             crate_deps.append(dep)
 
         if crate_group:
-            if len(crate_group.crate_infos) != len(crate_group.dep_infos):
-                fail("CrateGroupInfo must have len(crate_infos) == len(dep_infos)")
-            for (crate_info, dep_info) in zip(crate_group.crate_infos, crate_group.dep_infos):
+            for dep_variant_info in crate_group.dep_variant_infos.to_list():
                 crate_deps.append(struct(
-                    crate_info = crate_info,
-                    dep_info = dep_info,
+                    crate_info = dep_variant_info.crate_info,
+                    dep_info = dep_variant_info.dep_info,
                 ))
 
     aliases = {k.label: v for k, v in aliases.items()}

--- a/rust/rust_common.bzl
+++ b/rust/rust_common.bzl
@@ -14,8 +14,19 @@
 
 """Module with Rust definitions required to write custom Rust rules."""
 
-load("//rust/private:providers.bzl", _BuildInfo = "BuildInfo", _ClippyInfo = "ClippyInfo", _CrateInfo = "CrateInfo")
+load(
+    "//rust/private:providers.bzl",
+    _BuildInfo = "BuildInfo",
+    _ClippyInfo = "ClippyInfo",
+    _CrateInfo = "CrateInfo",
+    _DepInfo = "DepInfo",
+    _DepVariantInfo = "DepVariantInfo",
+    _TestCrateInfo = "TestCrateInfo",
+)
 
 BuildInfo = _BuildInfo
-CrateInfo = _CrateInfo
 ClippyInfo = _ClippyInfo
+CrateInfo = _CrateInfo
+DepInfo = _DepInfo
+DepVariantInfo = _DepVariantInfo
+TestCrateInfo = _TestCrateInfo


### PR DESCRIPTION
This seems like a much cleaner interface and gives users more confidence that `CrateInfo` providers are paired with the right `DepInfo` providers.

A follow-up to https://github.com/bazelbuild/rules_rust/pull/1848