### PR TITLE
Support artifact dependencies in crate.spec

### DIFF
--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -35,7 +35,7 @@ def _spec(
     Args:
         package (str, optional): The explicit name of the package (used when attempting to alias a crate).
         version (str, optional): The exact version of the crate. Cannot be used with `git`.
-        artifact (str, optional): Set to "bin" to pull in a binary crate as an artifact dependency.
+        artifact (str, optional): Set to "bin" to pull in a binary crate as an artifact dependency. Requires a nightly Cargo.
         lib (bool, optional): If using `artifact = "bin"`, additionally setting `lib = True` declares a dependency on both the package's library and binary, as opposed to just the binary.
         default_features (bool, optional): Maps to the `default-features` flag.
         features (list, optional): A list of features to use for the crate

--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -50,16 +50,16 @@ def _spec(
     return json.encode({
         k: v
         for k, v in {
-            "package": package,
-            "version": version,
             "artifact": artifact,
-            "lib": lib,
+            "branch": branch,
             "default_features": default_features,
             "features": features,
             "git": git,
-            "branch": branch,
-            "tag": tag,
+            "lib": lib,
+            "package": package,
             "rev": rev,
+            "tag": tag,
+            "version": version,
         }.items()
         # The `cargo_toml` crate parses unstable fields to a flattened
         # BTreeMap<String, toml::Value> and toml::Value does not support null,

--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -18,6 +18,8 @@ def _workspace_member(version, sha256 = None):
 def _spec(
         package = None,
         version = None,
+        artifact = None,
+        lib = None,
         default_features = True,
         features = [],
         git = None,
@@ -33,6 +35,8 @@ def _spec(
     Args:
         package (str, optional): The explicit name of the package (used when attempting to alias a crate).
         version (str, optional): The exact version of the crate. Cannot be used with `git`.
+        artifact (str, optional): Set to "bin" to pull in a binary crate as an artifact dependency.
+        lib (bool, optional): If using `artifact = "bin"`, additionally setting `lib = True` declares a dependency on both the package's library and binary, as opposed to just the binary.
         default_features (bool, optional): Maps to the `default-features` flag.
         features (list, optional): A list of features to use for the crate
         git (str, optional): The Git url to use for the crate. Cannot be used with `version`.
@@ -43,16 +47,25 @@ def _spec(
     Returns:
         string: A json encoded string of all inputs
     """
-    return json.encode(struct(
-        package = package,
-        default_features = default_features,
-        features = features,
-        version = version,
-        git = git,
-        branch = branch,
-        tag = tag,
-        rev = rev,
-    ))
+    return json.encode({
+        k: v
+        for k, v in {
+            "package": package,
+            "version": version,
+            "artifact": artifact,
+            "lib": lib,
+            "default_features": default_features,
+            "features": features,
+            "git": git,
+            "branch": branch,
+            "tag": tag,
+            "rev": rev,
+        }.items()
+        # The `cargo_toml` crate parses unstable fields to a flattened
+        # BTreeMap<String, toml::Value> and toml::Value does not support null,
+        # so we must omit null values.
+        if v != None
+    })
 
 def _assert_absolute(label):
     """Ensure a given label is an absolute label

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -569,7 +569,7 @@ list: A list of labels to generated rust targets (str)
 ## crate.spec
 
 <pre>
-crate.spec(<a href="#crate.spec-package">package</a>, <a href="#crate.spec-version">version</a>, <a href="#crate.spec-default_features">default_features</a>, <a href="#crate.spec-features">features</a>, <a href="#crate.spec-git">git</a>, <a href="#crate.spec-branch">branch</a>, <a href="#crate.spec-tag">tag</a>, <a href="#crate.spec-rev">rev</a>)
+crate.spec(<a href="#crate.spec-package">package</a>, <a href="#crate.spec-version">version</a>, <a href="#crate.spec-artifact">artifact</a>, <a href="#crate.spec-lib">lib</a>, <a href="#crate.spec-default_features">default_features</a>, <a href="#crate.spec-features">features</a>, <a href="#crate.spec-git">git</a>, <a href="#crate.spec-branch">branch</a>, <a href="#crate.spec-tag">tag</a>, <a href="#crate.spec-rev">rev</a>)
 </pre>
 
 A constructor for a crate dependency.
@@ -586,6 +586,8 @@ See [specifying dependencies][sd] in the Cargo book for more details.
 | :------------- | :------------- | :------------- |
 | <a id="crate.spec-package"></a>package |  The explicit name of the package (used when attempting to alias a crate).   |  `None` |
 | <a id="crate.spec-version"></a>version |  The exact version of the crate. Cannot be used with <code>git</code>.   |  `None` |
+| <a id="crate.spec-artifact"></a>artifact |  Set to "bin" to pull in a binary crate as an artifact dependency.   |  `None` |
+| <a id="crate.spec-lib"></a>lib |  If using <code>artifact = "bin"</code>, additionally setting <code>lib = True</code> declares a dependency on both the package's library and binary, as opposed to just the binary.   |  `None` |
 | <a id="crate.spec-default_features"></a>default_features |  Maps to the <code>default-features</code> flag.   |  `True` |
 | <a id="crate.spec-features"></a>features |  A list of features to use for the crate   |  `[]` |
 | <a id="crate.spec-git"></a>git |  The Git url to use for the crate. Cannot be used with <code>version</code>.   |  `None` |

--- a/docs/crate_universe.md
+++ b/docs/crate_universe.md
@@ -586,7 +586,7 @@ See [specifying dependencies][sd] in the Cargo book for more details.
 | :------------- | :------------- | :------------- |
 | <a id="crate.spec-package"></a>package |  The explicit name of the package (used when attempting to alias a crate).   |  `None` |
 | <a id="crate.spec-version"></a>version |  The exact version of the crate. Cannot be used with <code>git</code>.   |  `None` |
-| <a id="crate.spec-artifact"></a>artifact |  Set to "bin" to pull in a binary crate as an artifact dependency.   |  `None` |
+| <a id="crate.spec-artifact"></a>artifact |  Set to "bin" to pull in a binary crate as an artifact dependency. Requires a nightly Cargo.   |  `None` |
 | <a id="crate.spec-lib"></a>lib |  If using <code>artifact = "bin"</code>, additionally setting <code>lib = True</code> declares a dependency on both the package's library and binary, as opposed to just the binary.   |  `None` |
 | <a id="crate.spec-default_features"></a>default_features |  Maps to the <code>default-features</code> flag.   |  `True` |
 | <a id="crate.spec-features"></a>features |  A list of features to use for the crate   |  `[]` |


### PR DESCRIPTION
Followup to #2226. That PR made bindeps work for crates repositories that use `manifests`.

https://github.com/bazelbuild/rules_rust/blob/d86faee8b85cc334e0529193142f4b61362e79a3/examples/crate_universe/WORKSPACE.bazel#L60

This PR makes it work for crates repositories that use `packages`.

https://github.com/bazelbuild/rules_rust/blob/43b101e6b3e679b333c2622d7615233edf344624/examples/crate_universe/WORKSPACE.bazel#L317-L320