### PR TITLE
Fix missing .wasm output for rust_wasm_bindgen

### DIFF
--- a/wasm_bindgen/private/wasm_bindgen.bzl
+++ b/wasm_bindgen/private/wasm_bindgen.bzl
@@ -96,7 +96,7 @@ def _rust_wasm_bindgen_impl(ctx):
 
     return [
         DefaultInfo(
-            files = depset(transitive = [info.js, info.ts]),
+            files = depset(transitive = [info.js, info.ts, depset([info.wasm])]),
         ),
         info,
     ]

--- a/wasm_bindgen/private/wasm_bindgen.bzl
+++ b/wasm_bindgen/private/wasm_bindgen.bzl
@@ -96,7 +96,7 @@ def _rust_wasm_bindgen_impl(ctx):
 
     return [
         DefaultInfo(
-            files = depset(transitive = [info.js, info.ts, depset([info.wasm])]),
+            files = depset([info.wasm], transitive = [info.js, info.ts]),
         ),
         info,
     ]


### PR DESCRIPTION
https://github.com/bazelbuild/rules_rust/pull/2284 removed the .wasm output file from the `DefaultInfo` provider, which makes it unavailable to other downstream rules.

This PR restores the behavior pre-0.32.0.