### PR TITLE
Update android example to use Starlark version of android_ndk_repository

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -582,6 +582,10 @@ tasks:
     build_targets:
       - "//:android_app"
     environment:
+      # This ndk version matches with rules_android_ndk repo's CI
+      # https://github.com/bazelbuild/rules_android_ndk/blob/877c68ef34c9f3353028bf490d269230c1990483/.bazelci/presubmit.yml#L37
+      # The ndk is installed by this script 
+      # https://github.com/bazelbuild/continuous-integration/blob/ba56013373821feadd9f2eaa6b81eb19528795f0/macos/mac-android.sh
       ANDROID_NDK_HOME: /opt/android-ndk-r25b
   android_examples_macos:
     name: Android Examples
@@ -594,6 +598,10 @@ tasks:
     build_targets:
       - "//:android_app"
     environment:
+      # This ndk version matches with rules_android_ndk repo's CI
+      # https://github.com/bazelbuild/rules_android_ndk/blob/877c68ef34c9f3353028bf490d269230c1990483/.bazelci/presubmit.yml#L42
+      # The ndk is installed by this script 
+      # https://github.com/bazelbuild/continuous-integration/blob/ba56013373821feadd9f2eaa6b81eb19528795f0/macos/mac-android.sh
       ANDROID_NDK_HOME: /Users/buildkite/android-ndk-r25b
   ios_examples:
     name: iOS Examples

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -581,6 +581,8 @@ tasks:
       - "--android_platforms=//:arm64-v8a"
     build_targets:
       - "//:android_app"
+    environment:
+      ANDROID_NDK_HOME: /opt/android-ndk-r25b
   android_examples_macos:
     name: Android Examples
     platform: macos
@@ -591,6 +593,8 @@ tasks:
       - "--android_platforms=//:arm64-v8a"
     build_targets:
       - "//:android_app"
+    environment:
+      ANDROID_NDK_HOME: /Users/buildkite/android-ndk-r25b
   ios_examples:
     name: iOS Examples
     platform: macos

--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -3,7 +3,7 @@ common --enable_platform_specific_config
 startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
-build --fat_apk_cpu=arm64-v8a
+build --fat_apk_cpu=arm64-v8a --android_crosstool_top=@androidndk//:toolchain
 
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/bazelbuild/rules_rust/issues/2181

--- a/examples/android/WORKSPACE.bazel
+++ b/examples/android/WORKSPACE.bazel
@@ -45,6 +45,19 @@ rbe_preconfig(
     toolchain = "ubuntu1804-bazel-java11",
 )
 
-android_sdk_repository(name = "androidsdk")
+android_sdk_repository(
+    name = "androidsdk",
+)
 
-android_ndk_repository(name = "androidndk")
+http_archive(
+    name = "rules_android_ndk",
+    sha256 = "b1a5ddd784e6ed915c2035c0db536a278b5f50c64412128c06877115991391ef",
+    strip_prefix = "rules_android_ndk-877c68ef34c9f3353028bf490d269230c1990483",
+    url = "https://github.com/bazelbuild/rules_android_ndk/archive/877c68ef34c9f3353028bf490d269230c1990483.zip",
+)
+
+load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
+
+android_ndk_repository(
+    name = "androidndk",
+)


### PR DESCRIPTION
The native version of `android_ndk_repository` rule no longer work with the newer ndk versions.

When I set `ANDROID_NDK_HOME` to `/usr/local/vinhdaitran/Android/Sdk/ndk/26.1.10909125`, the rule expects a different structure from the Android NDK path.
```
ERROR: /usr/local/vinhdaitran/github/rules_rust/examples/android/WORKSPACE.bazel:67:23: fetching android_ndk_repository rule //external:androidndk: java.io.IOException:
Expected directory at /usr/local/vinhdaitran/Android/Sdk/ndk/26.1.10909125/platforms but it is not a directory or it does not exist.
Unable to read the Android NDK at /usr/local/vinhdaitran/Android/Sdk/ndk/26.1.10909125, the path may be invalid. Is the path in android_ndk_repository() or ANDROID_NDK_HOME set correctly?
If the path is correct, the contents in the Android NDK directory may have been modified.
```

Using the Starlark version of the rule, as recommended in https://bazel.build/reference/be/android#android_ndk_repository, fixes the issue.

cc: @keith 