### PR TITLE
Add a new presubmit environment for bzlmod

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -186,6 +186,17 @@ tasks:
     test_targets: *default_windows_targets
     soft_fail: yes
     bazel: "rolling"
+  ubuntu2004_bzlmod_only:
+    name: With bzlmod
+    platform: ubuntu2004
+    # See https://bazel.build/external/migration#migration-process
+    # When WORKSPACE.bzlmod is provided, the workspace file is ignored.
+    shell_commands:
+      - "touch WORKSPACE.bzlmod"
+    build_flags:
+      - "--enable_bzlmod"
+    build_targets:
+      - "//tools/runfiles"
   ubuntu2004_clang:
     name: With Clang
     platform: ubuntu2004


### PR DESCRIPTION
Add an environment which builds without a workspace file.

This will allow us to verify that targets such as cargo_bazel can build with bzlmod. This is mainly useful to ensure that your dependencies are specified in MODULE.bazel, rather than WORKSPACE. At the moment, I only specify a single target, to verify that it's working. As we start supporting additional targets, entries will be added here to prevent regressions.