### PR TITLE
Remove cfg exec from link_deps attribute

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -301,7 +301,6 @@ cargo_build_script = rule(
                 variables to this build script.
             """),
             providers = [rust_common.dep_info],
-            cfg = "exec",
         ),
         "links": attr.string(
             doc = "The name of the native library this crate links against.",


### PR DESCRIPTION
Build scripts of link dependencies need access to the 'target' environment which contains the library being linked against. This is needed to correctly cross-compile.