### PR TITLE
Add crate_name attribute

### DIFF
--- a/examples/proto/basic/BUILD.bazel
+++ b/examples/proto/basic/BUILD.bazel
@@ -4,7 +4,8 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
 package(default_visibility = ["//proto:__subpackages__"])
 
 rust_proto_library(
-    name = "common_proto_rust",
+    name = "libcommon_proto_rust",
+    crate_name = "common_proto_rust",
     tags = ["manual"],
     deps = ["//proto:common"],
 )
@@ -13,7 +14,7 @@ rust_library(
     name = "common_lib",
     srcs = ["lib.rs"],
     tags = ["manual"],
-    deps = [":common_proto_rust"],
+    deps = [":libcommon_proto_rust"],
 )
 
 rust_binary(
@@ -22,6 +23,6 @@ rust_binary(
     tags = ["manual"],
     deps = [
         ":common_lib",
-        ":common_proto_rust",
+        ":libcommon_proto_rust",
     ],
 )

--- a/examples/proto/helloworld/BUILD.bazel
+++ b/examples/proto/helloworld/BUILD.bazel
@@ -10,7 +10,8 @@ proto_library(
 )
 
 rust_grpc_library(
-    name = "helloworld_proto",
+    name = "libhelloworld_proto",
+    crate_name = "helloworld_proto",
     tags = ["manual"],
     visibility = ["//proto/helloworld:__subpackages__"],
     deps = [":helloworld"],

--- a/examples/proto/helloworld/greeter_client/BUILD.bazel
+++ b/examples/proto/helloworld/greeter_client/BUILD.bazel
@@ -7,6 +7,6 @@ rust_binary(
     tags = ["manual"],
     visibility = ["//proto/helloworld:__subpackages__"],
     deps = [
-        "//proto/helloworld:helloworld_proto",
+        "//proto/helloworld:libhelloworld_proto",
     ] + GRPC_COMPILE_DEPS,
 )

--- a/proto/protobuf/proto.bzl
+++ b/proto/protobuf/proto.bzl
@@ -253,7 +253,7 @@ def _rust_protogrpc_library_impl(ctx, is_grpc):
     ]
 
     toolchain = find_toolchain(ctx)
-    crate_name = compute_crate_name(ctx.workspace_name, ctx.label, toolchain)
+    crate_name = compute_crate_name(ctx.workspace_name, ctx.label, toolchain, ctx.attr.crate_name)
 
     return _rust_proto_compile(
         protos = depset(transitive = transitive_sources),
@@ -280,6 +280,14 @@ def _rust_proto_library_impl(ctx):
 rust_proto_library = rule(
     implementation = _rust_proto_library_impl,
     attrs = {
+        "crate_name": attr.string(
+            doc = """\
+                Crate name to use for this target.
+
+                This must be a valid Rust identifier, i.e. it may contain only alphanumeric characters and underscores.
+                Defaults to the target name, with any hyphens replaced by underscores.
+            """,
+        ),
         "deps": attr.label_list(
             doc = (
                 "List of proto_library dependencies that will be built. " +
@@ -368,6 +376,14 @@ def _rust_grpc_library_impl(ctx):
 rust_grpc_library = rule(
     implementation = _rust_grpc_library_impl,
     attrs = {
+        "crate_name": attr.string(
+            doc = """\
+                Crate name to use for this target.
+
+                This must be a valid Rust identifier, i.e. it may contain only alphanumeric characters and underscores.
+                Defaults to the target name, with any hyphens replaced by underscores.
+            """,
+        ),
         "deps": attr.label_list(
             doc = (
                 "List of proto_library dependencies that will be built. " +


### PR DESCRIPTION
This PR adds `crate_name` attribute to `rust_proto_library` and `rust_grpc_library` rules. This aligns with `crate_name` attribute provided in other rules to allow custom crate name different from label name.

Setting `--crate-name` flag to `rustc_flags` attribute is not an option because `rustc` does not allow `--crate-name` flag to be set twice.
