### PR TITLE
Use canonical labels for analysistest config_settings

### DIFF
--- a/test/toolchain/toolchain_test.bzl
+++ b/test/toolchain/toolchain_test.bzl
@@ -41,7 +41,7 @@ def _toolchain_adds_rustc_flags_impl(ctx):
 toolchain_adds_rustc_flags_test = analysistest.make(
     _toolchain_adds_rustc_flags_impl,
     config_settings = {
-        "@//:extra_rustc_flags": [CONFIG_FLAG],
+        str(Label("//:extra_rustc_flags")): [CONFIG_FLAG],
     },
 )
 

--- a/test/unit/channel_transitions/channel_transiitons_test.bzl
+++ b/test/unit/channel_transitions/channel_transiitons_test.bzl
@@ -31,7 +31,7 @@ nightly_transition_test = analysistest.make(
     _nightly_transition_test_impl,
     doc = "Test that targets can be forced to use a nightly toolchain",
     config_settings = {
-        "@//rust/toolchain/channel:channel": "nightly",
+        str(Label("//rust/toolchain/channel:channel")): "nightly",
     },
 )
 
@@ -42,7 +42,7 @@ stable_transition_test = analysistest.make(
     _stable_transition_test_impl,
     doc = "Test that targets can be forced to use a stable toolchain",
     config_settings = {
-        "@//rust/toolchain/channel:channel": "stable",
+        str(Label("//rust/toolchain/channel:channel")): "stable",
     },
 )
 

--- a/test/unit/clippy/clippy_test.bzl
+++ b/test/unit/clippy/clippy_test.bzl
@@ -84,7 +84,12 @@ def make_clippy_aspect_unittest(impl, **kwargs):
 binary_clippy_aspect_action_has_warnings_flag_test = make_clippy_aspect_unittest(_binary_clippy_aspect_action_has_warnings_flag_test_impl)
 library_clippy_aspect_action_has_warnings_flag_test = make_clippy_aspect_unittest(_library_clippy_aspect_action_has_warnings_flag_test_impl)
 test_clippy_aspect_action_has_warnings_flag_test = make_clippy_aspect_unittest(_test_clippy_aspect_action_has_warnings_flag_test_impl)
