### PR TITLE
Cleanup args construction

### DIFF
--- a/bindgen/bindgen.bzl
+++ b/bindgen/bindgen.bzl
@@ -115,7 +115,7 @@ def _rust_bindgen_impl(ctx):
 
     # Configure Bindgen Arguments
     args.add_all(ctx.attr.bindgen_flags)
-    args.add(header.path)
+    args.add(header)
     args.add("--output", output)
 
     # Vanilla usage of bindgen produces formatted output, here we do the same if we have `rustfmt` in our toolchain.

--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -213,18 +213,17 @@ def _cargo_build_script_impl(ctx):
     # See https://doc.rust-lang.org/cargo/reference/build-scripts.html#-sys-packages
     # for details.
     args = ctx.actions.args()
-    args.add_all([
-        script.path,
-        links,
-        out_dir.path,
-        env_out.path,
-        flags_out.path,
-        link_flags.path,
-        link_search_paths.path,
-        dep_env_out.path,
-        streams.stdout.path,
-        streams.stderr.path,
-    ])
+    args.add(script)
+    args.add(links)
+    args.add(out_dir.path)
+    args.add(env_out)
+    args.add(flags_out)
+    args.add(link_flags)
+    args.add(link_search_paths)
+    args.add(dep_env_out)
+    args.add(streams.stdout)
+    args.add(streams.stderr)
+
     build_script_inputs = []
     for dep in ctx.attr.link_deps:
         if rust_common.dep_info in dep and dep[rust_common.dep_info].dep_env:

--- a/proto/protobuf/toolchain.bzl
+++ b/proto/protobuf/toolchain.bzl
@@ -80,10 +80,10 @@ def rust_generate_proto(
         # so we create an empty grpc module in the other case.
         tools.append(proto_toolchain.grpc_plugin)
         tools.append(ctx.executable._optional_output_wrapper)
-        args.add_all([f.path for f in grpc_files])
+        args.add_all(grpc_files)
         args.add_all([
             "--",
-            proto_toolchain.protoc.path,
+            proto_toolchain.protoc,
             "--plugin=protoc-gen-grpc-rust=" + proto_toolchain.grpc_plugin.path,
             "--grpc-rust_out=" + output_directory,
         ])

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -137,7 +137,7 @@ def _clippy_aspect_impl(target, ctx):
     # or rustc may fail to create intermediate output files because the directory does not exist.
     if ctx.attr._capture_output[CaptureClippyOutputInfo].capture_output:
         clippy_out = ctx.actions.declare_file(ctx.label.name + ".clippy.out", sibling = crate_info.output)
-        args.process_wrapper_flags.add("--stderr-file", clippy_out.path)
+        args.process_wrapper_flags.add("--stderr-file", clippy_out)
 
         if clippy_flags:
             fail("""Combining @rules_rust//:clippy_flags with @rules_rust//:capture_clippy_output=true is currently not supported.
@@ -150,7 +150,7 @@ See https://github.com/bazelbuild/rules_rust/pull/1264#discussion_r853241339 for
         # A marker file indicating clippy has executed successfully.
         # This file is necessary because "ctx.actions.run" mandates an output.
         clippy_out = ctx.actions.declare_file(ctx.label.name + ".clippy.ok", sibling = crate_info.output)
-        args.process_wrapper_flags.add("--touch-file", clippy_out.path)
+        args.process_wrapper_flags.add("--touch-file", clippy_out)
 
         if clippy_flags:
             args.rustc_flags.add_all(clippy_flags)

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -138,7 +138,7 @@ def rustdoc_compile_action(
 
         # `rustdoc` does not support the SYSROOT environment variable. To account
         # for this, the flag must be explicitly passed to the `rustdoc` binary.
-        args.rustc_flags.add("--sysroot=${{pwd}}/{}".format(toolchain.sysroot_short_path))
+        args.rustc_flags.add(toolchain.sysroot_short_path, format = "--sysroot=${{pwd}}/%s")
 
     return struct(
         executable = ctx.executable._process_wrapper,

--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -74,14 +74,11 @@ def _perform_check(edition, srcs, ctx):
     marker = ctx.actions.declare_file(ctx.label.name + ".rustfmt.ok")
 
     args = ctx.actions.args()
-    args.add("--touch-file")
-    args.add(marker)
+    args.add("--touch-file", marker)
     args.add("--")
     args.add(rustfmt_toolchain.rustfmt)
-    args.add("--config-path")
-    args.add(config)
-    args.add("--edition")
-    args.add(edition)
+    args.add("--config-path", config)
+    args.add("--edition", edition)
     args.add("--check")
     args.add_all(srcs)
 

--- a/test/process_wrapper/process_wrapper_tester.bzl
+++ b/test/process_wrapper/process_wrapper_tester.bzl
@@ -25,21 +25,21 @@ def _impl(ctx):
     if combined or ctx.attr.test_config == "stdout":
         stdout_output = ctx.actions.declare_file(ctx.label.name + ".stdout")
         outputs.append(stdout_output)
-        args.add("--stdout-file", stdout_output.path)
+        args.add("--stdout-file", stdout_output)
 
     if combined or ctx.attr.test_config == "stderr":
         stderr_output = ctx.actions.declare_file(ctx.label.name + ".stderr")
         outputs.append(stderr_output)
-        args.add("--stderr-file", stderr_output.path)
+        args.add("--stderr-file", stderr_output)
 
     if combined or (ctx.attr.test_config != "stdout" and ctx.attr.test_config != "stderr"):
         touch_output = ctx.actions.declare_file(ctx.label.name + ".touch")
         outputs.append(touch_output)
-        args.add("--touch-file", touch_output.path)
+        args.add("--touch-file", touch_output)
         if ctx.attr.test_config == "copy-output":
             copy_output = ctx.actions.declare_file(ctx.label.name + ".touch.copy")
             outputs.append(copy_output)
-            args.add_all("--copy-output", [touch_output.path, copy_output.path])
+            args.add_all("--copy-output", [touch_output, copy_output])
 
     if combined or ctx.attr.test_config == "env-files":
         args.add_all(ctx.files.env_files, before_each = "--env-file")
@@ -53,7 +53,7 @@ def _impl(ctx):
 
     args.add("--")
 
-    args.add(ctx.executable._process_wrapper_tester.path)
+    args.add(ctx.executable._process_wrapper_tester)
     args.add(ctx.attr.test_config)
     args.add("--current-dir", "${pwd}")
     args.add("--test-subst", "subst key to ${key}")


### PR DESCRIPTION
Some minor optimizations to analysis time memory usage (avoid creating some list temporaries, some extra strings, etc.)
Some of the usage might be simpler as `args.add("foo", foo)` instead of `args.add(foo, format="foo=%s")` but I opted to keep the usage the same as before for safety.