### PR TITLE
Add test for query and cquery in the repo

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -53,6 +53,8 @@ tasks:
     test_targets: *default_linux_targets
     coverage_targets: *default_linux_targets
     post_shell_commands: *coverage_validation_post_shell_commands
+    run_targets:
+      - //test:query_test_binary
   rbe_ubuntu2004:
     shell_commands:
       - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,4 @@
+sh_binary(
+    name = "query_test_binary",
+    srcs = ["query_test_binary.sh"],
+)

--- a/test/query_test_binary.sh
+++ b/test/query_test_binary.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "${BUILD_WORKSPACE_DIRECTORY}"
+
+# We always expect to be able to query ... in this repo with no flags.
+# In the past this has regressed, e.g. in https://github.com/bazelbuild/rules_rust/issues/2359, so we have this test to ensure we don't regress again.
+bazel query //... >/dev/null
+bazel cquery //... >/dev/null


### PR DESCRIPTION
This will ensure we don't regress https://github.com/bazelbuild/rules_rust/issues/2359

We can discuss adding this to different configurations (e.g. bazel versions, bzlmod enabled vs disabled, ...), but I think "latest bazel in its default config" is a reasonable place to start.