### PR TITLE
replace pwd in rust-project.json output #1

### DIFF
--- a/tools/rust_analyzer/rust_project.rs
+++ b/tools/rust_analyzer/rust_project.rs
@@ -208,6 +208,7 @@ pub fn write_rust_project(
     // Render the `rust-project.json` file and replace the exec root
     // placeholders with the path to the local exec root.
     let rust_project_content = serde_json::to_string(rust_project)?
+        .replace("${pwd}", execution_root)
         .replace("__EXEC_ROOT__", execution_root)
         .replace("__OUTPUT_BASE__", output_base);
 


### PR DESCRIPTION
The generated content uses ${pwd} and in the rust-analyzer server output I see error logs saying can't find dir with ${pwd} references

Though I'm not sure if this actually affect anything as it seems work fine most of the time, but I think it maybe good to not have rust-analyzer errors