### PR TITLE
Use canonical repo name for aspects

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -644,6 +644,7 @@ tasks:
     working_directory: examples/bzlmod/hello_world
     run_targets:
       - "//third-party:vendor"
+      - "@rules_rust//tools/rust_analyzer:gen_rust_project"
     test_targets:
       - "//..."
   macos_bzlmod_bcr:
@@ -652,6 +653,7 @@ tasks:
     working_directory: examples/bzlmod/hello_world
     run_targets:
       - "//third-party:vendor"
+      - "@rules_rust//tools/rust_analyzer:gen_rust_project"
     test_targets:
       - "//..."
 

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -9,5 +9,6 @@ bcr_test_module:
       platform: ${{ platform }}
       run_targets:
         - "//third-party:vendor"
+        - "@rules_rust//tools/rust_analyzer:gen_rust_project"
       test_targets:
         - "//..."

--- a/tools/tool_utils.bzl
+++ b/tools/tool_utils.bzl
@@ -12,4 +12,4 @@ def aspect_repository():
     """
     if native.repository_name() == "@":
         return ""
-    return native.repository_name()
+    return "@" + native.repository_name()


### PR DESCRIPTION
Currently when running `gen_rust_project`, the aspect given to bazel has the canonical repo name but only a single `@`. This does not work with bzlmod, since it tries to resolve this using the repository mappings, and complains that the repository does not exist:

```
ERROR: Unable to find package for @@[unknown repo 'rules_rust~0.38.0' requested from @@]//rust:defs.bzl: The repository '@@[unknown repo 'rules_rust~0.38.0' requested from @@]' could not be resolved: No repository visible as '@rules_rust~0.38.0' from main repository.
ERROR: Analysis of aspects '[@@[unknown repo 'rules_rust~0.38.0' requested from @@]//rust:defs.bzl%rust_analyzer_aspect] with parameters {} on //prost:prost_toolchain_impl' failed; build aborted: Unable to find package for @@[unknown repo 'rules_rust~0.38.0' requested from @@]//rust:defs.bzl: The repository '@@[unknown repo 'rules_rust~0.38.0' requested from @@]' could not be resolved: No repository visible as '@rules_rust~0.38.0' from main repository.
```

This adds an extra `@`, so that the repository in the label is of canonical form.

Fixes #2449