### PR TITLE
Adjust is_exec_configuration heuristic

### DIFF
--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -457,7 +457,7 @@ def is_exec_configuration(ctx):
     """
 
     # TODO(djmarcin): Is there any better way to determine cfg=exec?
-    return ctx.genfiles_dir.path.find("-exec-") != -1
+    return ctx.genfiles_dir.path.find("-exec") != -1
 
 def transform_deps(deps):
     """Transforms a [Target] into [DepVariantInfo].


### PR DESCRIPTION
Instead of looking for "-exec-" look for "-exec" since that portion may be the last component of the output path mneumonic.

Ultimately fixes issues with --experimental_platforms_in_output_dir that had sufficiently improved calculations to remove the need for an ST-hash and thus surfaced this issue.

Ideally, in the long term, this heuristic would not be used and whether an artifact is in the exec configuration would be determined by tracking the provenance of that artifact. However, this would likely require a more significant rework.