### PR TITLE
feat: Strip debug info from opt builds

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -958,6 +958,7 @@ def construct_arguments(
     compilation_mode = get_compilation_mode_opts(ctx, toolchain)
     rustc_flags.add(compilation_mode.opt_level, format = "--codegen=opt-level=%s")
     rustc_flags.add(compilation_mode.debug_info, format = "--codegen=debuginfo=%s")
+    rustc_flags.add(compilation_mode.strip_level, format = "--codegen=strip=%s")
 
     # For determinism to help with build distribution and such
     if remap_path_prefix != None:

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -464,10 +464,12 @@ def _rust_toolchain_impl(ctx):
         list: A list containing the target's toolchain Provider info
     """
     compilation_mode_opts = {}
-    for k, v in ctx.attr.opt_level.items():
+    for k, opt_level in ctx.attr.opt_level.items():
         if not k in ctx.attr.debug_info:
             fail("Compilation mode {} is not defined in debug_info but is defined opt_level".format(k))
-        compilation_mode_opts[k] = struct(debug_info = ctx.attr.debug_info[k], opt_level = v)
+        if not k in ctx.attr.strip_level:
+            fail("Compilation mode {} is not defined in strip_level but is defined opt_level".format(k))
+        compilation_mode_opts[k] = struct(debug_info = ctx.attr.debug_info[k], opt_level = opt_level, strip_level = ctx.attr.strip_level[k])
     for k, v in ctx.attr.debug_info.items():
         if not k in ctx.attr.opt_level:
             fail("Compilation mode {} is not defined in opt_level but is defined debug_info".format(k))
@@ -736,6 +738,14 @@ rust_toolchain = rule(
                 "dbg": "0",
                 "fastbuild": "0",
                 "opt": "3",
+            },
+        ),
+        "strip_level": attr.string_dict(
+            doc = "Rustc strip levels.",
+            default = {
+                "dbg": "none",
+                "fastbuild": "none",
+                "opt": "debuginfo",
             },
         ),
         "per_crate_rustc_flags": attr.string_list(


### PR DESCRIPTION
Attempts to follow the cargo proposal linked below to remove debug info for release builds. Furthermore this should uphold the expected behavior of bazel for cc builds which automatically strips debug symbols for optimized builds.

https://github.com/rust-lang/cargo/issues/4122#issuecomment-1868318860