-clippy_aspect_with_explicit_flags_test = make_clippy_aspect_unittest(_clippy_aspect_with_explicit_flags_test_impl, config_settings = {"@//:clippy_flags": _CLIPPY_EXPLICIT_FLAGS})
+clippy_aspect_with_explicit_flags_test = make_clippy_aspect_unittest(
+    _clippy_aspect_with_explicit_flags_test_impl,
+    config_settings = {
+        str(Label("//:clippy_flags")): _CLIPPY_EXPLICIT_FLAGS
+    },
+)
 
 def clippy_test_suite(name):
     """Entry-point macro called from the BUILD file.

--- a/test/unit/clippy/clippy_test.bzl
+++ b/test/unit/clippy/clippy_test.bzl
@@ -87,7 +87,7 @@ test_clippy_aspect_action_has_warnings_flag_test = make_clippy_aspect_unittest(_
 clippy_aspect_with_explicit_flags_test = make_clippy_aspect_unittest(
     _clippy_aspect_with_explicit_flags_test_impl,
     config_settings = {
-        str(Label("//:clippy_flags")): _CLIPPY_EXPLICIT_FLAGS
+        str(Label("//:clippy_flags")): _CLIPPY_EXPLICIT_FLAGS,
     },
 )
 

--- a/test/unit/extra_rustc_flags/extra_rustc_flags_test.bzl
+++ b/test/unit/extra_rustc_flags/extra_rustc_flags_test.bzl
@@ -54,7 +54,7 @@ extra_rustc_flags_present_test = analysistest.make(
         ),
     },
     config_settings = {
-        "@//:extra_rustc_flags": [EXTRA_FLAG],
+        str(Label("//:extra_rustc_flags")): [EXTRA_FLAG],
     },
 )
 
@@ -67,8 +67,8 @@ extra_rustc_flag_present_test = analysistest.make(
         ),
     },
     config_settings = {
-        "@//:extra_rustc_flag": [EXTRA_FLAG],
-        "@//:extra_rustc_flags": [],
+        str(Label("//:extra_rustc_flag")): [EXTRA_FLAG],
+        str(Label("//:extra_rustc_flags")): [],
     },
 )
 

--- a/test/unit/per_crate_rustc_flag/per_crate_rustc_flag_test.bzl
+++ b/test/unit/per_crate_rustc_flag/per_crate_rustc_flag_test.bzl
@@ -59,7 +59,7 @@ per_crate_rustc_flag_not_present_test = analysistest.make(_per_crate_rustc_flag_
 per_crate_rustc_flag_not_present_non_matching_test = analysistest.make(
     _per_crate_rustc_flag_not_present_test,
     config_settings = {
-        "@//:experimental_per_crate_rustc_flag": [NON_MATCHING_FLAG],
+        str(Label("//:experimental_per_crate_rustc_flag")): [NON_MATCHING_FLAG],
     },
 )
 
@@ -72,7 +72,7 @@ per_crate_rustc_flag_present_label_test = analysistest.make(
         ),
     },
     config_settings = {
-        "@//:experimental_per_crate_rustc_flag": [MATCHING_LABEL_FLAG],
+        str(Label("//:experimental_per_crate_rustc_flag")): [MATCHING_LABEL_FLAG],
     },
 )
 
@@ -85,7 +85,7 @@ per_crate_rustc_flag_present_execution_path_test = analysistest.make(
         ),
     },
     config_settings = {
-        "@//:experimental_per_crate_rustc_flag": [MATCHING_EXECUTION_PATH_FLAG],
+        str(Label("//:experimental_per_crate_rustc_flag")): [MATCHING_EXECUTION_PATH_FLAG],
     },
 )
 
@@ -93,7 +93,7 @@ per_crate_rustc_flag_invalid_pattern_test = analysistest.make(
     _per_crate_rustc_flag_invalid_pattern_test,
     expect_failure = True,
     config_settings = {
-        "@//:experimental_per_crate_rustc_flag": [INVALID_FLAG],
+        str(Label("//:experimental_per_crate_rustc_flag")): [INVALID_FLAG],
     },
 )
 

--- a/test/unit/pipelined_compilation/pipelined_compilation_test.bzl
+++ b/test/unit/pipelined_compilation/pipelined_compilation_test.bzl
@@ -12,7 +12,7 @@ NOT_WINDOWS = select({
 })
 
 ENABLE_PIPELINING = {
-    "@//rust/settings:pipelined_compilation": True,
+    str(Label("//rust/settings:pipelined_compilation")): True,
 }
 
 def _second_lib_test_impl(ctx):

--- a/test/unit/proc_macro/leaks_deps/proc_macro_does_not_leak_deps.bzl
+++ b/test/unit/proc_macro/leaks_deps/proc_macro_does_not_leak_deps.bzl
@@ -140,7 +140,12 @@ def _proc_macro_does_not_leak_lib_deps_test():
         target_compatible_with = NOT_WINDOWS,
     )
 
-proc_macro_does_not_leak_lib_deps_test = analysistest.make(_proc_macro_does_not_leak_lib_deps_impl, config_settings = {"@//rust/settings:pipelined_compilation": True})
+proc_macro_does_not_leak_lib_deps_test = analysistest.make(
+    _proc_macro_does_not_leak_lib_deps_impl,
+    config_settings = {
+        str(Label("//rust/settings:pipelined_compilation")): True,
+    },
+)
 
 def proc_macro_does_not_leak_deps_test_suite(name):
     """Entry-point macro called from the BUILD file.

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -132,7 +132,7 @@ rustdoc_for_lib_with_cc_lib_test = analysistest.make(_rustdoc_for_lib_with_cc_li
 rustdoc_with_args_test = analysistest.make(_rustdoc_with_args_test_impl)
 rustdoc_zip_output_test = analysistest.make(_rustdoc_zip_output_test_impl)
 rustdoc_with_json_error_format_test = analysistest.make(_rustdoc_with_json_error_format_test_impl, config_settings = {
-    "@//:error_format": "json",
+    str(Label("//:error_format")): "json",
 })
 
 def _target_maker(rule_fn, name, rustdoc_deps = [], **kwargs):


### PR DESCRIPTION
With bzlmod enabled, errors like the following would occur:
```
Error in analysis_test_transition: invalid transition output '@[unknown repo '' requested from @bazel_skylib~1.3.0]//:clippy_flags': no repo visible as @ from repository '@bazel_skylib~1.3.0'
```

To resolve this, use str(Label("...")) to get the canonical label to use as the key in config_settings.

Related issues: #2181, bazelbuild/bazel#19286