### PR TITLE
Fix #2406: use codegen option `link-args` to forward `user_link_flags` in bindgen.

### DIFF
--- a/bindgen/private/bindgen.bzl
+++ b/bindgen/private/bindgen.bzl
@@ -124,7 +124,9 @@ def _generate_cc_link_build_info(ctx, cc_lib):
                 linker_search_paths.append(lib.pic_static_library.dirname)
                 compile_data.append(lib.pic_static_library)
 
-        linker_flags.extend(linker_input.user_link_flags)
+        if linker_input.user_link_flags:
+            linker_flags.append("-C")
+            linker_flags.append("link-args={}".format(" ".join(linker_input.user_link_flags)))
 
     if not compile_data:
         fail("No static libraries found in {}".format(


### PR DESCRIPTION
This commit fixes issue #2406 by using the [`link-args`] codegen option of `rustc`:

```
-C
link-args=<user_link_flags>
```

where `<user_link_flags>` are the flags from the [`user_link_flags`] field of [`LinkerInput`].

[`user_link_flags`]: https://bazel.build/rules/lib/builtins/LinkerInput#user_link_flags
[`LinkerInput`]: https://bazel.build/rules/lib/builtins/LinkerInput
[`link-args`]: https://doc.rust-lang.org/rustc/codegen-options/index.html#link-args