### PR TITLE
Fix `crate_universe` when using bzlmod

### DIFF
--- a/crate_universe/extension.bzl
+++ b/crate_universe/extension.bzl
@@ -44,9 +44,15 @@ def _generate_hub_and_spokes(module_ctx, cargo_bazel, cfg, annotations):
     cargo_lockfile = module_ctx.path(cfg.cargo_lockfile)
     tag_path = module_ctx.path(cfg.name)
 
+    # Get the prefix of the canonical repo name that will be used for crates
+    canonical_label = Label(":dummy_target")
+    idx = str(canonical_label).find("//")
+    canonical_repository = str(canonical_label)[:idx]
+    # The "~crate~" portion comes from the definition of the module_extension (currently at the bottom of this file)
+    canonical_crate_label_metatemplate = "{}~crate~{{repository}}__{{name}}-{{version}}//:{{target}}"
     rendering_config = json.decode(render_config(
         regen_command = "Run 'cargo update [--workspace]'",
-        crate_label_template = "@@rules_rust~override~crate~{repository}__{name}-{version}//:{target}",
+        crate_label_template = canonical_crate_label_metatemplate.format(canonical_repository),
     ))
     config_file = tag_path.get_child("config.json")
     module_ctx.file(

--- a/crate_universe/extension.bzl
+++ b/crate_universe/extension.bzl
@@ -48,6 +48,7 @@ def _generate_hub_and_spokes(module_ctx, cargo_bazel, cfg, annotations):
     canonical_label = Label(":dummy_target")
     idx = str(canonical_label).find("//")
     canonical_repository = str(canonical_label)[:idx]
+
     # The "~crate~" portion comes from the definition of the module_extension (currently at the bottom of this file)
     canonical_crate_label_metatemplate = "{}~crate~{{repository}}__{{name}}-{{version}}//:{{target}}"
     rendering_config = json.decode(render_config(

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -203,6 +203,7 @@ def generate_config_file(
     if render_config == None:
         render_config = default_render_config
 
+    original_crate_label_template = render_config["crate_label_template"]
     if mode == "local":
         build_file_base_template = "@{}//{}/{{name}}-{{version}}:BUILD.bazel"
         crate_label_template = "//{}/{{name}}-{{version}}:{{target}}".format(
@@ -210,14 +211,14 @@ def generate_config_file(
         )
     else:
         build_file_base_template = "@{}//{}:BUILD.{{name}}-{{version}}.bazel"
-        crate_label_template = render_config["crate_label_template"]
+        crate_label_template = original_crate_label_template
 
     updates = {
         "build_file_template": build_file_base_template.format(
             workspace_name,
             output_pkg,
         ),
-        "crate_label_template": crate_label_template,
+        "crate_label_template": crate_label_template if crate_label_template else original_crate_label_template,
         "crates_module_template": "@{}//{}:{{file}}".format(
             workspace_name,
             output_pkg,


### PR DESCRIPTION
Addresses the issue raised here: https://github.com/bazelbuild/rules_rust/issues/2483

Now, we programmatically determine the canonical repository name prefix. This assumes that the repositories created by `crate_universe` will all inherit the same prefix as `rules_rust`.

If there is a more ideal approach to determining the canonical repository name, please suggest! I was unable to find anything else. 

Additionally, I'm not sure how to code a test case against this, since we have to override the `rules_rust` location in order to test it? 