### PR TITLE
Fix #2413: don't use rustc codegen option `link-args` if `cc_common.link` is used.

### DIFF
--- a/bindgen/private/bindgen.bzl
+++ b/bindgen/private/bindgen.bzl
@@ -113,6 +113,8 @@ def _generate_cc_link_build_info(ctx, cc_lib):
     linker_flags = []
     linker_search_paths = []
 
+    rust_toolchain = ctx.toolchains[str(Label("//rust:toolchain_type"))]
+
     for linker_input in cc_lib[CcInfo].linking_context.linker_inputs.to_list():
         for lib in linker_input.libraries:
             if lib.static_library:
@@ -124,7 +126,9 @@ def _generate_cc_link_build_info(ctx, cc_lib):
                 linker_search_paths.append(lib.pic_static_library.dirname)
                 compile_data.append(lib.pic_static_library)
 
-        if linker_input.user_link_flags:
+        if rust_toolchain._experimental_use_cc_common_link:
+            linker_flags.extend(linker_input.user_link_flags)
+        elif linker_input.user_link_flags:
             linker_flags.append("-C")
             linker_flags.append("link-args={}".format(" ".join(linker_input.user_link_flags)))
 


### PR DESCRIPTION
This commit is an attempt to fix #2413 (see https://github.com/bazelbuild/rules_rust/pull/2407#discussion_r1446339662 for more context).

When `cc_common.link` is used (using [`experimental_use_cc_common_link`]), we must not use the rustc codegen option [`link-args`] since it is unknown to the `cc_common.link` executable. Instead, we must forward values of [`user_link_flags`] directly to the `cc_common.link` command line.


[`experimental_use_cc_common_link`]: https://github.com/bazelbuild/rules_rust/blob/012af3ba8fda6acb91a440f8c86b5a45d2c4e64e/rust/settings/BUILD.bazel#L69
[`link-args`]: https://doc.rust-lang.org/rustc/codegen-options/index.html#link-args
[`user_link_flags`]: https://bazel.build/rules/lib/builtins/LinkerInput#user_link_flags