### PR TITLE
fix: Renamed dependencies handling

### DIFF
--- a/crate_universe/src/metadata/dependency.rs
+++ b/crate_universe/src/metadata/dependency.rs
@@ -147,7 +147,7 @@ fn is_optional_crate_enabled(
         .filter(|&d| d.kind == kind)
         .filter(|&d| d.target.as_ref() == target)
         .filter(|&d| d.optional)
-        .find(|&d| sanitize_module_name(&d.name) == dep.name)
+        .find(|&d| sanitize_module_name(d.rename.as_ref().unwrap_or(&d.name)) == dep.name)
     {
         enabled_deps.any(|d| d == toml_dep.name.as_str())
     } else {


### PR DESCRIPTION
Ensure renamed dependencies are selected correctly in crate_universe.

It fixes #2252 