### PR TITLE
bzlmod: fix issue with nightly versions

### DIFF
--- a/rust/extensions.bzl
+++ b/rust/extensions.bzl
@@ -83,10 +83,9 @@ def _rust_impl(module_ctx):
 
     iso_date = None
     version = host_tools.version or rust_common.default_version
-    version_array = version.split("/")
-    if len(version_array) > 1:
-        version = version_array[0]
-        iso_date = version_array[1]
+    # Any version containing a slash is expected to be a nightly/beta release with iso date. E.g. `nightly/2024-03-21`
+    if "/" in version:
+        version, _, iso_date = version.partition("/")
 
     rust_toolchain_tools_repository(
         name = "rust_host_tools",

--- a/rust/extensions.bzl
+++ b/rust/extensions.bzl
@@ -83,6 +83,7 @@ def _rust_impl(module_ctx):
 
     iso_date = None
     version = host_tools.version or rust_common.default_version
+
     # Any version containing a slash is expected to be a nightly/beta release with iso date. E.g. `nightly/2024-03-21`
     if "/" in version:
         version, _, iso_date = version.partition("/")

--- a/rust/extensions.bzl
+++ b/rust/extensions.bzl
@@ -80,6 +80,14 @@ def _rust_impl(module_ctx):
         fail("Multiple host_tools were defined in your root MODULE.bazel")
 
     host_triple = get_host_triple(module_ctx)
+
+    iso_date = None
+    version = host_tools.version or rust_common.default_version
+    version_array = version.split("/")
+    if len(version_array) > 1:
+        version = version_array[0]
+        iso_date = version_array[1]
+
     rust_toolchain_tools_repository(
         name = "rust_host_tools",
         exec_triple = host_triple.str,
@@ -90,7 +98,8 @@ def _rust_impl(module_ctx):
         rustfmt_version = host_tools.rustfmt_version,
         sha256s = host_tools.sha256s,
         urls = host_tools.urls,
-        version = host_tools.version or rust_common.default_version,
+        version = version,
+        iso_date = iso_date,
     )
 
     for toolchain in toolchains:


### PR DESCRIPTION
Hi there 👋 

I tried using bzlmod with rules_rust, and I encountered an issue with the download of the toolchains.
I applied a "hotfix," but I'm sure it's not the correct approach. Hence, feel free to take over the PR.

```
bazel_dep(name = "rules_rust", version = "0.40.0")

rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")

rust.toolchain(
    edition = "2021",
    extra_target_triples = [
        "aarch64-apple-ios-sim",
        "aarch64-apple-ios",
        "aarch64-linux-android",
        "x86_64-unknown-linux-gnu",
    ],
    rustfmt_version = "nightly/2024-02-22",
    versions = ["nightly/2024-02-22"],
)

crate = use_extension(
    "@rules_rust//crate_universe:extension.bzl",
    "crate",
)
crate.from_cargo(
    name = "crates",
    cargo_lockfile = "//:Cargo.lock",
    manifests = [
        "//:Cargo.toml",
    ],
)
use_repo(crate, "crates")
```