### PR TITLE
Set allow_empty on unknown globs

### DIFF
--- a/crate_universe/3rdparty/crates/BUILD.adler-1.0.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.adler-1.0.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "adler",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.aho-corasick-1.0.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.aho-corasick-1.0.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "aho_corasick",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.android-tzdata-0.1.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.android-tzdata-0.1.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "android_tzdata",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.android_system_properties-0.1.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.android_system_properties-0.1.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "android_system_properties",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.anstream-0.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anstream-0.3.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "anstream",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.anstyle-1.0.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anstyle-1.0.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "anstyle",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.anstyle-parse-0.2.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anstyle-parse-0.2.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "anstyle_parse",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.anstyle-query-1.0.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anstyle-query-1.0.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "anstyle_query",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.anstyle-wincon-1.0.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anstyle-wincon-1.0.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "anstyle_wincon",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.75.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.75.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "anyhow",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -86,7 +90,10 @@ rust_library(
 
 cargo_build_script(
     name = "anyhow_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "std",
@@ -95,6 +102,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.arc-swap-1.6.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.arc-swap-1.6.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "arc_swap",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.arrayvec-0.7.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.arrayvec-0.7.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "arrayvec",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.autocfg-1.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.autocfg-1.1.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "autocfg",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bazel
@@ -13,15 +13,21 @@ exports_files(
         "cargo-bazel.json",
         "crates.bzl",
         "defs.bzl",
-    ] + glob(["*.bazel"]),
+    ] + glob(
+        include = ["*.bazel"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
     name = "srcs",
-    srcs = glob([
-        "*.bazel",
-        "*.bzl",
-    ]),
+    srcs = glob(
+        include = [
+            "*.bazel",
+            "*.bzl",
+        ],
+        allow_empty = True,
+    ),
 )
 
 # Workspace Member Dependencies

--- a/crate_universe/3rdparty/crates/BUILD.bitflags-1.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bitflags-1.3.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "bitflags",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.bitflags-2.4.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bitflags-2.4.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "bitflags",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.block-buffer-0.10.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.block-buffer-0.10.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "block_buffer",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.bstr-1.6.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bstr-1.6.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "bstr",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.btoi-0.4.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.btoi-0.4.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "btoi",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.bumpalo-3.13.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bumpalo-3.13.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "bumpalo",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.byteyarn-0.2.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.byteyarn-0.2.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "byteyarn",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.camino-1.1.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.camino-1.1.6.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "camino",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -87,7 +91,10 @@ rust_library(
 
 cargo_build_script(
     name = "camino_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "serde",
         "serde1",
@@ -96,6 +103,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.cargo-lock-9.0.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cargo-lock-9.0.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "cargo_lock",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.cargo-platform-0.1.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cargo-platform-0.1.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "cargo_platform",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.cargo_metadata-0.18.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cargo_metadata-0.18.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "cargo_metadata",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.cargo_toml-0.17.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cargo_toml-0.17.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "cargo_toml",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.cc-1.0.79.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cc-1.0.79.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "cc",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.cfg-expr-0.15.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cfg-expr-0.15.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "cfg_expr",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.cfg-if-1.0.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cfg-if-1.0.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "cfg_if",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.chrono-0.4.26.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-0.4.26.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "chrono",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.8.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.8.4.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "chrono_tz",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -88,7 +92,10 @@ rust_library(
 
 cargo_build_script(
     name = "chrono-tz_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "std",
@@ -97,6 +104,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.chrono-tz-build-0.2.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-tz-build-0.2.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "chrono_tz_build",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.clap-4.3.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clap-4.3.11.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "clap",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.clap_builder-4.3.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clap_builder-4.3.11.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "clap_builder",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.clap_derive-4.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clap_derive-4.3.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "clap_derive",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.clap_lex-0.5.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clap_lex-0.5.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "clap_lex",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.clru-0.6.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.clru-0.6.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "clru",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.colorchoice-1.0.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.colorchoice-1.0.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "colorchoice",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.core-foundation-sys-0.8.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.core-foundation-sys-0.8.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "core_foundation_sys",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.cpufeatures-0.2.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.cpufeatures-0.2.9.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "cpufeatures",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.crates-index-2.2.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crates-index-2.2.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crates_index",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crc32fast",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -87,7 +91,10 @@ rust_library(
 
 cargo_build_script(
     name = "crc32fast_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "std",
@@ -96,6 +103,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-0.8.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-0.8.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crossbeam",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-channel-0.5.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-channel-0.5.8.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crossbeam_channel",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-deque-0.8.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-deque-0.8.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crossbeam_deque",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crossbeam_epoch",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -90,7 +94,10 @@ rust_library(
 
 cargo_build_script(
     name = "crossbeam-epoch_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "alloc",
         "std",
@@ -99,6 +106,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-queue-0.3.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-queue-0.3.8.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crossbeam_queue",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -88,7 +92,10 @@ rust_library(
 
 cargo_build_script(
     name = "crossbeam-queue_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "alloc",
         "std",
@@ -97,6 +104,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crossbeam_utils",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -87,7 +91,10 @@ rust_library(
 
 cargo_build_script(
     name = "crossbeam-utils_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "std",
@@ -96,6 +103,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.crypto-common-0.1.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crypto-common-0.1.6.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crypto_common",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.deranged-0.3.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.deranged-0.3.9.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "deranged",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.deunicode-0.4.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.deunicode-0.4.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "deunicode",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.digest-0.10.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.digest-0.10.7.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "digest",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.dunce-1.0.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.dunce-1.0.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "dunce",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.either-1.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.either-1.9.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "either",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.encoding_rs-0.8.33.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.encoding_rs-0.8.33.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "encoding_rs",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.equivalent-1.0.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.equivalent-1.0.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "equivalent",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.errno-0.3.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.errno-0.3.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "errno",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "errno_dragonfly",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -83,11 +87,15 @@ rust_library(
 
 cargo_build_script(
     name = "errno-dragonfly_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.faster-hex-0.8.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.faster-hex-0.8.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "faster_hex",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.fastrand-2.0.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.fastrand-2.0.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "fastrand",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.filetime-0.2.22.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.filetime-0.2.22.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "filetime",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.flate2-1.0.28.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.flate2-1.0.28.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "flate2",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.fnv-1.0.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.fnv-1.0.7.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "fnv",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.form_urlencoded-1.2.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.form_urlencoded-1.2.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "form_urlencoded",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.fuchsia-cprng-0.1.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.fuchsia-cprng-0.1.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "fuchsia_cprng",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.7.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "generic_array",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -86,7 +90,10 @@ rust_library(
 
 cargo_build_script(
     name = "generic-array_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "more_lengths",
     ],
@@ -94,6 +101,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.getrandom-0.2.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.getrandom-0.2.10.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "getrandom",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-0.54.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-0.54.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-actor-0.27.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-actor-0.27.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_actor",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-attributes-0.19.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-attributes-0.19.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_attributes",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-bitmap-0.2.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-bitmap-0.2.7.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_bitmap",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-chunk-0.4.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-chunk-0.4.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_chunk",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-command-0.2.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-command-0.2.10.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_command",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-commitgraph-0.21.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-commitgraph-0.21.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_commitgraph",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-config-0.30.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-config-0.30.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_config",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-config-value-0.14.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-config-value-0.14.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_config_value",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-credentials-0.20.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-credentials-0.20.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_credentials",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-date-0.8.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-date-0.8.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_date",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-diff-0.36.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-diff-0.36.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_diff",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-discover-0.25.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-discover-0.25.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_discover",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-features-0.35.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-features-0.35.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_features",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-filter-0.5.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-filter-0.5.0.bazel
@@ -12,12 +12,16 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_filter",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     aliases = {
         "@cui__gix-packetline-blocking-0.16.6//:gix_packetline_blocking": "gix_packetline",
     },
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-fs-0.7.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-fs-0.7.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_fs",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-glob-0.13.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-glob-0.13.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_glob",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-hash-0.13.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-hash-0.13.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_hash",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-hashtable-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-hashtable-0.4.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_hashtable",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-ignore-0.8.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-ignore-0.8.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_ignore",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-index-0.25.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-index-0.25.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_index",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-lock-10.0.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-lock-10.0.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_lock",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-macros-0.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-macros-0.1.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "gix_macros",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-negotiate-0.8.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-negotiate-0.8.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_negotiate",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-object-0.37.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-object-0.37.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_object",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-odb-0.53.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-odb-0.53.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_odb",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-pack-0.43.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-pack-0.43.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_pack",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-packetline-0.16.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-packetline-0.16.7.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_packetline",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-packetline-blocking-0.16.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-packetline-blocking-0.16.6.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_packetline_blocking",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-path-0.10.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-path-0.10.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_path",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-pathspec-0.3.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-pathspec-0.3.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_pathspec",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-prompt-0.7.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-prompt-0.7.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_prompt",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-protocol-0.40.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-protocol-0.40.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_protocol",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-quote-0.4.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-quote-0.4.7.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_quote",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-ref-0.37.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-ref-0.37.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_ref",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-refspec-0.18.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-refspec-0.18.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_refspec",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-revision-0.22.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-revision-0.22.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_revision",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-revwalk-0.8.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-revwalk-0.8.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_revwalk",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-sec-0.10.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-sec-0.10.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_sec",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-submodule-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-submodule-0.4.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_submodule",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-tempfile-10.0.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-tempfile-10.0.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_tempfile",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-trace-0.1.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-trace-0.1.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_trace",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-transport-0.37.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-transport-0.37.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_transport",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-traverse-0.33.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-traverse-0.33.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_traverse",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-url-0.24.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-url-0.24.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_url",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-utils-0.1.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-utils-0.1.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_utils",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-validate-0.8.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-validate-0.8.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_validate",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.gix-worktree-0.26.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-worktree-0.26.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "gix_worktree",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.globset-0.4.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.globset-0.4.11.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "globset",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.globwalk-0.8.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.globwalk-0.8.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "globwalk",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.hashbrown-0.14.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.hashbrown-0.14.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "hashbrown",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.heck-0.4.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.heck-0.4.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "heck",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.hermit-abi-0.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.hermit-abi-0.3.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "hermit_abi",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.hex-0.4.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.hex-0.4.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "hex",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.home-0.5.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.home-0.5.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "home",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.humansize-2.1.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.humansize-2.1.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "humansize",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.iana-time-zone-0.1.57.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.iana-time-zone-0.1.57.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "iana_time_zone",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "iana_time_zone_haiku",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "iana-time-zone-haiku_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.idna-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.idna-0.4.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "idna",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.ignore-0.4.18.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.ignore-0.4.18.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "ignore",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.indexmap-2.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.indexmap-2.1.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "indexmap",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.indoc-2.0.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.indoc-2.0.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "indoc",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "io_lifetimes",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -193,7 +197,10 @@ rust_library(
 
 cargo_build_script(
     name = "io-lifetimes_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "close",
         "default",
@@ -205,6 +212,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.is-terminal-0.4.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.is-terminal-0.4.7.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "is_terminal",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.itertools-0.12.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.itertools-0.12.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "itertools",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.itoa-1.0.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.itoa-1.0.8.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "itoa",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.js-sys-0.3.64.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.js-sys-0.3.64.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "js_sys",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.jwalk-0.8.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.jwalk-0.8.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "jwalk",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.lazy_static-1.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.lazy_static-1.4.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "lazy_static",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.libc-0.2.149.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libc-0.2.149.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "libc",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -178,7 +182,10 @@ rust_library(
 
 cargo_build_script(
     name = "libc_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "std",
@@ -279,6 +286,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.libm-0.2.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libm-0.2.7.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "libm",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -85,7 +89,10 @@ rust_library(
 
 cargo_build_script(
     name = "libm_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
     ],
@@ -93,6 +100,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.linux-raw-sys-0.3.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.linux-raw-sys-0.3.8.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "linux_raw_sys",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.linux-raw-sys-0.4.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.linux-raw-sys-0.4.10.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "linux_raw_sys",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.lock_api-0.4.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.lock_api-0.4.11.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "lock_api",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -87,7 +91,10 @@ rust_library(
 
 cargo_build_script(
     name = "lock_api_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "atomic_usize",
         "default",
@@ -96,6 +103,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.log-0.4.19.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.log-0.4.19.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "log",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.maplit-1.0.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.maplit-1.0.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "maplit",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.maybe-async-0.2.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.maybe-async-0.2.7.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "maybe_async",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.memchr-2.6.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.memchr-2.6.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "memchr",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.memmap2-0.7.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.memmap2-0.7.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "memmap2",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "memoffset",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -85,7 +89,10 @@ rust_library(
 
 cargo_build_script(
     name = "memoffset_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
     ],
@@ -93,6 +100,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.miniz_oxide-0.7.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.miniz_oxide-0.7.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "miniz_oxide",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.normpath-1.1.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.normpath-1.1.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "normpath",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.nu-ansi-term-0.46.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.nu-ansi-term-0.46.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "nu_ansi_term",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.num-0.1.42.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-0.1.42.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "num",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.num-bigint-0.1.44.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-bigint-0.1.44.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "num_bigint",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.num-complex-0.1.43.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-complex-0.1.43.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "num_complex",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "num_integer",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -87,7 +91,10 @@ rust_library(
 
 cargo_build_script(
     name = "num-integer_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "std",
@@ -96,6 +103,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "num_iter",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -88,7 +92,10 @@ rust_library(
 
 cargo_build_script(
     name = "num-iter_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "std",
@@ -97,6 +104,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.num-rational-0.1.42.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-rational-0.1.42.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "num_rational",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "num_traits",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -86,7 +90,10 @@ rust_library(
 
 cargo_build_script(
     name = "num-traits_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "std",
@@ -95,6 +102,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.num_threads-0.1.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num_threads-0.1.6.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "num_threads",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.once_cell-1.18.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.once_cell-1.18.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "once_cell",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.overload-0.1.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.overload-0.1.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "overload",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.parking_lot-0.12.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.parking_lot-0.12.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "parking_lot",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.parking_lot_core-0.9.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.parking_lot_core-0.9.9.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "parking_lot_core",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -167,11 +171,15 @@ rust_library(
 
 cargo_build_script(
     name = "parking_lot_core_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.parse-zoneinfo-0.3.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.parse-zoneinfo-0.3.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "parse_zoneinfo",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.pathdiff-0.2.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pathdiff-0.2.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "pathdiff",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.percent-encoding-2.3.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.percent-encoding-2.3.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "percent_encoding",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.pest-2.7.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pest-2.7.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "pest",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.pest_derive-2.7.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pest_derive-2.7.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "pest_derive",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.pest_generator-2.7.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pest_generator-2.7.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "pest_generator",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.pest_meta-2.7.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pest_meta-2.7.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "pest_meta",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.phf-0.11.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.phf-0.11.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "phf",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.phf_codegen-0.11.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.phf_codegen-0.11.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "phf_codegen",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.phf_generator-0.11.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.phf_generator-0.11.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "phf_generator",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.phf_shared-0.11.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.phf_shared-0.11.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "phf_shared",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.pin-project-lite-0.2.13.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.pin-project-lite-0.2.13.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "pin_project_lite",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.powerfmt-0.2.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.powerfmt-0.2.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "powerfmt",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.ppv-lite86-0.2.17.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.ppv-lite86-0.2.17.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "ppv_lite86",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "proc_macro2",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -87,7 +91,10 @@ rust_library(
 
 cargo_build_script(
     name = "proc-macro2_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "proc-macro",
@@ -96,6 +103,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.prodash-26.2.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.prodash-26.2.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "prodash",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "quote",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -87,7 +91,10 @@ rust_library(
 
 cargo_build_script(
     name = "quote_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "proc-macro",
@@ -96,6 +103,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rand-0.4.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand-0.4.6.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rand",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rand-0.8.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand-0.8.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rand",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rand_chacha-0.3.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand_chacha-0.3.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rand_chacha",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rand_core-0.3.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand_core-0.3.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rand_core",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rand_core-0.4.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand_core-0.4.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rand_core",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rand_core-0.6.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rand_core-0.6.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rand_core",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rayon-1.8.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rayon-1.8.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rayon",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rayon-core-1.12.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rayon-core-1.12.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rayon_core",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -84,11 +88,15 @@ rust_library(
 
 cargo_build_script(
     name = "rayon-core_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rdrand-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rdrand-0.4.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rdrand",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.redox_syscall-0.3.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.redox_syscall-0.3.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "syscall",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.redox_syscall-0.4.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.redox_syscall-0.4.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "syscall",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.regex-1.10.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.regex-1.10.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "regex",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.regex-automata-0.3.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.regex-automata-0.3.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "regex_automata",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.regex-automata-0.4.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.regex-automata-0.4.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "regex_automata",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.regex-syntax-0.8.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.regex-syntax-0.8.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "regex_syntax",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rustc-hash-1.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustc-hash-1.1.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rustc_hash",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rustc-serialize-0.3.25.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustc-serialize-0.3.25.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rustc_serialize",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -13,7 +13,10 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rustix",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     aliases = select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": {
             "@cui__errno-0.3.1//:errno": "libc_errno",  # cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", any(target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64"), all(target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "mips", target_arch = "mips64"))))))))
@@ -100,6 +103,7 @@ rust_library(
     }),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -320,7 +324,10 @@ rust_library(
 
 cargo_build_script(
     name = "rustix_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "io-lifetimes",
@@ -333,6 +340,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.rustix-0.38.21.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustix-0.38.21.bazel
@@ -13,7 +13,10 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "rustix",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     aliases = select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": {
             "@cui__errno-0.3.1//:errno": "libc_errno",  # cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))
@@ -100,6 +103,7 @@ rust_library(
     }),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -385,7 +389,10 @@ rust_library(
 
 cargo_build_script(
     name = "rustix_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "alloc",
         "default",
@@ -471,6 +478,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.ryu-1.0.14.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.ryu-1.0.14.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "ryu",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.same-file-1.0.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.same-file-1.0.6.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "same_file",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.scopeguard-1.2.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.scopeguard-1.2.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "scopeguard",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.semver-1.0.20.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.semver-1.0.20.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "semver",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -88,7 +92,10 @@ rust_library(
 
 cargo_build_script(
     name = "semver_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "serde",
@@ -98,6 +105,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.serde-1.0.190.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde-1.0.190.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "serde",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -92,7 +96,10 @@ rust_library(
 
 cargo_build_script(
     name = "serde_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "derive",
@@ -104,6 +111,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.serde_derive-1.0.190.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_derive-1.0.190.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "serde_derive",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.108.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.108.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "serde_json",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -90,7 +94,10 @@ rust_library(
 
 cargo_build_script(
     name = "serde_json_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "default",
         "std",
@@ -100,6 +107,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.serde_spanned-0.6.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_spanned-0.6.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "serde_spanned",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.serde_starlark-0.1.14.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_starlark-0.1.14.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "serde_starlark",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.sha1_smol-1.0.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.sha1_smol-1.0.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "sha1_smol",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.sha2-0.10.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.sha2-0.10.8.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "sha2",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.sharded-slab-0.1.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.sharded-slab-0.1.7.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "sharded_slab",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.siphasher-0.3.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.siphasher-0.3.10.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "siphasher",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.slug-0.1.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.slug-0.1.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "slug",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.smallvec-1.11.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.smallvec-1.11.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "smallvec",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.smawk-0.3.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.smawk-0.3.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "smawk",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.smol_str-0.2.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.smol_str-0.2.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "smol_str",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.spdx-0.10.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.spdx-0.10.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "spdx",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.spectral-0.6.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.spectral-0.6.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "spectral",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.strsim-0.10.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.strsim-0.10.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "strsim",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.syn-1.0.109.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.syn-1.0.109.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "syn",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -96,7 +100,10 @@ rust_library(
 
 cargo_build_script(
     name = "syn_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "clone-impls",
         "default",
@@ -112,6 +119,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.syn-2.0.32.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.syn-2.0.32.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "syn",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.tempfile-3.8.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tempfile-3.8.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "tempfile",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.tera-1.19.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tera-1.19.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "tera",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.textwrap-0.16.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.textwrap-0.16.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "textwrap",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.thiserror-1.0.50.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.thiserror-1.0.50.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "thiserror",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -85,11 +89,15 @@ rust_library(
 
 cargo_build_script(
     name = "thiserror_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.thiserror-impl-1.0.50.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.thiserror-impl-1.0.50.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "thiserror_impl",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.thread_local-1.1.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.thread_local-1.1.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "thread_local",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.time-0.3.30.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.time-0.3.30.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "time",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.time-core-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.time-core-0.1.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "time_core",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.time-macros-0.2.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.time-macros-0.2.15.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "time_macros",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.tinyvec-1.6.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tinyvec-1.6.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "tinyvec",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.tinyvec_macros-0.1.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tinyvec_macros-0.1.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "tinyvec_macros",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.toml-0.7.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.toml-0.7.6.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "toml",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.toml-0.8.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.toml-0.8.10.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "toml",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.toml_datetime-0.6.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.toml_datetime-0.6.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "toml_datetime",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.toml_edit-0.19.13.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.toml_edit-0.19.13.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "toml_edit",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.toml_edit-0.22.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.toml_edit-0.22.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "toml_edit",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.tracing-0.1.40.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tracing-0.1.40.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "tracing",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.tracing-attributes-0.1.27.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tracing-attributes-0.1.27.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "tracing_attributes",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.tracing-core-0.1.32.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tracing-core-0.1.32.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "tracing_core",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.tracing-log-0.1.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tracing-log-0.1.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "tracing_log",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.tracing-subscriber-0.3.17.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.tracing-subscriber-0.3.17.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "tracing_subscriber",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.typenum-1.16.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.typenum-1.16.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "typenum",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "typenum_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_main",
     crate_root = "build/main.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.ucd-trie-0.1.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.ucd-trie-0.1.6.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "ucd_trie",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.uluru-3.0.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.uluru-3.0.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "uluru",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unic-char-property-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-char-property-0.9.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unic_char_property",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unic-char-range-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-char-range-0.9.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unic_char_range",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unic-common-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-common-0.9.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unic_common",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unic-segment-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-segment-0.9.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unic_segment",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unic-ucd-segment-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-ucd-segment-0.9.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unic_ucd_segment",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unic-ucd-version-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unic-ucd-version-0.9.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unic_ucd_version",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unicode-bidi-0.3.13.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-bidi-0.3.13.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unicode_bidi",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unicode-bom-2.0.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-bom-2.0.2.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unicode_bom",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unicode-ident-1.0.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-ident-1.0.10.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unicode_ident",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unicode-linebreak-0.1.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-linebreak-0.1.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unicode_linebreak",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unicode-normalization-0.1.22.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-normalization-0.1.22.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unicode_normalization",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.unicode-width-0.1.10.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.unicode-width-0.1.10.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "unicode_width",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.url-2.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.url-2.4.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "url",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.utf8parse-0.2.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.utf8parse-0.2.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "utf8parse",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.valuable-0.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.valuable-0.1.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "valuable",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "valuable_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.version_check-0.9.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.version_check-0.9.4.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "version_check",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.walkdir-2.3.3.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.walkdir-2.3.3.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "walkdir",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "wasi",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-0.2.87.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "wasm_bindgen",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -86,11 +90,15 @@ rust_library(
 
 cargo_build_script(
     name = "wasm-bindgen_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-backend-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-backend-0.2.87.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "wasm_bindgen_backend",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-macro-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-macro-0.2.87.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_proc_macro(
     name = "wasm_bindgen_macro",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-macro-support-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-macro-support-0.2.87.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "wasm_bindgen_macro_support",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.87.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "wasm_bindgen_shared",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "wasm-bindgen-shared_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "winapi",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -100,7 +104,10 @@ rust_library(
 
 cargo_build_script(
     name = "winapi_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_features = [
         "consoleapi",
         "errhandlingapi",
@@ -123,6 +130,7 @@ cargo_build_script(
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "winapi_i686_pc_windows_gnu",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "winapi-i686-pc-windows-gnu_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.winapi-util-0.1.5.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-util-0.1.5.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "winapi_util",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "winapi_x86_64_pc_windows_gnu",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "winapi-x86_64-pc-windows-gnu_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows-0.48.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows-sys-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows-sys-0.48.0.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows_sys",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows-targets-0.48.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows-targets-0.48.1.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows_targets",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows_aarch64_gnullvm",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "windows_aarch64_gnullvm_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows_aarch64_msvc",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "windows_aarch64_msvc_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows_i686_gnu",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "windows_i686_gnu_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows_i686_msvc",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "windows_i686_msvc_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows_x86_64_gnu",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "windows_x86_64_gnu_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows_x86_64_gnullvm",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "windows_x86_64_gnullvm_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -13,9 +13,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "windows_x86_64_msvc",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",
@@ -82,11 +86,15 @@ rust_library(
 
 cargo_build_script(
     name = "windows_x86_64_msvc_build_script",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/BUILD.winnow-0.5.18.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winnow-0.5.18.bazel
@@ -12,9 +12,13 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "winnow",
-    srcs = glob(["**/*.rs"]),
+    srcs = glob(
+        include = ["**/*.rs"],
+        allow_empty = False,
+    ),
     compile_data = glob(
         include = ["**"],
+        allow_empty = True,
         exclude = [
             "**/* *",
             ".tmp_git_root/**/*",

--- a/crate_universe/3rdparty/crates/defs.bzl
+++ b/crate_universe/3rdparty/crates/defs.bzl
@@ -295,45 +295,45 @@ def aliases(
 _NORMAL_DEPENDENCIES = {
     "crate_universe": {
         _COMMON_CONDITION: {
-            "anyhow": "@cui__anyhow-1.0.75//:anyhow",
-            "camino": "@cui__camino-1.1.6//:camino",
-            "cargo-lock": "@cui__cargo-lock-9.0.0//:cargo_lock",
-            "cargo-platform": "@cui__cargo-platform-0.1.4//:cargo_platform",
-            "cargo_metadata": "@cui__cargo_metadata-0.18.1//:cargo_metadata",
-            "cargo_toml": "@cui__cargo_toml-0.17.1//:cargo_toml",
-            "cfg-expr": "@cui__cfg-expr-0.15.5//:cfg_expr",
-            "clap": "@cui__clap-4.3.11//:clap",
-            "crates-index": "@cui__crates-index-2.2.0//:crates_index",
-            "hex": "@cui__hex-0.4.3//:hex",
-            "itertools": "@cui__itertools-0.12.0//:itertools",
-            "normpath": "@cui__normpath-1.1.1//:normpath",
-            "pathdiff": "@cui__pathdiff-0.2.1//:pathdiff",
-            "regex": "@cui__regex-1.10.2//:regex",
-            "semver": "@cui__semver-1.0.20//:semver",
-            "serde": "@cui__serde-1.0.190//:serde",
-            "serde_json": "@cui__serde_json-1.0.108//:serde_json",
-            "serde_starlark": "@cui__serde_starlark-0.1.14//:serde_starlark",
-            "sha2": "@cui__sha2-0.10.8//:sha2",
-            "spdx": "@cui__spdx-0.10.3//:spdx",
-            "tempfile": "@cui__tempfile-3.8.1//:tempfile",
-            "tera": "@cui__tera-1.19.1//:tera",
-            "textwrap": "@cui__textwrap-0.16.0//:textwrap",
-            "toml": "@cui__toml-0.8.10//:toml",
-            "tracing": "@cui__tracing-0.1.40//:tracing",
-            "tracing-subscriber": "@cui__tracing-subscriber-0.3.17//:tracing_subscriber",
+            "anyhow": Label("@cui__anyhow-1.0.75//:anyhow"),
+            "camino": Label("@cui__camino-1.1.6//:camino"),
+            "cargo-lock": Label("@cui__cargo-lock-9.0.0//:cargo_lock"),
+            "cargo-platform": Label("@cui__cargo-platform-0.1.4//:cargo_platform"),
+            "cargo_metadata": Label("@cui__cargo_metadata-0.18.1//:cargo_metadata"),
+            "cargo_toml": Label("@cui__cargo_toml-0.17.1//:cargo_toml"),
+            "cfg-expr": Label("@cui__cfg-expr-0.15.5//:cfg_expr"),
+            "clap": Label("@cui__clap-4.3.11//:clap"),
+            "crates-index": Label("@cui__crates-index-2.2.0//:crates_index"),
+            "hex": Label("@cui__hex-0.4.3//:hex"),
+            "itertools": Label("@cui__itertools-0.12.0//:itertools"),
+            "normpath": Label("@cui__normpath-1.1.1//:normpath"),
+            "pathdiff": Label("@cui__pathdiff-0.2.1//:pathdiff"),
+            "regex": Label("@cui__regex-1.10.2//:regex"),
+            "semver": Label("@cui__semver-1.0.20//:semver"),
+            "serde": Label("@cui__serde-1.0.190//:serde"),
+            "serde_json": Label("@cui__serde_json-1.0.108//:serde_json"),
+            "serde_starlark": Label("@cui__serde_starlark-0.1.14//:serde_starlark"),
+            "sha2": Label("@cui__sha2-0.10.8//:sha2"),
+            "spdx": Label("@cui__spdx-0.10.3//:spdx"),
+            "tempfile": Label("@cui__tempfile-3.8.1//:tempfile"),
+            "tera": Label("@cui__tera-1.19.1//:tera"),
+            "textwrap": Label("@cui__textwrap-0.16.0//:textwrap"),
+            "toml": Label("@cui__toml-0.8.10//:toml"),
+            "tracing": Label("@cui__tracing-0.1.40//:tracing"),
+            "tracing-subscriber": Label("@cui__tracing-subscriber-0.3.17//:tracing_subscriber"),
         },
     },
     "crate_universe/tools/cross_installer": {
         _COMMON_CONDITION: {
-            "clap": "@cui__clap-4.3.11//:clap",
+            "clap": Label("@cui__clap-4.3.11//:clap"),
         },
     },
     "crate_universe/tools/urls_generator": {
         _COMMON_CONDITION: {
-            "clap": "@cui__clap-4.3.11//:clap",
-            "hex": "@cui__hex-0.4.3//:hex",
-            "serde_json": "@cui__serde_json-1.0.108//:serde_json",
-            "sha2": "@cui__sha2-0.10.8//:sha2",
+            "clap": Label("@cui__clap-4.3.11//:clap"),
+            "hex": Label("@cui__hex-0.4.3//:hex"),
+            "serde_json": Label("@cui__serde_json-1.0.108//:serde_json"),
+            "sha2": Label("@cui__sha2-0.10.8//:sha2"),
         },
     },
 }
@@ -356,8 +356,8 @@ _NORMAL_ALIASES = {
 _NORMAL_DEV_DEPENDENCIES = {
     "crate_universe": {
         _COMMON_CONDITION: {
-            "maplit": "@cui__maplit-1.0.2//:maplit",
-            "spectral": "@cui__spectral-0.6.0//:spectral",
+            "maplit": Label("@cui__maplit-1.0.2//:maplit"),
+            "spectral": Label("@cui__spectral-0.6.0//:spectral"),
         },
     },
     "crate_universe/tools/cross_installer": {
@@ -380,7 +380,7 @@ _NORMAL_DEV_ALIASES = {
 _PROC_MACRO_DEPENDENCIES = {
     "crate_universe": {
         _COMMON_CONDITION: {
-            "indoc": "@cui__indoc-2.0.4//:indoc",
+            "indoc": Label("@cui__indoc-2.0.4//:indoc"),
         },
     },
     "crate_universe/tools/cross_installer": {

--- a/crate_universe/src/context.rs
+++ b/crate_universe/src/context.rs
@@ -291,7 +291,7 @@ mod test {
     }
 
     #[test]
-    fn seralization() {
+    fn serialization() {
         let context = mock_context_aliases();
 
         // Seralize and deseralize the context object

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -153,6 +153,7 @@ impl Renderer {
         let mut exports_files = ExportsFiles {
             paths: BTreeSet::from(["cargo-bazel.json".to_owned(), "defs.bzl".to_owned()]),
             globs: Glob {
+                allow_empty: true,
                 include: BTreeSet::from(["*.bazel".to_owned()]),
                 exclude: BTreeSet::new(),
             },
@@ -165,6 +166,7 @@ impl Renderer {
         let filegroup = Filegroup {
             name: "srcs".to_owned(),
             srcs: Glob {
+                allow_empty: true,
                 include: BTreeSet::from(["*.bazel".to_owned(), "*.bzl".to_owned()]),
                 exclude: BTreeSet::new(),
             },
@@ -873,6 +875,7 @@ fn make_data(
 
     Data {
         glob: Glob {
+            allow_empty: true,
             include: glob,
             exclude: COMMON_GLOB_EXCLUDES
                 .iter()

--- a/crate_universe/src/utils/starlark/serialize.rs
+++ b/crate_universe/src/utils/starlark/serialize.rs
@@ -130,7 +130,7 @@ impl Serialize for ExportsFiles {
 
 impl Data {
     pub fn is_empty(&self) -> bool {
-        self.glob.is_empty() && self.select.is_empty()
+        self.glob.has_any_include() && self.select.is_empty()
     }
 }
 
@@ -140,10 +140,10 @@ impl Serialize for Data {
         S: Serializer,
     {
         let mut plus = serializer.serialize_tuple_struct("+", MULTILINE)?;
-        if !self.glob.is_empty() {
+        if !self.glob.has_any_include() {
             plus.serialize_field(&self.glob)?;
         }
-        if !self.select.is_empty() || self.glob.is_empty() {
+        if !self.select.is_empty() || self.glob.has_any_include() {
             plus.serialize_field(&self.select)?;
         }
         plus.end()

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -18,6 +18,9 @@ build:clippy --output_groups=+clippy_checks
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
 
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -8,3 +8,6 @@ build --fat_apk_cpu=arm64-v8a --android_crosstool_top=@androidndk//:toolchain
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/examples/bzlmod/all_crate_deps/.bazelrc
+++ b/examples/bzlmod/all_crate_deps/.bazelrc
@@ -4,3 +4,6 @@ startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 build --experimental_enable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/examples/bzlmod/cross_compile/.bazelrc
+++ b/examples/bzlmod/cross_compile/.bazelrc
@@ -1,1 +1,4 @@
 build --experimental_enable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/examples/bzlmod/hello_world/.bazelrc
+++ b/examples/bzlmod/hello_world/.bazelrc
@@ -4,3 +4,6 @@ startup --windows_enable_symlinks
 build:windows --enable_runfiles
 
 build --experimental_enable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/examples/cargo_manifest_dir/external_crate/.bazelrc
+++ b/examples/cargo_manifest_dir/external_crate/.bazelrc
@@ -1,1 +1,4 @@
 common --noenable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/examples/crate_universe/.bazelrc
+++ b/examples/crate_universe/.bazelrc
@@ -22,6 +22,9 @@ build --nolegacy_external_runfiles
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
 
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5a8e6daff7916154647cf462928b2fa707b5264768c43c334e04316c34664959",
+  "checksum": "29b3baa67c12dc0f5ff62bd02183029b2bb2b9894ee84774c77871de8c0023e1",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -11,9 +11,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -53,18 +56,24 @@
           "Library": {
             "crate_name": "test_data_passing_crate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "332235231d1fa45438b88c1e0469f9f8cb63314ad19ff3dbdbcf12aabee5a02e",
+  "checksum": "4991fe7d81e0ebe9a35949068c388a69d999ee729634d48b2be11820a8615e60",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -11,9 +11,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -53,18 +56,24 @@
           "Library": {
             "crate_name": "test_data_passing_crate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f2e20aa28dcbfde2549ad61a7533ede6ac64ed85f0f1a810409a32b492d83573",
+  "checksum": "b86b7a7cb303025c3eaff9cb49e779e55a9034b1892fb6cf2403e87803a3f6db",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -11,9 +11,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -53,18 +56,24 @@
           "Library": {
             "crate_name": "test_data_passing_crate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "de46a9b4d68c2e581f268a93ac93565399b8310667d5ecdaa5cc35ab2ca6ad01",
+  "checksum": "f0c92e0ffd9cc767600b88da2d1f670e32ecdf4a5919b799c2e2c13c707f231a",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -11,9 +11,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -53,18 +56,24 @@
           "Library": {
             "crate_name": "test_data_passing_crate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "78648a05909b2fc0b3d5468281640c5e5015fe6f248c9e86db35eb5e7fa241db",
+  "checksum": "b0bb4ae2ee3d60a8962badb7f4cd08d3ae607e9488c73f2240d8b3b4aab2b042",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -11,9 +11,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -53,18 +56,24 @@
           "Library": {
             "crate_name": "test_data_passing_crate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "21aa882aac1b80e6920c3238ed9f498e72339a63c47ca14a1cb7b7ad5c1926e0",
+  "checksum": "a8e4b52992734f8c2f9b2353c83a4aefc9b02e848b7a7644de12e2d87e63d58f",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -11,9 +11,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -53,18 +56,24 @@
           "Library": {
             "crate_name": "test_data_passing_crate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5964eed158ef36d227eb6c90edb00833ab471d8674f3a25675205c6ff7ba3732",
+  "checksum": "f0b40c08fea2a32274119fabd0fe0a1249565eaa8833b50377a2e099f39b9da9",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -11,9 +11,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -53,18 +56,24 @@
           "Library": {
             "crate_name": "test_data_passing_crate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/cargo_aliases/.bazelrc
+++ b/examples/crate_universe/cargo_aliases/.bazelrc
@@ -17,6 +17,9 @@ build:strict --output_groups=+clippy_checks
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
 
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "dceaecfd65ca2afe89286cc5c49b1672834d35eba4193b10ff8eefee3ab9edb5",
+  "checksum": "7a7d4f7cf7145a4d932de0a192ea334f5d608280e9913a541d018eb3f8d81861",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",
@@ -16,9 +16,12 @@
           "Library": {
             "crate_name": "aho_corasick",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -63,9 +66,12 @@
           "Library": {
             "crate_name": "aliases",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -132,9 +138,12 @@
           "Library": {
             "crate_name": "atty",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -190,9 +199,12 @@
           "Library": {
             "crate_name": "autocfg",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -226,9 +238,12 @@
           "Library": {
             "crate_name": "bitflags",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -268,9 +283,12 @@
           "Library": {
             "crate_name": "cfg_if",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -304,9 +322,12 @@
           "Library": {
             "crate_name": "clap",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -401,9 +422,12 @@
           "ProcMacro": {
             "crate_name": "clap_derive",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -468,9 +492,12 @@
           "Library": {
             "crate_name": "clap_lex",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -513,9 +540,12 @@
           "ProcMacro": {
             "crate_name": "ctor",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -562,9 +592,12 @@
           "Library": {
             "crate_name": "env_logger",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -633,9 +666,12 @@
           "Library": {
             "crate_name": "getrandom",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -697,9 +733,12 @@
           "Library": {
             "crate_name": "hashbrown",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -739,9 +778,12 @@
           "Library": {
             "crate_name": "heck",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -781,9 +823,12 @@
           "Library": {
             "crate_name": "hermit_abi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -826,9 +871,12 @@
           "Library": {
             "crate_name": "humantime",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -862,18 +910,24 @@
           "Library": {
             "crate_name": "indexmap",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -940,18 +994,24 @@
           "Library": {
             "crate_name": "libc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -999,9 +1059,12 @@
           "Library": {
             "crate_name": "log",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1051,18 +1114,24 @@
           "Library": {
             "crate_name": "log",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1120,18 +1189,24 @@
           "Library": {
             "crate_name": "memchr",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1189,18 +1264,24 @@
           "Library": {
             "crate_name": "names",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1263,18 +1344,24 @@
           "Library": {
             "crate_name": "names",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1337,9 +1424,12 @@
           "Library": {
             "crate_name": "once_cell",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1382,9 +1472,12 @@
           "Library": {
             "crate_name": "os_str_bytes",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1424,9 +1517,12 @@
           "Library": {
             "crate_name": "ppv_lite86",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1467,18 +1563,24 @@
           "Library": {
             "crate_name": "proc_macro_error",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1564,18 +1666,24 @@
           "ProcMacro": {
             "crate_name": "proc_macro_error_attr",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1640,18 +1748,24 @@
           "Library": {
             "crate_name": "proc_macro2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1710,18 +1824,24 @@
           "Library": {
             "crate_name": "quote",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1780,9 +1900,12 @@
           "Library": {
             "crate_name": "rand",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1848,9 +1971,12 @@
           "Library": {
             "crate_name": "rand_chacha",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1903,9 +2029,12 @@
           "Library": {
             "crate_name": "rand_core",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1956,9 +2085,12 @@
           "Library": {
             "crate_name": "regex",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2022,9 +2154,12 @@
           "Library": {
             "crate_name": "regex_syntax",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2058,9 +2193,12 @@
           "Library": {
             "crate_name": "strsim",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2093,18 +2231,24 @@
           "Library": {
             "crate_name": "syn",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2177,9 +2321,12 @@
           "Library": {
             "crate_name": "termcolor",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2224,9 +2371,12 @@
           "Library": {
             "crate_name": "textwrap",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2259,9 +2409,12 @@
           "Library": {
             "crate_name": "unicode_ident",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2296,18 +2449,24 @@
           "Library": {
             "crate_name": "value_bag",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2374,9 +2533,12 @@
           "Library": {
             "crate_name": "version_check",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2410,9 +2572,12 @@
           "Library": {
             "crate_name": "wasi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2453,18 +2618,24 @@
           "Library": {
             "crate_name": "winapi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2541,18 +2712,24 @@
           "Library": {
             "crate_name": "winapi_i686_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2600,9 +2777,12 @@
           "Library": {
             "crate_name": "winapi_util",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2647,18 +2827,24 @@
           "Library": {
             "crate_name": "winapi_x86_64_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/cargo_conditional_deps/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_conditional_deps/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "8d2ed817b37a2020eb334ba6530260d1062590022f3b9b68ab09e0f7d94030e7",
+  "checksum": "2a380523a8d2af44db9039a1159b146be87a517dc1b8d9bf8fafc9760a7a0a4f",
   "crates": {
     "autocfg 1.1.0": {
       "name": "autocfg",
@@ -16,9 +16,12 @@
           "Library": {
             "crate_name": "autocfg",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -52,9 +55,12 @@
           "Library": {
             "crate_name": "bitflags",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -94,9 +100,12 @@
           "Library": {
             "crate_name": "cfg_if",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -159,18 +168,24 @@
           "Library": {
             "crate_name": "libc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -226,18 +241,24 @@
           "Library": {
             "crate_name": "memoffset",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -299,9 +320,12 @@
           "Library": {
             "crate_name": "nix",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -406,9 +430,12 @@
           "Library": {
             "crate_name": "pin_utils",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -442,9 +469,12 @@
           "Library": {
             "crate_name": "static_assertions",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/cargo_remote/.bazelrc
+++ b/examples/crate_universe/cargo_remote/.bazelrc
@@ -17,6 +17,9 @@ build:strict --output_groups=+clippy_checks
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
 
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/cargo_workspace/.bazelrc
+++ b/examples/crate_universe/cargo_workspace/.bazelrc
@@ -17,6 +17,9 @@ build:strict --output_groups=+clippy_checks
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
 
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c05f046485ab3a82c47a3e76af5d4da2a0771a4c643e4788d53f6692333f4007",
+  "checksum": "3a89d0898e33ad0841990f0b56fa2807eaceb8b98f565c50ebfb59095bef8df9",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -16,9 +16,12 @@
           "Library": {
             "crate_name": "ansi_term",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -62,9 +65,12 @@
           "Library": {
             "crate_name": "atty",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -120,9 +126,12 @@
           "Library": {
             "crate_name": "bitflags",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -162,9 +171,12 @@
           "Library": {
             "crate_name": "cfg_if",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -198,9 +210,12 @@
           "Library": {
             "crate_name": "clap",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -281,9 +296,12 @@
           "Library": {
             "crate_name": "ferris_says",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -334,18 +352,24 @@
           "Library": {
             "crate_name": "getrandom",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -416,9 +440,12 @@
           "Library": {
             "crate_name": "hermit_abi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -461,18 +488,24 @@
           "Library": {
             "crate_name": "libc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -547,9 +580,12 @@
           "Library": {
             "crate_name": "ppv_lite86",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -585,9 +621,12 @@
           "Library": {
             "crate_name": "printer",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -627,9 +666,12 @@
           "Library": {
             "crate_name": "rand",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -707,9 +749,12 @@
           "Library": {
             "crate_name": "rand_chacha",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -762,9 +807,12 @@
           "Library": {
             "crate_name": "rand_core",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -815,9 +863,12 @@
           "Library": {
             "crate_name": "rand_hc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -855,9 +906,12 @@
           "Library": {
             "crate_name": "rng",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -897,9 +951,12 @@
           "Library": {
             "crate_name": "smallvec",
             "crate_root": "lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -939,9 +996,12 @@
           "Library": {
             "crate_name": "smawk",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -974,9 +1034,12 @@
           "Library": {
             "crate_name": "strsim",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1009,9 +1072,12 @@
           "Library": {
             "crate_name": "textwrap",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1053,9 +1119,12 @@
           "Library": {
             "crate_name": "textwrap",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1109,9 +1178,12 @@
           "Library": {
             "crate_name": "unicode_width",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1151,9 +1223,12 @@
           "Library": {
             "crate_name": "vec_map",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1187,9 +1262,12 @@
           "Library": {
             "crate_name": "wasi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1230,18 +1308,24 @@
           "Library": {
             "crate_name": "winapi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1315,18 +1399,24 @@
           "Library": {
             "crate_name": "winapi_i686_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1374,18 +1464,24 @@
           "Library": {
             "crate_name": "winapi_x86_64_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/multi_package/.bazelrc
+++ b/examples/crate_universe/multi_package/.bazelrc
@@ -17,6 +17,9 @@ build:strict --output_groups=+clippy_checks
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
 
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/multi_package/cargo-bazel-lock.json
+++ b/examples/crate_universe/multi_package/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d5f0da162ae35dd8eaa47d54e6aeec69d34b38f2dd9d4ac846d3749d8aa0103f",
+  "checksum": "d94d3a74aa0e73ed1c9b8bd803bb6ecaaeaf258f7c3a937d4783aaf5891b31b0",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",
@@ -16,9 +16,12 @@
           "Library": {
             "crate_name": "aho_corasick",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -68,18 +71,24 @@
           "Library": {
             "crate_name": "anyhow",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -134,9 +143,12 @@
           "Library": {
             "crate_name": "assert_json_diff",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -182,9 +194,12 @@
           "Library": {
             "crate_name": "async_channel",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -235,9 +250,12 @@
           "Library": {
             "crate_name": "async_executor",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -300,9 +318,12 @@
           "Library": {
             "crate_name": "async_global_executor",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -376,18 +397,24 @@
           "Library": {
             "crate_name": "async_io",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -493,9 +520,12 @@
           "Library": {
             "crate_name": "async_lock",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -538,9 +568,12 @@
           "Library": {
             "crate_name": "async_object_pool",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -582,18 +615,24 @@
           "Library": {
             "crate_name": "async_process",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -691,9 +730,12 @@
           "Library": {
             "crate_name": "async_std",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -841,9 +883,12 @@
           "Library": {
             "crate_name": "async_task",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -884,18 +929,24 @@
           "ProcMacro": {
             "crate_name": "async_trait",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -955,9 +1006,12 @@
           "Library": {
             "crate_name": "atomic_waker",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -991,9 +1045,12 @@
           "Library": {
             "crate_name": "autocfg",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1027,9 +1084,12 @@
           "Library": {
             "crate_name": "base64",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1070,9 +1130,12 @@
           "Library": {
             "crate_name": "base64",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1113,9 +1176,12 @@
           "Library": {
             "crate_name": "block_buffer",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1158,9 +1224,12 @@
           "Library": {
             "crate_name": "blocking",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1223,9 +1292,12 @@
           "Library": {
             "crate_name": "bumpalo",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1265,9 +1337,12 @@
           "Library": {
             "crate_name": "bytes",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1307,9 +1382,12 @@
           "Library": {
             "crate_name": "castaway",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1358,9 +1436,12 @@
           "Library": {
             "crate_name": "cc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1394,9 +1475,12 @@
           "Library": {
             "crate_name": "cfg_if",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1430,9 +1514,12 @@
           "Library": {
             "crate_name": "concurrent_queue",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1482,18 +1569,24 @@
           "Library": {
             "crate_name": "crossbeam_utils",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1552,9 +1645,12 @@
           "ProcMacro": {
             "crate_name": "ctor",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1601,18 +1697,24 @@
           "Library": {
             "crate_name": "curl",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1699,9 +1801,12 @@
           "Library": {
             "crate_name": "curl_sys",
             "crate_root": "lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1778,9 +1883,12 @@
           "Library": {
             "crate_name": "digest",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1830,9 +1938,12 @@
           "Library": {
             "crate_name": "encoding_rs",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1883,9 +1994,12 @@
           "Library": {
             "crate_name": "event_listener",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1919,9 +2033,12 @@
           "Library": {
             "crate_name": "fastrand",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1966,9 +2083,12 @@
           "Library": {
             "crate_name": "fnv",
             "crate_root": "lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2009,9 +2129,12 @@
           "Library": {
             "crate_name": "form_urlencoded",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2054,18 +2177,24 @@
           "Library": {
             "crate_name": "futures_channel",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2125,18 +2254,24 @@
           "Library": {
             "crate_name": "futures_core",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2192,9 +2327,12 @@
           "Library": {
             "crate_name": "futures_io",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2235,9 +2373,12 @@
           "Library": {
             "crate_name": "futures_lite",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2639,9 +2780,12 @@
           "ProcMacro": {
             "crate_name": "futures_macro",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2692,9 +2836,12 @@
           "Library": {
             "crate_name": "futures_sink",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2736,18 +2883,24 @@
           "Library": {
             "crate_name": "futures_task",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2802,18 +2955,24 @@
           "Library": {
             "crate_name": "futures_util",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2913,18 +3072,24 @@
           "Library": {
             "crate_name": "generic_array",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2984,9 +3149,12 @@
           "Library": {
             "crate_name": "gloo_timers",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3050,9 +3218,12 @@
           "Library": {
             "crate_name": "h2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3134,9 +3305,12 @@
           "Library": {
             "crate_name": "hashbrown",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3176,9 +3350,12 @@
           "Library": {
             "crate_name": "hermit_abi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3221,9 +3398,12 @@
           "ProcMacro": {
             "crate_name": "hex_literal",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3257,9 +3437,12 @@
           "Library": {
             "crate_name": "http",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3310,9 +3493,12 @@
           "Library": {
             "crate_name": "http_body",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3362,18 +3548,24 @@
           "Library": {
             "crate_name": "httparse",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3428,9 +3620,12 @@
           "Library": {
             "crate_name": "httpdate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3467,9 +3662,12 @@
           "Library": {
             "crate_name": "httpmock",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3594,9 +3792,12 @@
           "Library": {
             "crate_name": "hyper",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3901,9 +4102,12 @@
           "Library": {
             "crate_name": "hyper_rustls",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3963,9 +4167,12 @@
           "Library": {
             "crate_name": "idna",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4012,18 +4219,24 @@
           "Library": {
             "crate_name": "indexmap",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4185,9 +4398,12 @@
           "Library": {
             "crate_name": "instant",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4229,9 +4445,12 @@
           "Library": {
             "crate_name": "ipnet",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4274,18 +4493,24 @@
           "Library": {
             "crate_name": "isahc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4439,9 +4664,12 @@
           "Library": {
             "crate_name": "itoa",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4475,9 +4703,12 @@
           "Library": {
             "crate_name": "js_sys",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4520,9 +4751,12 @@
           "Library": {
             "crate_name": "kv_log_macro",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4565,9 +4799,12 @@
           "Library": {
             "crate_name": "lazy_static",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4601,9 +4838,12 @@
           "Library": {
             "crate_name": "levenshtein",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4636,18 +4876,24 @@
           "Library": {
             "crate_name": "libc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4702,18 +4948,24 @@
           "Library": {
             "crate_name": "libnghttp2_sys",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4779,18 +5031,24 @@
           "Library": {
             "crate_name": "libz_sys",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4869,18 +5127,24 @@
           "Library": {
             "crate_name": "log",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4943,9 +5207,12 @@
           "Library": {
             "crate_name": "md5",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5003,18 +5270,24 @@
           "Library": {
             "crate_name": "memchr",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5069,9 +5342,12 @@
           "Library": {
             "crate_name": "mime",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5105,9 +5381,12 @@
           "Library": {
             "crate_name": "mio",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5181,9 +5460,12 @@
           "Library": {
             "crate_name": "num_cpus",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5234,9 +5516,12 @@
           "Library": {
             "crate_name": "num_enum",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5287,9 +5572,12 @@
           "ProcMacro": {
             "crate_name": "num_enum_derive",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5352,9 +5640,12 @@
           "Library": {
             "crate_name": "once_cell",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5397,9 +5688,12 @@
           "Library": {
             "crate_name": "opaque_debug",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5433,9 +5727,12 @@
           "Library": {
             "crate_name": "parking",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5469,9 +5766,12 @@
           "Library": {
             "crate_name": "percent_encoding",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5512,9 +5812,12 @@
           "Library": {
             "crate_name": "pin_project",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5557,9 +5860,12 @@
           "ProcMacro": {
             "crate_name": "pin_project_internal",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5610,9 +5916,12 @@
           "Library": {
             "crate_name": "pin_project_lite",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5646,9 +5955,12 @@
           "Library": {
             "crate_name": "pin_utils",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5682,9 +5994,12 @@
           "Library": {
             "crate_name": "pkg_config",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5713,9 +6028,12 @@
           "Library": {
             "crate_name": "pkg_a",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5763,9 +6081,12 @@
           "Library": {
             "crate_name": "pkg_b",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5804,9 +6125,12 @@
           "Library": {
             "crate_name": "pkg_c",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5855,18 +6179,24 @@
           "Library": {
             "crate_name": "polling",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5955,9 +6285,12 @@
           "Library": {
             "crate_name": "proc_macro_crate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6004,18 +6337,24 @@
           "Library": {
             "crate_name": "proc_macro2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6074,18 +6413,24 @@
           "Library": {
             "crate_name": "quote",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6144,9 +6489,12 @@
           "Library": {
             "crate_name": "regex",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6219,9 +6567,12 @@
           "Library": {
             "crate_name": "regex_syntax",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6269,9 +6620,12 @@
           "Library": {
             "crate_name": "reqwest",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6458,18 +6812,24 @@
           "Library": {
             "crate_name": "ring",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6572,18 +6932,24 @@
           "Library": {
             "crate_name": "rustls",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6667,18 +7033,24 @@
           "Library": {
             "crate_name": "rustls_ffi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6762,9 +7134,12 @@
           "Library": {
             "crate_name": "rustls_pemfile",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6808,9 +7183,12 @@
           "Library": {
             "crate_name": "rustls_pemfile",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6854,18 +7232,24 @@
           "ProcMacro": {
             "crate_name": "rustversion",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build/build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6913,9 +7297,12 @@
           "Library": {
             "crate_name": "ryu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6949,9 +7336,12 @@
           "Library": {
             "crate_name": "schannel",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -6993,9 +7383,12 @@
           "Library": {
             "crate_name": "sct",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7043,18 +7436,24 @@
           "Library": {
             "crate_name": "serde",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7120,18 +7519,24 @@
           "ProcMacro": {
             "crate_name": "serde_derive",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7197,18 +7602,24 @@
           "Library": {
             "crate_name": "serde_json",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7275,9 +7686,12 @@
           "Library": {
             "crate_name": "serde_regex",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7324,9 +7738,12 @@
           "Library": {
             "crate_name": "serde_urlencoded",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7381,18 +7798,24 @@
           "Library": {
             "crate_name": "signal_hook",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7455,9 +7878,12 @@
           "Library": {
             "crate_name": "signal_hook_registry",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7500,9 +7926,12 @@
           "Library": {
             "crate_name": "similar",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7542,18 +7971,24 @@
           "Library": {
             "crate_name": "slab",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7616,9 +8051,12 @@
           "Library": {
             "crate_name": "sluice",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7668,9 +8106,12 @@
           "Library": {
             "crate_name": "socket2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7727,9 +8168,12 @@
           "Library": {
             "crate_name": "spin",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7762,18 +8206,24 @@
           "Library": {
             "crate_name": "syn",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7849,9 +8299,12 @@
           "Library": {
             "crate_name": "tinyvec",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7903,9 +8356,12 @@
           "Library": {
             "crate_name": "tinyvec_macros",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -7940,18 +8396,24 @@
           "Library": {
             "crate_name": "tokio",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8248,9 +8710,12 @@
           "ProcMacro": {
             "crate_name": "tokio_macros",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8300,9 +8765,12 @@
           "Library": {
             "crate_name": "tokio_rustls",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8361,9 +8829,12 @@
           "Library": {
             "crate_name": "tokio_util",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8433,9 +8904,12 @@
           "Library": {
             "crate_name": "toml_datetime",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8469,9 +8943,12 @@
           "Library": {
             "crate_name": "toml_edit",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8528,9 +9005,12 @@
           "Library": {
             "crate_name": "tower_service",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8563,9 +9043,12 @@
           "Library": {
             "crate_name": "tracing",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8638,9 +9121,12 @@
           "ProcMacro": {
             "crate_name": "tracing_attributes",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8690,9 +9176,12 @@
           "Library": {
             "crate_name": "tracing_core",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8741,9 +9230,12 @@
           "Library": {
             "crate_name": "tracing_futures",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8797,9 +9289,12 @@
           "Library": {
             "crate_name": "try_lock",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8832,18 +9327,24 @@
           "Library": {
             "crate_name": "typenum",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_main",
             "crate_root": "build/main.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8891,9 +9392,12 @@
           "Library": {
             "crate_name": "unicode_bidi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8935,9 +9439,12 @@
           "Library": {
             "crate_name": "unicode_ident",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -8972,9 +9479,12 @@
           "Library": {
             "crate_name": "unicode_normalization",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9024,9 +9534,12 @@
           "Library": {
             "crate_name": "untrusted",
             "crate_root": "src/untrusted.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9059,9 +9572,12 @@
           "Library": {
             "crate_name": "url",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9118,18 +9634,24 @@
           "Library": {
             "crate_name": "value_bag",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9196,9 +9718,12 @@
           "Library": {
             "crate_name": "vcpkg",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9232,9 +9757,12 @@
           "Library": {
             "crate_name": "version_check",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9268,9 +9796,12 @@
           "Library": {
             "crate_name": "waker_fn",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9304,9 +9835,12 @@
           "Library": {
             "crate_name": "want",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9352,9 +9886,12 @@
           "Library": {
             "crate_name": "wasi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9395,18 +9932,24 @@
           "Library": {
             "crate_name": "wasm_bindgen",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9475,9 +10018,12 @@
           "Library": {
             "crate_name": "wasm_bindgen_backend",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9550,9 +10096,12 @@
           "Library": {
             "crate_name": "wasm_bindgen_futures",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9610,9 +10159,12 @@
           "ProcMacro": {
             "crate_name": "wasm_bindgen_macro",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9665,9 +10217,12 @@
           "Library": {
             "crate_name": "wasm_bindgen_macro_support",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9732,18 +10287,24 @@
           "Library": {
             "crate_name": "wasm_bindgen_shared",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9792,9 +10353,12 @@
           "Library": {
             "crate_name": "web_sys",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9865,9 +10429,12 @@
           "Library": {
             "crate_name": "webpki",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9918,9 +10485,12 @@
           "Library": {
             "crate_name": "webpki_roots",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -9962,18 +10532,24 @@
           "Library": {
             "crate_name": "wepoll_ffi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10038,18 +10614,24 @@
           "Library": {
             "crate_name": "winapi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10132,18 +10714,24 @@
           "Library": {
             "crate_name": "winapi_i686_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10191,18 +10779,24 @@
           "Library": {
             "crate_name": "winapi_x86_64_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10250,9 +10844,12 @@
           "Library": {
             "crate_name": "windows_sys",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10383,9 +10980,12 @@
           "Library": {
             "crate_name": "windows_sys",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10449,9 +11049,12 @@
           "Library": {
             "crate_name": "windows_targets",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10562,18 +11165,24 @@
           "Library": {
             "crate_name": "windows_aarch64_gnullvm",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10621,18 +11230,24 @@
           "Library": {
             "crate_name": "windows_aarch64_msvc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10680,18 +11295,24 @@
           "Library": {
             "crate_name": "windows_i686_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10739,18 +11360,24 @@
           "Library": {
             "crate_name": "windows_i686_msvc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10798,18 +11425,24 @@
           "Library": {
             "crate_name": "windows_x86_64_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10857,18 +11490,24 @@
           "Library": {
             "crate_name": "windows_x86_64_gnullvm",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10916,18 +11555,24 @@
           "Library": {
             "crate_name": "windows_x86_64_msvc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -10975,9 +11620,12 @@
           "Library": {
             "crate_name": "winnow",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -11018,18 +11666,24 @@
           "Library": {
             "crate_name": "winreg",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/no_cargo_manifests/.bazelrc
+++ b/examples/crate_universe/no_cargo_manifests/.bazelrc
@@ -17,6 +17,9 @@ build:strict --output_groups=+clippy_checks
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
 
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/crate_universe/no_cargo_manifests/cargo-bazel-lock.json
+++ b/examples/crate_universe/no_cargo_manifests/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d7ccf00532fa42b7cf54ed4c7fb6f6646db8b46fb65cdd008fbc3857ab0ad4f6",
+  "checksum": "cc41998fcd293f1342341b866946d99336cf5f4db6641ad7c44ea3305093dc99",
   "crates": {
     "async-trait 0.1.64": {
       "name": "async-trait",
@@ -16,18 +16,24 @@
           "ProcMacro": {
             "crate_name": "async_trait",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -87,9 +93,12 @@
           "Library": {
             "crate_name": "autocfg",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -123,9 +132,12 @@
           "Library": {
             "crate_name": "axum",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -267,9 +279,12 @@
           "Library": {
             "crate_name": "axum_core",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -336,9 +351,12 @@
           "Library": {
             "crate_name": "bitflags",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -378,9 +396,12 @@
           "Library": {
             "crate_name": "bytes",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -420,9 +441,12 @@
           "Library": {
             "crate_name": "cfg_if",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -451,9 +475,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -529,9 +556,12 @@
           "Library": {
             "crate_name": "fnv",
             "crate_root": "lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -572,9 +602,12 @@
           "Library": {
             "crate_name": "form_urlencoded",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -617,18 +650,24 @@
           "Library": {
             "crate_name": "futures_channel",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -688,18 +727,24 @@
           "Library": {
             "crate_name": "futures_core",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -755,9 +800,12 @@
           "Library": {
             "crate_name": "futures_sink",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -799,18 +847,24 @@
           "Library": {
             "crate_name": "futures_task",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -864,18 +918,24 @@
           "Library": {
             "crate_name": "futures_util",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -945,9 +1005,12 @@
           "Library": {
             "crate_name": "h2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1029,9 +1092,12 @@
           "Library": {
             "crate_name": "hashbrown",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1071,9 +1137,12 @@
           "Library": {
             "crate_name": "hermit_abi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1116,9 +1185,12 @@
           "Library": {
             "crate_name": "http",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1169,9 +1241,12 @@
           "Library": {
             "crate_name": "http_body",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1221,9 +1296,12 @@
           "Library": {
             "crate_name": "http_range_header",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1256,18 +1334,24 @@
           "Library": {
             "crate_name": "httparse",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1322,9 +1406,12 @@
           "Library": {
             "crate_name": "httpdate",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1358,9 +1445,12 @@
           "Library": {
             "crate_name": "hyper",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1478,18 +1568,24 @@
           "Library": {
             "crate_name": "indexmap",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1556,9 +1652,12 @@
           "Library": {
             "crate_name": "itoa",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1592,9 +1691,12 @@
           "Library": {
             "crate_name": "lazy_static",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1628,18 +1730,24 @@
           "Library": {
             "crate_name": "libc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1694,18 +1802,24 @@
           "Library": {
             "crate_name": "lock_api",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1766,18 +1880,24 @@
           "Library": {
             "crate_name": "log",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1835,9 +1955,12 @@
           "Library": {
             "crate_name": "matchit",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1876,18 +1999,24 @@
           "Library": {
             "crate_name": "memchr",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1942,9 +2071,12 @@
           "Library": {
             "crate_name": "mime",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1978,9 +2110,12 @@
           "Library": {
             "crate_name": "mio",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2054,9 +2189,12 @@
           "Library": {
             "crate_name": "nu_ansi_term",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2105,9 +2243,12 @@
           "Library": {
             "crate_name": "num_cpus",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2158,9 +2299,12 @@
           "Library": {
             "crate_name": "once_cell",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2203,9 +2347,12 @@
           "Library": {
             "crate_name": "overload",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2238,9 +2385,12 @@
           "Library": {
             "crate_name": "parking_lot",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2293,18 +2443,24 @@
           "Library": {
             "crate_name": "parking_lot_core",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2379,9 +2535,12 @@
           "Library": {
             "crate_name": "percent_encoding",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2422,9 +2581,12 @@
           "Library": {
             "crate_name": "pin_project",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2467,9 +2629,12 @@
           "ProcMacro": {
             "crate_name": "pin_project_internal",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2520,9 +2685,12 @@
           "Library": {
             "crate_name": "pin_project_lite",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2556,9 +2724,12 @@
           "Library": {
             "crate_name": "pin_utils",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2592,18 +2763,24 @@
           "Library": {
             "crate_name": "proc_macro2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2662,18 +2839,24 @@
           "Library": {
             "crate_name": "quote",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2732,9 +2915,12 @@
           "Library": {
             "crate_name": "syscall",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2776,9 +2962,12 @@
           "Library": {
             "crate_name": "ryu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2812,9 +3001,12 @@
           "Library": {
             "crate_name": "scopeguard",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2848,18 +3040,24 @@
           "Library": {
             "crate_name": "serde",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2914,18 +3112,24 @@
           "Library": {
             "crate_name": "serde_json",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2993,9 +3197,12 @@
           "Library": {
             "crate_name": "serde_urlencoded",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3050,9 +3257,12 @@
           "Library": {
             "crate_name": "sharded_slab",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3094,9 +3304,12 @@
           "Library": {
             "crate_name": "signal_hook_registry",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3139,18 +3352,24 @@
           "Library": {
             "crate_name": "slab",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3213,9 +3432,12 @@
           "Library": {
             "crate_name": "smallvec",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3249,9 +3471,12 @@
           "Library": {
             "crate_name": "socket2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3308,18 +3533,24 @@
           "Library": {
             "crate_name": "syn",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3395,9 +3626,12 @@
           "Library": {
             "crate_name": "sync_wrapper",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3430,9 +3664,12 @@
           "Library": {
             "crate_name": "thread_local",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3479,18 +3716,24 @@
           "Library": {
             "crate_name": "tokio",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3645,9 +3888,12 @@
           "ProcMacro": {
             "crate_name": "tokio_macros",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3697,9 +3943,12 @@
           "Library": {
             "crate_name": "tokio_util",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3769,9 +4018,12 @@
           "Library": {
             "crate_name": "tower",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3863,9 +4115,12 @@
           "Library": {
             "crate_name": "tower_http",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3962,9 +4217,12 @@
           "Library": {
             "crate_name": "tower_layer",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -3997,9 +4255,12 @@
           "Library": {
             "crate_name": "tower_service",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4032,9 +4293,12 @@
           "Library": {
             "crate_name": "tracing",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4107,9 +4371,12 @@
           "ProcMacro": {
             "crate_name": "tracing_attributes",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4159,9 +4426,12 @@
           "Library": {
             "crate_name": "tracing_core",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4218,9 +4488,12 @@
           "Library": {
             "crate_name": "tracing_log",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4277,9 +4550,12 @@
           "Library": {
             "crate_name": "tracing_subscriber",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4357,9 +4633,12 @@
           "Library": {
             "crate_name": "try_lock",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4392,9 +4671,12 @@
           "Library": {
             "crate_name": "unicode_ident",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4429,18 +4711,24 @@
           "Library": {
             "crate_name": "valuable",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4487,9 +4775,12 @@
           "Library": {
             "crate_name": "want",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4535,9 +4826,12 @@
           "Library": {
             "crate_name": "wasi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4578,18 +4872,24 @@
           "Library": {
             "crate_name": "winapi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4662,18 +4962,24 @@
           "Library": {
             "crate_name": "winapi_i686_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4721,18 +5027,24 @@
           "Library": {
             "crate_name": "winapi_x86_64_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4780,9 +5092,12 @@
           "Library": {
             "crate_name": "windows_sys",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4848,9 +5163,12 @@
           "Library": {
             "crate_name": "windows_targets",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -4961,18 +5279,24 @@
           "Library": {
             "crate_name": "windows_aarch64_gnullvm",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5020,18 +5344,24 @@
           "Library": {
             "crate_name": "windows_aarch64_msvc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5079,18 +5409,24 @@
           "Library": {
             "crate_name": "windows_i686_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5138,18 +5474,24 @@
           "Library": {
             "crate_name": "windows_i686_msvc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5197,18 +5539,24 @@
           "Library": {
             "crate_name": "windows_x86_64_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5256,18 +5604,24 @@
           "Library": {
             "crate_name": "windows_x86_64_gnullvm",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -5315,18 +5669,24 @@
           "Library": {
             "crate_name": "windows_x86_64_msvc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/using_cxx/cargo-bazel-lock.json
+++ b/examples/crate_universe/using_cxx/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "16b73512b2012096a5fc15ca40bac421afb40ff2272eaa8ee135df0d8e391091",
+  "checksum": "f17fc799775800c4a232c296398b58013d3d9b87605fcd8fee480528b6f8c34e",
   "crates": {
     "cc 1.0.82": {
       "name": "cc",
@@ -16,9 +16,12 @@
           "Library": {
             "crate_name": "cc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -63,9 +66,12 @@
           "Library": {
             "crate_name": "cxx",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -135,9 +141,12 @@
           "Library": {
             "crate_name": "cxxbridge_flags",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -177,9 +186,12 @@
           "ProcMacro": {
             "crate_name": "cxxbridge_macro",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -225,9 +237,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -267,18 +282,24 @@
           "Library": {
             "crate_name": "libc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -333,18 +354,24 @@
           "Library": {
             "crate_name": "link_cplusplus",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -408,18 +435,24 @@
           "Library": {
             "crate_name": "proc_macro2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -478,9 +511,12 @@
           "Library": {
             "crate_name": "quote",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -530,9 +566,12 @@
           "Library": {
             "crate_name": "syn",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -596,9 +635,12 @@
           "Library": {
             "crate_name": "unicode_ident",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.Bazel.lock
+++ b/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a50ecb2e2e8a87dc49c15b40a67b71f2d1492f54112634c8a23abe2f8968b815",
+  "checksum": "3d3e005e08dd2662d2957883c2776ddc1f334e05a643d302e0fd0325f0427514",
   "crates": {
     "anstyle 1.0.1": {
       "name": "anstyle",
@@ -16,9 +16,12 @@
           "Library": {
             "crate_name": "anstyle",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -59,9 +62,12 @@
           "Library": {
             "crate_name": "clap",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -114,9 +120,12 @@
           "Library": {
             "crate_name": "clap_builder",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -177,9 +186,12 @@
           "Library": {
             "crate_name": "clap_lex",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -213,9 +225,12 @@
           "Library": {
             "crate_name": "codespan_reporting",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -307,18 +322,24 @@
           "Library": {
             "crate_name": "proc_macro2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -376,9 +397,12 @@
           "Library": {
             "crate_name": "quote",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -421,9 +445,12 @@
           "Library": {
             "crate_name": "strsim",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -456,9 +483,12 @@
           "Library": {
             "crate_name": "syn",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -519,9 +549,12 @@
           "Library": {
             "crate_name": "termcolor",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -566,9 +599,12 @@
           "Library": {
             "crate_name": "unicode_ident",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -603,9 +639,12 @@
           "Library": {
             "crate_name": "unicode_width",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -645,18 +684,24 @@
           "Library": {
             "crate_name": "winapi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -732,18 +777,24 @@
           "Library": {
             "crate_name": "winapi_i686_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -791,9 +842,12 @@
           "Library": {
             "crate_name": "winapi_util",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -838,18 +892,24 @@
           "Library": {
             "crate_name": "winapi_x86_64_pc_windows_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         },
         {
           "BuildScript": {
             "crate_name": "build_script_build",
             "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/crate_universe_unnamed/.bazelrc
+++ b/examples/crate_universe_unnamed/.bazelrc
@@ -18,6 +18,9 @@ build:clippy --output_groups=+clippy_checks
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
 
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob
+
 # This import should always be last to allow users to override
 # settings for local development.
 try-import %workspace%/user.bazelrc

--- a/examples/ios/.bazelrc
+++ b/examples/ios/.bazelrc
@@ -11,3 +11,6 @@ build --host_crosstool_top=@local_config_apple_cc//:toolchain
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/examples/ios_build/.bazelrc
+++ b/examples/ios_build/.bazelrc
@@ -11,3 +11,6 @@ build --host_crosstool_top=@local_config_apple_cc//:toolchain
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/examples/nix_cross_compiling/.bazelrc
+++ b/examples/nix_cross_compiling/.bazelrc
@@ -4,6 +4,9 @@ build --incompatible_strict_action_env
 build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build --incompatible_enable_cc_toolchain_resolution=true
 
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob
+
 # Require Platform Transitions
 ## This works by setting the targte platform to an invalid platform
 ## and each `x_binary()` and `x_library()` rule unfortunately needs

--- a/examples/nix_cross_compiling/bazel/cargo/cargo-bazel-lock.json
+++ b/examples/nix_cross_compiling/bazel/cargo/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "232eaaaebe387cb9c7eecc05fe0689b879ad773c50d1265d8303f0aae3e07b33",
+  "checksum": "4814dfd4d96d8f66b1a02d7917c17fd93e85b6544f33e09f516d7efab7c9ebb5",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -16,9 +16,12 @@
           "Library": {
             "crate_name": "addr2line",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -61,9 +64,12 @@
           "Library": {
             "crate_name": "adler",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -98,9 +104,12 @@
           "Library": {
             "crate_name": "anyhow",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -141,9 +150,12 @@
           "Library": {
             "crate_name": "autocfg",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -177,9 +189,12 @@
           "Library": {
             "crate_name": "backtrace",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -245,9 +260,12 @@
           "Library": {
             "crate_name": "bitflags",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -281,9 +299,12 @@
           "Library": {
             "crate_name": "bytes",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -323,9 +344,12 @@
           "Library": {
             "crate_name": "cc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -370,9 +394,12 @@
           "Library": {
             "crate_name": "cfg_if",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -401,9 +428,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -447,9 +477,12 @@
           "Library": {
             "crate_name": "gimli",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -483,9 +516,12 @@
           "Library": {
             "crate_name": "hermit_abi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -519,9 +555,12 @@
           "Library": {
             "crate_name": "libc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -585,9 +624,12 @@
           "Library": {
             "crate_name": "lock_api",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -637,9 +679,12 @@
           "Library": {
             "crate_name": "memchr",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -673,9 +718,12 @@
           "Library": {
             "crate_name": "miniz_oxide",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -719,9 +767,12 @@
           "Library": {
             "crate_name": "mio",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -789,9 +840,12 @@
           "Library": {
             "crate_name": "num_cpus",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -842,9 +896,12 @@
           "Library": {
             "crate_name": "object",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -887,9 +944,12 @@
           "Library": {
             "crate_name": "parking_lot",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -942,9 +1002,12 @@
           "Library": {
             "crate_name": "parking_lot_core",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1010,9 +1073,12 @@
           "Library": {
             "crate_name": "pin_project_lite",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1046,9 +1112,12 @@
           "Library": {
             "crate_name": "proc_macro2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1107,9 +1176,12 @@
           "Library": {
             "crate_name": "quote",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1159,9 +1231,12 @@
           "Library": {
             "crate_name": "syscall",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1203,9 +1278,12 @@
           "Library": {
             "crate_name": "rustc_demangle",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1239,9 +1317,12 @@
           "Library": {
             "crate_name": "scopeguard",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1275,9 +1356,12 @@
           "Library": {
             "crate_name": "signal_hook_registry",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1320,9 +1404,12 @@
           "Library": {
             "crate_name": "smallvec",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1356,9 +1443,12 @@
           "Library": {
             "crate_name": "socket2",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1415,9 +1505,12 @@
           "Library": {
             "crate_name": "syn",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1485,9 +1578,12 @@
           "Library": {
             "crate_name": "tokio",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1613,9 +1709,12 @@
           "ProcMacro": {
             "crate_name": "tokio_macros",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1665,9 +1764,12 @@
           "Library": {
             "crate_name": "unicode_ident",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1702,9 +1804,12 @@
           "Library": {
             "crate_name": "wasi",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1745,9 +1850,12 @@
           "Library": {
             "crate_name": "windows_sys",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1810,9 +1918,12 @@
           "Library": {
             "crate_name": "windows_targets",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1893,9 +2004,12 @@
           "Library": {
             "crate_name": "windows_aarch64_gnullvm",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1929,9 +2043,12 @@
           "Library": {
             "crate_name": "windows_aarch64_msvc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -1965,9 +2082,12 @@
           "Library": {
             "crate_name": "windows_i686_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2001,9 +2121,12 @@
           "Library": {
             "crate_name": "windows_i686_msvc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2037,9 +2160,12 @@
           "Library": {
             "crate_name": "windows_x86_64_gnu",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2073,9 +2199,12 @@
           "Library": {
             "crate_name": "windows_x86_64_gnullvm",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -2109,9 +2238,12 @@
           "Library": {
             "crate_name": "windows_x86_64_msvc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],

--- a/examples/zig_cross_compiling/.bazelrc
+++ b/examples/zig_cross_compiling/.bazelrc
@@ -8,3 +8,6 @@ build --incompatible_enable_cc_toolchain_resolution
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/bazelbuild/rules_rust/issues/2181
 common --noenable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/test/cc_common_link/.bazelrc
+++ b/test/cc_common_link/.bazelrc
@@ -1,1 +1,4 @@
 common --noenable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/test/cc_common_link/with_global_alloc/.bazelrc
+++ b/test/cc_common_link/with_global_alloc/.bazelrc
@@ -1,1 +1,4 @@
 common --noenable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/test/no_std/.bazelrc
+++ b/test/no_std/.bazelrc
@@ -1,1 +1,4 @@
 common --noenable_bzlmod
+
+# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+build --incompatible_disallow_empty_glob

--- a/test/no_std/cargo-bazel-lock.json
+++ b/test/no_std/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "67617e96b8c4e3ba62674c91eb4c9d76c00078db37183254b16b56370828a5d9",
+  "checksum": "ba25958007103d1dab35908ed528d064bc4250c7048484837f543d4c8bcacc61",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -11,9 +11,12 @@
           "Library": {
             "crate_name": "direct_cargo_bazel_deps",
             "crate_root": ".direct_cargo_bazel_deps.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],
@@ -53,9 +56,12 @@
           "Library": {
             "crate_name": "libc_alloc",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
+            "srcs": {
+              "allow_empty": false,
+              "include": [
+                "**/*.rs"
+              ]
+            }
           }
         }
       ],


### PR DESCRIPTION
This means that if people build with
`--incompatible_disallow_empty_glob` things will still work.