### PR TITLE
Updated direct dependencies

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,7 +16,10 @@ load(
     "rustc_output_diagnostics",
 )
 
-exports_files(["LICENSE"])
+exports_files([
+    "LICENSE",
+    "MODULE.bazel",
+])
 
 bzl_library(
     name = "bzl_lib",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,16 +1,18 @@
+"""bazelbuild/rules_rust"""
+
 module(
     name = "rules_rust",
-    version = "0.20.0",
+    version = "0.32.0",
 )
 
 print("WARNING: The rules_rust Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.")  # buildifier: disable=print
 
-bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "bazel_skylib", version = "1.2.0")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(
     name = "apple_support",
-    version = "1.3.1",
+    version = "1.11.1",
     repo_name = "build_bazel_apple_support",
 )
 

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -52,10 +52,10 @@ def rules_rust_dependencies():
         http_archive,
         name = "platforms",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
         ],
-        sha256 = "3a561c99e7bdbe9173aa653fd579fe849f1d8d67395780ab4770b1f381431d51",
+        sha256 = "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74",
     )
     maybe(
         http_archive,
@@ -68,10 +68,10 @@ def rules_rust_dependencies():
     maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+        sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
         ],
     )
 
@@ -80,8 +80,8 @@ def rules_rust_dependencies():
     maybe(
         http_archive,
         name = "build_bazel_apple_support",
-        sha256 = "45d6bbad5316c9c300878bf7fffc4ffde13d620484c9184708c917e20b8b63ff",
-        url = "https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz",
+        sha256 = "cf4d63f39c7ba9059f70e995bf5fe1019267d3f77379c2028561a5d7645ef67c",
+        url = "https://github.com/bazelbuild/apple_support/releases/download/1.11.1/apple_support.1.11.1.tar.gz",
     )
 
     # process_wrapper needs a low-dependency way to process json.

--- a/test/bzl_version/BUILD.bazel
+++ b/test/bzl_version/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//:version.bzl", "VERSION")
+load("//rust:defs.bzl", "rust_test")
+
+rust_test(
+    name = "bzl_version_test",
+    srcs = ["bzl_version_test.rs"],
+    data = [
+        "//:MODULE.bazel",
+    ],
+    edition = "2021",
+    env = {
+        "MODULE_BAZEL": "$(rlocationpath //:MODULE.bazel)",
+        "VERSION": VERSION,
+    },
+    deps = [
+        "//tools/runfiles",
+    ],
+)

--- a/test/bzl_version/bzl_version_test.rs
+++ b/test/bzl_version/bzl_version_test.rs
@@ -1,0 +1,40 @@
+//! A test to ensure the rules_rust bzlmod versions match the standard versions.
+
+use runfiles::Runfiles;
+
+fn parse_module_bazel_version(text: &str) -> String {
+    let mut found_module = false;
+    for line in text.split('\n') {
+        if found_module {
+            assert!(!line.ends_with(')'), "Failed to parse version");
+            if let Some((param, value)) = line.rsplit_once(" = ") {
+                if param.trim() == "version" {
+                    return value.trim().trim_matches(',').trim_matches('"').to_owned();
+                }
+            }
+        } else if line.starts_with("module(") {
+            found_module = true;
+            continue;
+        }
+    }
+    panic!("Failed to find MODULE.bazel version");
+}
+
+/// If this test fails it means `//:version.bzl` and `//:MODULE.bazel` need to
+/// be synced up. `//:version.bzl` should contain the source of truth.
+#[test]
+fn module_bzl_has_correct_version() {
+    let version = std::env::var("VERSION").unwrap();
+    let module_bazel_text = {
+        let r = Runfiles::create().unwrap();
+        let path = r.rlocation(std::env::var("MODULE_BAZEL").unwrap());
+        std::fs::read_to_string(path).unwrap()
+    };
+
+    let module_bazel_version = parse_module_bazel_version(&module_bazel_text);
+
+    assert_eq!(
+        version, module_bazel_version,
+        "//:version.bzl and //:MODULE.bazel versions are out of sync"
+    );
+}


### PR DESCRIPTION
This also adds a test to ensure `//:version.bzl` and `//:MODULE.bazel` both specify the same version for `rules_rust`. Note that `//:version.bzl` is still the source of truth that will kick off releases via github actions