### PR TITLE
Allow using cargo_bazel_bootstrap from module extensions

### DIFF
--- a/crate_universe/private/module_extensions/cargo_bazel_bootstrap.bzl
+++ b/crate_universe/private/module_extensions/cargo_bazel_bootstrap.bzl
@@ -12,3 +12,43 @@ cargo_bazel_bootstrap = module_extension(
     implementation = _cargo_bazel_bootstrap_impl,
     doc = """Module extension to generate the cargo_bazel binary.""",
 )
+
+def get_cargo_bazel_runner(module_ctx):
+    """A helper function to allow executing cargo_bazel in module extensions.
+
+    Args:
+        module_ctx: The module extension's context.
+
+    Returns:
+        A function that can be called to execute cargo_bazel.
+    """
+
+    cargo_path = str(module_ctx.path(Label("@rust_host_tools//:bin/cargo")))
+    rustc_path = str(module_ctx.path(Label("@rust_host_tools//:bin/rustc")))
+    cargo_bazel = module_ctx.path(Label("@cargo_bazel_bootstrap//:cargo-bazel"))
+
+    # Placing this as a nested function allows users to call this right at the
+    # start of a module extension, thus triggering any restarts as early as
+    # possible (since module_ctx.path triggers restarts).
+    def run(args, env = {}, timeout = 600):
+        final_args = [cargo_bazel]
+        final_args.extend(args)
+        final_args.extend([
+            "--cargo",
+            cargo_path,
+            "--rustc",
+            rustc_path,
+        ])
+        result = module_ctx.execute(
+            final_args,
+            environment = dict(CARGO = cargo_path, RUSTC = rustc_path, **env),
+            timeout = timeout,
+        )
+        if result.return_code != 0:
+            if result.stdout:
+                print("Stdout:", result.stdout)  # buildifier: disable=print
+            pretty_args = " ".join([str(arg) for arg in final_args])
+            fail("%s returned with exit code %d:\n%s" % (pretty_args, result.return_code, result.stderr))
+        return result
+
+    return run


### PR DESCRIPTION
This function isn't yet used. It will be used in #1910. I'm splitting it into its own PR because no-one seems to want to review #1910 because it's too big.