### PR TITLE
Only add coverage instrumentation to tests

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -996,7 +996,7 @@ def construct_arguments(
         rustc_flags.add("--extern")
         rustc_flags.add("proc_macro")
 
-    if toolchain.llvm_cov and ctx.configuration.coverage_enabled:
+    if toolchain.llvm_cov and ctx.configuration.coverage_enabled and crate_info.is_test:
         rustc_flags.add("--codegen=instrument-coverage")
 
     # Make bin crate data deps available to tests.


### PR DESCRIPTION
Linking a rust_shared_library with ld.gold fails when building a rust_shared_library that exposes FFI bindings used by a test written in another language.