### PR TITLE
Look up CARGO_BAZEL_GENERATOR_PATH correctly

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Francois-Rene Rideau <tunes@google.com>
 Julio Merino <jmmv@google.com>
 Kamal Marhubi <kamal@marhubi.com>
 Kristina Chodorow <kchodorow@google.com>
+Michael Hackner <mhackner@gmail.com>
 Philipp Wollermann <philwo@google.com>
 Ulf Adams <ulfjack@google.com>
 Justine Alexandra Roberts Tunney <jart@google.com>

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -297,8 +297,8 @@ def _crates_vendor_impl(ctx):
     cargo_bazel_runfiles = []
 
     # Allow action envs to override the use of the cargo-bazel target.
-    if CARGO_BAZEL_GENERATOR_PATH in ctx.var:
-        bin_path = ctx.var[CARGO_BAZEL_GENERATOR_PATH]
+    if CARGO_BAZEL_GENERATOR_PATH in ctx.configuration.default_shell_env:
+        bin_path = ctx.configuration.default_shell_env[CARGO_BAZEL_GENERATOR_PATH]
     elif ctx.executable.cargo_bazel:
         bin_path = _runfiles_path(ctx.executable.cargo_bazel, is_windows)
         cargo_bazel_runfiles.append(ctx.executable.cargo_bazel)


### PR DESCRIPTION
The intent is to allow this variable to be passed in an --action_env, but ctx.var is not where these show up: ctx.configuration.default_shell_env is.