### PR TITLE
Add thumbv6m-none-eabi and thumbv7em-none-eabihf support

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -38,7 +38,9 @@ SUPPORTED_T2_PLATFORM_TRIPLES = [
     "riscv32imc-unknown-none-elf",
     "riscv64gc-unknown-none-elf",
     "s390x-unknown-linux-gnu",
+    "thumbv6m-none-eabi",
     "thumbv7em-none-eabi",
+    "thumbv7em-none-eabihf",
     "thumbv8m.main-none-eabi",
     "wasm32-unknown-unknown",
     "wasm32-wasi",
@@ -213,7 +215,7 @@ _SYSTEM_TO_STDLIB_LINKFLAGS = {
     "windows": ["advapi32.lib", "ws2_32.lib", "userenv.lib", "Bcrypt.lib"],
 }
 
-def cpu_arch_to_constraints(cpu_arch, *, system = None):
+def cpu_arch_to_constraints(cpu_arch, *, system = None, abi = None):
     """Returns a list of contraint values which represents a triple's CPU.
 
     Args:
@@ -229,7 +231,7 @@ def cpu_arch_to_constraints(cpu_arch, *, system = None):
     plat_suffix = _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX[cpu_arch]
 
     # Patch armv7e-m to mf if hardfloat abi is selected
-    if plat_suffix == "armv7e-m" and system == "eabihf":
+    if plat_suffix == "armv7e-m" and (system == "eabihf" or abi == "eabihf"):
         plat_suffix = "armv7e-mf"
 
     return ["@platforms//cpu:{}".format(plat_suffix)]
@@ -357,6 +359,7 @@ def triple_to_constraint_set(target_triple):
     constraint_set += cpu_arch_to_constraints(
         triple_struct.arch,
         system = triple_struct.system,
+        abi = triple_struct.abi,
     )
     constraint_set += vendor_to_constraints(triple_struct.vendor)
     constraint_set += system_to_constraints(triple_struct.system)


### PR DESCRIPTION
There was a bug in the workaround for eabihf support.  I'm not sure whether backwards compatibility is required or not.