### PR TITLE
Use # not / as a sed escape character

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,8 +147,8 @@ jobs:
       - name: Generate release notes
         run: |
           # Generate the release notes
-          sed 's/{version}/${{ env.RELEASE_VERSION }}/g' ${{ github.workspace }}/.github/release_notes.template \
-          | sed 's/{sha256_base64}/${{ env.ARCHIVE_SHA256_BASE64 }}/g' \
+          sed 's#{version}#${{ env.RELEASE_VERSION }}#g' ${{ github.workspace }}/.github/release_notes.template \
+          | sed 's#{sha256_base64}#${{ env.ARCHIVE_SHA256_BASE64 }}#g' \
           > ${{ github.workspace }}/.github/release_notes.txt
       - name: Create release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The base64-encoding we use may contain / characters, so we pick a different character to we don't need to worry about escaping the replacement string.