### PR TITLE
Use cc_toolchain.linker_files() for files required at linking steps

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -670,7 +670,7 @@ def collect_inputs(
     """
     linker_script = getattr(file, "linker_script") if hasattr(file, "linker_script") else None
 
-    linker_depset = cc_toolchain.all_files
+    linker_depset = cc_toolchain.linker_files()
     compilation_mode = ctx.var["COMPILATION_MODE"]
 
     use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_info.type, compilation_mode)


### PR DESCRIPTION
[cc_toolchain.linker_files()](https://github.com/bazelbuild/bazel/blob/69d3eccf8d75af80586fcb8249db66ba2e5476cb/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcToolchainProviderApi.java#L198-L199) returns the linker files [used by cc](https://github.com/bazelbuild/bazel/blob/69d3eccf8d75af80586fcb8249db66ba2e5476cb/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java#L881-L885) when building cc link action.

Using the same files in rust ensure it has the correct files to resolve the link args returned from cc toolchain. This also allows custom specification on [cc_toolchain.linker_files attribute](https://bazel.build/versions/6.2.0/reference/be/c-cpp#cc_toolchain) is correctly resolved.