### PR TITLE
Fix bzlmod examples on windows

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -667,6 +667,16 @@ tasks:
       - "@rules_rust//tools/rust_analyzer:gen_rust_project"
     test_targets:
       - "//..."
+  windows_bzlmod_bcr:
+    name: bzlmod BCR presubmit
+    platform: windows
+    working_directory: examples/bzlmod/hello_world
+    run_targets:
+      - "//third-party:vendor"
+    build_targets:
+      - "@rules_rust//tools/rust_analyzer:gen_rust_project"
+    test_targets:
+      - "//..."
 
 buildifier:
   version: latest

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -14,3 +14,20 @@ bcr_test_module:
         - "@rules_rust//tools/rust_analyzer:gen_rust_project"
       test_targets:
         - "//..."
+# Windows is run separately because currently gen_rust_project doesn't run on windows, although it does build
+bcr_test_module_windows:
+  module_path: ""
+  matrix:
+    bazel: ["6.x", "7.x"]
+  tasks:
+    run_tests:
+      working_directory: examples/bzlmod/hello_world
+      name: "Run test module"
+      platform: windows
+      bazel: ${{ bazel }}
+      run_targets:
+        - "//third-party:vendor"
+      build_targets:
+        - "@rules_rust//tools/rust_analyzer:gen_rust_project"
+      test_targets:
+        - "//..."

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,7 +36,7 @@ bazel_dep(
     repo_name = "com_google_protobuf",
 )
 
-internal_deps = use_extension("//rust/private:extensions.bzl", "internal_deps")
+internal_deps = use_extension("//rust/private:extensions.bzl", "i")
 use_repo(
     internal_deps,
     "bazelci_rules",

--- a/bindgen/3rdparty/crates/BUILD.bindgen-0.69.1.bazel
+++ b/bindgen/3rdparty/crates/BUILD.bindgen-0.69.1.bazel
@@ -103,7 +103,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "bindgen_build_script",
+    name = "bindgen_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -147,6 +147,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":bindgen_build_script",
+    actual = ":bindgen_bs",
     tags = ["manual"],
 )

--- a/bindgen/3rdparty/crates/BUILD.clang-sys-1.6.1.bazel
+++ b/bindgen/3rdparty/crates/BUILD.clang-sys-1.6.1.bazel
@@ -108,7 +108,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "clang-sys_build_script",
+    name = "clang-sys_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -168,6 +168,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":clang-sys_build_script",
+    actual = ":clang-sys_bs",
     tags = ["manual"],
 )

--- a/bindgen/3rdparty/crates/BUILD.libc-0.2.146.bazel
+++ b/bindgen/3rdparty/crates/BUILD.libc-0.2.146.bazel
@@ -242,7 +242,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -435,6 +435,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/bindgen/3rdparty/crates/BUILD.rustix-0.37.20.bazel
+++ b/bindgen/3rdparty/crates/BUILD.rustix-0.37.20.bazel
@@ -323,7 +323,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustix_build_script",
+    name = "rustix_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -367,6 +367,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustix_build_script",
+    actual = ":rustix_bs",
     tags = ["manual"],
 )

