### PR TITLE
Switch from `sha256` to `integrity` in release notes

### DIFF
--- a/.github/release_notes.template
+++ b/.github/release_notes.template
@@ -4,7 +4,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_rust",
-    sha256 = "{sha256}",
+    integrity = "sha256-{sha256_base64}",
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/{version}/rules_rust-v{version}.tar.gz"],
 )
 ```

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,8 +132,8 @@ jobs:
           # `examples/bzlmod` is included for the BCR presubmit; it must appear before --exclude="examples"
           tar -czf ${{ github.workspace }}/.github/rules_rust.tar.gz -C ${{ github.workspace }} --exclude=".git" --exclude=".github" --exclude="crate_universe/target" examples/bzlmod --exclude="examples" .
           # Save the sha256 checksum of the distro archive to the environment
-          sha256="$(shasum --algorithm 256 ${{ github.workspace }}/.github/rules_rust.tar.gz | awk '{ print $1 }')"
-          echo "ARCHIVE_SHA256=${sha256}" >> $GITHUB_ENV
+          sha256_base64="$(shasum --algorithm 256 ${{ github.workspace }}/.github/rules_rust.tar.gz | awk '{ print $1 }' | xxd -r -p | base64)"
+          echo "ARCHIVE_SHA256_BASE64=${sha256_base64}" >> $GITHUB_ENV
         env:
           CARGO_BAZEL_GENERATOR_URL: file://${{ github.workspace }}/crate_universe/target/artifacts/x86_64-unknown-linux-gnu/cargo-bazel
           ARTIFACTS_DIR: ${{ github.workspace }}/crate_universe/target/artifacts
@@ -148,7 +148,7 @@ jobs:
         run: |
           # Generate the release notes
           sed 's/{version}/${{ env.RELEASE_VERSION }}/g' ${{ github.workspace }}/.github/release_notes.template \
-          | sed 's/{sha256}/${{ env.ARCHIVE_SHA256 }}/g' \
+          | sed 's/{sha256_base64}/${{ env.ARCHIVE_SHA256_BASE64 }}/g' \
           > ${{ github.workspace }}/.github/release_notes.txt
       - name: Create release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
`integrity` is preferred because it works for both `http_archive` (legacy) and `archive_override` (bzlmod). `sha256` only works for `http_archive`. Context: https://github.com/bazelbuild/bazel/pull/20156

I confirmed that `xxd` and `base64` commands are available in the GitHub ubuntu-20.04 runner:

![Screenshot from 2024-01-02 17-24-23](https://github.com/bazelbuild/rules_rust/assets/1940490/a30e58c4-fd78-4c37-969d-1938b2dc2215)

and that this produces an integrity string that checks out with what Bazel wants. See https://github.com/dtolnay/cxx/commit/17f46ec7a5392a6d4b817464847e5261b5133f09 for a successful use of `integrity` with `http_archive`:

```starlark
# WORKSPACE.bazel

http_archive(
    name = "rules_rust",
    integrity = "sha256-p2HVTknbBvhjRo5rukoTJSsb1Jno9wbaZeJ5s7y8XFI=",
    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.36.2/rules_rust-v0.36.2.tar.gz"],
)
```

and https://github.com/dtolnay/cxx/pull/1294 for a successful use of `integrity` with `archive_override`.

```starlark
# MODULE.bazel

archive_override(
    module_name = "rules_rust",
    integrity = "sha256-p2HVTknbBvhjRo5rukoTJSsb1Jno9wbaZeJ5s7y8XFI=",
    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.36.2/rules_rust-v0.36.2.tar.gz"],
)
```

`sha256` does not work in `archive_override`.

```console
ERROR: Traceback (most recent call last):
	File "/git/cxx/MODULE.bazel", line 5, column 17, in <toplevel>
		archive_override(
Error in archive_override: archive_override() got unexpected keyword argument 'sha256'
ERROR: Error computing the main repository mapping: error executing MODULE.bazel file for <root>
```