### PR TITLE
Disable Bzlmod explicitly in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,4 +50,12 @@ build --nolegacy_external_runfiles
 ## evaluated top to bottom.
 ###############################################################################
 
+###############################################################################
+## Bzlmod
+###############################################################################
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod
+
 try-import %workspace%/user.bazelrc

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -14,6 +14,10 @@ build:rustfmt --output_groups=+rustfmt_checks
 build:clippy --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:clippy --output_groups=+clippy_checks
 
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -4,3 +4,7 @@ startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 build --fat_apk_cpu=arm64-v8a
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod

--- a/examples/crate_universe/.bazelrc
+++ b/examples/crate_universe/.bazelrc
@@ -18,6 +18,10 @@ build:clippy --output_groups=+clippy_checks
 # external symlink in runfiles.
 build --nolegacy_external_runfiles
 
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/cargo_aliases/.bazelrc
+++ b/examples/crate_universe/cargo_aliases/.bazelrc
@@ -13,6 +13,10 @@ build:strict --output_groups=+rustfmt_checks
 build:strict --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:strict --output_groups=+clippy_checks
 
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/cargo_remote/.bazelrc
+++ b/examples/crate_universe/cargo_remote/.bazelrc
@@ -13,6 +13,10 @@ build:strict --output_groups=+rustfmt_checks
 build:strict --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:strict --output_groups=+clippy_checks
 
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/cargo_workspace/.bazelrc
+++ b/examples/crate_universe/cargo_workspace/.bazelrc
@@ -13,6 +13,10 @@ build:strict --output_groups=+rustfmt_checks
 build:strict --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:strict --output_groups=+clippy_checks
 
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/multi_package/.bazelrc
+++ b/examples/crate_universe/multi_package/.bazelrc
@@ -13,6 +13,10 @@ build:strict --output_groups=+rustfmt_checks
 build:strict --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:strict --output_groups=+clippy_checks
 
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/no_cargo_manifests/.bazelrc
+++ b/examples/crate_universe/no_cargo_manifests/.bazelrc
@@ -13,6 +13,10 @@ build:strict --output_groups=+rustfmt_checks
 build:strict --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:strict --output_groups=+clippy_checks
 
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe_unnamed/.bazelrc
+++ b/examples/crate_universe_unnamed/.bazelrc
@@ -14,6 +14,10 @@ build:rustfmt --output_groups=+rustfmt_checks
 build:clippy --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:clippy --output_groups=+clippy_checks
 
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/ios/.bazelrc
+++ b/examples/ios/.bazelrc
@@ -7,3 +7,7 @@ build:windows --enable_runfiles
 build --apple_crosstool_top=@local_config_apple_cc//:toolchain
 build --crosstool_top=@local_config_apple_cc//:toolchain
 build --host_crosstool_top=@local_config_apple_cc//:toolchain
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod

--- a/examples/ios_build/.bazelrc
+++ b/examples/ios_build/.bazelrc
@@ -7,3 +7,7 @@ build:windows --enable_runfiles
 build --apple_crosstool_top=@local_config_apple_cc//:toolchain
 build --crosstool_top=@local_config_apple_cc//:toolchain
 build --host_crosstool_top=@local_config_apple_cc//:toolchain
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod

--- a/examples/zig_cross_compiling/.bazelrc
+++ b/examples/zig_cross_compiling/.bazelrc
@@ -4,3 +4,7 @@ startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 build --incompatible_enable_cc_toolchain_resolution
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/rules_rust/issues/2181
+common --noenable_bzlmod


### PR DESCRIPTION
This will help make sure [Bazel Downstream Pipeline](https://github.com/bazelbuild/continuous-integration/blob/master/docs/downstream-testing.md) is green after enabling Bzlmod at Bazel@HEAD

See https://github.com/bazelbuild/bazel/issues/18958#issuecomment-1749058780

Related issue: https://github.com/bazelbuild/rules_rust/issues/2181