### PR TITLE
Fix type error in rust-analyzer rule

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -330,6 +330,17 @@ tasks:
     platform: ubuntu2004
     run_targets:
       - "//test/rust_analyzer:rust_analyzer_test"
+  rust_analyzer_integration_test:
+    name: Rust-Analyzer Integration Test
+    platform: ubuntu2004
+    run_targets:
+      - "@rules_rust//tools/rust_analyzer:gen_rust_project"
+  examples_rust_analyzer_integration_test:
+    name: Rust-Analyzer Integration Test
+    platform: ubuntu2004
+    working_directory: examples
+    run_targets:
+      - "@rules_rust//tools/rust_analyzer:gen_rust_project"
   ubuntu2004_examples:
     name: Examples
     platform: ubuntu2004

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -229,7 +229,7 @@ def _create_single_crate(ctx, info):
     crate["root_module"] = path_prefix + info.crate.root.path
     crate_root = path_prefix + info.crate.root.dirname
 
-    if info.build_info != None:
+    if info.build_info != None and info.build_info.out_dir != None:
         out_dir_path = info.build_info.out_dir.path
         crate["env"].update({"OUT_DIR": _EXEC_ROOT_TEMPLATE + out_dir_path})
         crate["source"] = {


### PR DESCRIPTION
Before this change, users would fail with the following error:
```
~/Code/rules_rust/examples (main ✔) bazel run @rules_rust//tools/rust_analyzer:gen_rust_project
INFO: Analyzed target @@rules_rust//tools/rust_analyzer:gen_rust_project (51 packages loaded, 2095 targets configured).
INFO: Found 1 target...
Target @@rules_rust//tools/rust_analyzer:gen_rust_project up-to-date:
  bazel-bin/external/rules_rust/tools/rust_analyzer/gen_rust_project
INFO: Elapsed time: 0.530s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/external/rules_rust/tools/rust_analyzer/gen_rust_project
Error: bazel build failed:(exit status: 1)
Computing main repo mapping:
Loading:
Loading: 0 packages loaded
Analyzing: 99 targets (38 packages loaded, 0 targets configured)
Analyzing: 99 targets (38 packages loaded, 0 targets configured)
[0 / 1] [Prepa] BazelWorkspaceStatusAction stable-status.txt
DEBUG: /private/var/tmp/_bazel_user/1426ad6c00f8f7b996ddc75bef70871c/external/rules_rust/bindgen/private/bindgen.bzl:280:14: WARN: rust_bindgen.leak_symbols is set to True for @//bindgen:simple_leaked_bindgen__bindgen - please file an issue at https://github.com/bazelbuild/rules_rust/issues explaining why this was necessary, as this support will be removed soon.
ERROR: /Users/user/Code/rules_rust/examples/bindgen/BUILD.bazel:4:21: in @@rules_rust//rust/private:rust_analyzer.bzl%rust_analyzer_aspect aspect on rust_library rule //bindgen:simple_bindgen:
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_user/1426ad6c00f8f7b996ddc75bef70871c/external/rules_rust/rust/private/rust_analyzer.bzl", line 149, column 51, in _rust_analyzer_aspect_impl
		content = json.encode(_create_single_crate(ctx, rust_analyzer_info)),
	File "/private/var/tmp/_bazel_user/1426ad6c00f8f7b996ddc75bef70871c/external/rules_rust/rust/private/rust_analyzer.bzl", line 233, column 47, in _create_single_crate
		out_dir_path = info.build_info.out_dir.path
Error: 'NoneType' value has no field or method 'path'
ERROR: Analysis of aspects '[@@rules_rust//rust:defs.bzl%rust_analyzer_aspect] with parameters {} on //bindgen:simple_bindgen' failed; build aborted: Analysis of target '//bindgen:simple_bindgen' failed
INFO: Elapsed time: 0.552s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```
This change fixes this issue.