--- a/bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -99,7 +99,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -149,6 +149,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -415,8 +415,8 @@ def name_to_pkg_name(name):
     Returns:
         str: A cleaned up name for a build script target.
     """
-    if name.endswith("_build_script"):
-        return name[:-len("_build_script")]
+    if name.endswith("_bs"):
+        return name[:-len("_bs")]
     return name
 
 def _cargo_dep_env_implementation(ctx):

--- a/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.75.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.75.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "anyhow_build_script",
+    name = "anyhow_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":anyhow_build_script",
+    actual = ":anyhow_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.camino-1.1.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.camino-1.1.6.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "camino_build_script",
+    name = "camino_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":camino_build_script",
+    actual = ":camino_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.8.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.8.4.bazel
@@ -91,7 +91,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "chrono-tz_build_script",
+    name = "chrono-tz_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -134,6 +134,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":chrono-tz_build_script",
+    actual = ":chrono-tz_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "crc32fast_build_script",
+    name = "crc32fast_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":crc32fast_build_script",
+    actual = ":crc32fast_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
@@ -93,7 +93,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "crossbeam-epoch_build_script",
+    name = "crossbeam-epoch_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -136,6 +136,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":crossbeam-epoch_build_script",
+    actual = ":crossbeam-epoch_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-queue-0.3.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-queue-0.3.8.bazel
@@ -91,7 +91,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "crossbeam-queue_build_script",
+    name = "crossbeam-queue_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -131,6 +131,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":crossbeam-queue_build_script",
+    actual = ":crossbeam-queue_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "crossbeam-utils_build_script",
+    name = "crossbeam-utils_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":crossbeam-utils_build_script",
+    actual = ":crossbeam-utils_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -86,7 +86,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "errno-dragonfly_build_script",
+    name = "errno-dragonfly_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -125,6 +125,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":errno-dragonfly_build_script",
+    actual = ":errno-dragonfly_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.7.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "generic-array_build_script",
+    name = "generic-array_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -131,6 +131,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":generic-array_build_script",
+    actual = ":generic-array_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "iana-time-zone-haiku_build_script",
+    name = "iana-time-zone-haiku_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":iana-time-zone-haiku_build_script",
+    actual = ":iana-time-zone-haiku_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -196,7 +196,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "io-lifetimes_build_script",
+    name = "io-lifetimes_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -239,6 +239,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":io-lifetimes_build_script",
+    actual = ":io-lifetimes_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.libc-0.2.149.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libc-0.2.149.bazel
@@ -181,7 +181,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -313,6 +313,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.libm-0.2.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libm-0.2.7.bazel
@@ -88,7 +88,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libm_build_script",
+    name = "libm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -127,6 +127,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libm_build_script",
+    actual = ":libm_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.lock_api-0.4.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.lock_api-0.4.11.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "lock_api_build_script",
+    name = "lock_api_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -133,6 +133,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":lock_api_build_script",
+    actual = ":lock_api_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
@@ -88,7 +88,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "memoffset_build_script",
+    name = "memoffset_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":memoffset_build_script",
+    actual = ":memoffset_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "num-integer_build_script",
+    name = "num-integer_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -133,6 +133,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":num-integer_build_script",
+    actual = ":num-integer_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
@@ -91,7 +91,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "num-iter_build_script",
+    name = "num-iter_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -134,6 +134,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":num-iter_build_script",
+    actual = ":num-iter_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "num-traits_build_script",
+    name = "num-traits_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":num-traits_build_script",
+    actual = ":num-traits_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.parking_lot_core-0.9.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.parking_lot_core-0.9.9.bazel
@@ -170,7 +170,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_core_build_script",
+    name = "parking_lot_core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -206,6 +206,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_core_build_script",
+    actual = ":parking_lot_core_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "quote_build_script",
+    name = "quote_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":quote_build_script",
+    actual = ":quote_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.rayon-core-1.12.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rayon-core-1.12.0.bazel
@@ -87,7 +87,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rayon-core_build_script",
+    name = "rayon-core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rayon-core_build_script",
+    actual = ":rayon-core_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -323,7 +323,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustix_build_script",
+    name = "rustix_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -367,6 +367,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustix_build_script",
+    actual = ":rustix_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.rustix-0.38.21.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustix-0.38.21.bazel
@@ -388,7 +388,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustix_build_script",
+    name = "rustix_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -505,6 +505,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustix_build_script",
+    actual = ":rustix_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.semver-1.0.20.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.semver-1.0.20.bazel
@@ -91,7 +91,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "semver_build_script",
+    name = "semver_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":semver_build_script",
+    actual = ":semver_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.serde-1.0.190.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde-1.0.190.bazel
@@ -95,7 +95,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_build_script",
+    name = "serde_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -138,6 +138,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_build_script",
+    actual = ":serde_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.108.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.108.bazel
@@ -93,7 +93,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_json_build_script",
+    name = "serde_json_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -134,6 +134,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_json_build_script",
+    actual = ":serde_json_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.syn-1.0.109.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.syn-1.0.109.bazel
@@ -99,7 +99,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "syn_build_script",
+    name = "syn_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -146,6 +146,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":syn_build_script",
+    actual = ":syn_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.thiserror-1.0.50.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.thiserror-1.0.50.bazel
@@ -88,7 +88,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "thiserror_build_script",
+    name = "thiserror_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":thiserror_build_script",
+    actual = ":thiserror_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.typenum-1.16.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.typenum-1.16.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "typenum_build_script",
+    name = "typenum_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_main",
-    actual = ":typenum_build_script",
+    actual = ":typenum_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.valuable-0.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.valuable-0.1.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "valuable_build_script",
+    name = "valuable_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":valuable_build_script",
+    actual = ":valuable_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-0.2.87.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "wasm-bindgen_build_script",
+    name = "wasm-bindgen_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -125,6 +125,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":wasm-bindgen_build_script",
+    actual = ":wasm-bindgen_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.87.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "wasm-bindgen-shared_build_script",
+    name = "wasm-bindgen-shared_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -122,6 +122,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":wasm-bindgen-shared_build_script",
+    actual = ":wasm-bindgen-shared_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -103,7 +103,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -157,6 +157,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-i686-pc-windows-gnu_build_script",
+    name = "winapi-i686-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-i686-pc-windows-gnu_build_script",
+    actual = ":winapi-i686-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-x86_64-pc-windows-gnu_build_script",
+    name = "winapi-x86_64-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-x86_64-pc-windows-gnu_build_script",
+    actual = ":winapi-x86_64-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/crate_universe/private/module_extensions/cargo_bazel_bootstrap.bzl
+++ b/crate_universe/private/module_extensions/cargo_bazel_bootstrap.bzl
@@ -1,6 +1,8 @@
 """Module extension for bootstrapping cargo-bazel."""
 
 load("//crate_universe:deps_bootstrap.bzl", _cargo_bazel_bootstrap_repo_rule = "cargo_bazel_bootstrap")
+load("//rust/platform:triple.bzl", "get_host_triple")
+load("//rust/platform:triple_mappings.bzl", "system_to_binary_ext")
 
 def _cargo_bazel_bootstrap_impl(_):
     _cargo_bazel_bootstrap_repo_rule(
@@ -23,8 +25,11 @@ def get_cargo_bazel_runner(module_ctx):
         A function that can be called to execute cargo_bazel.
     """
 
-    cargo_path = str(module_ctx.path(Label("@rust_host_tools//:bin/cargo")))
-    rustc_path = str(module_ctx.path(Label("@rust_host_tools//:bin/rustc")))
+    host_triple = get_host_triple(module_ctx)
+    binary_ext = system_to_binary_ext(host_triple.system)
+
+    cargo_path = str(module_ctx.path(Label("@rust_host_tools//:bin/cargo{}".format(binary_ext))))
+    rustc_path = str(module_ctx.path(Label("@rust_host_tools//:bin/rustc{}".format(binary_ext))))
     cargo_bazel = module_ctx.path(Label("@cargo_bazel_bootstrap//:cargo-bazel"))
 
     # Placing this as a nested function allows users to call this right at the

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -374,7 +374,7 @@ impl Renderer {
                     starlark.push(Starlark::Alias(Alias {
                         rule: AliasRule::default().rule(),
                         name: target.crate_name.clone(),
-                        actual: Label::from_str(&format!(":{}_build_script", krate.name)).unwrap(),
+                        actual: Label::from_str(&format!(":{}_bs", krate.name)).unwrap(),
                         tags: BTreeSet::from(["manual".to_owned()]),
                     }));
                 }
