### PR TITLE
Introduced `TargetTriple` newtype.

### DIFF
--- a/crate_universe/private/srcs.bzl
+++ b/crate_universe/private/srcs.bzl
@@ -39,4 +39,5 @@ CARGO_BAZEL_SRCS = [
     Label("//crate_universe:src/utils/starlark/select.rs"),
     Label("//crate_universe:src/utils/starlark/serialize.rs"),
     Label("//crate_universe:src/utils/starlark/target_compatible_with.rs"),
+    Label("//crate_universe:src/utils/target_triple.rs"),
 ]

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -15,6 +15,8 @@ use serde::de::value::SeqAccessDeserializer;
 use serde::de::{Deserializer, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize, Serializer};
 
+use crate::utils::target_triple::TargetTriple;
+
 /// Representations of different kinds of crate vendoring into workspaces.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -632,7 +634,7 @@ pub struct Config {
 
     /// A set of platform triples to use in generated select statements
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
-    pub supported_platform_triples: BTreeSet<String>,
+    pub supported_platform_triples: BTreeSet<TargetTriple>,
 }
 
 impl Config {

--- a/crate_universe/src/context.rs
+++ b/crate_universe/src/context.rs
@@ -16,6 +16,7 @@ use crate::context::platforms::resolve_cfg_platforms;
 use crate::lockfile::Digest;
 use crate::metadata::{Annotations, Dependency};
 use crate::utils::starlark::{Select, SelectList};
+use crate::utils::target_triple::TargetTriple;
 
 pub use self::crate_context::*;
 
@@ -37,7 +38,7 @@ pub struct Context {
     pub workspace_members: BTreeMap<CrateId, String>,
 
     /// A mapping of `cfg` flags to platform triples supporting the configuration
-    pub conditions: BTreeMap<String, BTreeSet<String>>,
+    pub conditions: BTreeMap<String, BTreeSet<TargetTriple>>,
 
     /// A list of crates visible to any bazel module.
     pub direct_deps: BTreeSet<CrateId>,

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -189,6 +189,7 @@ impl PartialEq<String> for Digest {
 mod test {
     use crate::config::{CrateAnnotations, CrateId};
     use crate::splicing::cargo_config::{AdditionalRegistry, CargoConfig, Registry};
+    use crate::utils::target_triple::TargetTriple;
 
     use super::*;
 
@@ -230,15 +231,15 @@ mod test {
             )]),
             cargo_config: None,
             supported_platform_triples: BTreeSet::from([
-                "aarch64-apple-darwin".to_owned(),
-                "aarch64-unknown-linux-gnu".to_owned(),
-                "aarch64-pc-windows-msvc".to_owned(),
-                "wasm32-unknown-unknown".to_owned(),
-                "wasm32-wasi".to_owned(),
-                "x86_64-apple-darwin".to_owned(),
-                "x86_64-pc-windows-msvc".to_owned(),
-                "x86_64-unknown-freebsd".to_owned(),
-                "x86_64-unknown-linux-gnu".to_owned(),
+                TargetTriple::from_bazel("aarch64-apple-darwin".to_owned()),
+                TargetTriple::from_bazel("aarch64-unknown-linux-gnu".to_owned()),
+                TargetTriple::from_bazel("aarch64-pc-windows-msvc".to_owned()),
+                TargetTriple::from_bazel("wasm32-unknown-unknown".to_owned()),
+                TargetTriple::from_bazel("wasm32-wasi".to_owned()),
+                TargetTriple::from_bazel("x86_64-apple-darwin".to_owned()),
+                TargetTriple::from_bazel("x86_64-pc-windows-msvc".to_owned()),
+                TargetTriple::from_bazel("x86_64-unknown-freebsd".to_owned()),
+                TargetTriple::from_bazel("x86_64-unknown-linux-gnu".to_owned()),
             ]),
             ..Config::default()
         };

--- a/crate_universe/src/utils.rs
+++ b/crate_universe/src/utils.rs
@@ -1,6 +1,7 @@
 //! Common utilities
 
 pub mod starlark;
+pub mod target_triple;
 
 pub const CRATES_IO_INDEX_URL: &str = "https://github.com/rust-lang/crates.io-index";
 
@@ -14,12 +15,4 @@ pub fn sanitize_module_name(name: &str) -> String {
 /// [RepositoryName.java](https://github.com/bazelbuild/bazel/blob/4.0.0/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java#L42)
 pub fn sanitize_repository_name(name: &str) -> String {
     name.replace('+', "-")
-}
-
-// While Bazel is NixOS aware (via `@platforms//os:nixos`), `rustc`
-// is not, so any target triples for `nixos` get remapped to `linux`
-// for the purposes of determining `cargo metadata`, resolving `cfg`
-// targets, etc.
-pub fn cargo_target(target: &str) -> String {
-    target.replace("nixos", "linux")
 }

--- a/crate_universe/src/utils/target_triple.rs
+++ b/crate_universe/src/utils/target_triple.rs
@@ -1,0 +1,36 @@
+use std::fmt::{Display, Formatter, Result};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TargetTriple(String);
+
+impl TargetTriple {
+    pub fn from_bazel(bazel: String) -> Self {
+        Self(bazel)
+    }
+
+    pub fn to_bazel(&self) -> String {
+        self.0.clone()
+    }
+
+    pub fn to_cargo(&self) -> String {
+        // While Bazel is NixOS aware (via `@platforms//os:nixos`), `rustc`
+        // is not, so any target triples for `nixos` get remapped to `linux`
+        // for the purposes of determining `cargo metadata`, resolving `cfg`
+        // targets, etc.
+        self.0.replace("nixos", "linux")
+    }
+}
+
+impl Display for TargetTriple {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let bazel = self.to_bazel();
+        let cargo = self.to_cargo();
+        match bazel == cargo {
+            true => write!(f, "{}", bazel),
+            false => write!(f, "{} (cargo: {})", bazel, cargo),
+        }
+    }
+}

--- a/examples/nix_cross_compiling/bazel/cargo/cargo-bazel-lock.json
+++ b/examples/nix_cross_compiling/bazel/cargo/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08a590b0ec2d6a1d59d568b6c177bbb9785ae7c42578449c3024e19532c7c166",
+  "checksum": "6f1a1015d47aa1124c5d5c8e0b1b137113407b532348213646ed5331ed31f033",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -1954,10 +1954,8 @@
       "x86_64-pc-windows-msvc"
     ],
     "x86_64-unknown-linux-gnu": [
-      "x86_64-unknown-linux-gnu"
-    ],
-    "x86_64-unknown-nixos-gnu": [
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ]
   },
   "direct_deps": [


### PR DESCRIPTION
As discussed on Slack with @illicitonion (hopefully).  With the `Select` refactor, we presumably want `selects` to be keyed by `TargetTriple` instead of `String`.  Please let me know if you have a better interface for `TargetTriple` and/or any bikesheds 🙂