### PR TITLE
Update android example to to use rules_android_ndk

### DIFF
--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -3,7 +3,7 @@ common --enable_platform_specific_config
 startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
-build --fat_apk_cpu=arm64-v8a
+build --fat_apk_cpu=arm64-v8a --android_crosstool_top=@androidndk//:toolchain
 
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/bazelbuild/rules_rust/issues/2181

--- a/examples/android/WORKSPACE.bazel
+++ b/examples/android/WORKSPACE.bazel
@@ -45,6 +45,24 @@ rbe_preconfig(
     toolchain = "ubuntu1804-bazel-java11",
 )
 
-android_sdk_repository(name = "androidsdk")
+android_sdk_repository(
+    name = "androidsdk",
+)
 
-android_ndk_repository(name = "androidndk")
+# Or a later commit
+RULES_ANDROID_NDK_COMMIT = "877c68ef34c9f3353028bf490d269230c1990483"
+
+RULES_ANDROID_NDK_SHA = "b1a5ddd784e6ed915c2035c0db536a278b5f50c64412128c06877115991391ef"
+
+http_archive(
+    name = "rules_android_ndk",
+    sha256 = RULES_ANDROID_NDK_SHA,
+    strip_prefix = "rules_android_ndk-%s" % RULES_ANDROID_NDK_COMMIT,
+    url = "https://github.com/bazelbuild/rules_android_ndk/archive/%s.zip" % RULES_ANDROID_NDK_COMMIT,
+)
+
+load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
+
+android_ndk_repository(
+    name = "androidndk",
+)


### PR DESCRIPTION
The native version of `android_ndk_repository` rule doesn't work with the directory structure of the newer ndk versions anymore.

When I set `ANDROID_NDK_HOME` to `/usr/local/vinhdaitran/Android/Sdk/ndk/26.1.10909125`, the rule expects a different folder structure.
```
ERROR: /usr/local/vinhdaitran/github/rules_rust/examples/android/WORKSPACE.bazel:67:23: fetching android_ndk_repository rule //external:androidndk: java.io.IOException: Expected directory at /usr/local/vinhdaitran/Android/Sdk/ndk/26.1.10909125/platforms but it is not a directory or it does not exist. Unable to read the Android NDK at /usr/local/vinhdaitran/Android/Sdk/ndk/26.1.10909125, the path may be invalid. Is the path in android_ndk_repository() or ANDROID_NDK_HOME set correctly? If the path is correct, the contents in the Android NDK directory may have been modified.
ERROR: Analysis of target '//:jni_shim' failed; build aborted: Expected directory at /usr/local/vinhdaitran/Android/Sdk/ndk/26.1.10909125/platforms but it is not a directory or it does not exist. Unable to read the Android NDK at /usr/local/vinhdaitran/Android/Sdk/ndk/26.1.10909125, the path may be invalid. Is the path in android_ndk_repository() or ANDROID_NDK_HOME set correctly? If the path is correct, the contents in the Android NDK directory may have been modified.
```

Using the Starlark version of the rule, as recommended in https://bazel.build/reference/be/android#android_ndk_repository, fixes the issue.