### PR TITLE
Prep release 0.29.1

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.29.0"
+VERSION = "0.29.1"


### PR DESCRIPTION
To pick up recent internal API changes about the crate_info -> dict changes. Some users like Crubit and rust Protobuf use these internal APIs, it would be nice for them to be adapted accordingly and refer them to the new version.  But since these are internal, just updating the minor version.

(it's my first time prepping a release, is there anything beyond just getting something like this submitted for the released archives to be created?)