### PR TITLE
Use pub(crate) rather than pub

### DIFF
--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -25,7 +25,7 @@ use crate::utils::target_triple::TargetTriple;
 /// Representations of different kinds of crate vendoring into workspaces.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
-pub enum VendorMode {
+pub(crate) enum VendorMode {
     /// Crates having full source being vendored into a workspace
     Local,
 
@@ -47,58 +47,58 @@ impl std::fmt::Display for VendorMode {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct RenderConfig {
+pub(crate) struct RenderConfig {
     /// The name of the repository being rendered
-    pub repository_name: String,
+    pub(crate) repository_name: String,
 
     /// The pattern to use for BUILD file names.
     /// Eg. `//:BUILD.{name}-{version}.bazel`
     #[serde(default = "default_build_file_template")]
-    pub build_file_template: String,
+    pub(crate) build_file_template: String,
 
     /// The pattern to use for a crate target.
     /// Eg. `@{repository}__{name}-{version}//:{target}`
     #[serde(default = "default_crate_label_template")]
-    pub crate_label_template: String,
+    pub(crate) crate_label_template: String,
 
     /// The pattern to use for the `defs.bzl` and `BUILD.bazel`
     /// file names used for the crates module.
     /// Eg. `//:{file}`
     #[serde(default = "default_crates_module_template")]
-    pub crates_module_template: String,
+    pub(crate) crates_module_template: String,
 
     /// The pattern used for a crate's repository name.
     /// Eg. `{repository}__{name}-{version}`
     #[serde(default = "default_crate_repository_template")]
-    pub crate_repository_template: String,
+    pub(crate) crate_repository_template: String,
 
     /// Default alias rule to use for packages.  Can be overridden by annotations.
     #[serde(default)]
-    pub default_alias_rule: AliasRule,
+    pub(crate) default_alias_rule: AliasRule,
 
     /// The default of the `package_name` parameter to use for the module macros like `all_crate_deps`.
     /// In general, this should be be unset to allow the macros to do auto-detection in the analysis phase.
-    pub default_package_name: Option<String>,
+    pub(crate) default_package_name: Option<String>,
 
     /// Whether to generate `target_compatible_with` annotations on the generated BUILD files.  This
     /// catches a `target_triple`being targeted that isn't declared in `supported_platform_triples`.
     #[serde(default = "default_generate_target_compatible_with")]
-    pub generate_target_compatible_with: bool,
+    pub(crate) generate_target_compatible_with: bool,
 
     /// The pattern to use for platform constraints.
     /// Eg. `@rules_rust//rust/platform:{triple}`.
     #[serde(default = "default_platforms_template")]
-    pub platforms_template: String,
+    pub(crate) platforms_template: String,
 
     /// The command to use for regenerating generated files.
-    pub regen_command: String,
+    pub(crate) regen_command: String,
 
     /// An optional configuration for rendering content to be rendered into repositories.
-    pub vendor_mode: Option<VendorMode>,
+    pub(crate) vendor_mode: Option<VendorMode>,
 
     /// Whether to generate package metadata
     #[serde(default = "default_generate_rules_license_metadata")]
-    pub generate_rules_license_metadata: bool,
+    pub(crate) generate_rules_license_metadata: bool,
 }
 
 // Default is manually implemented so that the default values match the default
@@ -153,7 +153,7 @@ fn default_generate_rules_license_metadata() -> bool {
 
 /// A representation of some Git identifier used to represent the "revision" or "pin" of a checkout.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Commitish {
+pub(crate) enum Commitish {
     /// From a tag.
     Tag(String),
 
@@ -176,7 +176,7 @@ impl From<GitReference> for Commitish {
 
 /// Information representing deterministic identifiers for some remote asset.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum Checksumish {
+pub(crate) enum Checksumish {
     Http {
         /// The sha256 digest of an http archive
         sha256: Option<String>,
@@ -193,7 +193,7 @@ pub enum Checksumish {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Clone)]
-pub enum AliasRule {
+pub(crate) enum AliasRule {
     #[default]
     #[serde(rename = "alias")]
     Alias,
@@ -208,7 +208,7 @@ pub enum AliasRule {
 }
 
 impl AliasRule {
-    pub fn bzl(&self) -> Option<String> {
+    pub(crate) fn bzl(&self) -> Option<String> {
         match self {
             AliasRule::Alias => None,
             AliasRule::Dbg | AliasRule::Fastbuild | AliasRule::Opt => {
@@ -218,7 +218,7 @@ impl AliasRule {
         }
     }
 
-    pub fn rule(&self) -> String {
+    pub(crate) fn rule(&self) -> String {
         match self {
             AliasRule::Alias => "alias".to_owned(),
             AliasRule::Dbg => "transition_alias_dbg".to_owned(),
@@ -230,115 +230,115 @@ impl AliasRule {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CrateAnnotations {
+pub(crate) struct CrateAnnotations {
     /// Which subset of the crate's bins should get produced as `rust_binary` targets.
-    pub gen_binaries: Option<GenBinaries>,
+    pub(crate) gen_binaries: Option<GenBinaries>,
 
     /// Determins whether or not Cargo build scripts should be generated for the current package
-    pub gen_build_script: Option<bool>,
+    pub(crate) gen_build_script: Option<bool>,
 
     /// Additional data to pass to
     /// [deps](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-deps) attribute.
-    pub deps: Option<Select<BTreeSet<Label>>>,
+    pub(crate) deps: Option<Select<BTreeSet<Label>>>,
 
     /// Additional data to pass to
     /// [proc_macro_deps](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-proc_macro_deps) attribute.
-    pub proc_macro_deps: Option<Select<BTreeSet<Label>>>,
+    pub(crate) proc_macro_deps: Option<Select<BTreeSet<Label>>>,
 
     /// Additional data to pass to  the target's
     /// [crate_features](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-crate_features) attribute.
-    pub crate_features: Option<Select<BTreeSet<String>>>,
+    pub(crate) crate_features: Option<Select<BTreeSet<String>>>,
 
     /// Additional data to pass to  the target's
     /// [data](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-data) attribute.
-    pub data: Option<Select<BTreeSet<Label>>>,
+    pub(crate) data: Option<Select<BTreeSet<Label>>>,
 
     /// An optional glob pattern to set on the
     /// [data](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-data) attribute.
-    pub data_glob: Option<BTreeSet<String>>,
+    pub(crate) data_glob: Option<BTreeSet<String>>,
 
     /// Additional data to pass to
     /// [compile_data](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-compile_data) attribute.
-    pub compile_data: Option<Select<BTreeSet<Label>>>,
+    pub(crate) compile_data: Option<Select<BTreeSet<Label>>>,
 
     /// An optional glob pattern to set on the
     /// [compile_data](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-compile_data) attribute.
-    pub compile_data_glob: Option<BTreeSet<String>>,
+    pub(crate) compile_data_glob: Option<BTreeSet<String>>,
 
     /// If true, disables pipelining for library targets generated for this crate.
-    pub disable_pipelining: bool,
+    pub(crate) disable_pipelining: bool,
 
     /// Additional data to pass to  the target's
     /// [rustc_env](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-rustc_env) attribute.
-    pub rustc_env: Option<Select<BTreeMap<String, String>>>,
+    pub(crate) rustc_env: Option<Select<BTreeMap<String, String>>>,
 
     /// Additional data to pass to  the target's
     /// [rustc_env_files](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-rustc_env_files) attribute.
-    pub rustc_env_files: Option<Select<BTreeSet<String>>>,
+    pub(crate) rustc_env_files: Option<Select<BTreeSet<String>>>,
 
     /// Additional data to pass to the target's
     /// [rustc_flags](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-rustc_flags) attribute.
-    pub rustc_flags: Option<Select<Vec<String>>>,
+    pub(crate) rustc_flags: Option<Select<Vec<String>>>,
 
     /// Additional dependencies to pass to a build script's
     /// [deps](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-deps) attribute.
-    pub build_script_deps: Option<Select<BTreeSet<Label>>>,
+    pub(crate) build_script_deps: Option<Select<BTreeSet<Label>>>,
 
     /// Additional data to pass to a build script's
     /// [proc_macro_deps](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-proc_macro_deps) attribute.
-    pub build_script_proc_macro_deps: Option<Select<BTreeSet<Label>>>,
+    pub(crate) build_script_proc_macro_deps: Option<Select<BTreeSet<Label>>>,
 
     /// Additional data to pass to a build script's
     /// [build_script_data](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-data) attribute.
-    pub build_script_data: Option<Select<BTreeSet<Label>>>,
+    pub(crate) build_script_data: Option<Select<BTreeSet<Label>>>,
 
     /// Additional data to pass to a build script's
     /// [tools](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-tools) attribute.
-    pub build_script_tools: Option<Select<BTreeSet<Label>>>,
+    pub(crate) build_script_tools: Option<Select<BTreeSet<Label>>>,
 
     /// An optional glob pattern to set on the
     /// [build_script_data](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-build_script_env) attribute.
-    pub build_script_data_glob: Option<BTreeSet<String>>,
+    pub(crate) build_script_data_glob: Option<BTreeSet<String>>,
 
     /// Additional environment variables to pass to a build script's
     /// [build_script_env](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-rustc_env) attribute.
-    pub build_script_env: Option<Select<BTreeMap<String, String>>>,
+    pub(crate) build_script_env: Option<Select<BTreeMap<String, String>>>,
 
     /// Additional rustc_env flags to pass to a build script's
     /// [rustc_env](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-rustc_env) attribute.
-    pub build_script_rustc_env: Option<Select<BTreeMap<String, String>>>,
+    pub(crate) build_script_rustc_env: Option<Select<BTreeMap<String, String>>>,
 
     /// Additional labels to pass to a build script's
     /// [toolchains](https://bazel.build/reference/be/common-definitions#common-attributes) attribute.
-    pub build_script_toolchains: Option<BTreeSet<Label>>,
+    pub(crate) build_script_toolchains: Option<BTreeSet<Label>>,
 
     /// Directory to run the crate's build script in. If not set, will run in the manifest directory, otherwise a directory relative to the exec root.
-    pub build_script_rundir: Option<Select<String>>,
+    pub(crate) build_script_rundir: Option<Select<String>>,
 
     /// A scratch pad used to write arbitrary text to target BUILD files.
-    pub additive_build_file_content: Option<String>,
+    pub(crate) additive_build_file_content: Option<String>,
 
     /// For git sourced crates, this is a the
     /// [git_repository::shallow_since](https://docs.bazel.build/versions/main/repo/git.html#new_git_repository-shallow_since) attribute.
-    pub shallow_since: Option<String>,
+    pub(crate) shallow_since: Option<String>,
 
     /// The `patch_args` attribute of a Bazel repository rule. See
     /// [http_archive.patch_args](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_args)
-    pub patch_args: Option<Vec<String>>,
+    pub(crate) patch_args: Option<Vec<String>>,
 
     /// The `patch_tool` attribute of a Bazel repository rule. See
     /// [http_archive.patch_tool](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_tool)
-    pub patch_tool: Option<String>,
+    pub(crate) patch_tool: Option<String>,
 
     /// The `patches` attribute of a Bazel repository rule. See
     /// [http_archive.patches](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patches)
-    pub patches: Option<BTreeSet<String>>,
+    pub(crate) patches: Option<BTreeSet<String>>,
 
     /// Extra targets the should be aliased during rendering.
-    pub extra_aliased_targets: Option<BTreeMap<String, String>>,
+    pub(crate) extra_aliased_targets: Option<BTreeMap<String, String>>,
 
     /// Transition rule to use instead of `native.alias()`.
-    pub alias_rule: Option<AliasRule>,
+    pub(crate) alias_rule: Option<AliasRule>,
 }
 
 macro_rules! joined_extra_member {
@@ -440,25 +440,28 @@ impl Sum for CrateAnnotations {
 /// not specify a different value for the same annotation in their
 /// crates_repository attributes.
 #[derive(Debug, Deserialize)]
-pub struct AnnotationsProvidedByPackage {
-    pub gen_build_script: Option<bool>,
-    pub data: Option<Select<BTreeSet<Label>>>,
-    pub data_glob: Option<BTreeSet<String>>,
-    pub deps: Option<Select<BTreeSet<Label>>>,
-    pub compile_data: Option<Select<BTreeSet<Label>>>,
-    pub compile_data_glob: Option<BTreeSet<String>>,
-    pub rustc_env: Option<Select<BTreeMap<String, String>>>,
-    pub rustc_env_files: Option<Select<BTreeSet<String>>>,
-    pub rustc_flags: Option<Select<Vec<String>>>,
-    pub build_script_env: Option<Select<BTreeMap<String, String>>>,
-    pub build_script_rustc_env: Option<Select<BTreeMap<String, String>>>,
-    pub build_script_rundir: Option<Select<String>>,
-    pub additive_build_file_content: Option<String>,
-    pub extra_aliased_targets: Option<BTreeMap<String, String>>,
+pub(crate) struct AnnotationsProvidedByPackage {
+    pub(crate) gen_build_script: Option<bool>,
+    pub(crate) data: Option<Select<BTreeSet<Label>>>,
+    pub(crate) data_glob: Option<BTreeSet<String>>,
+    pub(crate) deps: Option<Select<BTreeSet<Label>>>,
+    pub(crate) compile_data: Option<Select<BTreeSet<Label>>>,
+    pub(crate) compile_data_glob: Option<BTreeSet<String>>,
+    pub(crate) rustc_env: Option<Select<BTreeMap<String, String>>>,
+    pub(crate) rustc_env_files: Option<Select<BTreeSet<String>>>,
+    pub(crate) rustc_flags: Option<Select<Vec<String>>>,
+    pub(crate) build_script_env: Option<Select<BTreeMap<String, String>>>,
+    pub(crate) build_script_rustc_env: Option<Select<BTreeMap<String, String>>>,
+    pub(crate) build_script_rundir: Option<Select<String>>,
+    pub(crate) additive_build_file_content: Option<String>,
+    pub(crate) extra_aliased_targets: Option<BTreeMap<String, String>>,
 }
 
 impl CrateAnnotations {
-    pub fn apply_defaults_from_package_metadata(&mut self, pkg_metadata: &serde_json::Value) {
+    pub(crate) fn apply_defaults_from_package_metadata(
+        &mut self,
+        pkg_metadata: &serde_json::Value,
+    ) {
         #[deny(unused_variables)]
         let AnnotationsProvidedByPackage {
             gen_build_script,
@@ -524,7 +527,7 @@ pub struct CrateId {
 
 impl CrateId {
     /// Construct a new [CrateId]
-    pub fn new(name: String, version: semver::Version) -> Self {
+    pub(crate) fn new(name: String, version: semver::Version) -> Self {
         Self { name, version }
     }
 }
@@ -592,7 +595,7 @@ impl std::fmt::Display for CrateId {
 }
 
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
-pub enum GenBinaries {
+pub(crate) enum GenBinaries {
     All,
     Some(BTreeSet<String>),
 }
@@ -652,30 +655,30 @@ impl<'de> Visitor<'de> for GenBinariesVisitor {
 /// Workspace specific settings to control how targets are generated
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct Config {
+pub(crate) struct Config {
     /// Whether to generate `rust_binary` targets for all bins by default
-    pub generate_binaries: bool,
+    pub(crate) generate_binaries: bool,
 
     /// Whether or not to generate Cargo build scripts by default
-    pub generate_build_scripts: bool,
+    pub(crate) generate_build_scripts: bool,
 
     /// Additional settings to apply to generated crates
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub annotations: BTreeMap<CrateNameAndVersionReq, CrateAnnotations>,
+    pub(crate) annotations: BTreeMap<CrateNameAndVersionReq, CrateAnnotations>,
 
     /// Settings used to determine various render info
-    pub rendering: RenderConfig,
+    pub(crate) rendering: RenderConfig,
 
     /// The contents of a Cargo configuration file
-    pub cargo_config: Option<toml::Value>,
+    pub(crate) cargo_config: Option<toml::Value>,
 
     /// A set of platform triples to use in generated select statements
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
-    pub supported_platform_triples: BTreeSet<TargetTriple>,
+    pub(crate) supported_platform_triples: BTreeSet<TargetTriple>,
 }
 
 impl Config {
-    pub fn try_from_path<T: AsRef<Path>>(path: T) -> Result<Self> {
+    pub(crate) fn try_from_path<T: AsRef<Path>>(path: T) -> Result<Self> {
         let data = fs::read_to_string(path)?;
         Ok(serde_json::from_str(&data)?)
     }

--- a/crate_universe/src/context.rs
+++ b/crate_universe/src/context.rs
@@ -1,6 +1,6 @@
 //! Convert annotated metadata into a renderable context
 
-pub mod crate_context;
+pub(crate) mod crate_context;
 mod platforms;
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -18,42 +18,42 @@ use crate::metadata::{Annotations, Dependency};
 use crate::select::Select;
 use crate::utils::target_triple::TargetTriple;
 
-pub use self::crate_context::*;
+pub(crate) use self::crate_context::*;
 
 /// A struct containing information about a Cargo dependency graph in an easily to consume
 /// format for rendering reproducible Bazel targets.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct Context {
     /// The collective checksum of all inputs to the context
-    pub checksum: Option<Digest>,
+    pub(crate) checksum: Option<Digest>,
 
     /// The collection of all crates that make up the dependency graph
-    pub crates: BTreeMap<CrateId, CrateContext>,
+    pub(crate) crates: BTreeMap<CrateId, CrateContext>,
 
     /// A subset of only crates with binary targets
-    pub binary_crates: BTreeSet<CrateId>,
+    pub(crate) binary_crates: BTreeSet<CrateId>,
 
     /// A subset of workspace members mapping to their workspace
     /// path relative to the workspace root
-    pub workspace_members: BTreeMap<CrateId, String>,
+    pub(crate) workspace_members: BTreeMap<CrateId, String>,
 
     /// A mapping of `cfg` flags to platform triples supporting the configuration
-    pub conditions: BTreeMap<String, BTreeSet<TargetTriple>>,
+    pub(crate) conditions: BTreeMap<String, BTreeSet<TargetTriple>>,
 
     /// A list of crates visible to any bazel module.
-    pub direct_deps: BTreeSet<CrateId>,
+    pub(crate) direct_deps: BTreeSet<CrateId>,
 
     /// A list of crates visible to this bazel module.
-    pub direct_dev_deps: BTreeSet<CrateId>,
+    pub(crate) direct_dev_deps: BTreeSet<CrateId>,
 }
 
 impl Context {
-    pub fn try_from_path<T: AsRef<Path>>(path: T) -> Result<Self> {
+    pub(crate) fn try_from_path<T: AsRef<Path>>(path: T) -> Result<Self> {
         let data = fs::read_to_string(path.as_ref())?;
         Ok(serde_json::from_str(&data)?)
     }
 
-    pub fn new(annotations: Annotations) -> Result<Self> {
+    pub(crate) fn new(annotations: Annotations) -> Result<Self> {
         // Build a map of crate contexts
         let crates: BTreeMap<CrateId, CrateContext> = annotations
             .metadata
@@ -192,7 +192,7 @@ impl Context {
     }
 
     /// Create a set of all direct dependencies of workspace member crates.
-    pub fn workspace_member_deps(&self) -> BTreeSet<CrateDependency> {
+    pub(crate) fn workspace_member_deps(&self) -> BTreeSet<CrateDependency> {
         self.workspace_members
             .keys()
             .map(move |id| &self.crates[id])
@@ -208,7 +208,7 @@ impl Context {
             .collect()
     }
 
-    pub fn has_duplicate_workspace_member_dep(&self, dep: &CrateDependency) -> bool {
+    pub(crate) fn has_duplicate_workspace_member_dep(&self, dep: &CrateDependency) -> bool {
         1 < self
             .workspace_member_deps()
             .into_iter()
@@ -216,7 +216,7 @@ impl Context {
             .count()
     }
 
-    pub fn has_duplicate_binary_crate(&self, bin: &CrateId) -> bool {
+    pub(crate) fn has_duplicate_binary_crate(&self, bin: &CrateId) -> bool {
         1 < self
             .binary_crates
             .iter()

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -27,7 +27,7 @@ pub struct CrateDependency {
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Clone)]
 #[serde(default)]
-pub struct TargetAttributes {
+pub(crate) struct TargetAttributes {
     /// The module name of the crate (notably, not the package name).
     //
     // This must be the first field of `TargetAttributes` to make it the
@@ -35,17 +35,17 @@ pub struct TargetAttributes {
     // by. The `Ord` impl controls the order of multiple rules of the same type
     // in the same BUILD file. In particular, this makes packages with multiple
     // bin crates generate those `rust_binary` targets in alphanumeric order.
-    pub crate_name: String,
+    pub(crate) crate_name: String,
 
     /// The path to the crate's root source file, relative to the manifest.
-    pub crate_root: Option<String>,
+    pub(crate) crate_root: Option<String>,
 
     /// A glob pattern of all source files required by the target
-    pub srcs: Glob,
+    pub(crate) srcs: Glob,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Clone)]
-pub enum Rule {
+pub(crate) enum Rule {
     /// `rust_library`
     Library(TargetAttributes),
 
@@ -63,58 +63,58 @@ pub enum Rule {
 /// [core rules of `rules_rust`](https://bazelbuild.github.io/rules_rust/defs.html).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
-pub struct CommonAttributes {
+pub(crate) struct CommonAttributes {
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub compile_data: Select<BTreeSet<Label>>,
+    pub(crate) compile_data: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
-    pub compile_data_glob: BTreeSet<String>,
+    pub(crate) compile_data_glob: BTreeSet<String>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub crate_features: Select<BTreeSet<String>>,
+    pub(crate) crate_features: Select<BTreeSet<String>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub data: Select<BTreeSet<Label>>,
+    pub(crate) data: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
-    pub data_glob: BTreeSet<String>,
+    pub(crate) data_glob: BTreeSet<String>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub deps: Select<BTreeSet<CrateDependency>>,
+    pub(crate) deps: Select<BTreeSet<CrateDependency>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub extra_deps: Select<BTreeSet<Label>>,
+    pub(crate) extra_deps: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub deps_dev: Select<BTreeSet<CrateDependency>>,
+    pub(crate) deps_dev: Select<BTreeSet<CrateDependency>>,
 
-    pub edition: String,
+    pub(crate) edition: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub linker_script: Option<String>,
+    pub(crate) linker_script: Option<String>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub proc_macro_deps: Select<BTreeSet<CrateDependency>>,
+    pub(crate) proc_macro_deps: Select<BTreeSet<CrateDependency>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub extra_proc_macro_deps: Select<BTreeSet<Label>>,
+    pub(crate) extra_proc_macro_deps: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub proc_macro_deps_dev: Select<BTreeSet<CrateDependency>>,
+    pub(crate) proc_macro_deps_dev: Select<BTreeSet<CrateDependency>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub rustc_env: Select<BTreeMap<String, String>>,
+    pub(crate) rustc_env: Select<BTreeMap<String, String>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub rustc_env_files: Select<BTreeSet<String>>,
+    pub(crate) rustc_env_files: Select<BTreeSet<String>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub rustc_flags: Select<Vec<String>>,
+    pub(crate) rustc_flags: Select<Vec<String>>,
 
-    pub version: String,
+    pub(crate) version: String,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub tags: Vec<String>,
+    pub(crate) tags: Vec<String>,
 }
 
 impl Default for CommonAttributes {
@@ -147,21 +147,21 @@ impl Default for CommonAttributes {
 // https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
-pub struct BuildScriptAttributes {
+pub(crate) struct BuildScriptAttributes {
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub compile_data: Select<BTreeSet<Label>>,
+    pub(crate) compile_data: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub data: Select<BTreeSet<Label>>,
+    pub(crate) data: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
-    pub data_glob: BTreeSet<String>,
+    pub(crate) data_glob: BTreeSet<String>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub deps: Select<BTreeSet<CrateDependency>>,
+    pub(crate) deps: Select<BTreeSet<CrateDependency>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub extra_deps: Select<BTreeSet<Label>>,
+    pub(crate) extra_deps: Select<BTreeSet<Label>>,
 
     // TODO: refactor a crate with a build.rs file from two into three bazel
     // rules in order to deduplicate link_dep information. Currently as the
@@ -181,40 +181,40 @@ pub struct BuildScriptAttributes {
     // normal dependencies. This could be handled a special rule, or just using
     // a `filegroup`.
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub link_deps: Select<BTreeSet<CrateDependency>>,
+    pub(crate) link_deps: Select<BTreeSet<CrateDependency>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub extra_link_deps: Select<BTreeSet<Label>>,
+    pub(crate) extra_link_deps: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub build_script_env: Select<BTreeMap<String, String>>,
+    pub(crate) build_script_env: Select<BTreeMap<String, String>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub rundir: Select<String>,
+    pub(crate) rundir: Select<String>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub extra_proc_macro_deps: Select<BTreeSet<Label>>,
+    pub(crate) extra_proc_macro_deps: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub proc_macro_deps: Select<BTreeSet<CrateDependency>>,
+    pub(crate) proc_macro_deps: Select<BTreeSet<CrateDependency>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub rustc_env: Select<BTreeMap<String, String>>,
+    pub(crate) rustc_env: Select<BTreeMap<String, String>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub rustc_flags: Select<Vec<String>>,
+    pub(crate) rustc_flags: Select<Vec<String>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub rustc_env_files: Select<BTreeSet<String>>,
+    pub(crate) rustc_env_files: Select<BTreeSet<String>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
-    pub tools: Select<BTreeSet<Label>>,
+    pub(crate) tools: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<String>,
+    pub(crate) links: Option<String>,
 
     #[serde(skip_serializing_if = "BTreeSet::is_empty")]
-    pub toolchains: BTreeSet<Label>,
+    pub(crate) toolchains: BTreeSet<Label>,
 }
 
 impl Default for BuildScriptAttributes {
@@ -243,77 +243,77 @@ impl Default for BuildScriptAttributes {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CrateContext {
+pub(crate) struct CrateContext {
     /// The package name of the current crate
-    pub name: String,
+    pub(crate) name: String,
 
     /// The full version of the current crate
-    pub version: semver::Version,
+    pub(crate) version: semver::Version,
 
     /// The package URL of the current crate
     #[serde(default)]
-    pub package_url: Option<String>,
+    pub(crate) package_url: Option<String>,
 
     /// Optional source annotations if they were discoverable in the
     /// lockfile. Workspace Members will not have source annotations and
     /// potentially others.
     #[serde(default)]
-    pub repository: Option<SourceAnnotation>,
+    pub(crate) repository: Option<SourceAnnotation>,
 
     /// A list of all targets (lib, proc-macro, bin) associated with this package
     #[serde(default)]
-    pub targets: BTreeSet<Rule>,
+    pub(crate) targets: BTreeSet<Rule>,
 
     /// The name of the crate's root library target. This is the target that a dependent
     /// would get if they were to depend on `{crate_name}`.
     #[serde(default)]
-    pub library_target_name: Option<String>,
+    pub(crate) library_target_name: Option<String>,
 
     /// A set of attributes common to most [Rule] types or target types.
     #[serde(default)]
-    pub common_attrs: CommonAttributes,
+    pub(crate) common_attrs: CommonAttributes,
 
     /// Optional attributes for build scripts. This field is only populated if
     /// a build script (`custom-build`) target is defined for the crate.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub build_script_attrs: Option<BuildScriptAttributes>,
+    pub(crate) build_script_attrs: Option<BuildScriptAttributes>,
 
     /// The license used by the crate
     #[serde(default)]
-    pub license: Option<String>,
+    pub(crate) license: Option<String>,
 
     /// The SPDX licence IDs
     /// #[serde(default)]
-    pub license_ids: BTreeSet<String>,
+    pub(crate) license_ids: BTreeSet<String>,
 
     /// The license file
     #[serde(default)]
-    pub license_file: Option<String>,
+    pub(crate) license_file: Option<String>,
 
     /// Additional text to add to the generated BUILD file.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub additive_build_file_content: Option<String>,
+    pub(crate) additive_build_file_content: Option<String>,
 
     /// If true, disables pipelining for library targets generated for this crate
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     #[serde(default)]
-    pub disable_pipelining: bool,
+    pub(crate) disable_pipelining: bool,
 
     /// Extra targets that should be aliased.
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     #[serde(default)]
-    pub extra_aliased_targets: BTreeMap<String, String>,
+    pub(crate) extra_aliased_targets: BTreeMap<String, String>,
 
     /// Transition rule to use instead of `alias`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub alias_rule: Option<AliasRule>,
+    pub(crate) alias_rule: Option<AliasRule>,
 }
 
 impl CrateContext {
-    pub fn new(
+    pub(crate) fn new(
         annotation: &CrateAnnotation,
         packages: &BTreeMap<PackageId, Package>,
         source_annotations: &BTreeMap<PackageId, SourceAnnotation>,

--- a/crate_universe/src/context/platforms.rs
+++ b/crate_universe/src/context/platforms.rs
@@ -10,7 +10,7 @@ use crate::utils::target_triple::TargetTriple;
 /// Walk through all dependencies in a [CrateContext] list for all configuration specific
 /// dependencies to produce a mapping of configurations/Cargo target_triples to compatible
 /// Bazel target_triples.  Also adds mappings for all known target_triples.
-pub fn resolve_cfg_platforms(
+pub(crate) fn resolve_cfg_platforms(
     crates: Vec<&CrateContext>,
     supported_platform_triples: &BTreeSet<TargetTriple>,
 ) -> Result<BTreeMap<String, BTreeSet<TargetTriple>>> {

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -55,7 +55,7 @@ pub(crate) fn write_lockfile(lockfile: Context, path: &Path, dry_run: bool) -> R
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct Digest(String);
+pub(crate) struct Digest(String);
 
 impl Digest {
     pub(crate) fn new(
@@ -130,7 +130,7 @@ impl Digest {
         Self(hasher.finalize().encode_hex::<String>())
     }
 
-    pub fn bin_version(binary: &Path) -> Result<String> {
+    pub(crate) fn bin_version(binary: &Path) -> Result<String> {
         let safe_vars = [OsStr::new("HOMEDRIVE"), OsStr::new("PATHEXT")];
         let env = std::env::vars_os().filter(|(var, _)| safe_vars.contains(&var.as_os_str()));
 

--- a/crate_universe/src/metadata/dependency.rs
+++ b/crate_universe/src/metadata/dependency.rs
@@ -13,32 +13,32 @@ use crate::utils::sanitize_module_name;
 
 /// A representation of a crate dependency
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Dependency {
+pub(crate) struct Dependency {
     /// The PackageId of the target
-    pub package_id: PackageId,
+    pub(crate) package_id: PackageId,
 
     /// The library target name of the dependency.
-    pub target_name: String,
+    pub(crate) target_name: String,
 
     /// The alias for the dependency from the perspective of the current package
-    pub alias: Option<String>,
+    pub(crate) alias: Option<String>,
 }
 
 /// A collection of [Dependency]s sorted by dependency kind.
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub struct DependencySet {
-    pub normal_deps: Select<BTreeSet<Dependency>>,
-    pub normal_dev_deps: Select<BTreeSet<Dependency>>,
-    pub proc_macro_deps: Select<BTreeSet<Dependency>>,
-    pub proc_macro_dev_deps: Select<BTreeSet<Dependency>>,
-    pub build_deps: Select<BTreeSet<Dependency>>,
-    pub build_link_deps: Select<BTreeSet<Dependency>>,
-    pub build_proc_macro_deps: Select<BTreeSet<Dependency>>,
+pub(crate) struct DependencySet {
+    pub(crate) normal_deps: Select<BTreeSet<Dependency>>,
+    pub(crate) normal_dev_deps: Select<BTreeSet<Dependency>>,
+    pub(crate) proc_macro_deps: Select<BTreeSet<Dependency>>,
+    pub(crate) proc_macro_dev_deps: Select<BTreeSet<Dependency>>,
+    pub(crate) build_deps: Select<BTreeSet<Dependency>>,
+    pub(crate) build_link_deps: Select<BTreeSet<Dependency>>,
+    pub(crate) build_proc_macro_deps: Select<BTreeSet<Dependency>>,
 }
 
 impl DependencySet {
     /// Collect all dependencies for a given node in the resolve graph.
-    pub fn new_for_node(node: &Node, metadata: &CargoMetadata) -> Self {
+    pub(crate) fn new_for_node(node: &Node, metadata: &CargoMetadata) -> Self {
         let (normal_dev_deps, normal_deps) = {
             let (dev, normal) = node
                 .deps

--- a/crate_universe/src/metadata/metadata_annotation.rs
+++ b/crate_universe/src/metadata/metadata_annotation.rs
@@ -14,40 +14,40 @@ use crate::metadata::dependency::DependencySet;
 use crate::select::Select;
 use crate::splicing::{SourceInfo, WorkspaceMetadata};
 
-pub type CargoMetadata = cargo_metadata::Metadata;
-pub type CargoLockfile = cargo_lock::Lockfile;
+pub(crate) type CargoMetadata = cargo_metadata::Metadata;
+pub(crate) type CargoLockfile = cargo_lock::Lockfile;
 
 /// Additional information about a crate relative to other crates in a dependency graph.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct CrateAnnotation {
+pub(crate) struct CrateAnnotation {
     /// The crate's node in the Cargo "resolve" graph.
-    pub node: Node,
+    pub(crate) node: Node,
 
     /// The crate's sorted dependencies.
-    pub deps: DependencySet,
+    pub(crate) deps: DependencySet,
 }
 
 /// Additional information about a Cargo workspace's metadata.
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub struct MetadataAnnotation {
+pub(crate) struct MetadataAnnotation {
     /// All packages found within the Cargo metadata
-    pub packages: BTreeMap<PackageId, Package>,
+    pub(crate) packages: BTreeMap<PackageId, Package>,
 
     /// All [CrateAnnotation]s for all packages
-    pub crates: BTreeMap<PackageId, CrateAnnotation>,
+    pub(crate) crates: BTreeMap<PackageId, CrateAnnotation>,
 
     /// All packages that are workspace members
-    pub workspace_members: BTreeSet<PackageId>,
+    pub(crate) workspace_members: BTreeSet<PackageId>,
 
     /// The path to the directory containing the Cargo workspace that produced the metadata.
-    pub workspace_root: PathBuf,
+    pub(crate) workspace_root: PathBuf,
 
     /// Information on the Cargo workspace.
-    pub workspace_metadata: WorkspaceMetadata,
+    pub(crate) workspace_metadata: WorkspaceMetadata,
 }
 
 impl MetadataAnnotation {
-    pub fn new(metadata: CargoMetadata) -> MetadataAnnotation {
+    pub(crate) fn new(metadata: CargoMetadata) -> MetadataAnnotation {
         // UNWRAP: The workspace metadata should be written by a controlled process. This should not return a result
         let workspace_metadata = find_workspace_metadata(&metadata).unwrap_or_default();
 
@@ -104,7 +104,7 @@ impl MetadataAnnotation {
 
 /// Additional information about how and where to acquire a crate's source code from.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum SourceAnnotation {
+pub(crate) enum SourceAnnotation {
     Git {
         /// The Git url where to clone the source from.
         remote: String,
@@ -160,13 +160,13 @@ pub enum SourceAnnotation {
 /// Additional information related to [Cargo.lock](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html)
 /// data used for improved determinism.
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
-pub struct LockfileAnnotation {
+pub(crate) struct LockfileAnnotation {
     /// A mapping of crates/packages to additional source (network location) information.
-    pub crates: BTreeMap<PackageId, SourceAnnotation>,
+    pub(crate) crates: BTreeMap<PackageId, SourceAnnotation>,
 }
 
 impl LockfileAnnotation {
-    pub fn new(lockfile: CargoLockfile, metadata: &CargoMetadata) -> Result<Self> {
+    pub(crate) fn new(lockfile: CargoLockfile, metadata: &CargoMetadata) -> Result<Self> {
         let workspace_metadata = find_workspace_metadata(metadata).unwrap_or_default();
 
         let nodes: Vec<&Node> = metadata
@@ -341,35 +341,35 @@ impl LockfileAnnotation {
 
 /// A pairing of a crate's package identifier to its annotations.
 #[derive(Debug)]
-pub struct PairedExtras {
+pub(crate) struct PairedExtras {
     /// The crate's package identifier
-    pub package_id: cargo_metadata::PackageId,
+    pub(crate) package_id: cargo_metadata::PackageId,
 
     /// The crate's annotations
-    pub crate_extra: CrateAnnotations,
+    pub(crate) crate_extra: CrateAnnotations,
 }
 
 /// A collection of data which has been processed for optimal use in generating Bazel targets.
 #[derive(Debug, Default)]
-pub struct Annotations {
+pub(crate) struct Annotations {
     /// Annotated Cargo metadata
-    pub metadata: MetadataAnnotation,
+    pub(crate) metadata: MetadataAnnotation,
 
     /// Annotated Cargo lockfile
-    pub lockfile: LockfileAnnotation,
+    pub(crate) lockfile: LockfileAnnotation,
 
     /// The current workspace's configuration settings
-    pub config: Config,
+    pub(crate) config: Config,
 
     /// Pairred crate annotations
-    pub pairred_extras: BTreeMap<CrateId, PairedExtras>,
+    pub(crate) pairred_extras: BTreeMap<CrateId, PairedExtras>,
 
     /// Feature set for each target triplet and crate.
-    pub crate_features: BTreeMap<CrateId, Select<BTreeSet<String>>>,
+    pub(crate) crate_features: BTreeMap<CrateId, Select<BTreeSet<String>>>,
 }
 
 impl Annotations {
-    pub fn new(
+    pub(crate) fn new(
         cargo_metadata: CargoMetadata,
         cargo_lockfile: CargoLockfile,
         config: Config,

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -29,14 +29,17 @@ use crate::utils::{self, sanitize_repository_name};
 // to platform labels like "@rules_rust//rust/platform:x86_64-unknown-linux-gnu".
 pub(crate) type Platforms = BTreeMap<String, BTreeSet<String>>;
 
-pub struct Renderer {
+pub(crate) struct Renderer {
     config: RenderConfig,
     supported_platform_triples: BTreeSet<TargetTriple>,
     engine: TemplateEngine,
 }
 
 impl Renderer {
-    pub fn new(config: RenderConfig, supported_platform_triples: BTreeSet<TargetTriple>) -> Self {
+    pub(crate) fn new(
+        config: RenderConfig,
+        supported_platform_triples: BTreeSet<TargetTriple>,
+    ) -> Self {
         let engine = TemplateEngine::new(&config);
         Self {
             config,
@@ -777,7 +780,7 @@ impl Renderer {
 }
 
 /// Write a set of [crate::context::crate_context::CrateContext] to disk.
-pub fn write_outputs(
+pub(crate) fn write_outputs(
     outputs: BTreeMap<PathBuf, String>,
     out_dir: &Path,
     dry_run: bool,
@@ -815,7 +818,7 @@ pub fn write_outputs(
 }
 
 /// Render the Bazel label of a crate
-pub fn render_crate_bazel_label(
+pub(crate) fn render_crate_bazel_label(
     template: &str,
     repository_name: &str,
     name: &str,
@@ -830,7 +833,7 @@ pub fn render_crate_bazel_label(
 }
 
 /// Render the Bazel label of a crate
-pub fn render_crate_bazel_repository(
+pub(crate) fn render_crate_bazel_repository(
     template: &str,
     repository_name: &str,
     name: &str,
@@ -843,14 +846,14 @@ pub fn render_crate_bazel_repository(
 }
 
 /// Render the Bazel label of a crate
-pub fn render_crate_build_file(template: &str, name: &str, version: &str) -> String {
+pub(crate) fn render_crate_build_file(template: &str, name: &str, version: &str) -> String {
     template
         .replace("{name}", name)
         .replace("{version}", version)
 }
 
 /// Render the Bazel label of a vendor module label
-pub fn render_module_label(template: &str, name: &str) -> Result<Label> {
+pub(crate) fn render_module_label(template: &str, name: &str) -> Result<Label> {
     Label::from_str(&template.replace("{file}", name))
 }
 

--- a/crate_universe/src/rendering/template_engine.rs
+++ b/crate_universe/src/rendering/template_engine.rs
@@ -15,13 +15,13 @@ use crate::rendering::{
 use crate::select::Select;
 use crate::utils::sanitize_repository_name;
 
-pub struct TemplateEngine {
+pub(crate) struct TemplateEngine {
     engine: Tera,
     context: tera::Context,
 }
 
 impl TemplateEngine {
-    pub fn new(render_config: &RenderConfig) -> Self {
+    pub(crate) fn new(render_config: &RenderConfig) -> Self {
         let mut tera = Tera::default();
         tera.add_raw_templates(vec![
             (
@@ -123,7 +123,7 @@ impl TemplateEngine {
         self.context.clone()
     }
 
-    pub fn render_header(&self) -> Result<String> {
+    pub(crate) fn render_header(&self) -> Result<String> {
         let context = self.new_tera_ctx();
         let mut header = self
             .engine

--- a/crate_universe/src/select.rs
+++ b/crate_universe/src/select.rs
@@ -49,7 +49,7 @@ where
 
 impl<T> SelectableOrderedValue for T where T: SelectableValue + PartialOrd + Ord {}
 
-pub trait SelectableScalar
+pub(crate) trait SelectableScalar
 where
     Self: SelectableValue,
 {
@@ -64,45 +64,45 @@ impl<T> Select<T>
 where
     T: Selectable,
 {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             common: T::CommonType::default(),
             selects: BTreeMap::new(),
         }
     }
 
-    pub fn from_value(value: T::CommonType) -> Self {
+    pub(crate) fn from_value(value: T::CommonType) -> Self {
         Self {
             common: value,
             selects: BTreeMap::new(),
         }
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         T::is_empty(self)
     }
 
-    pub fn configurations(&self) -> BTreeSet<String> {
+    pub(crate) fn configurations(&self) -> BTreeSet<String> {
         self.selects.keys().cloned().collect()
     }
 
-    pub fn items(&self) -> Vec<(Option<String>, T::ItemType)> {
+    pub(crate) fn items(&self) -> Vec<(Option<String>, T::ItemType)> {
         T::items(self)
     }
 
-    pub fn values(&self) -> Vec<T::ItemType> {
+    pub(crate) fn values(&self) -> Vec<T::ItemType> {
         T::values(self)
     }
 
-    pub fn insert(&mut self, value: T::ItemType, configuration: Option<String>) {
+    pub(crate) fn insert(&mut self, value: T::ItemType, configuration: Option<String>) {
         T::insert(self, value, configuration);
     }
 
-    pub fn into_parts(self) -> (T::CommonType, BTreeMap<String, T::SelectsType>) {
+    pub(crate) fn into_parts(self) -> (T::CommonType, BTreeMap<String, T::SelectsType>) {
         (self.common, self.selects)
     }
 
-    pub fn merge(lhs: Self, rhs: Self) -> Self {
+    pub(crate) fn merge(lhs: Self, rhs: Self) -> Self {
         T::merge(lhs, rhs)
     }
 }
@@ -367,7 +367,7 @@ impl<T> Select<BTreeSet<T>>
 where
     T: SelectableOrderedValue,
 {
-    pub fn map<U, F>(self, func: F) -> Select<BTreeSet<U>>
+    pub(crate) fn map<U, F>(self, func: F) -> Select<BTreeSet<U>>
     where
         U: SelectableOrderedValue,
         F: Copy + FnMut(T) -> U,

--- a/crate_universe/src/splicing/crate_index_lookup.rs
+++ b/crate_universe/src/splicing/crate_index_lookup.rs
@@ -3,13 +3,13 @@ use anyhow::{Context, Result};
 use crates_index::IndexConfig;
 use hex::ToHex;
 
-pub enum CrateIndexLookup {
+pub(crate) enum CrateIndexLookup {
     Git(crates_index::GitIndex),
     Http(crates_index::SparseIndex),
 }
 
 impl CrateIndexLookup {
-    pub fn get_source_info(&self, pkg: &cargo_lock::Package) -> Result<Option<SourceInfo>> {
+    pub(crate) fn get_source_info(&self, pkg: &cargo_lock::Package) -> Result<Option<SourceInfo>> {
         let index_config = self
             .index_config()
             .context("Failed to get crate index config")?;

--- a/crate_universe/src/test.rs
+++ b/crate_universe/src/test.rs
@@ -1,6 +1,6 @@
 //! A module containing common test helpers
 
-pub fn mock_cargo_metadata_package() -> cargo_metadata::Package {
+pub(crate) fn mock_cargo_metadata_package() -> cargo_metadata::Package {
     serde_json::from_value(serde_json::json!({
         "name": "mock-pkg",
         "version": "3.3.3",
@@ -29,7 +29,7 @@ pub fn mock_cargo_metadata_package() -> cargo_metadata::Package {
     .unwrap()
 }
 
-pub fn mock_cargo_lock_package() -> cargo_lock::Package {
+pub(crate) fn mock_cargo_lock_package() -> cargo_lock::Package {
     toml::from_str(&textwrap::dedent(
         r#"
         name = "mock-pkg"
@@ -42,8 +42,8 @@ pub fn mock_cargo_lock_package() -> cargo_lock::Package {
     .unwrap()
 }
 
-pub mod metadata {
-    pub fn alias() -> cargo_metadata::Metadata {
+pub(crate) mod metadata {
+    pub(crate) fn alias() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/aliases/metadata.json"
@@ -51,7 +51,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn build_scripts() -> cargo_metadata::Metadata {
+    pub(crate) fn build_scripts() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/build_scripts/metadata.json"
@@ -59,7 +59,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn crate_types() -> cargo_metadata::Metadata {
+    pub(crate) fn crate_types() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/crate_types/metadata.json"
@@ -67,7 +67,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn multi_cfg_dep() -> cargo_metadata::Metadata {
+    pub(crate) fn multi_cfg_dep() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/multi_cfg_dep/metadata.json"
@@ -75,7 +75,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn multi_kind_proc_macro_dep() -> cargo_metadata::Metadata {
+    pub(crate) fn multi_kind_proc_macro_dep() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/multi_kind_proc_macro_dep/metadata.json"
@@ -83,7 +83,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn no_deps() -> cargo_metadata::Metadata {
+    pub(crate) fn no_deps() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/no_deps/metadata.json"
@@ -91,7 +91,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn optional_deps_disabled() -> cargo_metadata::Metadata {
+    pub(crate) fn optional_deps_disabled() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/crate_optional_deps_disabled/metadata.json"
@@ -99,7 +99,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn renamed_optional_deps_disabled() -> cargo_metadata::Metadata {
+    pub(crate) fn renamed_optional_deps_disabled() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/crate_renamed_optional_deps_disabled/metadata.json"
@@ -107,7 +107,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn optional_deps_disabled_build_dep_enabled() -> cargo_metadata::Metadata {
+    pub(crate) fn optional_deps_disabled_build_dep_enabled() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/crate_optional_deps_disabled_build_dep_enabled/metadata.json"
@@ -115,7 +115,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn optional_deps_enabled() -> cargo_metadata::Metadata {
+    pub(crate) fn optional_deps_enabled() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/crate_optional_deps_enabled/metadata.json"
@@ -123,7 +123,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn renamed_optional_deps_enabled() -> cargo_metadata::Metadata {
+    pub(crate) fn renamed_optional_deps_enabled() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/crate_renamed_optional_deps_enabled/metadata.json"
@@ -131,7 +131,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn common() -> cargo_metadata::Metadata {
+    pub(crate) fn common() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/common/metadata.json"
@@ -139,7 +139,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn git_repos() -> cargo_metadata::Metadata {
+    pub(crate) fn git_repos() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/git_repos/metadata.json"
@@ -147,7 +147,7 @@ pub mod metadata {
         .unwrap()
     }
 
-    pub fn has_package_metadata() -> cargo_metadata::Metadata {
+    pub(crate) fn has_package_metadata() -> cargo_metadata::Metadata {
         serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/has_package_metadata/metadata.json"
@@ -156,10 +156,10 @@ pub mod metadata {
     }
 }
 
-pub mod lockfile {
+pub(crate) mod lockfile {
     use std::str::FromStr;
 
-    pub fn alias() -> cargo_lock::Lockfile {
+    pub(crate) fn alias() -> cargo_lock::Lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/aliases/Cargo.lock"
@@ -167,7 +167,7 @@ pub mod lockfile {
         .unwrap()
     }
 
-    pub fn build_scripts() -> cargo_lock::Lockfile {
+    pub(crate) fn build_scripts() -> cargo_lock::Lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/build_scripts/Cargo.lock"
@@ -175,7 +175,7 @@ pub mod lockfile {
         .unwrap()
     }
 
-    pub fn crate_types() -> cargo_lock::Lockfile {
+    pub(crate) fn crate_types() -> cargo_lock::Lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/crate_types/Cargo.lock"
@@ -183,7 +183,7 @@ pub mod lockfile {
         .unwrap()
     }
 
-    pub fn multi_cfg_dep() -> cargo_lock::Lockfile {
+    pub(crate) fn multi_cfg_dep() -> cargo_lock::Lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/multi_cfg_dep/Cargo.lock"
@@ -191,7 +191,7 @@ pub mod lockfile {
         .unwrap()
     }
 
-    pub fn no_deps() -> cargo_lock::Lockfile {
+    pub(crate) fn no_deps() -> cargo_lock::Lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/no_deps/Cargo.lock"
@@ -199,7 +199,7 @@ pub mod lockfile {
         .unwrap()
     }
 
-    pub fn common() -> cargo_lock::Lockfile {
+    pub(crate) fn common() -> cargo_lock::Lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/common/Cargo.lock"
@@ -207,7 +207,7 @@ pub mod lockfile {
         .unwrap()
     }
 
-    pub fn git_repos() -> cargo_lock::Lockfile {
+    pub(crate) fn git_repos() -> cargo_lock::Lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/git_repos/Cargo.lock"
@@ -215,7 +215,7 @@ pub mod lockfile {
         .unwrap()
     }
 
-    pub fn has_package_metadata() -> cargo_lock::Lockfile {
+    pub(crate) fn has_package_metadata() -> cargo_lock::Lockfile {
         cargo_lock::Lockfile::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_data/metadata/has_package_metadata/Cargo.lock"

--- a/crate_universe/src/utils.rs
+++ b/crate_universe/src/utils.rs
@@ -1,18 +1,18 @@
 //! Common utilities
 
-pub mod starlark;
-pub mod target_triple;
+pub(crate) mod starlark;
+pub(crate) mod target_triple;
 
-pub const CRATES_IO_INDEX_URL: &str = "https://github.com/rust-lang/crates.io-index";
+pub(crate) const CRATES_IO_INDEX_URL: &str = "https://github.com/rust-lang/crates.io-index";
 
 /// Convert a string into a valid crate module name by applying transforms to invalid characters
-pub fn sanitize_module_name(name: &str) -> String {
+pub(crate) fn sanitize_module_name(name: &str) -> String {
     name.replace('-', "_")
 }
 
 /// Some character which may be present in version IDs are not valid
 /// in Bazel repository names. This converts invalid characters. See
 /// [RepositoryName.java](https://github.com/bazelbuild/bazel/blob/4.0.0/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java#L42)
-pub fn sanitize_repository_name(name: &str) -> String {
+pub(crate) fn sanitize_repository_name(name: &str) -> String {
     name.replace('+', "-")
 }

--- a/crate_universe/src/utils/starlark.rs
+++ b/crate_universe/src/utils/starlark.rs
@@ -15,18 +15,18 @@ use std::collections::BTreeSet as Set;
 use serde::{Serialize, Serializer};
 use serde_starlark::{Error as StarlarkError, FunctionCall};
 
-pub use glob::*;
-pub use label::*;
-pub use select::*;
-pub use select_dict::*;
-pub use select_list::*;
-pub use select_scalar::*;
-pub use select_set::*;
-pub use target_compatible_with::*;
+pub(crate) use glob::*;
+pub(crate) use label::*;
+pub(crate) use select::*;
+pub(crate) use select_dict::*;
+pub(crate) use select_list::*;
+pub(crate) use select_scalar::*;
+pub(crate) use select_set::*;
+pub(crate) use target_compatible_with::*;
 
 #[derive(Serialize)]
 #[serde(untagged)]
-pub enum Starlark {
+pub(crate) enum Starlark {
     Load(Load),
     Package(Package),
     PackageInfo(PackageInfo),
@@ -46,170 +46,170 @@ pub enum Starlark {
     Verbatim(String),
 }
 
-pub struct Load {
-    pub bzl: String,
-    pub items: Set<String>,
+pub(crate) struct Load {
+    pub(crate) bzl: String,
+    pub(crate) items: Set<String>,
 }
 
-pub struct Package {
-    pub default_package_metadata: Set<Label>,
-    pub default_visibility: Set<String>,
+pub(crate) struct Package {
+    pub(crate) default_package_metadata: Set<Label>,
+    pub(crate) default_visibility: Set<String>,
 }
 
-pub struct PackageInfo {
-    pub name: String,
-    pub package_name: String,
-    pub package_url: String,
-    pub package_version: String,
+pub(crate) struct PackageInfo {
+    pub(crate) name: String,
+    pub(crate) package_name: String,
+    pub(crate) package_url: String,
+    pub(crate) package_version: String,
 }
 
-pub struct License {
-    pub name: String,
-    pub license_kinds: Set<String>,
-    pub license_text: String,
+pub(crate) struct License {
+    pub(crate) name: String,
+    pub(crate) license_kinds: Set<String>,
+    pub(crate) license_text: String,
 }
 
-pub struct ExportsFiles {
-    pub paths: Set<String>,
-    pub globs: Glob,
+pub(crate) struct ExportsFiles {
+    pub(crate) paths: Set<String>,
+    pub(crate) globs: Glob,
 }
 
 #[derive(Serialize)]
 #[serde(rename = "filegroup")]
-pub struct Filegroup {
-    pub name: String,
-    pub srcs: Glob,
+pub(crate) struct Filegroup {
+    pub(crate) name: String,
+    pub(crate) srcs: Glob,
 }
 
-pub struct Alias {
-    pub rule: String,
-    pub name: String,
-    pub actual: Label,
-    pub tags: Set<String>,
+pub(crate) struct Alias {
+    pub(crate) rule: String,
+    pub(crate) name: String,
+    pub(crate) actual: Label,
+    pub(crate) tags: Set<String>,
 }
 
 #[derive(Serialize)]
 #[serde(rename = "cargo_build_script")]
-pub struct CargoBuildScript {
-    pub name: String,
+pub(crate) struct CargoBuildScript {
+    pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
-    pub aliases: SelectDict<Label, String>,
+    pub(crate) aliases: SelectDict<Label, String>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
-    pub build_script_env: SelectDict<String, String>,
+    pub(crate) build_script_env: SelectDict<String, String>,
     #[serde(skip_serializing_if = "Data::is_empty")]
-    pub compile_data: Data,
+    pub(crate) compile_data: Data,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub crate_features: SelectSet<String>,
-    pub crate_name: String,
+    pub(crate) crate_features: SelectSet<String>,
+    pub(crate) crate_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub crate_root: Option<String>,
+    pub(crate) crate_root: Option<String>,
     #[serde(skip_serializing_if = "Data::is_empty")]
-    pub data: Data,
+    pub(crate) data: Data,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub deps: SelectSet<Label>,
+    pub(crate) deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub link_deps: SelectSet<Label>,
-    pub edition: String,
+    pub(crate) link_deps: SelectSet<Label>,
+    pub(crate) edition: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub linker_script: Option<String>,
+    pub(crate) linker_script: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub links: Option<String>,
+    pub(crate) links: Option<String>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub proc_macro_deps: SelectSet<Label>,
+    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectScalar::is_empty")]
-    pub rundir: SelectScalar<String>,
+    pub(crate) rundir: SelectScalar<String>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
-    pub rustc_env: SelectDict<String, String>,
+    pub(crate) rustc_env: SelectDict<String, String>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub rustc_env_files: SelectSet<String>,
+    pub(crate) rustc_env_files: SelectSet<String>,
     #[serde(skip_serializing_if = "SelectList::is_empty")]
-    pub rustc_flags: SelectList<String>,
-    pub srcs: Glob,
+    pub(crate) rustc_flags: SelectList<String>,
+    pub(crate) srcs: Glob,
     #[serde(skip_serializing_if = "Set::is_empty")]
-    pub tags: Set<String>,
+    pub(crate) tags: Set<String>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub tools: SelectSet<Label>,
+    pub(crate) tools: SelectSet<Label>,
     #[serde(skip_serializing_if = "Set::is_empty")]
-    pub toolchains: Set<Label>,
-    pub version: String,
-    pub visibility: Set<String>,
+    pub(crate) toolchains: Set<Label>,
+    pub(crate) version: String,
+    pub(crate) visibility: Set<String>,
 }
 
 #[derive(Serialize)]
-pub struct RustProcMacro {
-    pub name: String,
+pub(crate) struct RustProcMacro {
+    pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub deps: SelectSet<Label>,
+    pub(crate) deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub proc_macro_deps: SelectSet<Label>,
+    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
-    pub aliases: SelectDict<Label, String>,
+    pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]
-    pub common: CommonAttrs,
+    pub(crate) common: CommonAttrs,
 }
 
 #[derive(Serialize)]
-pub struct RustLibrary {
-    pub name: String,
+pub(crate) struct RustLibrary {
+    pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub deps: SelectSet<Label>,
+    pub(crate) deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub proc_macro_deps: SelectSet<Label>,
+    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
-    pub aliases: SelectDict<Label, String>,
+    pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]
-    pub common: CommonAttrs,
+    pub(crate) common: CommonAttrs,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
-    pub disable_pipelining: bool,
+    pub(crate) disable_pipelining: bool,
 }
 
 #[derive(Serialize)]
-pub struct RustBinary {
-    pub name: String,
+pub(crate) struct RustBinary {
+    pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub deps: SelectSet<Label>,
+    pub(crate) deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub proc_macro_deps: SelectSet<Label>,
+    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
-    pub aliases: SelectDict<Label, String>,
+    pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]
-    pub common: CommonAttrs,
+    pub(crate) common: CommonAttrs,
 }
 
 #[derive(Serialize)]
-pub struct CommonAttrs {
+pub(crate) struct CommonAttrs {
     #[serde(skip_serializing_if = "Data::is_empty")]
-    pub compile_data: Data,
+    pub(crate) compile_data: Data,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub crate_features: SelectSet<String>,
+    pub(crate) crate_features: SelectSet<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub crate_root: Option<String>,
+    pub(crate) crate_root: Option<String>,
     #[serde(skip_serializing_if = "Data::is_empty")]
-    pub data: Data,
-    pub edition: String,
+    pub(crate) data: Data,
+    pub(crate) edition: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub linker_script: Option<String>,
+    pub(crate) linker_script: Option<String>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
-    pub rustc_env: SelectDict<String, String>,
+    pub(crate) rustc_env: SelectDict<String, String>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub rustc_env_files: SelectSet<String>,
+    pub(crate) rustc_env_files: SelectSet<String>,
     #[serde(skip_serializing_if = "SelectList::is_empty")]
-    pub rustc_flags: SelectList<String>,
-    pub srcs: Glob,
+    pub(crate) rustc_flags: SelectList<String>,
+    pub(crate) srcs: Glob,
     #[serde(skip_serializing_if = "Set::is_empty")]
-    pub tags: Set<String>,
+    pub(crate) tags: Set<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_compatible_with: Option<TargetCompatibleWith>,
-    pub version: String,
+    pub(crate) target_compatible_with: Option<TargetCompatibleWith>,
+    pub(crate) version: String,
 }
 
-pub struct Data {
-    pub glob: Glob,
-    pub select: SelectSet<Label>,
+pub(crate) struct Data {
+    pub(crate) glob: Glob,
+    pub(crate) select: SelectSet<Label>,
 }
 
 impl Package {
-    pub fn default_visibility_public(default_package_metadata: Set<Label>) -> Self {
+    pub(crate) fn default_visibility_public(default_package_metadata: Set<Label>) -> Self {
         let mut default_visibility = Set::new();
         default_visibility.insert("//visibility:public".to_owned());
         Package {
@@ -237,9 +237,9 @@ impl Serialize for Alias {
 
         #[derive(Serialize)]
         struct AliasInner<'a> {
-            pub name: &'a String,
-            pub actual: &'a Label,
-            pub tags: &'a Set<String>,
+            pub(crate) name: &'a String,
+            pub(crate) actual: &'a Label,
+            pub(crate) tags: &'a Set<String>,
         }
 
         FunctionCall::new(
@@ -254,7 +254,7 @@ impl Serialize for Alias {
     }
 }
 
-pub fn serialize(starlark: &[Starlark]) -> Result<String, StarlarkError> {
+pub(crate) fn serialize(starlark: &[Starlark]) -> Result<String, StarlarkError> {
     let mut content = String::new();
     for call in starlark {
         if !content.is_empty() {

--- a/crate_universe/src/utils/starlark/glob.rs
+++ b/crate_universe/src/utils/starlark/glob.rs
@@ -6,14 +6,14 @@ use serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct Glob {
-    pub allow_empty: bool,
-    pub include: BTreeSet<String>,
-    pub exclude: BTreeSet<String>,
+pub(crate) struct Glob {
+    pub(crate) allow_empty: bool,
+    pub(crate) include: BTreeSet<String>,
+    pub(crate) exclude: BTreeSet<String>,
 }
 
 impl Glob {
-    pub fn new_rust_srcs() -> Self {
+    pub(crate) fn new_rust_srcs() -> Self {
         Self {
             allow_empty: false,
             include: BTreeSet::from(["**/*.rs".to_owned()]),
@@ -21,7 +21,7 @@ impl Glob {
         }
     }
 
-    pub fn has_any_include(&self) -> bool {
+    pub(crate) fn has_any_include(&self) -> bool {
         self.include.is_empty()
         // Note: self.exclude intentionally not considered. A glob is empty if
         // there are no included globs. A glob cannot have only excludes.

--- a/crate_universe/src/utils/starlark/label.rs
+++ b/crate_universe/src/utils/starlark/label.rs
@@ -9,7 +9,7 @@ use serde::de::Visitor;
 use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub enum Label {
+pub(crate) enum Label {
     Relative {
         target: String,
     },
@@ -21,7 +21,7 @@ pub enum Label {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub enum Repository {
+pub(crate) enum Repository {
     Canonical(String), // stringifies to `@@self.0` where `self.0` may be empty
     Explicit(String),  // stringifies to `@self.0` where `self.0` may be empty
     Local,             // stringifies to the empty string
@@ -29,7 +29,7 @@ pub enum Repository {
 
 impl Label {
     #[cfg(test)]
-    pub fn is_absolute(&self) -> bool {
+    pub(crate) fn is_absolute(&self) -> bool {
         match self {
             Label::Relative { .. } => false,
             Label::Absolute { .. } => true,
@@ -37,21 +37,21 @@ impl Label {
     }
 
     #[cfg(test)]
-    pub fn repository(&self) -> Option<&Repository> {
+    pub(crate) fn repository(&self) -> Option<&Repository> {
         match self {
             Label::Relative { .. } => None,
             Label::Absolute { repository, .. } => Some(repository),
         }
     }
 
-    pub fn package(&self) -> Option<&str> {
+    pub(crate) fn package(&self) -> Option<&str> {
         match self {
             Label::Relative { .. } => None,
             Label::Absolute { package, .. } => Some(package.as_str()),
         }
     }
 
-    pub fn target(&self) -> &str {
+    pub(crate) fn target(&self) -> &str {
         match self {
             Label::Relative { target } => target.as_str(),
             Label::Absolute { target, .. } => target.as_str(),
@@ -183,7 +183,7 @@ impl Display for Label {
 impl Label {
     /// Generates a label appropriate for the passed Path by walking the filesystem to identify its
     /// workspace and package.
-    pub fn from_absolute_path(p: &Path) -> Result<Self, anyhow::Error> {
+    pub(crate) fn from_absolute_path(p: &Path) -> Result<Self, anyhow::Error> {
         let mut workspace_root = None;
         let mut package_root = None;
         for ancestor in p.ancestors().skip(1) {
@@ -287,7 +287,7 @@ impl<'de> Deserialize<'de> for Label {
 }
 
 impl Label {
-    pub fn repr(&self) -> String {
+    pub(crate) fn repr(&self) -> String {
         self.to_string()
     }
 }

--- a/crate_universe/src/utils/starlark/select.rs
+++ b/crate_universe/src/utils/starlark/select.rs
@@ -6,14 +6,14 @@ use serde::Serialize;
 use serde_starlark::LineComment;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct WithOriginalConfigurations<T> {
-    pub value: T,
-    pub original_configurations: BTreeSet<String>,
+pub(crate) struct WithOriginalConfigurations<T> {
+    pub(crate) value: T,
+    pub(crate) original_configurations: BTreeSet<String>,
 }
 
 #[derive(Serialize)]
 #[serde(rename = "selects.NO_MATCHING_PLATFORM_TRIPLES")]
-pub struct NoMatchingPlatformTriples;
+pub(crate) struct NoMatchingPlatformTriples;
 
 impl<T> Serialize for WithOriginalConfigurations<T>
 where
@@ -36,6 +36,6 @@ where
 // We don't expect any cfg-expressions or target triples to contain //,
 // and all labels _can_ be written in a way that they contain //,
 // so we use the presence of // as an indication something is a label.
-pub fn looks_like_bazel_configuration_label(configuration: &str) -> bool {
+pub(crate) fn looks_like_bazel_configuration_label(configuration: &str) -> bool {
     configuration.contains("//")
 }

--- a/crate_universe/src/utils/starlark/select_dict.rs
+++ b/crate_universe/src/utils/starlark/select_dict.rs
@@ -11,7 +11,7 @@ use crate::utils::starlark::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SelectDict<U, T>
+pub(crate) struct SelectDict<U, T>
 where
     U: SelectableOrderedValue,
     T: SelectableValue,
@@ -34,7 +34,7 @@ where
     /// Re-keys the provided Select by the given configuration mapping.
     /// This mapping maps from configurations in the input Select to sets
     /// of configurations in the output SelectDict.
-    pub fn new(
+    pub(crate) fn new(
         select: Select<BTreeMap<U, T>>,
         platforms: &BTreeMap<String, BTreeSet<String>>,
     ) -> Self {
@@ -95,7 +95,7 @@ where
         }
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.common.is_empty() && self.selects.is_empty() && self.unmapped.is_empty()
     }
 }

--- a/crate_universe/src/utils/starlark/select_list.rs
+++ b/crate_universe/src/utils/starlark/select_list.rs
@@ -12,7 +12,7 @@ use crate::utils::starlark::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SelectList<T>
+pub(crate) struct SelectList<T>
 where
     T: SelectableValue,
 {
@@ -31,7 +31,10 @@ where
     /// Re-keys the provided Select by the given configuration mapping.
     /// This mapping maps from configurations in the input Select to sets of
     /// configurations in the output SelectList.
-    pub fn new(select: Select<Vec<T>>, platforms: &BTreeMap<String, BTreeSet<String>>) -> Self {
+    pub(crate) fn new(
+        select: Select<Vec<T>>,
+        platforms: &BTreeMap<String, BTreeSet<String>>,
+    ) -> Self {
         let (common, selects) = select.into_parts();
 
         // Map new configuration -> WithOriginalConfigurations(value, old configuration).
@@ -84,7 +87,7 @@ where
     }
 
     /// Determine whether or not the select should be serialized
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.common.is_empty() && self.selects.is_empty() && self.unmapped.is_empty()
     }
 }

--- a/crate_universe/src/utils/starlark/select_scalar.rs
+++ b/crate_universe/src/utils/starlark/select_scalar.rs
@@ -11,7 +11,7 @@ use crate::utils::starlark::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SelectScalar<T>
+pub(crate) struct SelectScalar<T>
 where
     T: SelectableScalar,
 {
@@ -30,7 +30,7 @@ where
     /// Re-keys the provided Select by the given configuration mapping.
     /// This mapping maps from configurations in the input Select to sets of
     /// configurations in the output SelectScalar.
-    pub fn new(select: Select<T>, platforms: &BTreeMap<String, BTreeSet<String>>) -> Self {
+    pub(crate) fn new(select: Select<T>, platforms: &BTreeMap<String, BTreeSet<String>>) -> Self {
         let (common, selects) = select.into_parts();
 
         // Map new configuration -> WithOriginalConfigurations(value, old configurations).
@@ -77,7 +77,7 @@ where
     }
 
     /// Determine whether or not the select should be serialized
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.common.is_none() && self.selects.is_empty() && self.unmapped.is_empty()
     }
 }

--- a/crate_universe/src/utils/starlark/select_set.rs
+++ b/crate_universe/src/utils/starlark/select_set.rs
@@ -12,7 +12,7 @@ use crate::utils::starlark::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SelectSet<T>
+pub(crate) struct SelectSet<T>
 where
     T: SelectableOrderedValue,
 {
@@ -33,7 +33,7 @@ where
     /// Re-keys the provided Select by the given configuration mapping.
     /// This mapping maps from configurations in the input Select to sets of
     /// configurations in the output SelectSet.
-    pub fn new(
+    pub(crate) fn new(
         select: Select<BTreeSet<T>>,
         platforms: &BTreeMap<String, BTreeSet<String>>,
     ) -> Self {
@@ -102,7 +102,7 @@ where
     }
 
     /// Determine whether or not the select should be serialized
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.common.is_empty() && self.selects.is_empty() && self.unmapped.is_empty()
     }
 }

--- a/crate_universe/src/utils/starlark/serialize.rs
+++ b/crate_universe/src/utils/starlark/serialize.rs
@@ -10,21 +10,21 @@ use super::{
 // that attribute is that they get serialized as a map, not struct. In Starlark
 // unlike in JSON, maps and structs are differently serialized, so we need to
 // help fill in the function name or else we'd get a Starlark map instead.
-pub fn rust_proc_macro<S>(rule: &RustProcMacro, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn rust_proc_macro<S>(rule: &RustProcMacro, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     FunctionCall::new("rust_proc_macro", rule).serialize(serializer)
 }
 
-pub fn rust_library<S>(rule: &RustLibrary, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn rust_library<S>(rule: &RustLibrary, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     FunctionCall::new("rust_library", rule).serialize(serializer)
 }
 
-pub fn rust_binary<S>(rule: &RustBinary, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn rust_binary<S>(rule: &RustBinary, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -34,7 +34,7 @@ where
 // Serialize an array with each element on its own line, even if there is just a
 // single element which serde_starlark would ordinarily place on the same line
 // as the array brackets.
-pub struct MultilineArray<'a, A>(pub &'a A);
+pub(crate) struct MultilineArray<'a, A>(pub(crate) &'a A);
 
 impl<'a, A, T> Serialize for MultilineArray<'a, A>
 where
@@ -129,7 +129,7 @@ impl Serialize for ExportsFiles {
 }
 
 impl Data {
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.glob.has_any_include() && self.select.is_empty()
     }
 }

--- a/crate_universe/src/utils/starlark/target_compatible_with.rs
+++ b/crate_universe/src/utils/starlark/target_compatible_with.rs
@@ -5,12 +5,12 @@ use serde::Serialize;
 use serde_starlark::{FunctionCall, MULTILINE};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct TargetCompatibleWith {
+pub(crate) struct TargetCompatibleWith {
     target_triples: BTreeSet<String>,
 }
 
 impl TargetCompatibleWith {
-    pub fn new(target_triples: BTreeSet<String>) -> Self {
+    pub(crate) fn new(target_triples: BTreeSet<String>) -> Self {
         TargetCompatibleWith { target_triples }
     }
 }

--- a/crate_universe/src/utils/target_triple.rs
+++ b/crate_universe/src/utils/target_triple.rs
@@ -4,19 +4,19 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct TargetTriple(String);
+pub(crate) struct TargetTriple(String);
 
 impl TargetTriple {
     #[cfg(test)]
-    pub fn from_bazel(bazel: String) -> Self {
+    pub(crate) fn from_bazel(bazel: String) -> Self {
         Self(bazel)
     }
 
-    pub fn to_bazel(&self) -> String {
+    pub(crate) fn to_bazel(&self) -> String {
         self.0.clone()
     }
 
-    pub fn to_cargo(&self) -> String {
+    pub(crate) fn to_cargo(&self) -> String {
         // While Bazel is NixOS aware (via `@platforms//os:nixos`), `rustc`
         // is not, so any target triples for `nixos` get remapped to `linux`
         // for the purposes of determining `cargo metadata`, resolving `cfg`

--- a/crate_universe/test_data/test_data_passing_crate/src/lib.rs
+++ b/crate_universe/test_data/test_data_passing_crate/src/lib.rs
@@ -1,7 +1,7 @@
-pub const fn get_opt_level() -> &'static str {
+pub(crate) const fn get_opt_level() -> &'static str {
     env!("BUILD_SCRIPT_OPT_LEVEL")
 }
 
-pub const fn get_out_dir() -> &'static str {
+pub(crate) const fn get_out_dir() -> &'static str {
     env!("BUILD_SCRIPT_OUT_DIR")
 }

--- a/crate_universe/tools/cross_installer/src/main.rs
+++ b/crate_universe/tools/cross_installer/src/main.rs
@@ -11,11 +11,11 @@ struct Options {
     /// The path to an artifacts directory expecting to contain directories
     /// named after platform tripes with binaries inside.
     #[clap(long)]
-    pub output: PathBuf,
+    pub(crate) output: PathBuf,
 
     /// A url prefix where the artifacts can be found
     #[clap(long)]
-    pub target: String,
+    pub(crate) target: String,
 }
 
 /// This function is required until an upstream PR lands

--- a/crate_universe/tools/urls_generator/src/main.rs
+++ b/crate_universe/tools/urls_generator/src/main.rs
@@ -15,21 +15,21 @@ struct Options {
     /// The path to an artifacts directory expecting to contain directories
     /// named after platform tripes with binaries inside.
     #[clap(long)]
-    pub artifacts_dir: PathBuf,
+    pub(crate) artifacts_dir: PathBuf,
 
     /// A url prefix where the artifacts can be found
     #[clap(long)]
-    pub url_prefix: String,
+    pub(crate) url_prefix: String,
 
     /// The path to a buildifier binary. If set, it will be ran on the module
     #[clap(long)]
-    pub buildifier: Option<PathBuf>,
+    pub(crate) buildifier: Option<PathBuf>,
 }
 
 struct Artifact {
-    pub url: String,
-    pub triple: String,
-    pub sha256: String,
+    pub(crate) url: String,
+    pub(crate) triple: String,
+    pub(crate) sha256: String,
 }
 
 fn calculate_sha256(file_path: &Path) -> String {


### PR DESCRIPTION
Now that we actually have some pub items, this will help us to avoid accidentally leaking more (e.g. in
https://github.com/bazelbuild/rules_rust/pull/2515 we are leaking `CrateId`, `Select`, and `CrateDependency` to be public because they're marked `pub` not `pub(crate)`.

I'm not sure I like this, but wanted send as an RFC to discuss.