### PR TITLE
Fix the patch_tool annotation.

### DIFF
--- a/crate_universe/extension.bzl
+++ b/crate_universe/extension.bzl
@@ -279,7 +279,7 @@ _annotation = tag_class(
             default = "auto",
         ),
         patch_args = attr.string_list(doc = "The `patch_args` attribute of a Bazel repository rule. See [http_archive.patch_args](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_args)"),
-        patch_tool = attr.string_list(doc = "The `patch_tool` attribute of a Bazel repository rule. See [http_archive.patch_tool](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_tool)"),
+        patch_tool = attr.string(doc = "The `patch_tool` attribute of a Bazel repository rule. See [http_archive.patch_tool](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_tool)"),
         patches = attr.label_list(doc = "The `patches` attribute of a Bazel repository rule. See [http_archive.patches](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patches)"),
         proc_macro_deps = _relative_label_list(doc = "A list of labels to add to a crate's `rust_library::proc_macro_deps` attribute."),
         rustc_env = attr.string_dict(doc = "Additional variables to set on a crate's `rust_library::rustc_env` attribute."),

--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -154,7 +154,7 @@ def _annotation(
             `cargo_build_script` targets for the current crate.
         patch_args (list, optional): The `patch_args` attribute of a Bazel repository rule. See
             [http_archive.patch_args](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_args)
-        patch_tool (list, optional): The `patch_tool` attribute of a Bazel repository rule. See
+        patch_tool (string, optional): The `patch_tool` attribute of a Bazel repository rule. See
             [http_archive.patch_tool](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_tool)
         patches (list, optional): The `patches` attribute of a Bazel repository rule. See
             [http_archive.patches](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patches)


### PR DESCRIPTION
It was documented incorrectly as a list, but the parameter is actually an Option<String> in the rust code (https://github.com/bazelbuild/rules_rust/blob/a1e9f9600cd22ecfdd08fc4a7572ccbdeba97395/crate_universe/src/metadata/metadata_annotation.rs#L152)