### PR TITLE
Reproduce bug in clippy-driver

### DIFF
--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -93,6 +93,7 @@ def _clippy_aspect_impl(target, ctx):
         aliases = crate_info.aliases,
         # Clippy doesn't need to invoke transitive linking, therefore doesn't need linkstamps.
         are_linkstamps_supported = False,
+        from_clippy = True,
     )
 
     compile_inputs, out_dir, build_env_files, build_flags_files, linkstamp_outs, ambiguous_libs = collect_inputs(

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -195,7 +195,8 @@ def collect_deps(
         deps,
         proc_macro_deps,
         aliases,
-        are_linkstamps_supported = False):
+        are_linkstamps_supported = False,
+        from_clippy = False):
     """Walks through dependencies and collects the transitive dependencies.
 
     Args:
@@ -224,7 +225,15 @@ def collect_deps(
     transitive_metadata_outputs = []
 
     crate_deps = []
+    counter = 0
     for dep in depset(transitive = [deps, proc_macro_deps]).to_list():
+        if from_clippy:
+            # Change limit to 23 to reproduce error with duplicate --sysroot flag
+            if counter == 22:
+                break
+            else:
+                counter += 1
+
         crate_group = None
 
         if type(dep) == "Target" and rust_common.crate_group_info in dep:


### PR DESCRIPTION
Steps to reproduce https://github.com/bazelbuild/rules_rust/issues/2418

1. https://github.com/dmeister/rules_rules_clippy_repo and replace `http_archive(name = "rules_rust")` to `local_repository` pointing to a local repo of `rules_rust`
2. In `rules_rust` repo, apply the patch https://github.com/bazelbuild/rules_rust/pull/2444.diff
3. Flip the counter back and forth between 22 and 23 to reproduce the bug

I believe when there are too many arguments to `clippy-driver`, it breaks.
