### PR TITLE
Apply patch for rust analyzer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,7 +121,7 @@ jobs:
           path: ${{ github.workspace }}/crate_universe/target/artifacts
       - name: Detect the current version
         run: |
-          version="$(grep 'VERSION =' ${{ github.workspace }}/version.bzl | grep -o '[[:digit:].]\+')"
+          version="$(grep 'VERSION =' ${{ github.workspace }}/version.bzl | sed 's/VERSION = "//' | sed 's/"//')"
           echo "RELEASE_VERSION=${version}" >> $GITHUB_ENV
       - name: Create the rules archive
         run: |

--- a/bindgen/BUILD.bazel
+++ b/bindgen/BUILD.bazel
@@ -27,15 +27,19 @@ rust_bindgen_toolchain(
     name = "default_bindgen_toolchain_impl",
     bindgen = "//bindgen/3rdparty:bindgen",
     clang = select({
-        "//rust/platform:osx": "@bindgen_clang_osx//:clang",
-        "//conditions:default": "@bindgen_clang_linux//:clang",
+        "//rust/platform:x86_64-unknown-linux-gnu": "@bindgen_clang_linux_x86_64//:clang",
+        "//rust/platform:x86_64-apple-darwin": "@bindgen_clang_osx_x86_64//:clang",
+        "//rust/platform:aarch64-unknown-linux-gnu": "@bindgen_clang_linux_aarch64//:clang",
     }),
     libclang = select({
-        "//rust/platform:osx": "@bindgen_clang_osx//:libclang",
-        "//conditions:default": "@bindgen_clang_linux//:libclang",
+        "//rust/platform:x86_64-unknown-linux-gnu": "@bindgen_clang_linux_x86_64//:libclang",
+        "//rust/platform:x86_64-apple-darwin": "@bindgen_clang_osx_x86_64//:libclang",
+        "//rust/platform:aarch64-unknown-linux-gnu": "@bindgen_clang_linux_aarch64//:libclang",
+        # TODO aarch64 apple-darwin
     }),
     libstdcxx = select({
-        "//rust/platform:osx": "@bindgen_clang_osx//:libc++",
+        "//rust/platform:x86_64-apple-darwin": "@bindgen_clang_osx_x86_64//:libc++",
+        # TODO aarch64 apple-darwin
         "//conditions:default": None,
     }),
 )

--- a/bindgen/repositories.bzl
+++ b/bindgen/repositories.bzl
@@ -89,17 +89,27 @@ def _bindgen_clang_repositories():
     # Releases @ http://releases.llvm.org/download.html
     maybe(
         http_archive,
-        name = "bindgen_clang_linux",
+        name = "bindgen_clang_linux_x86_64",
         urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"],
         strip_prefix = "clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04",
         sha256 = "b25f592a0c00686f03e3b7db68ca6dc87418f681f4ead4df4745a01d9be63843",
         build_file_content = _CLANG_BUILD_FILE.format(suffix = "so"),
-        workspace_file_content = _COMMON_WORKSPACE.format("bindgen_clang_linux"),
+        workspace_file_content = _COMMON_WORKSPACE.format("bindgen_clang_linux_86_64"),
     )
 
     maybe(
         http_archive,
-        name = "bindgen_clang_osx",
+        name = "bindgen_clang_linux_aarch64",
+        urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz"],
+        strip_prefix = "clang+llvm-10.0.0-aarch64-linux-gnu",
+        sha256 = "c2072390dc6c8b4cc67737f487ef384148253a6a97b38030e012c4d7214b7295",
+        build_file_content = _CLANG_BUILD_FILE.format(suffix = "so"),
+        workspace_file_content = _COMMON_WORKSPACE.format("bindgen_clang_linux_aarch64"),
+    )
+
+    maybe(
+        http_archive,
+        name = "bindgen_clang_osx_x86_64",
         urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz"],
         strip_prefix = "clang+llvm-10.0.0-x86_64-apple-darwin",
         sha256 = "633a833396bf2276094c126b072d52b59aca6249e7ce8eae14c728016edb5e61",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -14,6 +14,7 @@
 
 """Functionality for constructing actions that invoke the Rust compiler"""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
@@ -398,6 +399,8 @@ def get_linker_and_args(ctx, attr, crate_type, cc_toolchain, feature_configurati
         action_name = action_name,
         variables = link_variables,
     )
+    link_args = [i for i in link_args]
+    link_args.append("-B" + paths.dirname(cc_toolchain.ld_executable))
     link_env = cc_common.get_environment_variables(
         feature_configuration = feature_configuration,
         action_name = action_name,

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.21.1"
+VERSION = "0.21.1-zitara-arm64_bindgen"

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.21.1-zitara-arm64_bindgen_2"
+VERSION = "0.21.1-zitara-arm64_bindgen_3"

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.21.1-zitara-arm64_bindgen"
+VERSION = "0.21.1-zitara-arm64_bindgen_2"


### PR DESCRIPTION
Add patch from 'https://github.com/bazelbuild/rules_rust/issues/1114#issuecomment-1059636514' in attempt to fix error when trying to run `bazel run @rules_rust//tools/rust_analyzer:gen_rust_project` in battmodel