### PR TITLE
fix: use `watch_file` in `.envrc`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,5 +6,5 @@
 #  - https://marketplace.visualstudio.com/items?itemName=mkhl.direnv
 
 # Use `path:` syntax to avoid copying the entire repo to the Nix Store.
-nix_direnv_watch_file ./nix/flake.nix
+watch_file ./nix/flake.nix
 use flake path:./nix


### PR DESCRIPTION
`nix_direnv_watch_file` is deprecated and appears to have been removed from some `direnv` distributions.