### PR TITLE
Update using_cxx example to cxx 1.0.109

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-**/Cargo.Bazel.lock linguist-generated
+**/*Cargo.Bazel.lock linguist-generated
 **/cargo-bazel-lock.json linguist-generated
 bindgen/3rdparty/crates/** linguist-generated
 crate_universe/3rdparty/crates/** linguist-generated

--- a/examples/crate_universe/WORKSPACE.bazel
+++ b/examples/crate_universe/WORKSPACE.bazel
@@ -277,14 +277,6 @@ no_cargo_crate_repositories()
 
 crates_repository(
     name = "using_cxx",
-    annotations = {
-        "cxx": [
-            crate.annotation(
-                # Until https://github.com/dtolnay/cxx/pull/1257#issuecomment-1755816850 gets resolved.
-                deps = [":cxx_cc"],
-            ),
-        ],
-    },
     cargo_lockfile = "//using_cxx:Cargo.Bazel.lock",
     # `generator` is not necessary in official releases.
     # See load satement for `cargo_bazel_bootstrap`.
@@ -292,7 +284,7 @@ crates_repository(
     lockfile = "//using_cxx:cargo-bazel-lock.json",
     packages = {
         "cxx": crate.spec(
-            version = "1.0.105",
+            version = "1.0.109",
         ),
     },
     splicing_config = splicing_config(
@@ -328,10 +320,10 @@ rust_binary(
     ),
 )
     """,
-    sha256 = "0b3eea393dbcbc1e875302846de4e4f9a31bf2e57ad3657bc83d61d00293b0fe",
-    strip_prefix = "cxxbridge-cmd-1.0.105",
+    sha256 = "d93600487d429c8bf013ee96719af4e62e809ac57fc4cac24f17cf58e4526009",
+    strip_prefix = "cxxbridge-cmd-1.0.109",
     type = "tar.gz",
-    urls = ["https://crates.io/api/v1/crates/cxxbridge-cmd/1.0.105/download"],
+    urls = ["https://crates.io/api/v1/crates/cxxbridge-cmd/1.0.109/download"],
 )
 
 crates_repository(

--- a/examples/crate_universe/using_cxx/Cargo.Bazel.lock
+++ b/examples/crate_universe/using_cxx/Cargo.Bazel.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.105"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666a3ec767f4bbaf0dcfcc3b4ea048b90520b254fdf88813e763f4c762636c14"
+checksum = "c390c123d671cc547244943ecad81bdaab756c6ea332d9ca9c1f48d952a24895"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -25,15 +25,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.105"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e8c238aadc4b9f2c00269d04c87abb23f96dd240803872536eed1a304bb40e"
+checksum = "94415827ecfea0f0c74c8cad7d1a86ddb3f05354d6a6ddeda0adee5e875d2939"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.105"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d9ffb4193dd22180b8d5747b1e095c3d9c9c665ce39b0483a488948f437e06"
+checksum = "e33dbbe9f5621c9247f97ec14213b04f350bff4b6cebefe834c60055db266ecf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/crate_universe/using_cxx/cargo-bazel-lock.json
+++ b/examples/crate_universe/using_cxx/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1c8a8ade9ae2054f346e20ad66cb1d2c0e95f4ec87cdb3299dc584df78f9b6a4",
+  "checksum": "71b6f19ac904caf96b1b84bdca72bfc5ef2b8696396d04314ebb4be13c98f62a",
   "crates": {
     "cc 1.0.82": {
       "name": "cc",
@@ -42,13 +42,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cxx 1.0.105": {
+    "cxx 1.0.109": {
       "name": "cxx",
-      "version": "1.0.105",
+      "version": "1.0.109",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxx/1.0.105/download",
-          "sha256": "666a3ec767f4bbaf0dcfcc3b4ea048b90520b254fdf88813e763f4c762636c14"
+          "url": "https://crates.io/api/v1/crates/cxx/1.0.109/download",
+          "sha256": "c390c123d671cc547244943ecad81bdaab756c6ea332d9ca9c1f48d952a24895"
         }
       },
       "targets": [
@@ -94,13 +94,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "cxxbridge-macro 1.0.105",
+              "id": "cxxbridge-macro 1.0.109",
               "target": "cxxbridge_macro"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.105"
+        "version": "1.0.109"
       },
       "license": "MIT OR Apache-2.0",
       "additive_build_file_content": "cc_library(\n    name = \"cxx_cc\",\n    srcs = [\"src/cxx.cc\"],\n    hdrs = [\"include/cxx.h\"],\n    include_prefix = \"rust\",\n    includes = [\"include\"],\n    linkstatic = True,\n    strip_include_prefix = \"include\",\n    visibility = [\"//visibility:public\"],\n)\n",
@@ -108,13 +108,13 @@
         "cxx_cc": "cxx_cc"
       }
     },
-    "cxxbridge-flags 1.0.105": {
+    "cxxbridge-flags 1.0.109": {
       "name": "cxxbridge-flags",
-      "version": "1.0.105",
+      "version": "1.0.109",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxxbridge-flags/1.0.105/download",
-          "sha256": "d6e8c238aadc4b9f2c00269d04c87abb23f96dd240803872536eed1a304bb40e"
+          "url": "https://crates.io/api/v1/crates/cxxbridge-flags/1.0.109/download",
+          "sha256": "94415827ecfea0f0c74c8cad7d1a86ddb3f05354d6a6ddeda0adee5e875d2939"
         }
       },
       "targets": [
@@ -140,17 +140,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.105"
+        "version": "1.0.109"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "cxxbridge-macro 1.0.105": {
+    "cxxbridge-macro 1.0.109": {
       "name": "cxxbridge-macro",
-      "version": "1.0.105",
+      "version": "1.0.109",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cxxbridge-macro/1.0.105/download",
-          "sha256": "59d9ffb4193dd22180b8d5747b1e095c3d9c9c665ce39b0483a488948f437e06"
+          "url": "https://crates.io/api/v1/crates/cxxbridge-macro/1.0.109/download",
+          "sha256": "e33dbbe9f5621c9247f97ec14213b04f350bff4b6cebefe834c60055db266ecf"
         }
       },
       "targets": [
@@ -187,7 +187,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.105"
+        "version": "1.0.109"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -214,7 +214,7 @@
         "deps": {
           "common": [
             {
-              "id": "cxx 1.0.105",
+              "id": "cxx 1.0.109",
               "target": "cxx"
             }
           ],

--- a/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.Bazel.lock
+++ b/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "0228cfef9fd54e916e9aa00486f13901aec64547da293627aabfb6bf1a426239",
+  "checksum": "2ac40591dc369d36ba80a6f16cd22421662cd96937636813a59af18726b8ad2c",
   "crates": {
     "anstyle 1.0.1": {
       "name": "anstyle",
@@ -217,9 +217,9 @@
       },
       "license": "Apache-2.0"
     },
-    "cxxbridge-cmd 1.0.105": {
+    "cxxbridge-cmd 1.0.109": {
       "name": "cxxbridge-cmd",
-      "version": "1.0.105",
+      "version": "1.0.109",
       "repository": null,
       "targets": [],
       "library_target_name": null,
@@ -253,7 +253,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.105"
+        "version": "1.0.109"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -784,7 +784,7 @@
   },
   "binary_crates": [],
   "workspace_members": {
-    "cxxbridge-cmd 1.0.105": ""
+    "cxxbridge-cmd 1.0.109": ""
   },
   "conditions": {
     "aarch64-apple-darwin": [

--- a/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.lock
+++ b/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.105"
+version = "1.0.109"
 dependencies = [
  "clap",
  "codespan-reporting",


### PR DESCRIPTION
This eliminates the annotation introduced by https://github.com/bazelbuild/rules_rust/pull/2192, because it includes https://github.com/dtolnay/cxx/pull/1277.

This PR includes handwritten changes to WORKSPACE.bazel followed by the generated result of running:

- `cd examples/crate_universe/using_cxx`
- `CARGO_BAZEL_REPIN=1 bazel sync --only=using_cxx`
- `CARGO_BAZEL_REPIN=1 bazel sync --only=cxxbridge_cmd_deps`

Tested by running `bazel build ...` in the same directory.