### PR TITLE
Stop rustfmt versioning from overriding rust-analyzer versioning.

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -191,7 +191,7 @@ def rust_register_toolchains(
     rust_analyzer_repo_name = "rust_analyzer_{}".format(rust_analyzer_version.replace("/", "-"))
     rust_analyzer_iso_date = None
     if rust_analyzer_version.startswith(("beta", "nightly")):
-        rust_analyzer_version, _, rust_analyzer_iso_date = rustfmt_version.partition("/")
+        rust_analyzer_version, _, rust_analyzer_iso_date = rust_analyzer_version.partition("/")
 
     toolchain_names = []
     toolchain_labels = {}


### PR DESCRIPTION
There is a bug/typo in `rust_register_toolchains` where `rustfmt_version` would always override `rust_analyzer_version` (default or otherwise specified). This causes problems related to mismatched ABIs when rust-analyzer tries to expand proc macros if one were to use an older-than-default nightly toolchain without specifying a specific `rustfmt_version`. This is because `rust-analyzer` will be set to use the default `rustfmt_version` which is `nightly/2024-02-08`: https://github.com/bazelbuild/rules_rust/blob/8b977b5f7020fc3a3b3bbc318e414269014f126a/rust/private/common.bzl#L36

As a very basic example of what I mean:
```
rust_register_toolchains(
    edition = "2021",
    versions = [
        "nightly/2024-01-31",
    ],
    extra_exec_rustc_flags = ["-A", "async_fn_in_trait"],
)
```
Will result in rust-analyzer complaining with:
```
proc macro `Deserialize` not expanded: Cannot create expander for /private/var/tmp/_bazel_a/a03e1cfb3989a3cda645602bbe0ee892/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-13d3ddad9198/bin/external/crate_index__serde_derive-1.0.195/libserde_derive-1365269244.dylib: mismatched ABI expected: `rustc 1.78.0-nightly (8ace7ea1f 2024-02-07)`, got `rustc 1.77.0-nightly (11f32b73e 2024-01-31)`rust-analyzer[unresolved-proc-macro](https://rust-analyzer.github.io/manual.html#unresolved-proc-macro)
```
Using a workaround of setting `rustfmt_version` causes the ABI mismatch to be resolved:
```
rust_register_toolchains(
    edition = "2021",
    versions = [
        "nightly/2024-01-31",
    ],
    rustfmt_version = "nightly/2024-01-31",
    extra_exec_rustc_flags = ["-A", "async_fn_in_trait"],
)
```
This PR fixes the issue so that rust-analyzer version selection actually works.