### PR TITLE
Disable frequently failing Windows CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -485,26 +485,27 @@ tasks:
     test_targets:
       - "//..."
     build_flags: *aspects_flags
-  crate_universe_examples_windows:
-    name: Crate Universe Examples
-    platform: windows
-    working_directory: examples/crate_universe
-    run_targets: *crate_universe_vendor_example_targets
-    build_flags: *aspects_flags
-    build_targets:
-      - "//..."
-    test_targets:
-      - "//..."
-  crate_universe_unnamed_examples_windows:
-    name: Crate Universe Unnamed Examples
-    platform: windows
-    working_directory: examples/crate_universe_unnamed
-    run_targets: *crate_universe_unnamed_vendor_example_targets
-    build_flags: *aspects_flags
-    build_targets:
-      - "//..."
-    test_targets:
-      - "//..."
+# See https://github.com/bazelbuild/rules_rust/issues/2186 about re-enabling these.
+#  crate_universe_examples_windows:
+#    name: Crate Universe Examples
+#    platform: windows
+#    working_directory: examples/crate_universe
+#    run_targets: *crate_universe_vendor_example_targets
+#    build_flags: *aspects_flags
+#    build_targets:
+#      - "//..."
+#    test_targets:
+#      - "//..."
+#  crate_universe_unnamed_examples_windows:
+#    name: Crate Universe Unnamed Examples
+#    platform: windows
+#    working_directory: examples/crate_universe_unnamed
+#    run_targets: *crate_universe_unnamed_vendor_example_targets
+#    build_flags: *aspects_flags
+#    build_targets:
+#      - "//..."
+#    test_targets:
+#      - "//..."
   cc_common_link_ubuntu2004:
     name: Build via cc_common.link
     platform: ubuntu2004

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,8 +99,8 @@ We test these rules against the latest rolling releases of Bazel, and aim for co
 
 ## Supported platforms
 
-We aim to support Linux, macOS, and Windows.
+We aim to support Linux and macOS.
 
-Windows support is less complete than the other two platforms, but most things work, and we welcome contributions to help improve its support.
+We do not have sufficient maintainer expertise to support Windows. Most things probably work, but we have had to disable many tests in CI because we lack the expertise to fix them. We welcome contributions to help improve its support.
 
 Windows support for some features requires `--enable_runfiles` to be passed to Bazel, we recommend putting it in your bazelrc. See [Using Bazel on Windows](https://bazel.build/configure/windows) for more Windows-specific recommendations.


### PR DESCRIPTION
Also, update the docs to reflect that realistically we can't support Windows well without a relevant maintainer.

This is a very large hammer, but realistically these tests have wasted a lot of our time and no one is well positioned to address them.

Fixes #1946 
Relates to #2186