### PR TITLE
Make @using_cxx example buildable on Windows

### DIFF
--- a/examples/crate_universe/WORKSPACE.bazel
+++ b/examples/crate_universe/WORKSPACE.bazel
@@ -290,9 +290,7 @@ crates_repository(
                     hdrs = ["include/cxx.h"],
                     srcs = ["src/cxx.cc"],
                     includes = ["include"],
-                    target_compatible_with = [
-                        "@platforms//os:linux",
-                    ],
+                    linkstatic = True,
                 )
             """,
                 extra_aliased_targets = {"cxx_cc": "cxx_cc"},

--- a/examples/crate_universe/using_cxx/BUILD.bazel
+++ b/examples/crate_universe/using_cxx/BUILD.bazel
@@ -23,6 +23,7 @@ cc_library(
     name = "blobstore-sys",
     srcs = ["src/blobstore.cc"],
     copts = ["-std=c++17"],
+    linkstatic = True,
     deps = [
         ":blobstore-include",
         ":bridge/include",

--- a/examples/crate_universe/using_cxx/cargo-bazel-lock.json
+++ b/examples/crate_universe/using_cxx/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e5d24b98993df177a8e5518f4dd7ea12b619dc811e1052d6212bbdc7749002be",
+  "checksum": "c1f1a6f4e385c34b24fba8b5f9cbf6ff89dc26aa85f4054d46b06e4a6efff068",
   "crates": {
     "cc 1.0.82": {
       "name": "cc",
@@ -97,7 +97,7 @@
         "version": "1.0.104"
       },
       "license": "MIT OR Apache-2.0",
-      "additive_build_file_content": "\n# This file is included in the BUILD for the cxx crate, to export its header\n# file for C++ code to depend on.\ncc_library(\n    name = \"cxx_cc\",\n    visibility = [\"//visibility:public\"],\n    hdrs = [\"include/cxx.h\"],\n    srcs = [\"src/cxx.cc\"],\n    includes = [\"include\"],\n    target_compatible_with = [\n        \"@platforms//os:linux\",\n    ],\n)\n",
+      "additive_build_file_content": "\n# This file is included in the BUILD for the cxx crate, to export its header\n# file for C++ code to depend on.\ncc_library(\n    name = \"cxx_cc\",\n    visibility = [\"//visibility:public\"],\n    hdrs = [\"include/cxx.h\"],\n    srcs = [\"src/cxx.cc\"],\n    includes = [\"include\"],\n    linkstatic = True,\n)\n",
       "extra_aliased_targets": {
         "cxx_cc": "cxx_cc"
       }

--- a/examples/crate_universe/using_cxx/rust_cxx_bridge.bzl
+++ b/examples/crate_universe/using_cxx/rust_cxx_bridge.bzl
@@ -40,6 +40,7 @@ def rust_cxx_bridge(name, src, deps = []):
     cc_library(
         name = name,
         srcs = [src + ".cc"],
+        linkstatic = True,
         deps = deps + [":%s/include" % name],
     )
 


### PR DESCRIPTION
See the build error on 9221306cb9ef2a77d732c89f6d9980b7e4a1b1b0 (the parent commit of 8b26c2d7637b445889224112ac0c021cb7821592).

```console
ERROR: C:/b/gk6ogkw7/external/using_cxx__cxx-1.0.104/BUILD.bazel:96:11: Linking external/using_cxx__cxx-1.0.104/cxx_cc_6cbd2ac8.dll failed: (Exit 1120): link.exe failed: error executing command (from target @using_cxx__cxx-1.0.104//:cxx_cc)
  cd /d C:/b/gk6ogkw7/execroot/examples
  SET LIB=C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\lib\x64;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x64;C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64;C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\um\x64
    SET PATH=C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\VC\VCPackages;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\bin\Roslyn;C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\devinit;C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64;C:\Program Files (x86)\Windows Kits\10\bin\x64;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\\MSBuild\Current\Bin;C:\Windows\Microsoft.NET\Framework64\v4.0.30319;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\;;C:\Windows\system32;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
    SET PWD=/proc/self/cwd
    SET TEMP=C:\temp
    SET TMP=C:\temp
  C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64\link.exe @bazel-out/x64_windows-fastbuild/bin/external/using_cxx__cxx-1.0.104/cxx_cc_6cbd2ac8.dll-2.params
# Configuration: 32fa8a1b9590f00081feb76803a4c79cdb2d501747a2a876b73c055492fe1027
# Execution platform: @local_config_platform//:host
   Creating library bazel-out/x64_windows-fastbuild/bin/external/using_cxx__cxx-1.0.104/cxx_cc.if.lib and object bazel-out/x64_windows-fastbuild/bin/external/using_cxx__cxx-1.0.104/cxx_cc.if.exp
cxx.obj : error LNK2019: unresolved external symbol cxxbridge1$string$new referenced in function "public: __cdecl rust::cxxbridge1::String::String(void)" (??0String@cxxbridge1@rust@@QEAA@XZ)
```

It's trying to build `cxx_cc_6cbd2ac8.dll`. The cxx crate's C++ library cxx.cc is not supposed to be a shared library. It depends on Rust symbols defined in the cxx crate's rlib. It is supposed to be statically linked into the rlib, as done in Cargo builds.