### PR TITLE
Include examples/bzlmod in release tgz for BCR presubmit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,8 +128,9 @@ jobs:
           # Update urls and sha256 values
           bazel ${BAZEL_STARTUP_FLAGS[@]}  run //crate_universe/tools/urls_generator -- --artifacts-dir="${ARTIFACTS_DIR}" --url-prefix="${URL_PREFIX}"
           bazel clean
-          # Build an archive of the repo contents
-          tar -czf ${{ github.workspace }}/.github/rules_rust.tar.gz --exclude=".git" --exclude=".github" --exclude="examples" --exclude="crate_universe/target" -C ${{ github.workspace }} .
+          # Build an archive of the repo contents.
+          # `examples/bzlmod` is included for the BCR presubmit; it must appear before --exclude="examples"
+          tar -czf ${{ github.workspace }}/.github/rules_rust.tar.gz -C ${{ github.workspace }} --exclude=".git" --exclude=".github" --exclude="crate_universe/target" examples/bzlmod --exclude="examples" .
           # Save the sha256 checksum of the distro archive to the environment
           sha256="$(shasum --algorithm 256 ${{ github.workspace }}/.github/rules_rust.tar.gz | awk '{ print $1 }')"
           echo "ARCHIVE_SHA256=${sha256}" >> $GITHUB_ENV


### PR DESCRIPTION
Fixes #2378.

```console
$ tar -czf .github/rules_rust.tar.gz --exclude=".git" --exclude=".github" --exclude="crate_universe/target" examples/bzlmod --exclude="examples" .

$ tar tf .github/rules_rust.tar.gz | rg examples
examples/bzlmod/
examples/bzlmod/hello_world/
examples/bzlmod/hello_world/WORKSPACE.bzlmod
examples/bzlmod/hello_world/hello_world_test.sh
examples/bzlmod/hello_world/.gitignore
examples/bzlmod/hello_world/WORKSPACE.bazel
examples/bzlmod/hello_world/src/
examples/bzlmod/hello_world/src/main.rs
examples/bzlmod/hello_world/BUILD.bazel
examples/bzlmod/hello_world/MODULE.bazel
examples/bzlmod/hello_world/third-party/
examples/bzlmod/hello_world/third-party/Cargo.lock
examples/bzlmod/hello_world/third-party/BUILD.bazel
examples/bzlmod/hello_world/third-party/extension.bzl
examples/bzlmod/hello_world/third-party/crates/
examples/bzlmod/hello_world/third-party/crates/defs.bzl
examples/bzlmod/hello_world/third-party/crates/BUILD.anyhow-1.0.77.bazel
examples/bzlmod/hello_world/third-party/crates/crates.bzl
examples/bzlmod/hello_world/third-party/crates/BUILD.bazel
examples/bzlmod/hello_world/third-party/crates/alias_rules.bzl
examples/bzlmod/hello_world/third-party/Cargo.toml
examples/bzlmod/hello_world/.bazelrc
```