### PR TITLE
Use non-canonical repo name in hub repo

### DIFF
--- a/crate_universe/extension.bzl
+++ b/crate_universe/extension.bzl
@@ -46,7 +46,6 @@ def _generate_hub_and_spokes(module_ctx, cargo_bazel, cfg, annotations):
 
     rendering_config = json.decode(render_config(
         regen_command = "Run 'cargo update [--workspace]'",
-        crate_label_template = "@@rules_rust~override~crate~{repository}__{name}-{version}//:{target}",
     ))
     config_file = tag_path.get_child("config.json")
     module_ctx.file(

--- a/crate_universe/src/rendering/templates/partials/module/deps_map.j2
+++ b/crate_universe/src/rendering/templates/partials/module/deps_map.j2
@@ -30,7 +30,7 @@
             {%- for dep in deps_set.common %}
             {%- if dep.id in context.workspace_members %}{% continue %}}{% endif %}{# Workspace member repositories are not defined, skip adding their labels here #}
             {%- set crate = context.crates | get(key=dep.id) %}
-            "{{ dep | get(key="alias", default=crate.name) }}": "{{ crate_label(name = crate.name, version = crate.version, target = dep.target) }}",
+            "{{ dep | get(key="alias", default=crate.name) }}": Label("{{ crate_label(name = crate.name, version = crate.version, target = dep.target) }}"),
             {%- endfor %}
         },
         {%- endif %}


### PR DESCRIPTION
 #2461 changed the rendering of the hub repo to use canonical repository names, but incorrectly. Doing so wasn't necessary - instead we just need to do the resolution of the non-canonical label from the perspective of the hub repo rather than the consumer.

Fixes #2483