### PR TITLE
rustc_compile_action: fix output_hash in filename

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1268,7 +1268,10 @@ def rustc_compile_action(
     output_o = None
     if experimental_use_cc_common_link:
         obj_ext = ".o"
-        output_o = ctx.actions.declare_file(crate_info.name + obj_ext, sibling = crate_info.output)
+        if output_hash != None:
+            output_o = ctx.actions.declare_file(crate_info.name + "-" + output_hash + obj_ext, sibling = crate_info.output)
+        else:
+            output_o = ctx.actions.declare_file(crate_info.name + obj_ext, sibling = crate_info.output)
         outputs = [output_o]
 
     # For a cdylib that might be added as a dependency to a cc_* target on Windows, it is important to include the


### PR DESCRIPTION
I'm experimenting with `experimental_use_cc_common_link` and found this to be wrong under certain circumstances (I suspect that this codepath could never be taken, since currently only rust_binary seems to support `experimental_use_cc_common_link`.

When I try to enable `experimental_use_cc_common_link` for `rust_library` and companions (https://github.com/adrianimboden/rules_rust/commit/08cb6907324de128fa1a62248e699a415dc2993c), the o file gets generated with the hash file in it, generating this error:
```
$ bazel build @rrra__unicode-ident-1.0.10//:unicode_ident --@rules_rust//rust/settings:experimental_use_cc_common_link
--- snip ---
WARNING: Remote Cache: Expected output external/rrra__unicode-ident-1.0.10/unicode_ident.o was not created locally.
ERROR: /home/thingdust/.cache/bazel/_bazel_thingdust/690491f57e04da302046e3d5841bd6e3/external/rrra__unicode-ident-1.0.10/BUILD.bazel:13:13: output 'external/rrra__unicode-ident-1.0.10/unicode_ident.o' was not created
ERROR: /home/thingdust/.cache/bazel/_bazel_thingdust/690491f57e04da302046e3d5841bd6e3/external/rrra__unicode-ident-1.0.10/BUILD.bazel:13:13: Compiling Rust rlib unicode_ident v1.0.10 (11 files) failed: not all outputs were created or valid
--- snip ---
```

when we look inside the sandbox:
```
$ find -name *.o
./bazel-out/k8-fastbuild/bin/external/rrra__unicode-ident-1.0.10/unicode_ident-1105039059.o
```

this MR fixes that