### PR TITLE
Register a toolchain by default in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -133,7 +133,6 @@ use_repo(rust, "rust_toolchains")
 
 register_toolchains(
     "@rust_toolchains//:all",
-    dev_dependency = True,
 )
 
 use_repo(rust, "rust_host_tools")


### PR DESCRIPTION
See discussion in github.com/bazelbuild/bazel-central-registry/pull/1199