### PR TITLE
Fix for bindgen use in rust_shared_library

### DIFF
--- a/bindgen/private/bindgen.bzl
+++ b/bindgen/private/bindgen.bzl
@@ -94,7 +94,7 @@ def rust_bindgen_library(
     rust_library(
         name = name,
         srcs = [name + "__bindgen.rs"],
-        deps = deps + [name + "__bindgen"],
+        deps = deps + [cc_lib],
         tags = tags,
         **kwargs
     )


### PR DESCRIPTION
When linking a rust_shared_library that depends on a bindgen_rust_library, I get errors such as:

```
          /usr/bin/ld.gold: error: /some_rust_binding.rlib(some_c_lib.o): requires dynamic R_X86_64_PC32 reloc against '_ZNSs4_Rep20_S_empty_rep_storageE' which may overflow at runtime; recompile with -fPIC
```

It looks to me like the rust_library target is including the cc_lib in its rlib output.  This PR changes it to depend on the cc_library target instead, where the cc toolchain will provide both PIC and non-PIC objects to select as appropriate at link time.