### PR TITLE
Fix name of toolchain repo

### DIFF
--- a/examples/bzlmod/hello_world/BUILD.bazel
+++ b/examples/bzlmod/hello_world/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_doc")
 
 package(default_visibility = ["//visibility:public"])
@@ -48,3 +49,10 @@ rust_binary(
         "vendored",
     ]
 ]
+
+build_test(
+    name = "gen_rust_project",
+    targets = [
+        "@rules_rust//tools/rust_analyzer:gen_rust_project",
+    ],
+)

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -200,7 +200,7 @@ def rust_register_toolchains(
     )
 
     toolchain_names.append(rust_analyzer_repo_name)
-    toolchain_labels[rust_analyzer_repo_name] = "@{}_srcs//:rust_analyzer_toolchain".format(
+    toolchain_labels[rust_analyzer_repo_name] = "@{}_tools//:rust_analyzer_toolchain".format(
         rust_analyzer_repo_name,
     )
     exec_compatible_with_by_toolchain[rust_analyzer_repo_name] = []


### PR DESCRIPTION
It looks like we register these as _tools not as _srcs, this looks like it was maybe a typo in https://github.com/bazelbuild/rules_rust/pull/1528

Fixes #2388