### PR TITLE
Update wasm_bindgen to not use deprecated/unmaintained JS rules

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -7,9 +7,9 @@ package(default_visibility = ["//visibility:private"])
 bzl_library(
     name = "docs_deps",
     srcs = [
+        "@aspect_rules_js//js:providers",
         "@bazel_tools//tools:bzl_srcs",
         "@com_google_protobuf//:bzl_srcs",
-        "@rules_nodejs//nodejs:bzl",
     ],
     deps = [
         "@bazel_skylib//lib:paths",

--- a/docs/WORKSPACE.bazel
+++ b/docs/WORKSPACE.bazel
@@ -37,6 +37,14 @@ rust_wasm_bindgen_dependencies()
 
 rust_wasm_bindgen_register_toolchains()
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -79,15 +79,20 @@ rust_repository_set(
 # Examples dependencies
 ###############################################################################
 
-http_archive(
-    name = "build_bazel_rules_nodejs",
-    sha256 = "c78216f5be5d451a42275b0b7dc809fb9347e2b04a68f68bad620a2b01f5c774",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.2/rules_nodejs-5.5.2.tar.gz"],
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
+load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
+
+nodejs_register_toolchains(
+    name = "nodejs",
+    node_version = DEFAULT_NODE_VERSION,
 )
 
-load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
-node_repositories()
+bazel_features_deps()
 
 http_archive(
     name = "rules_foreign_cc",

--- a/examples/wasm/BUILD.bazel
+++ b/examples/wasm/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
+load("@aspect_rules_js//js:defs.bzl", "js_test")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_shared_library")
 load("@rules_rust//wasm_bindgen:wasm_bindgen.bzl", "rust_wasm_bindgen")
 
@@ -65,7 +65,7 @@ rust_wasm_bindgen(
     wasm_file = ":hello_world_lib_wasm",
 )
 
-nodejs_test(
+js_test(
     name = "hello_world_wasm_test",
     data = [
         ":hello_world_bundler_wasm_bindgen",

--- a/wasm_bindgen/providers.bzl
+++ b/wasm_bindgen/providers.bzl
@@ -1,10 +1,8 @@
 """A module for re-exporting the providers used by the rust_wasm_bindgen rule"""
 
 load(
-    "@rules_nodejs//nodejs:providers.bzl",
-    _DeclarationInfo = "DeclarationInfo",
-    _JSModuleInfo = "JSModuleInfo",
+    "@aspect_rules_js//js:providers.bzl",
+    _JsInfo = "JsInfo",
 )
 
-DeclarationInfo = _DeclarationInfo
-JSModuleInfo = _JSModuleInfo
+JsInfo = _JsInfo

--- a/wasm_bindgen/repositories.bzl
+++ b/wasm_bindgen/repositories.bzl
@@ -41,9 +41,10 @@ def rust_wasm_bindgen_dependencies():
 
     maybe(
         http_archive,
-        name = "rules_nodejs",
-        sha256 = "017e2348bb8431156d5cf89b6f502c2e7fcffc568729f74f89e4a12bd8279e90",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.2/rules_nodejs-core-5.5.2.tar.gz"],
+        name = "aspect_rules_js",
+        sha256 = "7b2a4d1d264e105eae49a27e2e78065b23e2e45724df2251eacdd317e95bfdfd",
+        strip_prefix = "rules_js-1.31.0",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.31.0/rules_js-v1.31.0.tar.gz",
     )
 
     crate_repositories()
@@ -65,7 +66,7 @@ def rust_wasm_bindgen_register_toolchains(register_toolchains = True):
 def rust_wasm_bindgen_repositories(register_default_toolchain = True):
     """Declare dependencies needed for [rust_wasm_bindgen](#rust_wasm_bindgen).
 
-    **Deprecated**: Use [rust_wasm_bindgen_dependencies](#rust_wasm_bindgen_depednencies) and [rust_wasm_bindgen_register_toolchains](#rust_wasm_bindgen_register_toolchains).
+    **Deprecated**: Use [rust_wasm_bindgen_dependencies](#rust_wasm_bindgen_dependencies) and [rust_wasm_bindgen_register_toolchains](#rust_wasm_bindgen_register_toolchains).
 
     Args:
         register_default_toolchain (bool, optional): If True, the default [rust_wasm_bindgen_toolchain](#rust_wasm_bindgen_toolchain)

--- a/wasm_bindgen/wasm_bindgen.bzl
+++ b/wasm_bindgen/wasm_bindgen.bzl
@@ -15,11 +15,7 @@
 """Bazel rules for [wasm-bindgen](https://crates.io/crates/wasm-bindgen)"""
 
 load("//rust:defs.bzl", "rust_common")
-load(
-    "//wasm_bindgen:providers.bzl",
-    "DeclarationInfo",
-    "JSModuleInfo",
-)
+load("//wasm_bindgen:providers.bzl", "JsInfo")
 load("//wasm_bindgen/private:transitions.bzl", "wasm_bindgen_transition")
 
 _WASM_BINDGEN_DOC = """\
@@ -125,7 +121,7 @@ def _rust_wasm_bindgen_impl(ctx):
         arguments = [args],
     )
 
-    # Return a structure that is compatible with the deps[] of a ts_library.
+    # Return a structure that is compatible with the deps[] of the aspect JS/TS rules.
     declarations = depset(ts_out)
     es5_sources = depset(js_out)
 
@@ -133,14 +129,11 @@ def _rust_wasm_bindgen_impl(ctx):
         DefaultInfo(
             files = depset(outputs),
         ),
-        DeclarationInfo(
+        JsInfo(
             declarations = declarations,
-            transitive_declarations = declarations,
-            type_blocklisted_declarations = depset([]),
-        ),
-        JSModuleInfo(
-            direct_sources = es5_sources,
             sources = es5_sources,
+            transitive_declarations = declarations,
+            transitive_sources = es5_sources,
         ),
     ]
 


### PR DESCRIPTION
The providers the rule is using were deleted (I believe in https://github.com/bazelbuild/rules_nodejs/pull/3655).
It seems the community has standardized on https://github.com/aspect-build/rules_js as the future.

I removed the JS dependency from the bzl_lib as well, I didn't see an easy way to pull in the bzl_lib from providers, but please let me know if I missed something.

`cd examples && bazel test //wasm/...` works for me with this branch.