### PR TITLE
_rust_binary_impl: propagate `data` to the crate info

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -249,6 +249,7 @@ def _rust_binary_impl(ctx):
             rustc_env = ctx.attr.rustc_env,
             rustc_env_files = ctx.files.rustc_env_files,
             is_test = False,
+            data = depset(ctx.files.data),
             compile_data = depset(ctx.files.compile_data),
             compile_data_targets = depset(ctx.attr.compile_data),
             owner = ctx.label,


### PR DESCRIPTION
Just noticed this inconsistency, updated similarly to rust_library.