### PR TITLE
rust-analyzer: Include prost_runtime as a dep for rust_prost_library

### DIFF
--- a/proto/prost/private/prost.bzl
+++ b/proto/prost/private/prost.bzl
@@ -207,7 +207,7 @@ def _rust_prost_aspect_impl(target, ctx):
     proto_deps = getattr(ctx.rule.attr, "deps", [])
 
     direct_deps = []
-    transitive_deps = []
+    transitive_deps = [depset(runtime_deps)]
     for proto_dep in proto_deps:
         proto_info = proto_dep[ProstProtoInfo]
 


### PR DESCRIPTION
This allows rust-analyzer to autocomplete definitions like ::decode() and other methods that are found in ::prost::Message.