### PR TITLE
Introduce rules_rust_unsupported_feature

### DIFF
--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -24,6 +24,10 @@ UNSUPPORTED_FEATURES = [
     "use_header_modules",
     "fdo_instrument",
     "fdo_optimize",
+    # This feature is unsupported by definition. The authors of C++ toolchain
+    # configuration can place any linker flags that should not be applied when
+    # linking Rust targets in a feature with this name.
+    "rules_rust_unsupported_feature",
 ]
 
 def find_toolchain(ctx):


### PR DESCRIPTION
Add a special sentinel feature name to the UNSUPPORTED_FEATURES list. This feature name can be used by authors of C++ toolchain configurations to house any configuration fragments (e.g., linker flags) that should NOT be applied when linking Rust targets.

The specific motivation for this is that I'm working on a project that includes `-fsanitize=address` in its clang configuration. This needs to be disabled when linking Rust.

I tried the more straightforward approach of adding the `features` attribute to `rust_binary` targets in my repo, but this is not sufficient: a `rust_binary` has implicit deps on targets like @rules_rust//util/process_wrapper:bootstrap_process_wrapper.