@@ -428,7 +428,9 @@ impl Renderer {
             // on having certain Cargo environment variables set.
             //
             // Do not change this name to "cargo_build_script".
-            name: format!("{}_build_script", krate.name),
+            //
+            // This is set to a short suffix to avoid long path name issues on windows.
+            name: format!("{}_bs", krate.name),
             aliases: SelectDict::new(self.make_aliases(krate, true, false), platforms),
             build_script_env: SelectDict::new(
                 attrs
@@ -1026,7 +1028,7 @@ mod test {
         assert!(build_file_content.contains("\"crate-name=mock_crate\""));
 
         // Ensure `cargo_build_script` requirements are met
-        assert!(build_file_content.contains("name = \"mock_crate_build_script\""));
+        assert!(build_file_content.contains("name = \"mock_crate_bs\""));
     }
 
     #[test]

--- a/examples/bzlmod/hello_world/third-party/crates/BUILD.anyhow-1.0.77.bazel
+++ b/examples/bzlmod/hello_world/third-party/crates/BUILD.anyhow-1.0.77.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "anyhow_build_script",
+    name = "anyhow_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":anyhow_build_script",
+    actual = ":anyhow_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.indexmap-1.8.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.indexmap-1.8.0.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "indexmap_build_script",
+    name = "indexmap_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -131,6 +131,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":indexmap_build_script",
+    actual = ":indexmap_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.libc-0.2.119.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.libc-0.2.119.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.memchr-2.4.1.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.memchr-2.4.1.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "memchr_build_script",
+    name = "memchr_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":memchr_build_script",
+    actual = ":memchr_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-1.0.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-1.0.4.bazel
@@ -96,7 +96,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro-error_build_script",
+    name = "proc-macro-error_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -140,6 +140,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro-error_build_script",
+    actual = ":proc-macro-error_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -87,7 +87,7 @@ rust_proc_macro(
 )
 
 cargo_build_script(
-    name = "proc-macro-error-attr_build_script",
+    name = "proc-macro-error-attr_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -126,6 +126,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro-error-attr_build_script",
+    actual = ":proc-macro-error-attr_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro2-1.0.36.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro2-1.0.36.bazel
@@ -91,7 +91,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.pulldown-cmark-0.8.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.pulldown-cmark-0.8.0.bazel
@@ -88,7 +88,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "pulldown-cmark_build_script",
+    name = "pulldown-cmark_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":pulldown-cmark_build_script",
+    actual = ":pulldown-cmark_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.semver-1.0.6.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.semver-1.0.6.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "semver_build_script",
+    name = "semver_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":semver_build_script",
+    actual = ":semver_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.serde-1.0.136.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.serde-1.0.136.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_build_script",
+    name = "serde_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_build_script",
+    actual = ":serde_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.syn-1.0.86.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.syn-1.0.86.bazel
@@ -98,7 +98,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "syn_build_script",
+    name = "syn_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -144,6 +144,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":syn_build_script",
+    actual = ":syn_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.unicase-2.6.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.unicase-2.6.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "unicase_build_script",
+    name = "unicase_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":unicase_build_script",
+    actual = ":unicase_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-0.3.9.bazel
@@ -98,7 +98,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -147,6 +147,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-i686-pc-windows-gnu_build_script",
+    name = "winapi-i686-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-i686-pc-windows-gnu_build_script",
+    actual = ":winapi-i686-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-x86_64-pc-windows-gnu_build_script",
+    name = "winapi-x86_64-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-x86_64-pc-windows-gnu_build_script",
+    actual = ":winapi-x86_64-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/backtrace-0.3.69/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/backtrace-0.3.69/BUILD.bazel
@@ -275,7 +275,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "backtrace_build_script",
+    name = "backtrace_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -314,6 +314,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":backtrace_build_script",
+    actual = ":backtrace_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/libc-0.2.153/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/libc-0.2.153/BUILD.bazel
@@ -145,7 +145,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -241,6 +241,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/lock_api-0.4.11/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/lock_api-0.4.11/BUILD.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "lock_api_build_script",
+    name = "lock_api_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -133,6 +133,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":lock_api_build_script",
+    actual = ":lock_api_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/parking_lot_core-0.9.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/parking_lot_core-0.9.9/BUILD.bazel
@@ -170,7 +170,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_core_build_script",
+    name = "parking_lot_core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -206,6 +206,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_core_build_script",
+    actual = ":parking_lot_core_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/proc-macro2-1.0.78/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/proc-macro2-1.0.78/BUILD.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/rustix-0.38.31/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/rustix-0.38.31/BUILD.bazel
@@ -314,7 +314,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustix_build_script",
+    name = "rustix_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -357,6 +357,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustix_build_script",
+    actual = ":rustix_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_gnullvm-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_gnullvm-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_gnullvm-0.52.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_gnullvm-0.52.3/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_msvc-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_msvc-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_msvc-0.52.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_msvc-0.52.3/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnu-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnu-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnu-0.52.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnu-0.52.3/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_msvc-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_msvc-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_msvc-0.52.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_msvc-0.52.3/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnu-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnu-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnu-0.52.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnu-0.52.3/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnullvm-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnullvm-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnullvm-0.52.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnullvm-0.52.3/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_msvc-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_msvc-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_msvc-0.52.3/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_msvc-0.52.3/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/async-trait-0.1.77/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/async-trait-0.1.77/BUILD.bazel
@@ -88,7 +88,7 @@ rust_proc_macro(
 )
 
 cargo_build_script(
-    name = "async-trait_build_script",
+    name = "async-trait_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":async-trait_build_script",
+    actual = ":async-trait_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/backtrace-0.3.69/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/backtrace-0.3.69/BUILD.bazel
@@ -275,7 +275,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "backtrace_build_script",
+    name = "backtrace_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -314,6 +314,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":backtrace_build_script",
+    actual = ":backtrace_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/httparse-1.8.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/httparse-1.8.0/BUILD.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "httparse_build_script",
+    name = "httparse_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":httparse_build_script",
+    actual = ":httparse_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/libc-0.2.153/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/libc-0.2.153/BUILD.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/lock_api-0.4.11/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/lock_api-0.4.11/BUILD.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "lock_api_build_script",
+    name = "lock_api_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -133,6 +133,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":lock_api_build_script",
+    actual = ":lock_api_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/parking_lot_core-0.9.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/parking_lot_core-0.9.9/BUILD.bazel
@@ -170,7 +170,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_core_build_script",
+    name = "parking_lot_core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -206,6 +206,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_core_build_script",
+    actual = ":parking_lot_core_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/proc-macro2-1.0.78/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/proc-macro2-1.0.78/BUILD.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/serde-1.0.197/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/serde-1.0.197/BUILD.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_build_script",
+    name = "serde_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_build_script",
+    actual = ":serde_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/serde_json-1.0.114/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/serde_json-1.0.114/BUILD.bazel
@@ -93,7 +93,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_json_build_script",
+    name = "serde_json_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -134,6 +134,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_json_build_script",
+    actual = ":serde_json_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/slab-0.4.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/slab-0.4.9/BUILD.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "slab_build_script",
+    name = "slab_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":slab_build_script",
+    actual = ":slab_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/valuable-0.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/valuable-0.1.0/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "valuable_build_script",
+    name = "valuable_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":valuable_build_script",
+    actual = ":valuable_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-0.3.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-0.3.9/BUILD.bazel
@@ -94,7 +94,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -139,6 +139,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-i686-pc-windows-gnu_build_script",
+    name = "winapi-i686-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-i686-pc-windows-gnu_build_script",
+    actual = ":winapi-i686-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-x86_64-pc-windows-gnu_build_script",
+    name = "winapi-x86_64-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-x86_64-pc-windows-gnu_build_script",
+    actual = ":winapi-x86_64-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_gnullvm-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_gnullvm-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_msvc-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_msvc-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnu-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnu-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_msvc-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_msvc-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnu-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnu-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnullvm-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnullvm-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_msvc-0.48.5/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_msvc-0.48.5/BUILD.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.backtrace-0.3.69.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.backtrace-0.3.69.bazel
@@ -275,7 +275,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "backtrace_build_script",
+    name = "backtrace_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -314,6 +314,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":backtrace_build_script",
+    actual = ":backtrace_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.libc-0.2.153.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.libc-0.2.153.bazel
@@ -145,7 +145,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -241,6 +241,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.lock_api-0.4.11.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.lock_api-0.4.11.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "lock_api_build_script",
+    name = "lock_api_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -133,6 +133,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":lock_api_build_script",
+    actual = ":lock_api_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.9.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.9.bazel
@@ -170,7 +170,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_core_build_script",
+    name = "parking_lot_core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -206,6 +206,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_core_build_script",
+    actual = ":parking_lot_core_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.78.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.78.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.rustix-0.38.31.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.rustix-0.38.31.bazel
@@ -314,7 +314,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustix_build_script",
+    name = "rustix_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -357,6 +357,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustix_build_script",
+    actual = ":rustix_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.52.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.52.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.52.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.52.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.52.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.52.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.52.3.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.async-trait-0.1.77.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.async-trait-0.1.77.bazel
@@ -88,7 +88,7 @@ rust_proc_macro(
 )
 
 cargo_build_script(
-    name = "async-trait_build_script",
+    name = "async-trait_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":async-trait_build_script",
+    actual = ":async-trait_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.backtrace-0.3.69.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.backtrace-0.3.69.bazel
@@ -275,7 +275,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "backtrace_build_script",
+    name = "backtrace_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -314,6 +314,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":backtrace_build_script",
+    actual = ":backtrace_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httparse-1.8.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httparse-1.8.0.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "httparse_build_script",
+    name = "httparse_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":httparse_build_script",
+    actual = ":httparse_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.libc-0.2.153.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.libc-0.2.153.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.11.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.11.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "lock_api_build_script",
+    name = "lock_api_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -133,6 +133,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":lock_api_build_script",
+    actual = ":lock_api_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.9.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.9.9.bazel
@@ -170,7 +170,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_core_build_script",
+    name = "parking_lot_core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -206,6 +206,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_core_build_script",
+    actual = ":parking_lot_core_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.78.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.78.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde-1.0.197.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde-1.0.197.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_build_script",
+    name = "serde_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_build_script",
+    actual = ":serde_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.114.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.114.bazel
@@ -93,7 +93,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_json_build_script",
+    name = "serde_json_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -134,6 +134,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_json_build_script",
+    actual = ":serde_json_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.slab-0.4.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.slab-0.4.9.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "slab_build_script",
+    name = "slab_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":slab_build_script",
+    actual = ":slab_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "valuable_build_script",
+    name = "valuable_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":valuable_build_script",
+    actual = ":valuable_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
@@ -94,7 +94,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -139,6 +139,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-i686-pc-windows-gnu_build_script",
+    name = "winapi-i686-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-i686-pc-windows-gnu_build_script",
+    actual = ":winapi-i686-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-x86_64-pc-windows-gnu_build_script",
+    name = "winapi-x86_64-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-x86_64-pc-windows-gnu_build_script",
+    actual = ":winapi-x86_64-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_gnullvm-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_gnullvm-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_msvc-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnu-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnu-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_msvc-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnu-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnu-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnullvm-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnullvm-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_msvc-0.48.5.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.backtrace-0.3.69.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.backtrace-0.3.69.bazel
@@ -275,7 +275,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "backtrace_build_script",
+    name = "backtrace_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -314,6 +314,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":backtrace_build_script",
+    actual = ":backtrace_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.libc-0.2.153.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.libc-0.2.153.bazel
@@ -145,7 +145,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -241,6 +241,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.lock_api-0.4.11.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.lock_api-0.4.11.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "lock_api_build_script",
+    name = "lock_api_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -133,6 +133,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":lock_api_build_script",
+    actual = ":lock_api_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.9.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.9.bazel
@@ -170,7 +170,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_core_build_script",
+    name = "parking_lot_core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -206,6 +206,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_core_build_script",
+    actual = ":parking_lot_core_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.78.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.78.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.rustix-0.38.31.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.rustix-0.38.31.bazel
@@ -314,7 +314,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustix_build_script",
+    name = "rustix_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -357,6 +357,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustix_build_script",
+    actual = ":rustix_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.52.3.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.52.3.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.52.3.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.52.3.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.52.3.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.52.3.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.52.3.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.52.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.async-trait-0.1.77.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.async-trait-0.1.77.bazel
@@ -88,7 +88,7 @@ rust_proc_macro(
 )
 
 cargo_build_script(
-    name = "async-trait_build_script",
+    name = "async-trait_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":async-trait_build_script",
+    actual = ":async-trait_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.backtrace-0.3.69.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.backtrace-0.3.69.bazel
@@ -275,7 +275,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "backtrace_build_script",
+    name = "backtrace_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -314,6 +314,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":backtrace_build_script",
+    actual = ":backtrace_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.httparse-1.8.0.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.httparse-1.8.0.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "httparse_build_script",
+    name = "httparse_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":httparse_build_script",
+    actual = ":httparse_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.libc-0.2.153.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.libc-0.2.153.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.11.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.11.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "lock_api_build_script",
+    name = "lock_api_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -133,6 +133,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":lock_api_build_script",
+    actual = ":lock_api_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.9.9.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.9.9.bazel
@@ -170,7 +170,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_core_build_script",
+    name = "parking_lot_core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -206,6 +206,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_core_build_script",
+    actual = ":parking_lot_core_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.78.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.78.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.serde-1.0.197.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.serde-1.0.197.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_build_script",
+    name = "serde_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_build_script",
+    actual = ":serde_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.114.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.114.bazel
@@ -93,7 +93,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_json_build_script",
+    name = "serde_json_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -134,6 +134,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_json_build_script",
+    actual = ":serde_json_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.slab-0.4.9.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.slab-0.4.9.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "slab_build_script",
+    name = "slab_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":slab_build_script",
+    actual = ":slab_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "valuable_build_script",
+    name = "valuable_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":valuable_build_script",
+    actual = ":valuable_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
@@ -94,7 +94,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -139,6 +139,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-i686-pc-windows-gnu_build_script",
+    name = "winapi-i686-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-i686-pc-windows-gnu_build_script",
+    actual = ":winapi-i686-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-x86_64-pc-windows-gnu_build_script",
+    name = "winapi-x86_64-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-x86_64-pc-windows-gnu_build_script",
+    actual = ":winapi-x86_64-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_aarch64_gnullvm-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_aarch64_gnullvm-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_aarch64_msvc-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_aarch64_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_i686_gnu-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_i686_gnu-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_i686_msvc-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_i686_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnu-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnu-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnullvm-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnullvm-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_x86_64_msvc-0.48.5.bazel
+++ b/examples/crate_universe_unnamed/vendor_remote_pkgs/crates/BUILD.windows_x86_64_msvc-0.48.5.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/examples/ios_build/3rdparty/crates/BUILD.libc-0.2.134.bazel
+++ b/examples/ios_build/3rdparty/crates/BUILD.libc-0.2.134.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/examples/ios_build/3rdparty/crates/BUILD.zstd-safe-5.0.2+zstd.1.5.2.bazel
+++ b/examples/ios_build/3rdparty/crates/BUILD.zstd-safe-5.0.2+zstd.1.5.2.bazel
@@ -93,7 +93,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "zstd-safe_build_script",
+    name = "zstd-safe_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -138,6 +138,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":zstd-safe_build_script",
+    actual = ":zstd-safe_bs",
     tags = ["manual"],
 )

--- a/examples/ios_build/3rdparty/crates/BUILD.zstd-sys-2.0.1+zstd.1.5.2.bazel
+++ b/examples/ios_build/3rdparty/crates/BUILD.zstd-sys-2.0.1+zstd.1.5.2.bazel
@@ -91,7 +91,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "zstd-sys_build_script",
+    name = "zstd-sys_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -136,6 +136,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":zstd-sys_build_script",
+    actual = ":zstd-sys_bs",
     tags = ["manual"],
 )

--- a/examples/sys/basic/3rdparty/crates/BUILD.bzip2-sys-0.1.11+1.0.8.bazel
+++ b/examples/sys/basic/3rdparty/crates/BUILD.bzip2-sys-0.1.11+1.0.8.bazel
@@ -86,7 +86,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "bzip2-sys_build_script",
+    name = "bzip2-sys_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -127,6 +127,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":bzip2-sys_build_script",
+    actual = ":bzip2-sys_bs",
     tags = ["manual"],
 )

--- a/examples/sys/complex/3rdparty/crates/BUILD.libc-0.2.137.bazel
+++ b/examples/sys/complex/3rdparty/crates/BUILD.libc-0.2.137.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/examples/sys/complex/3rdparty/crates/BUILD.log-0.4.17.bazel
+++ b/examples/sys/complex/3rdparty/crates/BUILD.log-0.4.17.bazel
@@ -86,7 +86,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "log_build_script",
+    name = "log_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -122,6 +122,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":log_build_script",
+    actual = ":log_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "anyhow_build_script",
+    name = "anyhow_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":anyhow_build_script",
+    actual = ":anyhow_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.async-trait-0.1.68.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.async-trait-0.1.68.bazel
@@ -88,7 +88,7 @@ rust_proc_macro(
 )
 
 cargo_build_script(
-    name = "async-trait_build_script",
+    name = "async-trait_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":async-trait_build_script",
+    actual = ":async-trait_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.axum-0.6.18.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.axum-0.6.18.bazel
@@ -106,7 +106,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "axum_build_script",
+    name = "axum_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -145,6 +145,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":axum_build_script",
+    actual = ":axum_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.axum-core-0.3.4.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.axum-core-0.3.4.bazel
@@ -95,7 +95,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "axum-core_build_script",
+    name = "axum-core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -134,6 +134,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":axum-core_build_script",
+    actual = ":axum-core_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -86,7 +86,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "errno-dragonfly_build_script",
+    name = "errno-dragonfly_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -125,6 +125,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":errno-dragonfly_build_script",
+    actual = ":errno-dragonfly_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.futures-channel-0.3.28.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.futures-channel-0.3.28.bazel
@@ -91,7 +91,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "futures-channel_build_script",
+    name = "futures-channel_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":futures-channel_build_script",
+    actual = ":futures-channel_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.futures-core-0.3.28.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.futures-core-0.3.28.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "futures-core_build_script",
+    name = "futures-core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -131,6 +131,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":futures-core_build_script",
+    actual = ":futures-core_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.futures-task-0.3.28.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.futures-task-0.3.28.bazel
@@ -88,7 +88,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "futures-task_build_script",
+    name = "futures-task_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -127,6 +127,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":futures-task_build_script",
+    actual = ":futures-task_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.futures-util-0.3.28.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.futures-util-0.3.28.bazel
@@ -92,7 +92,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "futures-util_build_script",
+    name = "futures-util_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -131,6 +131,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":futures-util_build_script",
+    actual = ":futures-util_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.httparse-1.8.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.httparse-1.8.0.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "httparse_build_script",
+    name = "httparse_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":httparse_build_script",
+    actual = ":httparse_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "indexmap_build_script",
+    name = "indexmap_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -131,6 +131,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":indexmap_build_script",
+    actual = ":indexmap_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -195,7 +195,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "io-lifetimes_build_script",
+    name = "io-lifetimes_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -237,6 +237,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":io-lifetimes_build_script",
+    actual = ":io-lifetimes_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.libc-0.2.146.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.libc-0.2.146.bazel
@@ -166,7 +166,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -283,6 +283,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.lock_api-0.4.10.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.lock_api-0.4.10.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "lock_api_build_script",
+    name = "lock_api_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -133,6 +133,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":lock_api_build_script",
+    actual = ":lock_api_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.memchr-2.5.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.memchr-2.5.0.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "memchr_build_script",
+    name = "memchr_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":memchr_build_script",
+    actual = ":memchr_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.parking_lot_core-0.9.8.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.parking_lot_core-0.9.8.bazel
@@ -170,7 +170,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_core_build_script",
+    name = "parking_lot_core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -206,6 +206,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_core_build_script",
+    actual = ":parking_lot_core_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.prettyplease-0.1.25.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.prettyplease-0.1.25.bazel
@@ -87,7 +87,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "prettyplease_build_script",
+    name = "prettyplease_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":prettyplease_build_script",
+    actual = ":prettyplease_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.proc-macro2-1.0.60.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.proc-macro2-1.0.60.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.quote-1.0.28.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.quote-1.0.28.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "quote_build_script",
+    name = "quote_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":quote_build_script",
+    actual = ":quote_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.rustix-0.37.20.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.rustix-0.37.20.bazel
@@ -323,7 +323,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustix_build_script",
+    name = "rustix_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -367,6 +367,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustix_build_script",
+    actual = ":rustix_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.rustversion-1.0.12.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.rustversion-1.0.12.bazel
@@ -85,7 +85,7 @@ rust_proc_macro(
 )
 
 cargo_build_script(
-    name = "rustversion_build_script",
+    name = "rustversion_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustversion_build_script",
+    actual = ":rustversion_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.serde-1.0.164.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.serde-1.0.164.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_build_script",
+    name = "serde_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_build_script",
+    actual = ":serde_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.slab-0.4.8.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.slab-0.4.8.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "slab_build_script",
+    name = "slab_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":slab_build_script",
+    actual = ":slab_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.syn-1.0.109.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.syn-1.0.109.bazel
@@ -99,7 +99,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "syn_build_script",
+    name = "syn_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -146,6 +146,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":syn_build_script",
+    actual = ":syn_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.tempfile-3.6.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.tempfile-3.6.0.bazel
@@ -173,7 +173,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "tempfile_build_script",
+    name = "tempfile_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -212,6 +212,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":tempfile_build_script",
+    actual = ":tempfile_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.tokio-1.28.2.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.tokio-1.28.2.bazel
@@ -276,7 +276,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "tokio_build_script",
+    name = "tokio_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -349,6 +349,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":tokio_build_script",
+    actual = ":tokio_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -131,6 +131,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-i686-pc-windows-gnu_build_script",
+    name = "winapi-i686-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-i686-pc-windows-gnu_build_script",
+    actual = ":winapi-i686-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-x86_64-pc-windows-gnu_build_script",
+    name = "winapi-x86_64-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-x86_64-pc-windows-gnu_build_script",
+    actual = ":winapi-x86_64-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.crossbeam-epoch-0.8.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.crossbeam-epoch-0.8.2.bazel
@@ -96,7 +96,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "crossbeam-epoch_build_script",
+    name = "crossbeam-epoch_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -140,6 +140,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":crossbeam-epoch_build_script",
+    actual = ":crossbeam-epoch_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.crossbeam-utils-0.7.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.crossbeam-utils-0.7.2.bazel
@@ -92,7 +92,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "crossbeam-utils_build_script",
+    name = "crossbeam-utils_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -136,6 +136,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":crossbeam-utils_build_script",
+    actual = ":crossbeam-utils_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.httpbis-0.7.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.httpbis-0.7.0.bazel
@@ -195,7 +195,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "httpbis_build_script",
+    name = "httpbis_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -231,6 +231,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":httpbis_build_script",
+    actual = ":httpbis_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.kernel32-sys-0.2.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.kernel32-sys-0.2.2.bazel
@@ -86,7 +86,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "kernel32-sys_build_script",
+    name = "kernel32-sys_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -125,6 +125,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":kernel32-sys_build_script",
+    actual = ":kernel32-sys_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.libc-0.2.139.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.libc-0.2.139.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.log-0.4.17.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.log-0.4.17.bazel
@@ -161,7 +161,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "log_build_script",
+    name = "log_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -272,6 +272,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":log_build_script",
+    actual = ":log_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.maybe-uninit-2.0.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.maybe-uninit-2.0.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "maybe-uninit_build_script",
+    name = "maybe-uninit_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":maybe-uninit_build_script",
+    actual = ":maybe-uninit_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.memoffset-0.5.6.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.memoffset-0.5.6.bazel
@@ -88,7 +88,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "memoffset_build_script",
+    name = "memoffset_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":memoffset_build_script",
+    actual = ":memoffset_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.parking_lot-0.9.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.parking_lot-0.9.0.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_build_script",
+    name = "parking_lot_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_build_script",
+    actual = ":parking_lot_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.parking_lot_core-0.6.3.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.parking_lot_core-0.6.3.bazel
@@ -170,7 +170,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "parking_lot_core_build_script",
+    name = "parking_lot_core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -209,6 +209,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":parking_lot_core_build_script",
+    actual = ":parking_lot_core_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.protobuf-2.8.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.protobuf-2.8.2.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "protobuf_build_script",
+    name = "protobuf_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":protobuf_build_script",
+    actual = ":protobuf_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.slab-0.4.7.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.slab-0.4.7.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "slab_build_script",
+    name = "slab_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":slab_build_script",
+    actual = ":slab_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -98,7 +98,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -147,6 +147,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-i686-pc-windows-gnu_build_script",
+    name = "winapi-i686-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-i686-pc-windows-gnu_build_script",
+    actual = ":winapi-i686-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-x86_64-pc-windows-gnu_build_script",
+    name = "winapi-x86_64-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-x86_64-pc-windows-gnu_build_script",
+    actual = ":winapi-x86_64-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/proto/protobuf/3rdparty/crates/BUILD.ws2_32-sys-0.2.1.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.ws2_32-sys-0.2.1.bazel
@@ -86,7 +86,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "ws2_32-sys_build_script",
+    name = "ws2_32-sys_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -125,6 +125,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":ws2_32-sys_build_script",
+    actual = ":ws2_32-sys_bs",
     tags = ["manual"],
 )

--- a/rust/private/extensions.bzl
+++ b/rust/private/extensions.bzl
@@ -41,7 +41,9 @@ def _internal_deps_impl(module_ctx):
         root_module_direct_dev_deps = [],
     )
 
-internal_deps = module_extension(
+# This is named a single character to reduce the size of path names when running build scripts, to reduce the chance
+# of hitting the 260 character windows path name limit.
+i = module_extension(
     doc = "Dependencies for rules_rust",
     implementation = _internal_deps_impl,
 )

--- a/test/build_env/BUILD.bazel
+++ b/test/build_env/BUILD.bazel
@@ -60,7 +60,7 @@ rust_test(
     name = "cargo_env-vars_test",
     srcs = ["tests/cargo.rs"],
     edition = "2018",
-    deps = [":cargo_build_script_env-vars_build_script"],
+    deps = [":cargo_build_script_env-vars_bs"],
 )
 
 rust_test(
@@ -68,11 +68,11 @@ rust_test(
     srcs = ["tests/custom_crate_name.rs"],
     crate_name = "custom_crate_name",
     edition = "2018",
-    deps = [":cargo_build_script_env-vars_build_script"],
+    deps = [":cargo_build_script_env-vars_bs"],
 )
 
 cargo_build_script(
-    name = "cargo_build_script_env-vars_build_script",
+    name = "cargo_build_script_env-vars_bs",
     srcs = ["src/build.rs"],
     edition = "2018",
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
@@ -71,7 +71,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "anyhow_build_script",
+    name = "anyhow_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -111,6 +111,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":anyhow_build_script",
+    actual = ":anyhow_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -68,7 +68,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "errno-dragonfly_build_script",
+    name = "errno-dragonfly_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -107,6 +107,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":errno-dragonfly_build_script",
+    actual = ":errno-dragonfly_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -124,7 +124,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "io-lifetimes_build_script",
+    name = "io-lifetimes_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -167,6 +167,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":io-lifetimes_build_script",
+    actual = ":io-lifetimes_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.libc-0.2.147.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.libc-0.2.147.bazel
@@ -72,7 +72,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -113,6 +113,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.memchr-2.5.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.memchr-2.5.0.bazel
@@ -71,7 +71,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "memchr_build_script",
+    name = "memchr_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -111,6 +111,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":memchr_build_script",
+    actual = ":memchr_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -72,7 +72,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -112,6 +112,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -72,7 +72,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "quote_build_script",
+    name = "quote_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -112,6 +112,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":quote_build_script",
+    actual = ":quote_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -182,7 +182,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustix_build_script",
+    name = "rustix_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -226,6 +226,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustix_build_script",
+    actual = ":rustix_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.serde-1.0.171.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.serde-1.0.171.bazel
@@ -76,7 +76,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_build_script",
+    name = "serde_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -118,6 +118,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_build_script",
+    actual = ":serde_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
@@ -74,7 +74,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_json_build_script",
+    name = "serde_json_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -114,6 +114,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_json_build_script",
+    actual = ":serde_json_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -79,7 +79,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -127,6 +127,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -67,7 +67,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-i686-pc-windows-gnu_build_script",
+    name = "winapi-i686-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -103,6 +103,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-i686-pc-windows-gnu_build_script",
+    actual = ":winapi-i686-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -67,7 +67,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-x86_64-pc-windows-gnu_build_script",
+    name = "winapi-x86_64-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -103,6 +103,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-x86_64-pc-windows-gnu_build_script",
+    actual = ":winapi-x86_64-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -67,7 +67,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -103,6 +103,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -67,7 +67,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -103,6 +103,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -67,7 +67,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -103,6 +103,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -67,7 +67,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -103,6 +103,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -67,7 +67,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -103,6 +103,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -67,7 +67,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -103,6 +103,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -67,7 +67,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -103,6 +103,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "anyhow_build_script",
+    name = "anyhow_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":anyhow_build_script",
+    actual = ":anyhow_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "crc32fast_build_script",
+    name = "crc32fast_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":crc32fast_build_script",
+    actual = ":crc32fast_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
@@ -93,7 +93,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "crossbeam-epoch_build_script",
+    name = "crossbeam-epoch_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -136,6 +136,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":crossbeam-epoch_build_script",
+    actual = ":crossbeam-epoch_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "crossbeam-utils_build_script",
+    name = "crossbeam-utils_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":crossbeam-utils_build_script",
+    actual = ":crossbeam-utils_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.doc-comment-0.3.3.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.doc-comment-0.3.3.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "doc-comment_build_script",
+    name = "doc-comment_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":doc-comment_build_script",
+    actual = ":doc-comment_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -86,7 +86,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "errno-dragonfly_build_script",
+    name = "errno-dragonfly_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -125,6 +125,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":errno-dragonfly_build_script",
+    actual = ":errno-dragonfly_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.httparse-1.8.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.httparse-1.8.0.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "httparse_build_script",
+    name = "httparse_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":httparse_build_script",
+    actual = ":httparse_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "iana-time-zone-haiku_build_script",
+    name = "iana-time-zone-haiku_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":iana-time-zone-haiku_build_script",
+    actual = ":iana-time-zone-haiku_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
@@ -86,7 +86,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "indexmap_build_script",
+    name = "indexmap_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -125,6 +125,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":indexmap_build_script",
+    actual = ":indexmap_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -195,7 +195,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "io-lifetimes_build_script",
+    name = "io-lifetimes_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -237,6 +237,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":io-lifetimes_build_script",
+    actual = ":io-lifetimes_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.libc-0.2.150.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.libc-0.2.150.bazel
@@ -237,7 +237,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "libc_build_script",
+    name = "libc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -425,6 +425,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":libc_build_script",
+    actual = ":libc_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.memchr-2.5.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.memchr-2.5.0.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "memchr_build_script",
+    name = "memchr_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -131,6 +131,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":memchr_build_script",
+    actual = ":memchr_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
@@ -88,7 +88,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "memoffset_build_script",
+    name = "memoffset_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":memoffset_build_script",
+    actual = ":memoffset_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.mime_guess-2.0.4.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.mime_guess-2.0.4.bazel
@@ -91,7 +91,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "mime_guess_build_script",
+    name = "mime_guess_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -134,6 +134,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":mime_guess_build_script",
+    actual = ":mime_guess_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "num-traits_build_script",
+    name = "num-traits_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -124,6 +124,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":num-traits_build_script",
+    actual = ":num-traits_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -91,7 +91,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "proc-macro2_build_script",
+    name = "proc-macro2_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -131,6 +131,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":proc-macro2_build_script",
+    actual = ":proc-macro2_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -90,7 +90,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "quote_build_script",
+    name = "quote_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -130,6 +130,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":quote_build_script",
+    actual = ":quote_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.rayon-core-1.11.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.rayon-core-1.11.0.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rayon-core_build_script",
+    name = "rayon-core_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -126,6 +126,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rayon-core_build_script",
+    actual = ":rayon-core_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.ring-0.17.5.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.ring-0.17.5.bazel
@@ -178,7 +178,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "ring_build_script",
+    name = "ring_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -223,6 +223,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":ring_build_script",
+    actual = ":ring_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -323,7 +323,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustix_build_script",
+    name = "rustix_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -367,6 +367,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustix_build_script",
+    actual = ":rustix_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.rustls-0.21.8.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.rustls-0.21.8.bazel
@@ -95,7 +95,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "rustls_build_script",
+    name = "rustls_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -140,6 +140,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":rustls_build_script",
+    actual = ":rustls_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.semver-1.0.17.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.semver-1.0.17.bazel
@@ -89,7 +89,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "semver_build_script",
+    name = "semver_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -129,6 +129,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":semver_build_script",
+    actual = ":semver_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.serde-1.0.171.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.serde-1.0.171.bazel
@@ -94,7 +94,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_build_script",
+    name = "serde_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -136,6 +136,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_build_script",
+    actual = ":serde_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
@@ -92,7 +92,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "serde_json_build_script",
+    name = "serde_json_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -132,6 +132,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":serde_json_build_script",
+    actual = ":serde_json_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.syn-1.0.109.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.syn-1.0.109.bazel
@@ -98,7 +98,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "syn_build_script",
+    name = "syn_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -144,6 +144,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":syn_build_script",
+    actual = ":syn_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.tempfile-3.6.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.tempfile-3.6.0.bazel
@@ -173,7 +173,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "tempfile_build_script",
+    name = "tempfile_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -212,6 +212,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":tempfile_build_script",
+    actual = ":tempfile_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.unicase-2.6.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.unicase-2.6.0.bazel
@@ -87,7 +87,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "unicase_build_script",
+    name = "unicase_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -126,6 +126,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":unicase_build_script",
+    actual = ":unicase_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-0.2.91.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-0.2.91.bazel
@@ -94,7 +94,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "wasm-bindgen_build_script",
+    name = "wasm-bindgen_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -135,6 +135,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":wasm-bindgen_build_script",
+    actual = ":wasm-bindgen_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.91.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.91.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "wasm-bindgen-shared_build_script",
+    name = "wasm-bindgen-shared_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -122,6 +122,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":wasm-bindgen-shared_build_script",
+    actual = ":wasm-bindgen-shared_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -100,7 +100,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi_build_script",
+    name = "winapi_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -151,6 +151,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi_build_script",
+    actual = ":winapi_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-i686-pc-windows-gnu_build_script",
+    name = "winapi-i686-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-i686-pc-windows-gnu_build_script",
+    actual = ":winapi-i686-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "winapi-x86_64-pc-windows-gnu_build_script",
+    name = "winapi-x86_64-pc-windows-gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":winapi-x86_64-pc-windows-gnu_build_script",
+    actual = ":winapi-x86_64-pc-windows-gnu_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_gnullvm_build_script",
+    name = "windows_aarch64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_gnullvm_build_script",
+    actual = ":windows_aarch64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_aarch64_msvc_build_script",
+    name = "windows_aarch64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_aarch64_msvc_build_script",
+    actual = ":windows_aarch64_msvc_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_gnu_build_script",
+    name = "windows_i686_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_gnu_build_script",
+    actual = ":windows_i686_gnu_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_i686_msvc_build_script",
+    name = "windows_i686_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_i686_msvc_build_script",
+    actual = ":windows_i686_msvc_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnu_build_script",
+    name = "windows_x86_64_gnu_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnu_build_script",
+    actual = ":windows_x86_64_gnu_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_gnullvm_build_script",
+    name = "windows_x86_64_gnullvm_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_gnullvm_build_script",
+    actual = ":windows_x86_64_gnullvm_bs",
     tags = ["manual"],
 )

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -85,7 +85,7 @@ rust_library(
 )
 
 cargo_build_script(
-    name = "windows_x86_64_msvc_build_script",
+    name = "windows_x86_64_msvc_bs",
     srcs = glob(
         include = ["**/*.rs"],
         allow_empty = False,
@@ -121,6 +121,6 @@ cargo_build_script(
 
 alias(
     name = "build_script_build",
-    actual = ":windows_x86_64_msvc_build_script",
+    actual = ":windows_x86_64_msvc_bs",
     tags = ["manual"],
 )


### PR DESCRIPTION
On windows (and some other platforms), the file extension of cargo, rustc, etc have an extension. The module extension for loading crates did not take this into account, causing it to error on windows.

Additionally, when using bzlmod to build vendored crates, the runfiles tree would exceed the 260 char windows path limit. To mitigate this, I have shortened the internal_deps module extension to just `i` and changed the build script suffix to `_bs` from `_build_script`. This makes the path names below the 260 char limit.

This makes the bzlmod CI run on windows, to avoid regressing this. Currently gen_rust_project does not run on windows for other reasons, although we do build this.