### PR TITLE
Fix inclusion/exclusion of optional dependencies

### DIFF
--- a/crate_universe/src/metadata/dependency.rs
+++ b/crate_universe/src/metadata/dependency.rs
@@ -49,7 +49,7 @@ impl DependencySet {
                 .partition(|dep| is_dev_dependency(dep));
 
             (
-                collect_deps_selectable(node, dev, metadata, DependencyKind::Normal),
+                collect_deps_selectable(node, dev, metadata, DependencyKind::Development),
                 collect_deps_selectable(node, normal, metadata, DependencyKind::Normal),
             )
         };
@@ -66,7 +66,7 @@ impl DependencySet {
 
             (
                 collect_deps_selectable(node, dev, metadata, DependencyKind::Development),
-                collect_deps_selectable(node, normal, metadata, DependencyKind::Development),
+                collect_deps_selectable(node, normal, metadata, DependencyKind::Normal),
             )
         };
 


### PR DESCRIPTION
Follow-up to #2235 that corrects the `DependencyKind` used. This bug caused optional dependencies to be incorrectly _included_ even no feature activated that dependency. This can lead to crates being compiled with missing features, resulting in compile errors.

For example, `sqlx==0.7.3` compiled successfully with `0.30.0`, but fails with `0.31.0`:
```toml
sqlx = { version = "0.7.3", default-features = false, features = ["sqlite"] }
```
because `default-features = false` should remove the [optional dependency](https://github.com/launchbadge/sqlx/blob/c55aba0dc14f33b8a26cab6af565fcc4c8af8962/Cargo.toml#L54-L56) `sqlx-macros`. Instead, however, it gets incorrectly included but with its crate dependencies' features missing, resulting in compile errors.

Related issue:
- https://github.com/bazelbuild/rules_rust/issues/2262