### PR TITLE
Add configuration to mirror github releases to bazel central registry

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -1,0 +1,9 @@
+# Bazel Central Registry
+
+When the ruleset is released, we want it to be published to the
+Bazel Central Registry automatically:
+<https://registry.bazel.build>
+
+This folder contains configuration files to automate the publish step.
+See <https://github.com/bazel-contrib/publish-to-bcr/blob/main/templates/README.md>
+for authoritative documentation about these files.

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: UebelAndre
+  email: 26427366+UebelAndre@users.noreply.github.com

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,18 @@
+{
+  "homepage": "https://github.com/bazelbuild/rules_rust",
+  "maintainers": [
+    {
+        "email": "26427366+UebelAndre@users.noreply.github.com",
+        "github": "UebelAndre",
+        "name": "UebelAndre"
+    },
+    {
+      "email": "1131704+illicitonion@users.noreply.github.com",
+      "github": "illicitonion",
+      "name": "Daniel Wagner-Hall"
+    }
+  ],
+  "repository": ["github:bazelbuild/rules_rust"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,1 @@
+../.bazelci/presubmit.yml

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "**leave this alone**",
+  "strip_prefix": "",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{VERSION}.tar.gz"
+}


### PR DESCRIPTION
Add machinery to automatically push GitHub releases to bazel central registry. This will need some setup by the ruleset maintainers to enable the GitHub app when bzlmod support is ready. See the [instructions](https://github.com/apps/publish-to-bcr) for more details

Ref #2181 