### PR TITLE
Update test metadata for crate_universe

### DIFF
--- a/crate_universe/src/context.rs
+++ b/crate_universe/src/context.rs
@@ -282,7 +282,7 @@ mod test {
                 .collect::<Vec<_>>(),
             [
                 (&CrateId::new("log".to_owned(), Version::new(0, 3, 9)), false),
-                (&CrateId::new("log".to_owned(), Version::new(0, 4, 14)), false),
+                (&CrateId::new("log".to_owned(), Version::new(0, 4, 21)), false),
                 (&CrateId::new("names".to_owned(), Version::parse("0.12.1-dev").unwrap()), false),
                 (&CrateId::new("names".to_owned(), Version::new(0, 13, 0)), false),
                 (&CrateId::new("value-bag".to_owned(), Version::parse("1.0.0-alpha.7").unwrap()), false),

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -802,7 +802,7 @@ mod test {
         let annotations = common_annotations();
 
         let crate_annotation = &annotations.metadata.crates[&PackageId {
-            repr: "common 0.1.0 (path+file://{TEMP_DIR}/common)".to_owned(),
+            repr: "path+file://{TEMP_DIR}/common#0.1.0".to_owned(),
         }];
 
         let include_binaries = false;
@@ -833,7 +833,7 @@ mod test {
         let annotations = common_annotations();
 
         let package_id = PackageId {
-            repr: "common 0.1.0 (path+file://{TEMP_DIR}/common)".to_owned(),
+            repr: "path+file://{TEMP_DIR}/common#0.1.0".to_owned(),
         };
 
         let crate_annotation = &annotations.metadata.crates[&package_id];
@@ -908,7 +908,7 @@ mod test {
         let annotations = build_script_annotations();
 
         let package_id = PackageId {
-            repr: "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
+            repr: "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
                 .to_owned(),
         };
 
@@ -953,7 +953,7 @@ mod test {
         let annotations = build_script_annotations();
 
         let package_id = PackageId {
-            repr: "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
+            repr: "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
                 .to_owned(),
         };
 
@@ -988,8 +988,7 @@ mod test {
         let annotations = crate_type_annotations();
 
         let package_id = PackageId {
-            repr: "sysinfo 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)"
-                .to_owned(),
+            repr: "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.22.5".to_owned(),
         };
 
         let crate_annotation = &annotations.metadata.crates[&package_id];
@@ -1024,7 +1023,7 @@ mod test {
     ) {
         let mut annotations = common_annotations();
         let crate_annotation = &annotations.metadata.crates[&PackageId {
-            repr: "common 0.1.0 (path+file://{TEMP_DIR}/common)".to_owned(),
+            repr: "path+file://{TEMP_DIR}/common#0.1.0".to_owned(),
         }];
         let include_binaries = false;
         let include_build_scripts = false;

--- a/crate_universe/src/metadata/dependency.rs
+++ b/crate_universe/src/metadata/dependency.rs
@@ -500,10 +500,10 @@ mod test {
 
         assert_eq!(
             BTreeSet::from([
-                "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)".to_owned(),
-                "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)"
+                "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72".to_owned(),
+                "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24"
                     .to_owned(),
-                "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)".to_owned()
+                "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15".to_owned()
             ]),
             build_deps,
         );
@@ -518,9 +518,9 @@ mod test {
 
         assert_eq!(
             BTreeSet::from([
-                "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)".to_owned(),
-                "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)".to_owned(),
-                "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
+                "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112".to_owned(),
+                "registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.8".to_owned(),
+                "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
                     .to_owned(),
             ]),
             normal_deps,

--- a/crate_universe/src/metadata/metadata_annotation.rs
+++ b/crate_universe/src/metadata/metadata_annotation.rs
@@ -533,7 +533,7 @@ mod test {
                 .crates;
         let tracing_core = crates
             .iter()
-            .find(|(k, _)| k.repr.starts_with("tracing-core "))
+            .find(|(k, _)| k.repr.contains("#tracing-core@"))
             .map(|(_, v)| v)
             .unwrap();
         match tracing_core {
@@ -556,7 +556,9 @@ mod test {
                 .unwrap()
                 .crates;
 
-        let package_id = PackageId { repr: "tracing 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)".into() };
+        let package_id = PackageId {
+            repr: "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing@0.2.0".into(),
+        };
         let annotation = crates.get(&package_id).unwrap();
 
         let commitish = match annotation {

--- a/crate_universe/test_data/metadata/aliases/Cargo.lock
+++ b/crate_universe/test_data/metadata/aliases/Cargo.lock
@@ -7,7 +7,7 @@ name = "aliases"
 version = "0.1.0"
 dependencies = [
  "log 0.3.9",
- "log 0.4.14",
+ "log 0.4.21",
  "names 0.12.1-dev",
  "names 0.13.0",
  "value-bag",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -132,9 +132,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "log"
@@ -142,23 +142,20 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.21",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "names"
@@ -220,18 +217,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -259,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -274,13 +271,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -299,10 +296,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "value-bag"
@@ -322,9 +319,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/crate_universe/test_data/metadata/aliases/Cargo.toml
+++ b/crate_universe/test_data/metadata/aliases/Cargo.toml
@@ -14,7 +14,7 @@ path = "lib.rs"
 
 [dependencies]
 # Defines library targets
-log = "=0.4.14"
+log = "=0.4.21"
 pinned_log = { package = "log", version = "=0.3.9" }
 
 # Contains a transitive alias

--- a/crate_universe/test_data/metadata/aliases/metadata.json
+++ b/crate_universe/test_data/metadata/aliases/metadata.json
@@ -13,7 +13,7 @@
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "=0.4.14",
+                    "req": "=0.4.21",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": true
@@ -72,7 +72,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "aliases 0.1.0 (path+file://{TEMP_DIR}/aliases)",
+            "id": "path+file://{TEMP_DIR}/aliases#0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -158,7 +158,7 @@
             "edition": "2015",
             "features": {},
             "homepage": "https://github.com/softprops/atty",
-            "id": "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#atty@0.2.14",
             "keywords": [
                 "terminal",
                 "tty",
@@ -221,7 +221,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
             "keywords": [
                 "rustc",
                 "build",
@@ -450,7 +450,7 @@
                 ]
             },
             "homepage": "https://github.com/bitflags/bitflags",
-            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
             "keywords": [
                 "bit",
                 "bitmask",
@@ -570,7 +570,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -957,7 +957,7 @@
                 ]
             },
             "homepage": null,
-            "id": "clap 3.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#clap@3.1.5",
             "keywords": [
                 "argument",
                 "cli",
@@ -2012,7 +2012,7 @@
                 "default": []
             },
             "homepage": null,
-            "id": "clap_derive 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@3.1.4",
             "keywords": [
                 "clap",
                 "cli",
@@ -2125,7 +2125,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "ctor 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ctor@0.1.21",
             "keywords": [],
             "license": "Apache-2.0 OR MIT",
             "license_file": null,
@@ -2225,7 +2225,7 @@
                     "rename": null,
                     "req": "^0.3",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "target": "cfg(all(any(target_arch = \"wasm32\", target_arch = \"wasm64\"), target_os = \"unknown\"))",
                     "uses_default_features": true
                 },
                 {
@@ -2237,7 +2237,7 @@
                     "rename": null,
                     "req": "^0.2.62",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "target": "cfg(all(any(target_arch = \"wasm32\", target_arch = \"wasm64\"), target_os = \"unknown\"))",
                     "uses_default_features": false
                 },
                 {
@@ -2249,7 +2249,7 @@
                     "rename": null,
                     "req": "^0.3.18",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "target": "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))",
+                    "target": "cfg(all(any(target_arch = \"wasm32\", target_arch = \"wasm64\"), target_os = \"unknown\"))",
                     "uses_default_features": true
                 },
                 {
@@ -2259,10 +2259,10 @@
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^0.10",
+                    "req": "^0.11",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": "cfg(target_os = \"wasi\")",
-                    "uses_default_features": true
+                    "uses_default_features": false
                 },
                 {
                     "features": [],
@@ -2271,7 +2271,7 @@
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^0.2.64",
+                    "req": "^0.2.149",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": "cfg(unix)",
                     "uses_default_features": false
@@ -2309,13 +2309,27 @@
                 ]
             },
             "homepage": null,
-            "id": "getrandom 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.12",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.5/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/Cargo.toml",
             "metadata": {
+                "cross": {
+                    "target": {
+                        "x86_64-unknown-netbsd": {
+                            "pre-build": [
+                                "mkdir -p /tmp/netbsd",
+                                "curl https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz -O",
+                                "tar -C /tmp/netbsd -xJf base.tar.xz",
+                                "cp /tmp/netbsd/usr/lib/libexecinfo.so /usr/local/x86_64-unknown-netbsd/lib",
+                                "rm base.tar.xz",
+                                "rm -rf /tmp/netbsd"
+                            ]
+                        }
+                    }
+                },
                 "docs": {
                     "rs": {
                         "features": [
@@ -2347,7 +2361,7 @@
                         "lib"
                     ],
                     "name": "getrandom",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.5/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/src/lib.rs",
                     "test": true
                 },
                 {
@@ -2361,7 +2375,7 @@
                         "test"
                     ],
                     "name": "normal",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.5/tests/normal.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/tests/normal.rs",
                     "test": true
                 },
                 {
@@ -2375,7 +2389,7 @@
                         "test"
                     ],
                     "name": "custom",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.5/tests/custom.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/tests/custom.rs",
                     "test": true
                 },
                 {
@@ -2389,7 +2403,7 @@
                         "test"
                     ],
                     "name": "rdrand",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.5/tests/rdrand.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/tests/rdrand.rs",
                     "test": true
                 },
                 {
@@ -2402,12 +2416,12 @@
                     "kind": [
                         "bench"
                     ],
-                    "name": "mod",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.5/benches/mod.rs",
+                    "name": "buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/benches/buffer.rs",
                     "test": false
                 }
             ],
-            "version": "0.2.5"
+            "version": "0.2.12"
         },
         {
             "authors": [
@@ -2623,7 +2637,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hashbrown 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.11.2",
             "keywords": [
                 "hash",
                 "no_std",
@@ -2773,7 +2787,7 @@
                 ]
             },
             "homepage": "https://github.com/withoutboats/heck",
-            "id": "heck 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#heck@0.4.0",
             "keywords": [
                 "string",
                 "case",
@@ -2875,7 +2889,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.1.19",
             "keywords": [
                 "unikernel",
                 "libos"
@@ -3099,7 +3113,7 @@
                 "test_low_transition_point": []
             },
             "homepage": null,
-            "id": "indexmap 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.8.0",
             "keywords": [
                 "hashmap",
                 "no_std"
@@ -3292,7 +3306,7 @@
                 ]
             },
             "homepage": null,
-            "id": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0",
             "keywords": [
                 "macro",
                 "lazy",
@@ -3402,7 +3416,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/libc",
-            "id": "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153",
             "keywords": [
                 "libc",
                 "ffi",
@@ -3413,13 +3427,126 @@
             "license": "MIT OR Apache-2.0",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.119/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/Cargo.toml",
             "metadata": {
                 "docs": {
                     "rs": {
+                        "cargo-args": [
+                            "-Zbuild-std=core"
+                        ],
+                        "default-target": "x86_64-unknown-linux-gnu",
                         "features": [
                             "const-extern-fn",
                             "extra_traits"
+                        ],
+                        "targets": [
+                            "aarch64-apple-darwin",
+                            "aarch64-apple-ios",
+                            "aarch64-linux-android",
+                            "aarch64-pc-windows-msvc",
+                            "aarch64-unknown-freebsd",
+                            "aarch64-unknown-fuchsia",
+                            "aarch64-unknown-hermit",
+                            "aarch64-unknown-linux-gnu",
+                            "aarch64-unknown-linux-musl",
+                            "aarch64-unknown-netbsd",
+                            "aarch64-unknown-openbsd",
+                            "aarch64-wrs-vxworks",
+                            "arm-linux-androideabi",
+                            "arm-unknown-linux-gnueabi",
+                            "arm-unknown-linux-gnueabihf",
+                            "arm-unknown-linux-musleabi",
+                            "arm-unknown-linux-musleabihf",
+                            "armebv7r-none-eabi",
+                            "armebv7r-none-eabihf",
+                            "armv5te-unknown-linux-gnueabi",
+                            "armv5te-unknown-linux-musleabi",
+                            "armv7-linux-androideabi",
+                            "armv7-unknown-linux-gnueabihf",
+                            "armv7-unknown-linux-musleabihf",
+                            "armv7-wrs-vxworks-eabihf",
+                            "armv7r-none-eabi",
+                            "armv7r-none-eabihf",
+                            "hexagon-unknown-linux-musl",
+                            "i586-pc-windows-msvc",
+                            "i586-unknown-linux-gnu",
+                            "i586-unknown-linux-musl",
+                            "i686-linux-android",
+                            "i686-pc-windows-gnu",
+                            "i686-pc-windows-msvc",
+                            "i686-pc-windows-msvc",
+                            "i686-unknown-freebsd",
+                            "i686-unknown-haiku",
+                            "i686-unknown-linux-gnu",
+                            "i686-unknown-linux-musl",
+                            "i686-unknown-netbsd",
+                            "i686-unknown-openbsd",
+                            "i686-wrs-vxworks",
+                            "mips-unknown-linux-gnu",
+                            "mips-unknown-linux-musl",
+                            "mips64-unknown-linux-gnuabi64",
+                            "mips64-unknown-linux-muslabi64",
+                            "mips64el-unknown-linux-gnuabi64",
+                            "mips64el-unknown-linux-muslabi64",
+                            "mipsel-sony-psp",
+                            "mipsel-unknown-linux-gnu",
+                            "mipsel-unknown-linux-musl",
+                            "nvptx64-nvidia-cuda",
+                            "powerpc-unknown-linux-gnu",
+                            "powerpc-unknown-linux-gnuspe",
+                            "powerpc-unknown-netbsd",
+                            "powerpc-wrs-vxworks",
+                            "powerpc-wrs-vxworks-spe",
+                            "powerpc64-unknown-freebsd",
+                            "powerpc64-unknown-linux-gnu",
+                            "powerpc64-wrs-vxworks",
+                            "powerpc64le-unknown-linux-gnu",
+                            "riscv32gc-unknown-linux-gnu",
+                            "riscv32i-unknown-none-elf",
+                            "riscv32imac-unknown-none-elf",
+                            "riscv32imc-unknown-none-elf",
+                            "riscv64gc-unknown-freebsd",
+                            "riscv64gc-unknown-hermit",
+                            "riscv64gc-unknown-linux-gnu",
+                            "riscv64gc-unknown-linux-musl",
+                            "riscv64gc-unknown-none-elf",
+                            "riscv64imac-unknown-none-elf",
+                            "s390x-unknown-linux-gnu",
+                            "s390x-unknown-linux-musl",
+                            "sparc-unknown-linux-gnu",
+                            "sparc64-unknown-linux-gnu",
+                            "sparc64-unknown-netbsd",
+                            "sparcv9-sun-solaris",
+                            "thumbv6m-none-eabi",
+                            "thumbv7em-none-eabi",
+                            "thumbv7em-none-eabihf",
+                            "thumbv7m-none-eabi",
+                            "thumbv7neon-linux-androideabi",
+                            "thumbv7neon-unknown-linux-gnueabihf",
+                            "wasm32-unknown-emscripten",
+                            "wasm32-unknown-unknown",
+                            "wasm32-wasi",
+                            "x86_64-apple-darwin",
+                            "x86_64-apple-ios",
+                            "x86_64-fortanix-unknown-sgx",
+                            "x86_64-linux-android",
+                            "x86_64-pc-solaris",
+                            "x86_64-pc-windows-gnu",
+                            "x86_64-pc-windows-msvc",
+                            "x86_64-unknown-dragonfly",
+                            "x86_64-unknown-freebsd",
+                            "x86_64-unknown-fuchsia",
+                            "x86_64-unknown-haiku",
+                            "x86_64-unknown-hermit",
+                            "x86_64-unknown-illumos",
+                            "x86_64-unknown-l4re-uclibc",
+                            "x86_64-unknown-linux-gnu",
+                            "x86_64-unknown-linux-gnux32",
+                            "x86_64-unknown-linux-musl",
+                            "x86_64-unknown-netbsd",
+                            "x86_64-unknown-openbsd",
+                            "x86_64-unknown-redox",
+                            "x86_64-wrs-vxworks"
                         ]
                     }
                 }
@@ -3442,7 +3569,7 @@
                         "lib"
                     ],
                     "name": "libc",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.119/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/src/lib.rs",
                     "test": true
                 },
                 {
@@ -3456,7 +3583,7 @@
                         "test"
                     ],
                     "name": "const_fn",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.119/tests/const_fn.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/tests/const_fn.rs",
                     "test": true
                 },
                 {
@@ -3470,11 +3597,11 @@
                         "custom-build"
                     ],
                     "name": "build-script-build",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.119/build.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/build.rs",
                     "test": false
                 }
             ],
-            "version": "0.2.119"
+            "version": "0.2.153"
         },
         {
             "authors": [
@@ -3547,7 +3674,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/log",
-            "id": "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.3.9",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -3590,18 +3717,6 @@
                 {
                     "features": [],
                     "kind": null,
-                    "name": "cfg-if",
-                    "optional": false,
-                    "registry": null,
-                    "rename": null,
-                    "req": "^1.0",
-                    "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "target": null,
-                    "uses_default_features": true
-                },
-                {
-                    "features": [],
-                    "kind": null,
                     "name": "serde",
                     "optional": true,
                     "registry": null,
@@ -3618,7 +3733,7 @@
                     "optional": true,
                     "registry": null,
                     "rename": null,
-                    "req": "^1.0.0-alpha.5",
+                    "req": "^2.1",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": false
@@ -3626,11 +3741,37 @@
                 {
                     "features": [],
                     "kind": null,
+                    "name": "sval_ref",
+                    "optional": true,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^2.1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [
+                        "inline-i128"
+                    ],
+                    "kind": null,
                     "name": "value-bag",
                     "optional": true,
                     "registry": null,
                     "rename": null,
-                    "req": "^1.0.0-alpha.6",
+                    "req": "^1.7",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "proc-macro2",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0.63",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": false
@@ -3641,6 +3782,18 @@
                     ],
                     "kind": "dev",
                     "name": "serde",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "serde_json",
                     "optional": false,
                     "registry": null,
                     "rename": null,
@@ -3662,15 +3815,25 @@
                     "uses_default_features": true
                 },
                 {
-                    "features": [
-                        "derive"
-                    ],
+                    "features": [],
                     "kind": "dev",
                     "name": "sval",
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^1.0.0-alpha.5",
+                    "req": "^2.1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "sval_derive",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^2.1",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": true
@@ -3684,7 +3847,7 @@
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^1.0.0-alpha.6",
+                    "req": "^1.7",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": true
@@ -3692,25 +3855,40 @@
             ],
             "description": "A lightweight logging facade for Rust\n",
             "documentation": "https://docs.rs/log",
-            "edition": "2015",
+            "edition": "2021",
             "features": {
-                "kv_unstable": [
-                    "value-bag"
-                ],
-                "kv_unstable_serde": [
-                    "kv_unstable_std",
+                "kv": [],
+                "kv_serde": [
+                    "kv_std",
                     "value-bag/serde",
                     "serde"
                 ],
-                "kv_unstable_std": [
+                "kv_std": [
                     "std",
-                    "kv_unstable",
+                    "kv",
                     "value-bag/error"
                 ],
-                "kv_unstable_sval": [
-                    "kv_unstable",
+                "kv_sval": [
+                    "kv",
                     "value-bag/sval",
-                    "sval"
+                    "sval",
+                    "sval_ref"
+                ],
+                "kv_unstable": [
+                    "kv",
+                    "value-bag"
+                ],
+                "kv_unstable_serde": [
+                    "kv_serde",
+                    "kv_unstable_std"
+                ],
+                "kv_unstable_std": [
+                    "kv_std",
+                    "kv_unstable"
+                ],
+                "kv_unstable_sval": [
+                    "kv_sval",
+                    "kv_unstable"
                 ],
                 "max_level_debug": [],
                 "max_level_error": [],
@@ -3731,28 +3909,31 @@
                 "sval": [
                     "dep:sval"
                 ],
+                "sval_ref": [
+                    "dep:sval_ref"
+                ],
                 "value-bag": [
                     "dep:value-bag"
                 ]
             },
             "homepage": null,
-            "id": "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.21",
             "keywords": [
                 "logging"
             ],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.14/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.21/Cargo.toml",
             "metadata": {
                 "docs": {
                     "rs": {
                         "features": [
                             "std",
                             "serde",
-                            "kv_unstable_std",
-                            "kv_unstable_sval",
-                            "kv_unstable_serde"
+                            "kv_std",
+                            "kv_sval",
+                            "kv_serde"
                         ]
                     }
                 }
@@ -3761,7 +3942,7 @@
             "publish": null,
             "readme": "README.md",
             "repository": "https://github.com/rust-lang/log",
-            "rust_version": null,
+            "rust_version": "1.60.0",
             "source": "registry+https://github.com/rust-lang/crates.io-index",
             "targets": [
                 {
@@ -3770,12 +3951,12 @@
                     ],
                     "doc": true,
                     "doctest": true,
-                    "edition": "2015",
+                    "edition": "2021",
                     "kind": [
                         "lib"
                     ],
                     "name": "log",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.14/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.21/src/lib.rs",
                     "test": true
                 },
                 {
@@ -3784,12 +3965,12 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2015",
+                    "edition": "2021",
                     "kind": [
                         "test"
                     ],
                     "name": "filters",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.14/tests/filters.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.21/tests/filters.rs",
                     "test": true
                 },
                 {
@@ -3798,12 +3979,12 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2015",
+                    "edition": "2021",
                     "kind": [
                         "test"
                     ],
                     "name": "macros",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.14/tests/macros.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.21/tests/macros.rs",
                     "test": true
                 },
                 {
@@ -3812,30 +3993,16 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2015",
+                    "edition": "2021",
                     "kind": [
                         "bench"
                     ],
                     "name": "value",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.14/benches/value.rs",
-                    "test": false
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2015",
-                    "kind": [
-                        "custom-build"
-                    ],
-                    "name": "build-script-build",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.14/build.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/log-0.4.21/benches/value.rs",
                     "test": false
                 }
             ],
-            "version": "0.4.14"
+            "version": "0.4.21"
         },
         {
             "authors": [
@@ -3872,14 +4039,14 @@
                 {
                     "features": [],
                     "kind": null,
-                    "name": "libc",
+                    "name": "log",
                     "optional": true,
                     "registry": null,
                     "rename": null,
-                    "req": "^0.2.18",
+                    "req": "^0.4.20",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
-                    "uses_default_features": false
+                    "uses_default_features": true
                 },
                 {
                     "features": [],
@@ -3894,10 +4061,11 @@
                     "uses_default_features": false
                 }
             ],
-            "description": "Safe interface to memchr.",
+            "description": "Provides extremely fast (uses SIMD on x86_64, aarch64 and wasm32) routines for\n1, 2 or 3 byte search and single substring search.\n",
             "documentation": "https://docs.rs/memchr/",
-            "edition": "2018",
+            "edition": "2021",
             "features": {
+                "alloc": [],
                 "compiler_builtins": [
                     "dep:compiler_builtins"
                 ],
@@ -3907,37 +4075,48 @@
                 "default": [
                     "std"
                 ],
-                "libc": [
-                    "dep:libc"
+                "libc": [],
+                "logging": [
+                    "dep:log"
                 ],
                 "rustc-dep-of-std": [
                     "core",
                     "compiler_builtins"
                 ],
-                "std": [],
+                "std": [
+                    "alloc"
+                ],
                 "use_std": [
                     "std"
                 ]
             },
             "homepage": "https://github.com/BurntSushi/memchr",
-            "id": "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.7.2",
             "keywords": [
                 "memchr",
-                "char",
-                "scan",
-                "strchr",
-                "string"
+                "memmem",
+                "substring",
+                "find",
+                "search"
             ],
-            "license": "Unlicense/MIT",
+            "license": "Unlicense OR MIT",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/memchr-2.4.1/Cargo.toml",
-            "metadata": null,
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/memchr-2.7.2/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustdoc-args": [
+                            "--generate-link-to-definition"
+                        ]
+                    }
+                }
+            },
             "name": "memchr",
             "publish": null,
             "readme": "README.md",
             "repository": "https://github.com/BurntSushi/memchr",
-            "rust_version": null,
+            "rust_version": "1.61",
             "source": "registry+https://github.com/rust-lang/crates.io-index",
             "targets": [
                 {
@@ -3946,30 +4125,16 @@
                     ],
                     "doc": true,
                     "doctest": true,
-                    "edition": "2018",
+                    "edition": "2021",
                     "kind": [
                         "lib"
                     ],
                     "name": "memchr",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/memchr-2.4.1/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/memchr-2.7.2/src/lib.rs",
                     "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "custom-build"
-                    ],
-                    "name": "build-script-build",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/memchr-2.4.1/build.rs",
-                    "test": false
                 }
             ],
-            "version": "2.4.1"
+            "version": "2.7.2"
         },
         {
             "authors": [
@@ -4034,7 +4199,7 @@
                 ]
             },
             "homepage": "https://github.com/fnichol/names",
-            "id": "names 0.12.1-dev (git+https://github.com/fnichol/names.git?rev=760516503b89ddc8bc2ab42d579d4566cfb1054f#760516503b89ddc8bc2ab42d579d4566cfb1054f)",
+            "id": "git+https://github.com/fnichol/names.git?rev=760516503b89ddc8bc2ab42d579d4566cfb1054f#names@0.12.1-dev",
             "keywords": [
                 "name",
                 "random"
@@ -4179,7 +4344,7 @@
                 ]
             },
             "homepage": "https://github.com/fnichol/names",
-            "id": "names 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#names@0.13.0",
             "keywords": [
                 "name",
                 "random"
@@ -4343,7 +4508,7 @@
                 ]
             },
             "homepage": null,
-            "id": "os_str_bytes 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.0.0",
             "keywords": [
                 "bytes",
                 "osstr",
@@ -4416,7 +4581,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "ppv-lite86 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.16",
             "keywords": [
                 "crypto",
                 "simd",
@@ -4574,7 +4739,7 @@
                 ]
             },
             "homepage": null,
-            "id": "proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error@1.0.4",
             "keywords": [
                 "proc-macro",
                 "error",
@@ -4722,7 +4887,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr@1.0.4",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -4788,11 +4953,23 @@
                 {
                     "features": [],
                     "kind": null,
-                    "name": "unicode-xid",
+                    "name": "unicode-ident",
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^0.2",
+                    "req": "^1.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "flate2",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": true
@@ -4808,11 +4985,47 @@
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "rayon",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "rustversion",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "tar",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.4",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
                 }
             ],
-            "description": "A substitute implementation of the compiler's `proc_macro` API to decouple\ntoken-based libraries from the procedural macro use case.\n",
+            "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
             "documentation": "https://docs.rs/proc-macro2",
-            "edition": "2018",
+            "edition": "2021",
             "features": {
                 "default": [
                     "proc-macro"
@@ -4822,14 +5035,15 @@
                 "span-locations": []
             },
             "homepage": null,
-            "id": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
             "keywords": [
-                "macros"
+                "macros",
+                "syn"
             ],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.36/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/Cargo.toml",
             "metadata": {
                 "docs": {
                     "rs": {
@@ -4841,7 +5055,8 @@
                             "--cfg",
                             "procmacro2_semver_exempt",
                             "--cfg",
-                            "doc_cfg"
+                            "doc_cfg",
+                            "--generate-link-to-definition"
                         ],
                         "targets": [
                             "x86_64-unknown-linux-gnu"
@@ -4858,7 +5073,7 @@
             "publish": null,
             "readme": "README.md",
             "repository": "https://github.com/dtolnay/proc-macro2",
-            "rust_version": "1.31",
+            "rust_version": "1.56",
             "source": "registry+https://github.com/rust-lang/crates.io-index",
             "targets": [
                 {
@@ -4867,12 +5082,12 @@
                     ],
                     "doc": true,
                     "doctest": true,
-                    "edition": "2018",
+                    "edition": "2021",
                     "kind": [
                         "lib"
                     ],
                     "name": "proc-macro2",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.36/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/src/lib.rs",
                     "test": true
                 },
                 {
@@ -4881,12 +5096,12 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2018",
+                    "edition": "2021",
                     "kind": [
                         "test"
                     ],
                     "name": "features",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.36/tests/features.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/features.rs",
                     "test": true
                 },
                 {
@@ -4895,12 +5110,12 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2018",
+                    "edition": "2021",
                     "kind": [
                         "test"
                     ],
                     "name": "test",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.36/tests/test.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/test.rs",
                     "test": true
                 },
                 {
@@ -4909,12 +5124,26 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2018",
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/test_size.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
                     "kind": [
                         "test"
                     ],
                     "name": "test_fmt",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.36/tests/test_fmt.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/test_fmt.rs",
                     "test": true
                 },
                 {
@@ -4923,12 +5152,12 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2018",
+                    "edition": "2021",
                     "kind": [
                         "test"
                     ],
                     "name": "comments",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.36/tests/comments.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/comments.rs",
                     "test": true
                 },
                 {
@@ -4937,12 +5166,12 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2018",
+                    "edition": "2021",
                     "kind": [
                         "test"
                     ],
                     "name": "marker",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.36/tests/marker.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/marker.rs",
                     "test": true
                 },
                 {
@@ -4951,16 +5180,16 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2018",
+                    "edition": "2021",
                     "kind": [
                         "custom-build"
                     ],
                     "name": "build-script-build",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.36/build.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/build.rs",
                     "test": false
                 }
             ],
-            "version": "1.0.36"
+            "version": "1.0.79"
         },
         {
             "authors": [
@@ -4978,7 +5207,7 @@
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^1.0.36",
+                    "req": "^1.0.74",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": false
@@ -5004,7 +5233,7 @@
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^1.0.52",
+                    "req": "^1.0.66",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": true
@@ -5022,17 +5251,21 @@
                 ]
             },
             "homepage": null,
-            "id": "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
             "keywords": [
+                "macros",
                 "syn"
             ],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.15/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/Cargo.toml",
             "metadata": {
                 "docs": {
                     "rs": {
+                        "rustdoc-args": [
+                            "--generate-link-to-definition"
+                        ],
                         "targets": [
                             "x86_64-unknown-linux-gnu"
                         ]
@@ -5043,7 +5276,7 @@
             "publish": null,
             "readme": "README.md",
             "repository": "https://github.com/dtolnay/quote",
-            "rust_version": "1.31",
+            "rust_version": "1.56",
             "source": "registry+https://github.com/rust-lang/crates.io-index",
             "targets": [
                 {
@@ -5057,7 +5290,7 @@
                         "lib"
                     ],
                     "name": "quote",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.15/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/src/lib.rs",
                     "test": true
                 },
                 {
@@ -5071,7 +5304,7 @@
                         "test"
                     ],
                     "name": "test",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.15/tests/test.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/tests/test.rs",
                     "test": true
                 },
                 {
@@ -5085,11 +5318,11 @@
                         "test"
                     ],
                     "name": "compiletest",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.15/tests/compiletest.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/tests/compiletest.rs",
                     "test": true
                 }
             ],
-            "version": "1.0.15"
+            "version": "1.0.35"
         },
         {
             "authors": [
@@ -5254,7 +5487,7 @@
                 ]
             },
             "homepage": "https://rust-random.github.io/book",
-            "id": "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5",
             "keywords": [
                 "random",
                 "rng"
@@ -5388,7 +5621,7 @@
                 ]
             },
             "homepage": "https://rust-random.github.io/book",
-            "id": "rand_chacha 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1",
             "keywords": [
                 "random",
                 "rng",
@@ -5482,7 +5715,7 @@
                 ]
             },
             "homepage": "https://rust-random.github.io/book",
-            "id": "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4",
             "keywords": [
                 "random",
                 "rng"
@@ -5490,7 +5723,7 @@
             "license": "MIT OR Apache-2.0",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/rand_core-0.6.3/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/rand_core-0.6.4/Cargo.toml",
             "metadata": {
                 "docs": {
                     "rs": {
@@ -5523,11 +5756,11 @@
                         "lib"
                     ],
                     "name": "rand_core",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/rand_core-0.6.3/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/rand_core-0.6.4/src/lib.rs",
                     "test": true
                 }
             ],
-            "version": "0.6.3"
+            "version": "0.6.4"
         },
         {
             "authors": [
@@ -5541,7 +5774,7 @@
             "edition": "2015",
             "features": {},
             "homepage": "https://github.com/dguo/strsim-rs",
-            "id": "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.10.0",
             "keywords": [
                 "string",
                 "similarity",
@@ -5611,7 +5844,8 @@
                 "David Tolnay <dtolnay@gmail.com>"
             ],
             "categories": [
-                "development-tools::procedural-macro-helpers"
+                "development-tools::procedural-macro-helpers",
+                "parser-implementations"
             ],
             "default_run": null,
             "dependencies": [
@@ -5622,7 +5856,7 @@
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^1.0.32",
+                    "req": "^1.0.46",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": false
@@ -5642,11 +5876,11 @@
                 {
                     "features": [],
                     "kind": null,
-                    "name": "unicode-xid",
+                    "name": "unicode-ident",
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^0.2",
+                    "req": "^1.0",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": true
@@ -5832,12 +6066,15 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 1.0.86 (registry+https://github.com/rust-lang/crates.io-index)",
-            "keywords": [],
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109",
+            "keywords": [
+                "macros",
+                "syn"
+            ],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/Cargo.toml",
             "metadata": {
                 "docs": {
                     "rs": {
@@ -5879,7 +6116,7 @@
                         "lib"
                     ],
                     "name": "syn",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/src/lib.rs",
                     "test": true
                 },
                 {
@@ -5893,7 +6130,7 @@
                         "test"
                     ],
                     "name": "test_should_parse",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_should_parse.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_should_parse.rs",
                     "test": true
                 },
                 {
@@ -5907,7 +6144,7 @@
                         "test"
                     ],
                     "name": "test_visibility",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_visibility.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_visibility.rs",
                     "test": true
                 },
                 {
@@ -5921,7 +6158,7 @@
                         "test"
                     ],
                     "name": "test_stmt",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_stmt.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_stmt.rs",
                     "test": true
                 },
                 {
@@ -5935,7 +6172,7 @@
                         "test"
                     ],
                     "name": "test_round_trip",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_round_trip.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_round_trip.rs",
                     "test": true
                 },
                 {
@@ -5949,7 +6186,7 @@
                         "test"
                     ],
                     "name": "test_size",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_size.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_size.rs",
                     "test": true
                 },
                 {
@@ -5963,7 +6200,7 @@
                         "test"
                     ],
                     "name": "test_shebang",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_shebang.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_shebang.rs",
                     "test": true
                 },
                 {
@@ -5977,7 +6214,7 @@
                         "test"
                     ],
                     "name": "test_pat",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_pat.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_pat.rs",
                     "test": true
                 },
                 {
@@ -5991,7 +6228,7 @@
                         "test"
                     ],
                     "name": "test_receiver",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_receiver.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_receiver.rs",
                     "test": true
                 },
                 {
@@ -6005,7 +6242,7 @@
                         "test"
                     ],
                     "name": "test_precedence",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_precedence.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_precedence.rs",
                     "test": true
                 },
                 {
@@ -6019,7 +6256,7 @@
                         "test"
                     ],
                     "name": "test_lit",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_lit.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_lit.rs",
                     "test": true
                 },
                 {
@@ -6033,7 +6270,7 @@
                         "test"
                     ],
                     "name": "regression",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/regression.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/regression.rs",
                     "test": true
                 },
                 {
@@ -6047,7 +6284,7 @@
                         "test"
                     ],
                     "name": "test_parse_stream",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_parse_stream.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_parse_stream.rs",
                     "test": true
                 },
                 {
@@ -6061,7 +6298,7 @@
                         "test"
                     ],
                     "name": "test_grouping",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_grouping.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_grouping.rs",
                     "test": true
                 },
                 {
@@ -6075,7 +6312,7 @@
                         "test"
                     ],
                     "name": "test_ident",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_ident.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_ident.rs",
                     "test": true
                 },
                 {
@@ -6089,7 +6326,7 @@
                         "test"
                     ],
                     "name": "test_iterators",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_iterators.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_iterators.rs",
                     "test": true
                 },
                 {
@@ -6103,7 +6340,7 @@
                         "test"
                     ],
                     "name": "test_parse_buffer",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_parse_buffer.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_parse_buffer.rs",
                     "test": true
                 },
                 {
@@ -6117,7 +6354,7 @@
                         "test"
                     ],
                     "name": "test_asyncness",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_asyncness.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_asyncness.rs",
                     "test": true
                 },
                 {
@@ -6131,7 +6368,7 @@
                         "test"
                     ],
                     "name": "test_token_trees",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_token_trees.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_token_trees.rs",
                     "test": true
                 },
                 {
@@ -6145,7 +6382,7 @@
                         "test"
                     ],
                     "name": "test_ty",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_ty.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_ty.rs",
                     "test": true
                 },
                 {
@@ -6159,7 +6396,7 @@
                         "test"
                     ],
                     "name": "zzz_stable",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/zzz_stable.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/zzz_stable.rs",
                     "test": true
                 },
                 {
@@ -6173,7 +6410,7 @@
                         "test"
                     ],
                     "name": "test_meta",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_meta.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_meta.rs",
                     "test": true
                 },
                 {
@@ -6187,7 +6424,7 @@
                         "test"
                     ],
                     "name": "test_expr",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_expr.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_expr.rs",
                     "test": true
                 },
                 {
@@ -6201,7 +6438,7 @@
                         "test"
                     ],
                     "name": "test_item",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_item.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_item.rs",
                     "test": true
                 },
                 {
@@ -6215,7 +6452,7 @@
                         "test"
                     ],
                     "name": "test_path",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_path.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_path.rs",
                     "test": true
                 },
                 {
@@ -6229,7 +6466,7 @@
                         "test"
                     ],
                     "name": "test_derive_input",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_derive_input.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_derive_input.rs",
                     "test": true
                 },
                 {
@@ -6243,7 +6480,7 @@
                         "test"
                     ],
                     "name": "test_generics",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_generics.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_generics.rs",
                     "test": true
                 },
                 {
@@ -6257,7 +6494,7 @@
                         "test"
                     ],
                     "name": "test_attribute",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/tests/test_attribute.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/tests/test_attribute.rs",
                     "test": true
                 },
                 {
@@ -6275,7 +6512,7 @@
                         "full",
                         "parsing"
                     ],
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/benches/rust.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/benches/rust.rs",
                     "test": false
                 },
                 {
@@ -6293,7 +6530,7 @@
                         "full",
                         "parsing"
                     ],
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/benches/file.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/benches/file.rs",
                     "test": false
                 },
                 {
@@ -6307,11 +6544,11 @@
                         "custom-build"
                     ],
                     "name": "build-script-build",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.86/build.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/build.rs",
                     "test": false
                 }
             ],
-            "version": "1.0.86"
+            "version": "1.0.109"
         },
         {
             "authors": [
@@ -6338,7 +6575,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/termcolor",
-            "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3",
             "keywords": [
                 "windows",
                 "win",
@@ -6534,7 +6771,7 @@
                 ]
             },
             "homepage": null,
-            "id": "textwrap 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.15.0",
             "keywords": [
                 "text",
                 "formatting",
@@ -6669,11 +6906,13 @@
         },
         {
             "authors": [
-                "erick.tryzelaar <erick.tryzelaar@gmail.com>",
-                "kwantam <kwantam@gmail.com>",
-                "Manish Goregaokar <manishsmail@gmail.com>"
+                "David Tolnay <dtolnay@gmail.com>"
             ],
-            "categories": [],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "no-std",
+                "no-std::no-alloc"
+            ],
             "default_run": null,
             "dependencies": [
                 {
@@ -6683,37 +6922,105 @@
                     "optional": false,
                     "registry": null,
                     "rename": null,
-                    "req": "^0.3",
+                    "req": "^0.5",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "fst",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.4",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [
+                        "small_rng"
+                    ],
+                    "kind": "dev",
+                    "name": "rand",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.8",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "roaring",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.10",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "ucd-trie",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "unicode-xid",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.2.4",
                     "source": "registry+https://github.com/rust-lang/crates.io-index",
                     "target": null,
                     "uses_default_features": true
                 }
             ],
-            "description": "Determine whether characters have the XID_Start\nor XID_Continue properties according to\nUnicode Standard Annex #31.\n",
-            "documentation": "https://unicode-rs.github.io/unicode-xid",
-            "edition": "2015",
-            "features": {
-                "bench": [],
-                "default": [],
-                "no_std": []
-            },
-            "homepage": "https://github.com/unicode-rs/unicode-xid",
-            "id": "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
+            "documentation": "https://docs.rs/unicode-ident",
+            "edition": "2018",
+            "features": {},
+            "homepage": null,
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12",
             "keywords": [
-                "text",
                 "unicode",
                 "xid"
             ],
-            "license": "MIT OR Apache-2.0",
+            "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-xid-0.2.2/Cargo.toml",
-            "metadata": null,
-            "name": "unicode-xid",
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustdoc-args": [
+                            "--generate-link-to-definition"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "name": "unicode-ident",
             "publish": null,
             "readme": "README.md",
-            "repository": "https://github.com/unicode-rs/unicode-xid",
-            "rust_version": null,
+            "repository": "https://github.com/dtolnay/unicode-ident",
+            "rust_version": "1.31",
             "source": "registry+https://github.com/rust-lang/crates.io-index",
             "targets": [
                 {
@@ -6722,12 +7029,12 @@
                     ],
                     "doc": true,
                     "doctest": true,
-                    "edition": "2015",
+                    "edition": "2018",
                     "kind": [
                         "lib"
                     ],
-                    "name": "unicode-xid",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-xid-0.2.2/src/lib.rs",
+                    "name": "unicode-ident",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/src/lib.rs",
                     "test": true
                 },
                 {
@@ -6736,12 +7043,12 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2015",
+                    "edition": "2018",
                     "kind": [
                         "test"
                     ],
-                    "name": "exhaustive_tests",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-xid-0.2.2/tests/exhaustive_tests.rs",
+                    "name": "static_size",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/static_size.rs",
                     "test": true
                 },
                 {
@@ -6750,16 +7057,30 @@
                     ],
                     "doc": false,
                     "doctest": false,
-                    "edition": "2015",
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "compare",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/compare.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
                     "kind": [
                         "bench"
                     ],
                     "name": "xid",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-xid-0.2.2/benches/xid.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/benches/xid.rs",
                     "test": false
                 }
             ],
-            "version": "0.2.2"
+            "version": "1.0.12"
         },
         {
             "authors": [
@@ -6964,7 +7285,7 @@
                 ]
             },
             "homepage": null,
-            "id": "value-bag 1.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#value-bag@1.0.0-alpha.7",
             "keywords": [
                 "serialization",
                 "no_std"
@@ -7036,7 +7357,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4",
             "keywords": [
                 "version",
                 "rustc",
@@ -7143,7 +7464,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "wasi 0.10.2+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1",
             "keywords": [
                 "webassembly",
                 "wasm"
@@ -7151,7 +7472,7 @@
             "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
             "license_file": null,
             "links": null,
-            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasi-0.10.2+wasi-snapshot-preview1/Cargo.toml",
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasi-0.11.0+wasi-snapshot-preview1/Cargo.toml",
             "metadata": null,
             "name": "wasi",
             "publish": null,
@@ -7171,11 +7492,11 @@
                         "lib"
                     ],
                     "name": "wasi",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasi-0.10.2+wasi-snapshot-preview1/src/lib.rs",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasi-0.11.0+wasi-snapshot-preview1/src/lib.rs",
                     "test": true
                 }
             ],
-            "version": "0.10.2+wasi-snapshot-preview1"
+            "version": "0.11.0+wasi-snapshot-preview1"
         },
         {
             "authors": [
@@ -7620,7 +7941,7 @@
                 "xinput": []
             },
             "homepage": null,
-            "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9",
             "keywords": [
                 "windows",
                 "ffi",
@@ -7699,7 +8020,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -7785,7 +8106,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/winapi-util",
-            "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5",
             "keywords": [
                 "windows",
                 "winapi",
@@ -7841,7 +8162,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -7893,11 +8214,11 @@
         "nodes": [
             {
                 "dependencies": [
-                    "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "names 0.12.1-dev (git+https://github.com/fnichol/names.git?rev=760516503b89ddc8bc2ab42d579d4566cfb1054f#760516503b89ddc8bc2ab42d579d4566cfb1054f)",
-                    "names 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "value-bag 1.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.3.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.21",
+                    "git+https://github.com/fnichol/names.git?rev=760516503b89ddc8bc2ab42d579d4566cfb1054f#names@0.12.1-dev",
+                    "registry+https://github.com/rust-lang/crates.io-index#names@0.13.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#value-bag@1.0.0-alpha.7"
                 ],
                 "deps": [
                     {
@@ -7908,7 +8229,7 @@
                             }
                         ],
                         "name": "pinned_log",
-                        "pkg": "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.3.9"
                     },
                     {
                         "dep_kinds": [
@@ -7918,7 +8239,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.21"
                     },
                     {
                         "dep_kinds": [
@@ -7928,7 +8249,7 @@
                             }
                         ],
                         "name": "pinned_names",
-                        "pkg": "names 0.12.1-dev (git+https://github.com/fnichol/names.git?rev=760516503b89ddc8bc2ab42d579d4566cfb1054f#760516503b89ddc8bc2ab42d579d4566cfb1054f)"
+                        "pkg": "git+https://github.com/fnichol/names.git?rev=760516503b89ddc8bc2ab42d579d4566cfb1054f#names@0.12.1-dev"
                     },
                     {
                         "dep_kinds": [
@@ -7938,7 +8259,7 @@
                             }
                         ],
                         "name": "names",
-                        "pkg": "names 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#names@0.13.0"
                     },
                     {
                         "dep_kinds": [
@@ -7948,17 +8269,17 @@
                             }
                         ],
                         "name": "value_bag",
-                        "pkg": "value-bag 1.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#value-bag@1.0.0-alpha.7"
                     }
                 ],
                 "features": [],
-                "id": "aliases 0.1.0 (path+file://{TEMP_DIR}/aliases)"
+                "id": "path+file://{TEMP_DIR}/aliases#0.1.0"
             },
             {
                 "dependencies": [
-                    "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.1.19",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -7969,7 +8290,7 @@
                             }
                         ],
                         "name": "hermit_abi",
-                        "pkg": "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.1.19"
                     },
                     {
                         "dep_kinds": [
@@ -7979,7 +8300,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153"
                     },
                     {
                         "dep_kinds": [
@@ -7989,17 +8310,17 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [],
-                "id": "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#atty@0.2.14"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
             },
             {
                 "dependencies": [],
@@ -8007,25 +8328,25 @@
                 "features": [
                     "default"
                 ],
-                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [
-                    "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "clap_derive 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "indexmap 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "os_str_bytes 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "textwrap 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#atty@0.2.14",
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#clap_derive@3.1.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.8.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#strsim@0.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.15.0"
                 ],
                 "deps": [
                     {
@@ -8036,7 +8357,7 @@
                             }
                         ],
                         "name": "atty",
-                        "pkg": "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#atty@0.2.14"
                     },
                     {
                         "dep_kinds": [
@@ -8046,7 +8367,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -8056,7 +8377,7 @@
                             }
                         ],
                         "name": "clap_derive",
-                        "pkg": "clap_derive 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@3.1.4"
                     },
                     {
                         "dep_kinds": [
@@ -8066,7 +8387,7 @@
                             }
                         ],
                         "name": "indexmap",
-                        "pkg": "indexmap 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.8.0"
                     },
                     {
                         "dep_kinds": [
@@ -8076,7 +8397,7 @@
                             }
                         ],
                         "name": "lazy_static",
-                        "pkg": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -8086,7 +8407,7 @@
                             }
                         ],
                         "name": "os_str_bytes",
-                        "pkg": "os_str_bytes 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -8096,7 +8417,7 @@
                             }
                         ],
                         "name": "strsim",
-                        "pkg": "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -8106,7 +8427,7 @@
                             }
                         ],
                         "name": "termcolor",
-                        "pkg": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3"
                     },
                     {
                         "dep_kinds": [
@@ -8116,7 +8437,7 @@
                             }
                         ],
                         "name": "textwrap",
-                        "pkg": "textwrap 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.15.0"
                     }
                 ],
                 "features": [
@@ -8131,15 +8452,15 @@
                     "suggestions",
                     "termcolor"
                 ],
-                "id": "clap 3.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#clap@3.1.5"
             },
             {
                 "dependencies": [
-                    "heck 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.86 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#heck@0.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error@1.0.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                 ],
                 "deps": [
                     {
@@ -8150,7 +8471,7 @@
                             }
                         ],
                         "name": "heck",
-                        "pkg": "heck 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#heck@0.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -8160,7 +8481,7 @@
                             }
                         ],
                         "name": "proc_macro_error",
-                        "pkg": "proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error@1.0.4"
                     },
                     {
                         "dep_kinds": [
@@ -8170,7 +8491,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
                     },
                     {
                         "dep_kinds": [
@@ -8180,7 +8501,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35"
                     },
                     {
                         "dep_kinds": [
@@ -8190,18 +8511,18 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.86 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "clap_derive 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#clap_derive@3.1.4"
             },
             {
                 "dependencies": [
-                    "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.86 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                 ],
                 "deps": [
                     {
@@ -8212,7 +8533,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35"
                     },
                     {
                         "dep_kinds": [
@@ -8222,17 +8543,17 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.86 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                     }
                 ],
                 "features": [],
-                "id": "ctor 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ctor@0.1.21"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasi 0.10.2+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
                 ],
                 "deps": [
                     {
@@ -8243,7 +8564,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -8253,7 +8574,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153"
                     },
                     {
                         "dep_kinds": [
@@ -8263,13 +8584,13 @@
                             }
                         ],
                         "name": "wasi",
-                        "pkg": "wasi 0.10.2+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
                     }
                 ],
                 "features": [
                     "std"
                 ],
-                "id": "getrandom 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.12"
             },
             {
                 "dependencies": [],
@@ -8277,7 +8598,7 @@
                 "features": [
                     "raw"
                 ],
-                "id": "hashbrown 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.11.2"
             },
             {
                 "dependencies": [],
@@ -8285,11 +8606,11 @@
                 "features": [
                     "default"
                 ],
-                "id": "heck 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#heck@0.4.0"
             },
             {
                 "dependencies": [
-                    "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153"
                 ],
                 "deps": [
                     {
@@ -8300,18 +8621,18 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.1.19"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hashbrown 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.11.2"
                 ],
                 "deps": [
                     {
@@ -8322,7 +8643,7 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -8332,29 +8653,29 @@
                             }
                         ],
                         "name": "hashbrown",
-                        "pkg": "hashbrown 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.11.2"
                     }
                 ],
                 "features": [
                     "std"
                 ],
-                "id": "indexmap 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.8.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153"
             },
             {
                 "dependencies": [
-                    "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.21"
                 ],
                 "deps": [
                     {
@@ -8365,49 +8686,37 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.21"
                     }
                 ],
                 "features": [
                     "default",
                     "use_std"
                 ],
-                "id": "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
-            },
-            {
-                "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
-                ],
-                "deps": [
-                    {
-                        "dep_kinds": [
-                            {
-                                "kind": null,
-                                "target": null
-                            }
-                        ],
-                        "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
-                    }
-                ],
-                "features": [
-                    "std"
-                ],
-                "id": "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.3.9"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [
+                    "std"
+                ],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.21"
+            },
+            {
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "alloc",
                     "default",
                     "std"
                 ],
-                "id": "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.7.2"
             },
             {
                 "dependencies": [
-                    "clap 3.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#clap@3.1.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5"
                 ],
                 "deps": [
                     {
@@ -8418,7 +8727,7 @@
                             }
                         ],
                         "name": "clap",
-                        "pkg": "clap 3.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#clap@3.1.5"
                     },
                     {
                         "dep_kinds": [
@@ -8428,7 +8737,7 @@
                             }
                         ],
                         "name": "rand",
-                        "pkg": "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5"
                     }
                 ],
                 "features": [
@@ -8436,12 +8745,12 @@
                     "clap",
                     "default"
                 ],
-                "id": "names 0.12.1-dev (git+https://github.com/fnichol/names.git?rev=760516503b89ddc8bc2ab42d579d4566cfb1054f#760516503b89ddc8bc2ab42d579d4566cfb1054f)"
+                "id": "git+https://github.com/fnichol/names.git?rev=760516503b89ddc8bc2ab42d579d4566cfb1054f#names@0.12.1-dev"
             },
             {
                 "dependencies": [
-                    "clap 3.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#clap@3.1.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5"
                 ],
                 "deps": [
                     {
@@ -8452,7 +8761,7 @@
                             }
                         ],
                         "name": "clap",
-                        "pkg": "clap 3.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#clap@3.1.5"
                     },
                     {
                         "dep_kinds": [
@@ -8462,7 +8771,7 @@
                             }
                         ],
                         "name": "rand",
-                        "pkg": "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5"
                     }
                 ],
                 "features": [
@@ -8470,11 +8779,11 @@
                     "clap",
                     "default"
                 ],
-                "id": "names 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#names@0.13.0"
             },
             {
                 "dependencies": [
-                    "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#memchr@2.7.2"
                 ],
                 "deps": [
                     {
@@ -8485,7 +8794,7 @@
                             }
                         ],
                         "name": "memchr",
-                        "pkg": "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#memchr@2.7.2"
                     }
                 ],
                 "features": [
@@ -8493,7 +8802,7 @@
                     "memchr",
                     "raw_os_str"
                 ],
-                "id": "os_str_bytes 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.0.0"
             },
             {
                 "dependencies": [],
@@ -8502,15 +8811,15 @@
                     "simd",
                     "std"
                 ],
-                "id": "ppv-lite86 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.16"
             },
             {
                 "dependencies": [
-                    "proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.86 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr@1.0.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109",
+                    "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                 ],
                 "deps": [
                     {
@@ -8521,7 +8830,7 @@
                             }
                         ],
                         "name": "proc_macro_error_attr",
-                        "pkg": "proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr@1.0.4"
                     },
                     {
                         "dep_kinds": [
@@ -8531,7 +8840,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
                     },
                     {
                         "dep_kinds": [
@@ -8541,7 +8850,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35"
                     },
                     {
                         "dep_kinds": [
@@ -8551,7 +8860,7 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.86 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                     },
                     {
                         "dep_kinds": [
@@ -8561,7 +8870,7 @@
                             }
                         ],
                         "name": "version_check",
-                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                     }
                 ],
                 "features": [
@@ -8569,13 +8878,13 @@
                     "syn",
                     "syn-error"
                 ],
-                "id": "proc-macro-error 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error@1.0.4"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
+                    "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                 ],
                 "deps": [
                     {
@@ -8586,7 +8895,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
                     },
                     {
                         "dep_kinds": [
@@ -8596,7 +8905,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35"
                     },
                     {
                         "dep_kinds": [
@@ -8606,15 +8915,15 @@
                             }
                         ],
                         "name": "version_check",
-                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                     }
                 ],
                 "features": [],
-                "id": "proc-macro-error-attr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-error-attr@1.0.4"
             },
             {
                 "dependencies": [
-                    "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                 ],
                 "deps": [
                     {
@@ -8624,19 +8933,19 @@
                                 "target": null
                             }
                         ],
-                        "name": "unicode_xid",
-                        "pkg": "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "name": "unicode_ident",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
                 ],
                 "deps": [
                     {
@@ -8647,20 +8956,20 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35"
             },
             {
                 "dependencies": [
-                    "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rand_chacha 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153",
+                    "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                 ],
                 "deps": [
                     {
@@ -8671,7 +8980,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.119 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.153"
                     },
                     {
                         "dep_kinds": [
@@ -8681,7 +8990,7 @@
                             }
                         ],
                         "name": "rand_chacha",
-                        "pkg": "rand_chacha 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1"
                     },
                     {
                         "dep_kinds": [
@@ -8691,7 +9000,7 @@
                             }
                         ],
                         "name": "rand_core",
-                        "pkg": "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                     }
                 ],
                 "features": [
@@ -8703,12 +9012,12 @@
                     "std",
                     "std_rng"
                 ],
-                "id": "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rand@0.8.5"
             },
             {
                 "dependencies": [
-                    "ppv-lite86 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.16",
+                    "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                 ],
                 "deps": [
                     {
@@ -8719,7 +9028,7 @@
                             }
                         ],
                         "name": "ppv_lite86",
-                        "pkg": "ppv-lite86 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.16"
                     },
                     {
                         "dep_kinds": [
@@ -8729,17 +9038,17 @@
                             }
                         ],
                         "name": "rand_core",
-                        "pkg": "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                     }
                 ],
                 "features": [
                     "std"
                 ],
-                "id": "rand_chacha 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1"
             },
             {
                 "dependencies": [
-                    "getrandom 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.12"
                 ],
                 "deps": [
                     {
@@ -8750,7 +9059,7 @@
                             }
                         ],
                         "name": "getrandom",
-                        "pkg": "getrandom 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.12"
                     }
                 ],
                 "features": [
@@ -8758,19 +9067,19 @@
                     "getrandom",
                     "std"
                 ],
-                "id": "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.10.0"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                 ],
                 "deps": [
                     {
@@ -8781,7 +9090,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
                     },
                     {
                         "dep_kinds": [
@@ -8791,7 +9100,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35"
                     },
                     {
                         "dep_kinds": [
@@ -8800,8 +9109,8 @@
                                 "target": null
                             }
                         ],
-                        "name": "unicode_xid",
-                        "pkg": "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "name": "unicode_ident",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                     }
                 ],
                 "features": [
@@ -8814,11 +9123,11 @@
                     "proc-macro",
                     "quote"
                 ],
-                "id": "syn 1.0.86 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
             },
             {
                 "dependencies": [
-                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                 ],
                 "deps": [
                     {
@@ -8829,30 +9138,28 @@
                             }
                         ],
                         "name": "winapi_util",
-                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                     }
                 ],
                 "features": [],
-                "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "textwrap 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.15.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
-                "features": [
-                    "default"
-                ],
-                "id": "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "features": [],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
             },
             {
                 "dependencies": [
-                    "ctor 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#ctor@0.1.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                 ],
                 "deps": [
                     {
@@ -8863,7 +9170,7 @@
                             }
                         ],
                         "name": "ctor",
-                        "pkg": "ctor 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ctor@0.1.21"
                     },
                     {
                         "dep_kinds": [
@@ -8873,31 +9180,28 @@
                             }
                         ],
                         "name": "rustc",
-                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                     }
                 ],
                 "features": [],
-                "id": "value-bag 1.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#value-bag@1.0.0-alpha.7"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
-                "features": [
-                    "default",
-                    "std"
-                ],
-                "id": "wasi 0.10.2+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "features": [],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
             },
             {
                 "dependencies": [
-                    "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                 ],
                 "deps": [
                     {
@@ -8908,7 +9212,7 @@
                             }
                         ],
                         "name": "winapi_i686_pc_windows_gnu",
-                        "pkg": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -8918,7 +9222,7 @@
                             }
                         ],
                         "name": "winapi_x86_64_pc_windows_gnu",
-                        "pkg": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                     }
                 ],
                 "features": [
@@ -8934,17 +9238,17 @@
                     "winerror",
                     "winnt"
                 ],
-                "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
             },
             {
                 "dependencies": [
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -8955,28 +9259,28 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [],
-                "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
             }
         ],
-        "root": "aliases 0.1.0 (path+file://{TEMP_DIR}/aliases)"
+        "root": "path+file://{TEMP_DIR}/aliases#0.1.0"
     },
     "target_directory": "{TEMP_DIR}/aliases/target",
     "version": 1,
     "workspace_default_members": [
-        "aliases 0.1.0 (path+file://{TEMP_DIR}/aliases)"
+        "path+file://{TEMP_DIR}/aliases#0.1.0"
     ],
     "workspace_members": [
-        "aliases 0.1.0 (path+file://{TEMP_DIR}/aliases)"
+        "path+file://{TEMP_DIR}/aliases#0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/aliases"
 }

--- a/crate_universe/test_data/metadata/build_scripts/metadata.json
+++ b/crate_universe/test_data/metadata/build_scripts/metadata.json
@@ -125,7 +125,7 @@
                 ]
             },
             "homepage": "https://github.com/bitflags/bitflags",
-            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
             "keywords": [
                 "bit",
                 "bitmask",
@@ -232,7 +232,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "build-scripts 0.1.0 (path+file://{TEMP_DIR}/build_scripts)",
+            "id": "path+file://{TEMP_DIR}/build_scripts#build-scripts@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -309,7 +309,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cc-rs",
-            "id": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72",
             "keywords": [
                 "build-dependencies"
             ],
@@ -460,7 +460,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -530,7 +530,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -573,7 +573,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -629,7 +629,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -830,7 +830,7 @@
                 ]
             },
             "homepage": null,
-            "id": "git2 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#git2@0.17.1",
             "keywords": [
                 "git"
             ],
@@ -1200,7 +1200,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#idna@0.3.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -1358,7 +1358,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/alexcrichton/jobserver-rs",
-            "id": "jobserver 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.26",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -1506,7 +1506,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/libc",
-            "id": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112",
             "keywords": [
                 "libc",
                 "ffi",
@@ -1692,7 +1692,7 @@
                 ]
             },
             "homepage": null,
-            "id": "libgit2-sys 0.15.1+1.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libgit2-sys@0.15.1+1.6.4",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -1851,7 +1851,7 @@
                 ]
             },
             "homepage": null,
-            "id": "libssh2-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libssh2-sys@0.3.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -1991,7 +1991,7 @@
                 ]
             },
             "homepage": null,
-            "id": "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.8",
             "keywords": [
                 "zlib",
                 "zlib-ng"
@@ -2209,7 +2209,7 @@
                 ]
             },
             "homepage": null,
-            "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
             "keywords": [
                 "logging"
             ],
@@ -2404,7 +2404,7 @@
                 "unstable": []
             },
             "homepage": null,
-            "id": "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.9.0",
             "keywords": [
                 "lazy",
                 "static"
@@ -2704,7 +2704,7 @@
                 ]
             },
             "homepage": null,
-            "id": "openssl 0.10.52 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.52",
             "keywords": [
                 "crypto",
                 "tls",
@@ -2817,7 +2817,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "openssl-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -2860,7 +2860,7 @@
             "edition": "2015",
             "features": {},
             "homepage": "https://github.com/alexcrichton/openssl-probe",
-            "id": "openssl-probe 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.1.5",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -3024,7 +3024,7 @@
                 ]
             },
             "homepage": null,
-            "id": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -3090,7 +3090,7 @@
                 ]
             },
             "homepage": null,
-            "id": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3146,7 +3146,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24",
             "keywords": [
                 "build-dependencies"
             ],
@@ -3252,7 +3252,7 @@
                 "span-locations": []
             },
             "homepage": null,
-            "id": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.56",
             "keywords": [
                 "macros",
                 "syn"
@@ -3467,7 +3467,7 @@
                 ]
             },
             "homepage": null,
-            "id": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
             "keywords": [
                 "macros",
                 "syn"
@@ -3790,7 +3790,7 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.15",
             "keywords": [
                 "macros",
                 "syn"
@@ -4378,7 +4378,7 @@
                 ]
             },
             "homepage": null,
-            "id": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.6.0",
             "keywords": [
                 "vec",
                 "no_std",
@@ -4519,7 +4519,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0 OR Zlib",
             "license_file": null,
@@ -4642,7 +4642,7 @@
                 ]
             },
             "homepage": null,
-            "id": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.13",
             "keywords": [
                 "rtl",
                 "unicode",
@@ -4786,7 +4786,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8",
             "keywords": [
                 "unicode",
                 "xid"
@@ -4903,7 +4903,7 @@
                 "std": []
             },
             "homepage": "https://github.com/unicode-rs/unicode-normalization",
-            "id": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.22",
             "keywords": [
                 "text",
                 "unicode",
@@ -5076,7 +5076,7 @@
                 ]
             },
             "homepage": null,
-            "id": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#url@2.3.1",
             "keywords": [
                 "url",
                 "parser"
@@ -5208,7 +5208,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15",
             "keywords": [
                 "build-dependencies",
                 "windows",
@@ -5253,12 +5253,12 @@
                 "features": [
                     "default"
                 ],
-                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
             },
             {
                 "dependencies": [
-                    "git2 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "openssl 0.10.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#git2@0.17.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.52"
                 ],
                 "deps": [
                     {
@@ -5269,7 +5269,7 @@
                             }
                         ],
                         "name": "git2",
-                        "pkg": "git2 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#git2@0.17.1"
                     },
                     {
                         "dep_kinds": [
@@ -5279,15 +5279,15 @@
                             }
                         ],
                         "name": "openssl",
-                        "pkg": "openssl 0.10.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.52"
                     }
                 ],
                 "features": [],
-                "id": "build-scripts 0.1.0 (path+file://{TEMP_DIR}/build_scripts)"
+                "id": "path+file://{TEMP_DIR}/build_scripts#build-scripts@0.1.0"
             },
             {
                 "dependencies": [
-                    "jobserver 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.26"
                 ],
                 "deps": [
                     {
@@ -5298,24 +5298,24 @@
                             }
                         ],
                         "name": "jobserver",
-                        "pkg": "jobserver 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.26"
                     }
                 ],
                 "features": [
                     "jobserver",
                     "parallel"
                 ],
-                "id": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [
-                    "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
                 ],
                 "deps": [
                     {
@@ -5326,21 +5326,21 @@
                             }
                         ],
                         "name": "foreign_types_shared",
-                        "pkg": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
                     }
                 ],
                 "features": [],
-                "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
             },
             {
                 "dependencies": [
-                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
                 ],
                 "deps": [
                     {
@@ -5351,21 +5351,21 @@
                             }
                         ],
                         "name": "percent_encoding",
-                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
                     }
                 ],
                 "features": [],
-                "id": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libgit2-sys 0.15.1+1.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "openssl-probe 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112",
+                    "registry+https://github.com/rust-lang/crates.io-index#libgit2-sys@0.15.1+1.6.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.1.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87",
+                    "registry+https://github.com/rust-lang/crates.io-index#url@2.3.1"
                 ],
                 "deps": [
                     {
@@ -5376,7 +5376,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -5386,7 +5386,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     },
                     {
                         "dep_kinds": [
@@ -5396,7 +5396,7 @@
                             }
                         ],
                         "name": "libgit2_sys",
-                        "pkg": "libgit2-sys 0.15.1+1.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libgit2-sys@0.15.1+1.6.4"
                     },
                     {
                         "dep_kinds": [
@@ -5406,7 +5406,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -5416,7 +5416,7 @@
                             }
                         ],
                         "name": "openssl_probe",
-                        "pkg": "openssl-probe 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.1.5"
                     },
                     {
                         "dep_kinds": [
@@ -5426,7 +5426,7 @@
                             }
                         ],
                         "name": "openssl_sys",
-                        "pkg": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
                     },
                     {
                         "dep_kinds": [
@@ -5436,7 +5436,7 @@
                             }
                         ],
                         "name": "url",
-                        "pkg": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#url@2.3.1"
                     }
                 ],
                 "features": [
@@ -5447,12 +5447,12 @@
                     "ssh",
                     "ssh_key_from_memory"
                 ],
-                "id": "git2 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#git2@0.17.1"
             },
             {
                 "dependencies": [
-                    "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.13",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.22"
                 ],
                 "deps": [
                     {
@@ -5463,7 +5463,7 @@
                             }
                         ],
                         "name": "unicode_bidi",
-                        "pkg": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.13"
                     },
                     {
                         "dep_kinds": [
@@ -5473,15 +5473,15 @@
                             }
                         ],
                         "name": "unicode_normalization",
-                        "pkg": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.22"
                     }
                 ],
                 "features": [],
-                "id": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#idna@0.3.0"
             },
             {
                 "dependencies": [
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                 ],
                 "deps": [
                     {
@@ -5492,11 +5492,11 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     }
                 ],
                 "features": [],
-                "id": "jobserver 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#jobserver@0.1.26"
             },
             {
                 "dependencies": [],
@@ -5505,16 +5505,16 @@
                     "default",
                     "std"
                 ],
-                "id": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
             },
             {
                 "dependencies": [
-                    "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libssh2-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112",
+                    "registry+https://github.com/rust-lang/crates.io-index#libssh2-sys@0.3.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.8",
+                    "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87",
+                    "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24"
                 ],
                 "deps": [
                     {
@@ -5525,7 +5525,7 @@
                             }
                         ],
                         "name": "cc",
-                        "pkg": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72"
                     },
                     {
                         "dep_kinds": [
@@ -5535,7 +5535,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     },
                     {
                         "dep_kinds": [
@@ -5545,7 +5545,7 @@
                             }
                         ],
                         "name": "libssh2_sys",
-                        "pkg": "libssh2-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libssh2-sys@0.3.0"
                     },
                     {
                         "dep_kinds": [
@@ -5555,7 +5555,7 @@
                             }
                         ],
                         "name": "libz_sys",
-                        "pkg": "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.8"
                     },
                     {
                         "dep_kinds": [
@@ -5565,7 +5565,7 @@
                             }
                         ],
                         "name": "openssl_sys",
-                        "pkg": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
                     },
                     {
                         "dep_kinds": [
@@ -5575,7 +5575,7 @@
                             }
                         ],
                         "name": "pkg_config",
-                        "pkg": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24"
                     }
                 ],
                 "features": [
@@ -5585,16 +5585,16 @@
                     "ssh",
                     "ssh_key_from_memory"
                 ],
-                "id": "libgit2-sys 0.15.1+1.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libgit2-sys@0.15.1+1.6.4"
             },
             {
                 "dependencies": [
-                    "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112",
+                    "registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.8",
+                    "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87",
+                    "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24",
+                    "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
                 ],
                 "deps": [
                     {
@@ -5605,7 +5605,7 @@
                             }
                         ],
                         "name": "cc",
-                        "pkg": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72"
                     },
                     {
                         "dep_kinds": [
@@ -5615,7 +5615,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     },
                     {
                         "dep_kinds": [
@@ -5625,7 +5625,7 @@
                             }
                         ],
                         "name": "libz_sys",
-                        "pkg": "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.8"
                     },
                     {
                         "dep_kinds": [
@@ -5635,7 +5635,7 @@
                             }
                         ],
                         "name": "openssl_sys",
-                        "pkg": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
                     },
                     {
                         "dep_kinds": [
@@ -5645,7 +5645,7 @@
                             }
                         ],
                         "name": "pkg_config",
-                        "pkg": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24"
                     },
                     {
                         "dep_kinds": [
@@ -5655,18 +5655,18 @@
                             }
                         ],
                         "name": "vcpkg",
-                        "pkg": "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
                     }
                 ],
                 "features": [],
-                "id": "libssh2-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libssh2-sys@0.3.0"
             },
             {
                 "dependencies": [
-                    "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112",
+                    "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24",
+                    "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
                 ],
                 "deps": [
                     {
@@ -5677,7 +5677,7 @@
                             }
                         ],
                         "name": "cc",
-                        "pkg": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72"
                     },
                     {
                         "dep_kinds": [
@@ -5687,7 +5687,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     },
                     {
                         "dep_kinds": [
@@ -5697,7 +5697,7 @@
                             }
                         ],
                         "name": "pkg_config",
-                        "pkg": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24"
                     },
                     {
                         "dep_kinds": [
@@ -5707,17 +5707,17 @@
                             }
                         ],
                         "name": "vcpkg",
-                        "pkg": "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
                     }
                 ],
                 "features": [
                     "libc"
                 ],
-                "id": "libz-sys 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libz-sys@1.1.8"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                 ],
                 "deps": [
                     {
@@ -5728,11 +5728,11 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     }
                 ],
                 "features": [],
-                "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
             },
             {
                 "dependencies": [],
@@ -5743,17 +5743,17 @@
                     "race",
                     "std"
                 ],
-                "id": "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.9.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "openssl-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112",
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.9.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
                 ],
                 "deps": [
                     {
@@ -5764,7 +5764,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -5774,7 +5774,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -5784,7 +5784,7 @@
                             }
                         ],
                         "name": "foreign_types",
-                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -5794,7 +5794,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     },
                     {
                         "dep_kinds": [
@@ -5804,7 +5804,7 @@
                             }
                         ],
                         "name": "once_cell",
-                        "pkg": "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.9.0"
                     },
                     {
                         "dep_kinds": [
@@ -5814,7 +5814,7 @@
                             }
                         ],
                         "name": "openssl_macros",
-                        "pkg": "openssl-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -5824,19 +5824,19 @@
                             }
                         ],
                         "name": "ffi",
-                        "pkg": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "openssl 0.10.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#openssl@0.10.52"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.56",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.15"
                 ],
                 "deps": [
                     {
@@ -5847,7 +5847,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.56"
                     },
                     {
                         "dep_kinds": [
@@ -5857,7 +5857,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
                     },
                     {
                         "dep_kinds": [
@@ -5867,24 +5867,24 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.15"
                     }
                 ],
                 "features": [],
-                "id": "openssl-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#openssl-macros@0.1.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "openssl-probe 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#openssl-probe@0.1.5"
             },
             {
                 "dependencies": [
-                    "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112",
+                    "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24",
+                    "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
                 ],
                 "deps": [
                     {
@@ -5895,7 +5895,7 @@
                             }
                         ],
                         "name": "cc",
-                        "pkg": "cc 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.72"
                     },
                     {
                         "dep_kinds": [
@@ -5905,7 +5905,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     },
                     {
                         "dep_kinds": [
@@ -5915,7 +5915,7 @@
                             }
                         ],
                         "name": "pkg_config",
-                        "pkg": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24"
                     },
                     {
                         "dep_kinds": [
@@ -5925,11 +5925,11 @@
                             }
                         ],
                         "name": "vcpkg",
-                        "pkg": "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
                     }
                 ],
                 "features": [],
-                "id": "openssl-sys 0.9.87 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#openssl-sys@0.9.87"
             },
             {
                 "dependencies": [],
@@ -5938,17 +5938,17 @@
                     "alloc",
                     "default"
                 ],
-                "id": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "pkg-config 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.24"
             },
             {
                 "dependencies": [
-                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                 ],
                 "deps": [
                     {
@@ -5959,18 +5959,18 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.56"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.56"
                 ],
                 "deps": [
                     {
@@ -5981,20 +5981,20 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.56"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.56",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                 ],
                 "deps": [
                     {
@@ -6005,7 +6005,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.56"
                     },
                     {
                         "dep_kinds": [
@@ -6015,7 +6015,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
                     },
                     {
                         "dep_kinds": [
@@ -6025,7 +6025,7 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                     }
                 ],
                 "features": [
@@ -6038,11 +6038,11 @@
                     "proc-macro",
                     "quote"
                 ],
-                "id": "syn 2.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.15"
             },
             {
                 "dependencies": [
-                    "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
                 ],
                 "deps": [
                     {
@@ -6053,7 +6053,7 @@
                             }
                         ],
                         "name": "tinyvec_macros",
-                        "pkg": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
                     }
                 ],
                 "features": [
@@ -6061,13 +6061,13 @@
                     "default",
                     "tinyvec_macros"
                 ],
-                "id": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.6.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
             },
             {
                 "dependencies": [],
@@ -6077,17 +6077,17 @@
                     "hardcoded-data",
                     "std"
                 ],
-                "id": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.13"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
             },
             {
                 "dependencies": [
-                    "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.6.0"
                 ],
                 "deps": [
                     {
@@ -6098,20 +6098,20 @@
                             }
                         ],
                         "name": "tinyvec",
-                        "pkg": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.6.0"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.22"
             },
             {
                 "dependencies": [
-                    "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#idna@0.3.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
                 ],
                 "deps": [
                     {
@@ -6122,7 +6122,7 @@
                             }
                         ],
                         "name": "form_urlencoded",
-                        "pkg": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -6132,7 +6132,7 @@
                             }
                         ],
                         "name": "idna",
-                        "pkg": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#idna@0.3.0"
                     },
                     {
                         "dep_kinds": [
@@ -6142,30 +6142,30 @@
                             }
                         ],
                         "name": "percent_encoding",
-                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#url@2.3.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "vcpkg 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15"
             }
         ],
-        "root": "build-scripts 0.1.0 (path+file://{TEMP_DIR}/build_scripts)"
+        "root": "path+file://{TEMP_DIR}/build_scripts#build-scripts@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/build_scripts/target",
     "version": 1,
     "workspace_default_members": [
-        "build-scripts 0.1.0 (path+file://{TEMP_DIR}/build_scripts)"
+        "path+file://{TEMP_DIR}/build_scripts#build-scripts@0.1.0"
     ],
     "workspace_members": [
-        "build-scripts 0.1.0 (path+file://{TEMP_DIR}/build_scripts)"
+        "path+file://{TEMP_DIR}/build_scripts#build-scripts@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/build_scripts"
 }

--- a/crate_universe/test_data/metadata/common/metadata.json
+++ b/crate_universe/test_data/metadata/common/metadata.json
@@ -125,7 +125,7 @@
                 ]
             },
             "homepage": "https://github.com/bitflags/bitflags",
-            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
             "keywords": [
                 "bit",
                 "bitmask",
@@ -245,7 +245,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -325,7 +325,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "common 0.1.0 (path+file://{TEMP_DIR}/common)",
+            "id": "path+file://{TEMP_DIR}/common#0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -393,18 +393,18 @@
                 "features": [
                     "default"
                 ],
-                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                 ],
                 "deps": [
                     {
@@ -415,7 +415,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -425,22 +425,22 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     }
                 ],
                 "features": [],
-                "id": "common 0.1.0 (path+file://{TEMP_DIR}/common)"
+                "id": "path+file://{TEMP_DIR}/common#0.1.0"
             }
         ],
-        "root": "common 0.1.0 (path+file://{TEMP_DIR}/common)"
+        "root": "path+file://{TEMP_DIR}/common#0.1.0"
     },
     "target_directory": "{TEMP_DIR}/common/target",
     "version": 1,
     "workspace_default_members": [
-        "common 0.1.0 (path+file://{TEMP_DIR}/common)"
+        "path+file://{TEMP_DIR}/common#0.1.0"
     ],
     "workspace_members": [
-        "common 0.1.0 (path+file://{TEMP_DIR}/common)"
+        "path+file://{TEMP_DIR}/common#0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/common"
 }

--- a/crate_universe/test_data/metadata/crate_combined_features/metadata.json
+++ b/crate_universe/test_data/metadata/crate_combined_features/metadata.json
@@ -16,7 +16,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "assign 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#assign@1.1.1",
             "keywords": [
                 "macro"
             ],
@@ -63,7 +63,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
             "keywords": [
                 "rustc",
                 "build",
@@ -226,7 +226,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#base64@0.13.1",
             "keywords": [
                 "base64",
                 "utf8",
@@ -424,7 +424,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "bytes 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.4.0",
             "keywords": [
                 "buffers",
                 "zero-copy",
@@ -712,7 +712,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -780,7 +780,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "crate-combined-features 0.1.0 (path+file://{TEMP_DIR}/crate_combined_features)",
+            "id": "path+file://{TEMP_DIR}/crate_combined_features#crate-combined-features@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -836,7 +836,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -1081,7 +1081,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
             "keywords": [
                 "hash",
                 "no_std",
@@ -1297,7 +1297,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#idna@0.3.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -1578,7 +1578,7 @@
                 "test_low_transition_point": []
             },
             "homepage": null,
-            "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2",
             "keywords": [
                 "hashmap",
                 "no_std"
@@ -1757,7 +1757,7 @@
                 ]
             },
             "homepage": null,
-            "id": "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.6",
             "keywords": [
                 "integer"
             ],
@@ -1881,7 +1881,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#js_int@0.2.2",
             "keywords": [
                 "integer",
                 "no_std"
@@ -2002,7 +2002,7 @@
                 ]
             },
             "homepage": null,
-            "id": "js_option 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#js_option@0.1.1",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -2166,7 +2166,7 @@
                 "unstable": []
             },
             "homepage": null,
-            "id": "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.17.1",
             "keywords": [
                 "lazy",
                 "static"
@@ -2356,7 +2356,7 @@
                 ]
             },
             "homepage": null,
-            "id": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -2437,7 +2437,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.9",
             "keywords": [
                 "pin",
                 "macros"
@@ -2650,7 +2650,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "proc-macro-crate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@1.2.1",
             "keywords": [
                 "macro-rules",
                 "crate",
@@ -2745,7 +2745,7 @@
                 "span-locations": []
             },
             "homepage": null,
-            "id": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52",
             "keywords": [
                 "macros",
                 "syn"
@@ -2960,7 +2960,7 @@
                 ]
             },
             "homepage": null,
-            "id": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
             "keywords": [
                 "macros",
                 "syn"
@@ -3481,7 +3481,7 @@
                 ]
             },
             "homepage": "https://www.ruma.io/",
-            "id": "ruma 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ruma@0.6.4",
             "keywords": [
                 "matrix",
                 "chat",
@@ -3984,7 +3984,7 @@
                 ]
             },
             "homepage": "https://www.ruma.io/",
-            "id": "ruma-common 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ruma-common@0.9.3",
             "keywords": [
                 "matrix",
                 "chat",
@@ -4083,7 +4083,7 @@
                 "compat": []
             },
             "homepage": "https://www.ruma.io/",
-            "id": "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ruma-identifiers-validation@0.8.1",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -4200,7 +4200,7 @@
                 "compat": []
             },
             "homepage": "https://www.ruma.io/",
-            "id": "ruma-macros 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ruma-macros@0.9.3",
             "keywords": [
                 "matrix",
                 "chat",
@@ -4305,7 +4305,7 @@
                 "small": []
             },
             "homepage": null,
-            "id": "ryu 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.13",
             "keywords": [
                 "float"
             ],
@@ -4527,7 +4527,7 @@
                 "unstable": []
             },
             "homepage": "https://serde.rs",
-            "id": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158",
             "keywords": [
                 "serde",
                 "serialization",
@@ -4660,7 +4660,7 @@
                 "deserialize_in_place": []
             },
             "homepage": "https://serde.rs",
-            "id": "serde_derive 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.158",
             "keywords": [
                 "serde",
                 "serialization",
@@ -4919,7 +4919,7 @@
                 "unbounded_depth": []
             },
             "homepage": null,
-            "id": "serde_json 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.94",
             "keywords": [
                 "json",
                 "serde",
@@ -5314,7 +5314,7 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109",
             "keywords": [
                 "macros",
                 "syn"
@@ -6037,7 +6037,7 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.3",
             "keywords": [
                 "macros",
                 "syn"
@@ -6584,7 +6584,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.40",
             "keywords": [
                 "error",
                 "error-handling",
@@ -6872,7 +6872,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "thiserror-impl 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.40",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -7029,7 +7029,7 @@
                 ]
             },
             "homepage": null,
-            "id": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.6.0",
             "keywords": [
                 "vec",
                 "no_std",
@@ -7170,7 +7170,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0 OR Zlib",
             "license_file": null,
@@ -7275,7 +7275,7 @@
                 ]
             },
             "homepage": "https://github.com/toml-rs/toml",
-            "id": "toml 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#toml@0.5.11",
             "keywords": [
                 "encoding",
                 "toml"
@@ -7551,7 +7551,7 @@
                 ]
             },
             "homepage": "https://tokio.rs",
-            "id": "tracing 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.37",
             "keywords": [
                 "logging",
                 "tracing",
@@ -8147,7 +8147,7 @@
                 "async-await": []
             },
             "homepage": "https://tokio.rs",
-            "id": "tracing-attributes 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.23",
             "keywords": [
                 "logging",
                 "tracing",
@@ -8407,7 +8407,7 @@
                 ]
             },
             "homepage": "https://tokio.rs",
-            "id": "tracing-core 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.30",
             "keywords": [
                 "logging",
                 "tracing",
@@ -8592,7 +8592,7 @@
                 ]
             },
             "homepage": null,
-            "id": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.13",
             "keywords": [
                 "rtl",
                 "unicode",
@@ -8736,7 +8736,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8",
             "keywords": [
                 "unicode",
                 "xid"
@@ -8853,7 +8853,7 @@
                 "std": []
             },
             "homepage": "https://github.com/unicode-rs/unicode-normalization",
-            "id": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.22",
             "keywords": [
                 "text",
                 "unicode",
@@ -9026,7 +9026,7 @@
                 ]
             },
             "homepage": null,
-            "id": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#url@2.3.1",
             "keywords": [
                 "url",
                 "parser"
@@ -9182,7 +9182,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "wildmatch 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wildmatch@2.1.1",
             "keywords": [
                 "globbing",
                 "matching",
@@ -9240,13 +9240,13 @@
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "assign 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#assign@1.1.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
             },
             {
                 "dependencies": [],
@@ -9255,7 +9255,7 @@
                     "default",
                     "std"
                 ],
-                "id": "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#base64@0.13.1"
             },
             {
                 "dependencies": [],
@@ -9264,17 +9264,17 @@
                     "default",
                     "std"
                 ],
-                "id": "bytes 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.4.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [
-                    "ruma 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#ruma@0.6.4"
                 ],
                 "deps": [
                     {
@@ -9285,15 +9285,15 @@
                             }
                         ],
                         "name": "ruma",
-                        "pkg": "ruma 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ruma@0.6.4"
                     }
                 ],
                 "features": [],
-                "id": "crate-combined-features 0.1.0 (path+file://{TEMP_DIR}/crate_combined_features)"
+                "id": "path+file://{TEMP_DIR}/crate_combined_features#crate-combined-features@0.1.0"
             },
             {
                 "dependencies": [
-                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
                 ],
                 "deps": [
                     {
@@ -9304,11 +9304,11 @@
                             }
                         ],
                         "name": "percent_encoding",
-                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
                     }
                 ],
                 "features": [],
-                "id": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0"
             },
             {
                 "dependencies": [],
@@ -9316,12 +9316,12 @@
                 "features": [
                     "raw"
                 ],
-                "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
             },
             {
                 "dependencies": [
-                    "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.13",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.22"
                 ],
                 "deps": [
                     {
@@ -9332,7 +9332,7 @@
                             }
                         ],
                         "name": "unicode_bidi",
-                        "pkg": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.13"
                     },
                     {
                         "dep_kinds": [
@@ -9342,17 +9342,17 @@
                             }
                         ],
                         "name": "unicode_normalization",
-                        "pkg": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.22"
                     }
                 ],
                 "features": [],
-                "id": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#idna@0.3.0"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                 ],
                 "deps": [
                     {
@@ -9363,7 +9363,7 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -9373,7 +9373,7 @@
                             }
                         ],
                         "name": "hashbrown",
-                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                     },
                     {
                         "dep_kinds": [
@@ -9383,24 +9383,24 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                     }
                 ],
                 "features": [
                     "serde",
                     "serde-1"
                 ],
-                "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.6"
             },
             {
                 "dependencies": [
-                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                 ],
                 "deps": [
                     {
@@ -9411,7 +9411,7 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                     }
                 ],
                 "features": [
@@ -9419,11 +9419,11 @@
                     "serde",
                     "std"
                 ],
-                "id": "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#js_int@0.2.2"
             },
             {
                 "dependencies": [
-                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                 ],
                 "deps": [
                     {
@@ -9434,7 +9434,7 @@
                             }
                         ],
                         "name": "serde_crate",
-                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                     }
                 ],
                 "features": [
@@ -9442,7 +9442,7 @@
                     "serde",
                     "serde_crate"
                 ],
-                "id": "js_option 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#js_option@0.1.1"
             },
             {
                 "dependencies": [],
@@ -9453,7 +9453,7 @@
                     "race",
                     "std"
                 ],
-                "id": "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.17.1"
             },
             {
                 "dependencies": [],
@@ -9462,19 +9462,19 @@
                     "alloc",
                     "default"
                 ],
-                "id": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.9"
             },
             {
                 "dependencies": [
-                    "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "toml 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.17.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.40",
+                    "registry+https://github.com/rust-lang/crates.io-index#toml@0.5.11"
                 ],
                 "deps": [
                     {
@@ -9485,7 +9485,7 @@
                             }
                         ],
                         "name": "once_cell",
-                        "pkg": "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.17.1"
                     },
                     {
                         "dep_kinds": [
@@ -9495,7 +9495,7 @@
                             }
                         ],
                         "name": "thiserror",
-                        "pkg": "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.40"
                     },
                     {
                         "dep_kinds": [
@@ -9505,15 +9505,15 @@
                             }
                         ],
                         "name": "toml",
-                        "pkg": "toml 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#toml@0.5.11"
                     }
                 ],
                 "features": [],
-                "id": "proc-macro-crate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@1.2.1"
             },
             {
                 "dependencies": [
-                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                 ],
                 "deps": [
                     {
@@ -9524,18 +9524,18 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52"
                 ],
                 "deps": [
                     {
@@ -9546,20 +9546,20 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
             },
             {
                 "dependencies": [
-                    "assign 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ruma-common 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#assign@1.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#js_int@0.2.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#ruma-common@0.9.3"
                 ],
                 "deps": [
                     {
@@ -9570,7 +9570,7 @@
                             }
                         ],
                         "name": "assign",
-                        "pkg": "assign 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#assign@1.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -9580,7 +9580,7 @@
                             }
                         ],
                         "name": "js_int",
-                        "pkg": "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js_int@0.2.2"
                     },
                     {
                         "dep_kinds": [
@@ -9590,29 +9590,29 @@
                             }
                         ],
                         "name": "ruma_common",
-                        "pkg": "ruma-common 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ruma-common@0.9.3"
                     }
                 ],
                 "features": [],
-                "id": "ruma 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ruma@0.6.4"
             },
             {
                 "dependencies": [
-                    "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bytes 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js_option 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ruma-macros 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde_json 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "tracing 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wildmatch 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#base64@0.13.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#bytes@1.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#js_int@0.2.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#js_option@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#ruma-identifiers-validation@0.8.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#ruma-macros@0.9.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.94",
+                    "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.37",
+                    "registry+https://github.com/rust-lang/crates.io-index#url@2.3.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#wildmatch@2.1.1"
                 ],
                 "deps": [
                     {
@@ -9623,7 +9623,7 @@
                             }
                         ],
                         "name": "base64",
-                        "pkg": "base64 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#base64@0.13.1"
                     },
                     {
                         "dep_kinds": [
@@ -9633,7 +9633,7 @@
                             }
                         ],
                         "name": "bytes",
-                        "pkg": "bytes 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bytes@1.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -9643,7 +9643,7 @@
                             }
                         ],
                         "name": "form_urlencoded",
-                        "pkg": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -9653,7 +9653,7 @@
                             }
                         ],
                         "name": "indexmap",
-                        "pkg": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2"
                     },
                     {
                         "dep_kinds": [
@@ -9663,7 +9663,7 @@
                             }
                         ],
                         "name": "itoa",
-                        "pkg": "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.6"
                     },
                     {
                         "dep_kinds": [
@@ -9673,7 +9673,7 @@
                             }
                         ],
                         "name": "js_int",
-                        "pkg": "js_int 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js_int@0.2.2"
                     },
                     {
                         "dep_kinds": [
@@ -9683,7 +9683,7 @@
                             }
                         ],
                         "name": "js_option",
-                        "pkg": "js_option 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js_option@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -9693,7 +9693,7 @@
                             }
                         ],
                         "name": "percent_encoding",
-                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
                     },
                     {
                         "dep_kinds": [
@@ -9703,7 +9703,7 @@
                             }
                         ],
                         "name": "ruma_identifiers_validation",
-                        "pkg": "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ruma-identifiers-validation@0.8.1"
                     },
                     {
                         "dep_kinds": [
@@ -9713,7 +9713,7 @@
                             }
                         ],
                         "name": "ruma_macros",
-                        "pkg": "ruma-macros 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ruma-macros@0.9.3"
                     },
                     {
                         "dep_kinds": [
@@ -9723,7 +9723,7 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                     },
                     {
                         "dep_kinds": [
@@ -9733,7 +9733,7 @@
                             }
                         ],
                         "name": "serde_json",
-                        "pkg": "serde_json 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.94"
                     },
                     {
                         "dep_kinds": [
@@ -9743,7 +9743,7 @@
                             }
                         ],
                         "name": "tracing",
-                        "pkg": "tracing 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.37"
                     },
                     {
                         "dep_kinds": [
@@ -9753,7 +9753,7 @@
                             }
                         ],
                         "name": "url",
-                        "pkg": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#url@2.3.1"
                     },
                     {
                         "dep_kinds": [
@@ -9763,7 +9763,7 @@
                             }
                         ],
                         "name": "wildmatch",
-                        "pkg": "wildmatch 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wildmatch@2.1.1"
                     }
                 ],
                 "features": [
@@ -9771,11 +9771,11 @@
                     "default",
                     "server"
                 ],
-                "id": "ruma-common 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ruma-common@0.9.3"
             },
             {
                 "dependencies": [
-                    "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.40"
                 ],
                 "deps": [
                     {
@@ -9786,19 +9786,19 @@
                             }
                         ],
                         "name": "thiserror",
-                        "pkg": "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.40"
                     }
                 ],
                 "features": [],
-                "id": "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ruma-identifiers-validation@0.8.1"
             },
             {
                 "dependencies": [
-                    "proc-macro-crate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@1.2.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
+                    "registry+https://github.com/rust-lang/crates.io-index#ruma-identifiers-validation@0.8.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                 ],
                 "deps": [
                     {
@@ -9809,7 +9809,7 @@
                             }
                         ],
                         "name": "proc_macro_crate",
-                        "pkg": "proc-macro-crate 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-crate@1.2.1"
                     },
                     {
                         "dep_kinds": [
@@ -9819,7 +9819,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52"
                     },
                     {
                         "dep_kinds": [
@@ -9829,7 +9829,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
                     },
                     {
                         "dep_kinds": [
@@ -9839,7 +9839,7 @@
                             }
                         ],
                         "name": "ruma_identifiers_validation",
-                        "pkg": "ruma-identifiers-validation 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ruma-identifiers-validation@0.8.1"
                     },
                     {
                         "dep_kinds": [
@@ -9849,21 +9849,21 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                     }
                 ],
                 "features": [],
-                "id": "ruma-macros 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ruma-macros@0.9.3"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "ryu 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.13"
             },
             {
                 "dependencies": [
-                    "serde_derive 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.158"
                 ],
                 "deps": [
                     {
@@ -9874,7 +9874,7 @@
                             }
                         ],
                         "name": "serde_derive",
-                        "pkg": "serde_derive 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.158"
                     }
                 ],
                 "features": [
@@ -9883,13 +9883,13 @@
                     "serde_derive",
                     "std"
                 ],
-                "id": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.3"
                 ],
                 "deps": [
                     {
@@ -9900,7 +9900,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52"
                     },
                     {
                         "dep_kinds": [
@@ -9910,7 +9910,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
                     },
                     {
                         "dep_kinds": [
@@ -9920,19 +9920,19 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.3"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "serde_derive 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.158"
             },
             {
                 "dependencies": [
-                    "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ryu 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.13",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                 ],
                 "deps": [
                     {
@@ -9943,7 +9943,7 @@
                             }
                         ],
                         "name": "itoa",
-                        "pkg": "itoa 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.6"
                     },
                     {
                         "dep_kinds": [
@@ -9953,7 +9953,7 @@
                             }
                         ],
                         "name": "ryu",
-                        "pkg": "ryu 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.13"
                     },
                     {
                         "dep_kinds": [
@@ -9963,7 +9963,7 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                     }
                 ],
                 "features": [
@@ -9971,13 +9971,13 @@
                     "raw_value",
                     "std"
                 ],
-                "id": "serde_json 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.94"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                 ],
                 "deps": [
                     {
@@ -9988,7 +9988,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52"
                     },
                     {
                         "dep_kinds": [
@@ -9998,7 +9998,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
                     },
                     {
                         "dep_kinds": [
@@ -10008,7 +10008,7 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                     }
                 ],
                 "features": [
@@ -10024,13 +10024,13 @@
                     "visit",
                     "visit-mut"
                 ],
-                "id": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                 ],
                 "deps": [
                     {
@@ -10041,7 +10041,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52"
                     },
                     {
                         "dep_kinds": [
@@ -10051,7 +10051,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
                     },
                     {
                         "dep_kinds": [
@@ -10061,7 +10061,7 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
                     }
                 ],
                 "features": [
@@ -10073,11 +10073,11 @@
                     "proc-macro",
                     "quote"
                 ],
-                "id": "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.3"
             },
             {
                 "dependencies": [
-                    "thiserror-impl 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.40"
                 ],
                 "deps": [
                     {
@@ -10088,17 +10088,17 @@
                             }
                         ],
                         "name": "thiserror_impl",
-                        "pkg": "thiserror-impl 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.40"
                     }
                 ],
                 "features": [],
-                "id": "thiserror 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.40"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.3"
                 ],
                 "deps": [
                     {
@@ -10109,7 +10109,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52"
                     },
                     {
                         "dep_kinds": [
@@ -10119,7 +10119,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
                     },
                     {
                         "dep_kinds": [
@@ -10129,15 +10129,15 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.3"
                     }
                 ],
                 "features": [],
-                "id": "thiserror-impl 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.40"
             },
             {
                 "dependencies": [
-                    "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
                 ],
                 "deps": [
                     {
@@ -10148,7 +10148,7 @@
                             }
                         ],
                         "name": "tinyvec_macros",
-                        "pkg": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
                     }
                 ],
                 "features": [
@@ -10156,17 +10156,17 @@
                     "default",
                     "tinyvec_macros"
                 ],
-                "id": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.6.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "tinyvec_macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1"
             },
             {
                 "dependencies": [
-                    "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                 ],
                 "deps": [
                     {
@@ -10177,20 +10177,20 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.158 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.158"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "toml 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#toml@0.5.11"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "tracing-attributes 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "tracing-core 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.23",
+                    "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.30"
                 ],
                 "deps": [
                     {
@@ -10201,7 +10201,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -10211,7 +10211,7 @@
                             }
                         ],
                         "name": "pin_project_lite",
-                        "pkg": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.9"
                     },
                     {
                         "dep_kinds": [
@@ -10221,7 +10221,7 @@
                             }
                         ],
                         "name": "tracing_attributes",
-                        "pkg": "tracing-attributes 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.23"
                     },
                     {
                         "dep_kinds": [
@@ -10231,7 +10231,7 @@
                             }
                         ],
                         "name": "tracing_core",
-                        "pkg": "tracing-core 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.30"
                     }
                 ],
                 "features": [
@@ -10240,13 +10240,13 @@
                     "std",
                     "tracing-attributes"
                 ],
-                "id": "tracing 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.37"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                 ],
                 "deps": [
                     {
@@ -10257,7 +10257,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.52"
                     },
                     {
                         "dep_kinds": [
@@ -10267,7 +10267,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.26"
                     },
                     {
                         "dep_kinds": [
@@ -10277,15 +10277,15 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                     }
                 ],
                 "features": [],
-                "id": "tracing-attributes 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.23"
             },
             {
                 "dependencies": [
-                    "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.17.1"
                 ],
                 "deps": [
                     {
@@ -10296,14 +10296,14 @@
                             }
                         ],
                         "name": "once_cell",
-                        "pkg": "once_cell 1.17.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.17.1"
                     }
                 ],
                 "features": [
                     "once_cell",
                     "std"
                 ],
-                "id": "tracing-core 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tracing-core@0.1.30"
             },
             {
                 "dependencies": [],
@@ -10313,17 +10313,17 @@
                     "hardcoded-data",
                     "std"
                 ],
-                "id": "unicode-bidi 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.13"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "unicode-ident 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.8"
             },
             {
                 "dependencies": [
-                    "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.6.0"
                 ],
                 "deps": [
                     {
@@ -10334,20 +10334,20 @@
                             }
                         ],
                         "name": "tinyvec",
-                        "pkg": "tinyvec 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tinyvec@1.6.0"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "unicode-normalization 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.22"
             },
             {
                 "dependencies": [
-                    "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#idna@0.3.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
                 ],
                 "deps": [
                     {
@@ -10358,7 +10358,7 @@
                             }
                         ],
                         "name": "form_urlencoded",
-                        "pkg": "form_urlencoded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#form_urlencoded@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -10368,7 +10368,7 @@
                             }
                         ],
                         "name": "idna",
-                        "pkg": "idna 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#idna@0.3.0"
                     },
                     {
                         "dep_kinds": [
@@ -10378,30 +10378,30 @@
                             }
                         ],
                         "name": "percent_encoding",
-                        "pkg": "percent-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.2.0"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "url 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#url@2.3.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "wildmatch 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wildmatch@2.1.1"
             }
         ],
-        "root": "crate-combined-features 0.1.0 (path+file://{TEMP_DIR}/crate_combined_features)"
+        "root": "path+file://{TEMP_DIR}/crate_combined_features#crate-combined-features@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/crate_combined_features/target",
     "version": 1,
     "workspace_default_members": [
-        "crate-combined-features 0.1.0 (path+file://{TEMP_DIR}/crate_combined_features)"
+        "path+file://{TEMP_DIR}/crate_combined_features#crate-combined-features@0.1.0"
     ],
     "workspace_members": [
-        "crate-combined-features 0.1.0 (path+file://{TEMP_DIR}/crate_combined_features)"
+        "path+file://{TEMP_DIR}/crate_combined_features#crate-combined-features@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/crate_combined_features"
 }

--- a/crate_universe/test_data/metadata/crate_optional_deps_disabled/metadata.json
+++ b/crate_universe/test_data/metadata/crate_optional_deps_disabled/metadata.json
@@ -125,7 +125,7 @@
                 ]
             },
             "homepage": "https://github.com/bitflags/bitflags",
-            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
             "keywords": [
                 "bit",
                 "bitmask",
@@ -502,7 +502,7 @@
                 ]
             },
             "homepage": null,
-            "id": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#clap@4.1.1",
             "keywords": [
                 "argument",
                 "cli",
@@ -1557,7 +1557,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@0.3.3",
             "keywords": [
                 "argument",
                 "cli",
@@ -1659,7 +1659,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled)",
+            "id": "path+file://{TEMP_DIR}/crate_optional_deps_disabled#crate-with-optional-deps@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -1773,7 +1773,7 @@
                 ]
             },
             "homepage": null,
-            "id": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.5.0",
             "keywords": [
                 "bytes",
                 "osstr",
@@ -1833,12 +1833,12 @@
                 "features": [
                     "default"
                 ],
-                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#clap_lex@0.3.3"
                 ],
                 "deps": [
                     {
@@ -1849,7 +1849,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -1859,15 +1859,15 @@
                             }
                         ],
                         "name": "clap_lex",
-                        "pkg": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@0.3.3"
                     }
                 ],
                 "features": [],
-                "id": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#clap@4.1.1"
             },
             {
                 "dependencies": [
-                    "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.5.0"
                 ],
                 "deps": [
                     {
@@ -1878,15 +1878,15 @@
                             }
                         ],
                         "name": "os_str_bytes",
-                        "pkg": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.5.0"
                     }
                 ],
                 "features": [],
-                "id": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@0.3.3"
             },
             {
                 "dependencies": [
-                    "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#clap@4.1.1"
                 ],
                 "deps": [
                     {
@@ -1897,11 +1897,11 @@
                             }
                         ],
                         "name": "clap",
-                        "pkg": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#clap@4.1.1"
                     }
                 ],
                 "features": [],
-                "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled)"
+                "id": "path+file://{TEMP_DIR}/crate_optional_deps_disabled#crate-with-optional-deps@0.1.0"
             },
             {
                 "dependencies": [],
@@ -1909,18 +1909,18 @@
                 "features": [
                     "raw_os_str"
                 ],
-                "id": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.5.0"
             }
         ],
-        "root": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled)"
+        "root": "path+file://{TEMP_DIR}/crate_optional_deps_disabled#crate-with-optional-deps@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/crate_optional_deps_disabled/target",
     "version": 1,
     "workspace_default_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled)"
+        "path+file://{TEMP_DIR}/crate_optional_deps_disabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled)"
+        "path+file://{TEMP_DIR}/crate_optional_deps_disabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/crate_optional_deps_disabled"
 }

--- a/crate_universe/test_data/metadata/crate_optional_deps_disabled_build_dep_enabled/metadata.json
+++ b/crate_universe/test_data/metadata/crate_optional_deps_disabled_build_dep_enabled/metadata.json
@@ -24,7 +24,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled)",
+            "id": "path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled#crate-with-optional-deps@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -259,7 +259,7 @@
                 ]
             },
             "homepage": "https://github.com/cucumber-rs/gherkin",
-            "id": "gherkin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#gherkin@0.13.0",
             "keywords": [
                 "gherkin",
                 "cucumber",
@@ -367,7 +367,7 @@
                 ]
             },
             "homepage": "https://github.com/withoutboats/heck",
-            "id": "heck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1",
             "keywords": [
                 "string",
                 "case",
@@ -437,7 +437,7 @@
                 ]
             },
             "homepage": null,
-            "id": "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9",
             "keywords": [
                 "integer"
             ],
@@ -564,7 +564,7 @@
                 ]
             },
             "homepage": null,
-            "id": "peg 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#peg@0.6.3",
             "keywords": [
                 "peg",
                 "parser",
@@ -693,7 +693,7 @@
                 "trace": []
             },
             "homepage": null,
-            "id": "peg-macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#peg-macros@0.6.3",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -750,7 +750,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "peg-runtime 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#peg-runtime@0.6.3",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -840,7 +840,7 @@
                 "span-locations": []
             },
             "homepage": null,
-            "id": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
             "keywords": [
                 "macros",
                 "syn"
@@ -1056,7 +1056,7 @@
                 ]
             },
             "homepage": null,
-            "id": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
             "keywords": [
                 "macros",
                 "syn"
@@ -1199,7 +1199,7 @@
                 "small": []
             },
             "homepage": null,
-            "id": "ryu 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.15",
             "keywords": [
                 "float"
             ],
@@ -1437,7 +1437,7 @@
                 "unstable": []
             },
             "homepage": "https://serde.rs",
-            "id": "serde 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.190",
             "keywords": [
                 "serde",
                 "serialization",
@@ -1574,7 +1574,7 @@
                 "deserialize_in_place": []
             },
             "homepage": "https://serde.rs",
-            "id": "serde_derive 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.190",
             "keywords": [
                 "serde",
                 "serialization",
@@ -1820,7 +1820,7 @@
                 "unbounded_depth": []
             },
             "homepage": null,
-            "id": "serde_json 1.0.108 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.108",
             "keywords": [
                 "json",
                 "serde",
@@ -2070,7 +2070,7 @@
                 ]
             },
             "homepage": null,
-            "id": "smawk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#smawk@0.3.2",
             "keywords": [
                 "smawk",
                 "matrix",
@@ -2389,7 +2389,7 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109",
             "keywords": [
                 "macros",
                 "syn"
@@ -3112,7 +3112,7 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 2.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.38",
             "keywords": [
                 "macros",
                 "syn"
@@ -3718,7 +3718,7 @@
                 ]
             },
             "homepage": null,
-            "id": "textwrap 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.16.0",
             "keywords": [
                 "text",
                 "formatting",
@@ -3900,7 +3900,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "thiserror 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.50",
             "keywords": [
                 "error",
                 "error-handling",
@@ -4191,7 +4191,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "thiserror-impl 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.50",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -4288,7 +4288,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "typed-builder 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#typed-builder@0.10.0",
             "keywords": [
                 "builder"
             ],
@@ -4454,7 +4454,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12",
             "keywords": [
                 "unicode",
                 "xid"
@@ -4555,7 +4555,7 @@
             "edition": "2021",
             "features": {},
             "homepage": "https://github.com/axelf4/unicode-linebreak",
-            "id": "unicode-linebreak 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-linebreak@0.1.5",
             "keywords": [
                 "unicode",
                 "text",
@@ -4658,7 +4658,7 @@
                 ]
             },
             "homepage": "https://github.com/unicode-rs/unicode-width",
-            "id": "unicode-width 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.11",
             "keywords": [
                 "text",
                 "width",
@@ -4698,7 +4698,7 @@
         "nodes": [
             {
                 "dependencies": [
-                    "gherkin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#gherkin@0.13.0"
                 ],
                 "deps": [
                     {
@@ -4709,23 +4709,23 @@
                             }
                         ],
                         "name": "gherkin",
-                        "pkg": "gherkin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#gherkin@0.13.0"
                     }
                 ],
                 "features": [],
-                "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled)"
+                "id": "path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled#crate-with-optional-deps@0.1.0"
             },
             {
                 "dependencies": [
-                    "heck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "peg 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde_json 1.0.108 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "textwrap 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "thiserror 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "typed-builder 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#peg@0.6.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.190",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.108",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109",
+                    "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.16.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.50",
+                    "registry+https://github.com/rust-lang/crates.io-index#typed-builder@0.10.0"
                 ],
                 "deps": [
                     {
@@ -4736,7 +4736,7 @@
                             }
                         ],
                         "name": "heck",
-                        "pkg": "heck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1"
                     },
                     {
                         "dep_kinds": [
@@ -4746,7 +4746,7 @@
                             }
                         ],
                         "name": "peg",
-                        "pkg": "peg 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#peg@0.6.3"
                     },
                     {
                         "dep_kinds": [
@@ -4756,7 +4756,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -4766,7 +4766,7 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.190"
                     },
                     {
                         "dep_kinds": [
@@ -4776,7 +4776,7 @@
                             }
                         ],
                         "name": "serde_json",
-                        "pkg": "serde_json 1.0.108 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.108"
                     },
                     {
                         "dep_kinds": [
@@ -4786,7 +4786,7 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                     },
                     {
                         "dep_kinds": [
@@ -4796,7 +4796,7 @@
                             }
                         ],
                         "name": "textwrap",
-                        "pkg": "textwrap 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.16.0"
                     },
                     {
                         "dep_kinds": [
@@ -4806,7 +4806,7 @@
                             }
                         ],
                         "name": "thiserror",
-                        "pkg": "thiserror 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.50"
                     },
                     {
                         "dep_kinds": [
@@ -4816,7 +4816,7 @@
                             }
                         ],
                         "name": "typed_builder",
-                        "pkg": "typed-builder 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#typed-builder@0.10.0"
                     }
                 ],
                 "features": [
@@ -4824,7 +4824,7 @@
                     "parser",
                     "typed-builder"
                 ],
-                "id": "gherkin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#gherkin@0.13.0"
             },
             {
                 "dependencies": [],
@@ -4832,18 +4832,18 @@
                 "features": [
                     "default"
                 ],
-                "id": "heck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#heck@0.4.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9"
             },
             {
                 "dependencies": [
-                    "peg-macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "peg-runtime 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#peg-macros@0.6.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#peg-runtime@0.6.3"
                 ],
                 "deps": [
                     {
@@ -4854,7 +4854,7 @@
                             }
                         ],
                         "name": "peg_macros",
-                        "pkg": "peg-macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#peg-macros@0.6.3"
                     },
                     {
                         "dep_kinds": [
@@ -4864,17 +4864,17 @@
                             }
                         ],
                         "name": "peg_runtime",
-                        "pkg": "peg-runtime 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#peg-runtime@0.6.3"
                     }
                 ],
                 "features": [],
-                "id": "peg 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#peg@0.6.3"
             },
             {
                 "dependencies": [
-                    "peg-runtime 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#peg-runtime@0.6.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                 ],
                 "deps": [
                     {
@@ -4885,7 +4885,7 @@
                             }
                         ],
                         "name": "peg_runtime",
-                        "pkg": "peg-runtime 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#peg-runtime@0.6.3"
                     },
                     {
                         "dep_kinds": [
@@ -4895,7 +4895,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -4905,21 +4905,21 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     }
                 ],
                 "features": [],
-                "id": "peg-macros 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#peg-macros@0.6.3"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "peg-runtime 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#peg-runtime@0.6.3"
             },
             {
                 "dependencies": [
-                    "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                 ],
                 "deps": [
                     {
@@ -4930,18 +4930,18 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                 ],
                 "deps": [
                     {
@@ -4952,24 +4952,24 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "ryu 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.15"
             },
             {
                 "dependencies": [
-                    "serde_derive 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.190"
                 ],
                 "deps": [
                     {
@@ -4984,7 +4984,7 @@
                             }
                         ],
                         "name": "serde_derive",
-                        "pkg": "serde_derive 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.190"
                     }
                 ],
                 "features": [
@@ -4993,13 +4993,13 @@
                     "serde_derive",
                     "std"
                 ],
-                "id": "serde 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.190"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.38 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.38"
                 ],
                 "deps": [
                     {
@@ -5010,7 +5010,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -5020,7 +5020,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -5030,19 +5030,19 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.38 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.38"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "serde_derive 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.190"
             },
             {
                 "dependencies": [
-                    "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ryu 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.15",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.190"
                 ],
                 "deps": [
                     {
@@ -5053,7 +5053,7 @@
                             }
                         ],
                         "name": "itoa",
-                        "pkg": "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9"
                     },
                     {
                         "dep_kinds": [
@@ -5063,7 +5063,7 @@
                             }
                         ],
                         "name": "ryu",
-                        "pkg": "ryu 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.15"
                     },
                     {
                         "dep_kinds": [
@@ -5073,26 +5073,26 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.190 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.190"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "serde_json 1.0.108 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.108"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "smawk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#smawk@0.3.2"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                 ],
                 "deps": [
                     {
@@ -5103,7 +5103,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -5113,7 +5113,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -5123,7 +5123,7 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                     }
                 ],
                 "features": [
@@ -5137,13 +5137,13 @@
                     "proc-macro",
                     "quote"
                 ],
-                "id": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                 ],
                 "deps": [
                     {
@@ -5154,7 +5154,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -5164,7 +5164,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -5174,7 +5174,7 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                     }
                 ],
                 "features": [
@@ -5186,13 +5186,13 @@
                     "proc-macro",
                     "quote"
                 ],
-                "id": "syn 2.0.38 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.38"
             },
             {
                 "dependencies": [
-                    "smawk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-linebreak 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-width 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#smawk@0.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-linebreak@0.1.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.11"
                 ],
                 "deps": [
                     {
@@ -5203,7 +5203,7 @@
                             }
                         ],
                         "name": "smawk",
-                        "pkg": "smawk 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#smawk@0.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -5213,7 +5213,7 @@
                             }
                         ],
                         "name": "unicode_linebreak",
-                        "pkg": "unicode-linebreak 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-linebreak@0.1.5"
                     },
                     {
                         "dep_kinds": [
@@ -5223,7 +5223,7 @@
                             }
                         ],
                         "name": "unicode_width",
-                        "pkg": "unicode-width 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.11"
                     }
                 ],
                 "features": [
@@ -5232,11 +5232,11 @@
                     "unicode-linebreak",
                     "unicode-width"
                 ],
-                "id": "textwrap 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#textwrap@0.16.0"
             },
             {
                 "dependencies": [
-                    "thiserror-impl 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.50"
                 ],
                 "deps": [
                     {
@@ -5247,17 +5247,17 @@
                             }
                         ],
                         "name": "thiserror_impl",
-                        "pkg": "thiserror-impl 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.50"
                     }
                 ],
                 "features": [],
-                "id": "thiserror 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.50"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.38 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.38"
                 ],
                 "deps": [
                     {
@@ -5268,7 +5268,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -5278,7 +5278,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -5288,17 +5288,17 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.38 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.38"
                     }
                 ],
                 "features": [],
-                "id": "thiserror-impl 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.50"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                 ],
                 "deps": [
                     {
@@ -5309,7 +5309,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -5319,7 +5319,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -5329,23 +5329,23 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.109 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.109"
                     }
                 ],
                 "features": [],
-                "id": "typed-builder 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#typed-builder@0.10.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "unicode-linebreak 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-linebreak@0.1.5"
             },
             {
                 "dependencies": [],
@@ -5353,18 +5353,18 @@
                 "features": [
                     "default"
                 ],
-                "id": "unicode-width 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.11"
             }
         ],
-        "root": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled)"
+        "root": "path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled#crate-with-optional-deps@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled/target",
     "version": 1,
     "workspace_default_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled)"
+        "path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled)"
+        "path+file://{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/crate_optional_deps_disabled_build_dep_enabled"
 }

--- a/crate_universe/test_data/metadata/crate_optional_deps_enabled/metadata.json
+++ b/crate_universe/test_data/metadata/crate_optional_deps_enabled/metadata.json
@@ -125,7 +125,7 @@
                 ]
             },
             "homepage": "https://github.com/bitflags/bitflags",
-            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
             "keywords": [
                 "bit",
                 "bitmask",
@@ -243,7 +243,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/cc-rs",
-            "id": "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.79",
             "keywords": [
                 "build-dependencies"
             ],
@@ -394,7 +394,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -744,7 +744,7 @@
                 ]
             },
             "homepage": null,
-            "id": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#clap@4.1.1",
             "keywords": [
                 "argument",
                 "cli",
@@ -1799,7 +1799,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@0.3.3",
             "keywords": [
                 "argument",
                 "cli",
@@ -1915,7 +1915,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_enabled)",
+            "id": "path+file://{TEMP_DIR}/crate_optional_deps_enabled#crate-with-optional-deps@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -2031,7 +2031,7 @@
                 ]
             },
             "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel",
-            "id": "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.7",
             "keywords": [
                 "channel",
                 "mpmc",
@@ -2393,7 +2393,7 @@
                 "std": []
             },
             "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils",
-            "id": "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.15",
             "keywords": [
                 "scoped",
                 "thread",
@@ -2626,7 +2626,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#errno@0.2.8",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -2694,7 +2694,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#errno-dragonfly@0.1.2",
             "keywords": [
                 "dragonfly"
             ],
@@ -2817,7 +2817,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/alexcrichton/filetime",
-            "id": "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.20",
             "keywords": [
                 "timestamp",
                 "mtime"
@@ -2876,7 +2876,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#fsevent-sys@4.1.0",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -2982,7 +2982,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.3.1",
             "keywords": [
                 "unikernel",
                 "libos"
@@ -3150,7 +3150,7 @@
                 ]
             },
             "homepage": null,
-            "id": "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#inotify@0.9.6",
             "keywords": [
                 "inotify",
                 "linux"
@@ -3257,7 +3257,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#inotify-sys@0.1.5",
             "keywords": [
                 "inotify",
                 "linux"
@@ -3468,7 +3468,7 @@
                 ]
             },
             "homepage": null,
-            "id": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#io-lifetimes@1.0.9",
             "keywords": [
                 "api",
                 "io"
@@ -3622,7 +3622,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.5",
             "keywords": [
                 "terminal",
                 "tty",
@@ -3709,7 +3709,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#kqueue@1.0.7",
             "keywords": [
                 "kqueue",
                 "kevent",
@@ -3827,7 +3827,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#kqueue-sys@1.0.3",
             "keywords": [
                 "kqueue",
                 "kevent",
@@ -3911,7 +3911,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/libc",
-            "id": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140",
             "keywords": [
                 "libc",
                 "ffi",
@@ -4071,7 +4071,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.1.4",
             "keywords": [
                 "linux",
                 "uapi",
@@ -4290,7 +4290,7 @@
                 ]
             },
             "homepage": null,
-            "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
             "keywords": [
                 "logging"
             ],
@@ -4507,7 +4507,7 @@
                 "os-poll": []
             },
             "homepage": "https://github.com/tokio-rs/mio",
-            "id": "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#mio@0.8.6",
             "keywords": [
                 "io",
                 "async",
@@ -4890,7 +4890,7 @@
                 "timing_tests": []
             },
             "homepage": "https://github.com/notify-rs/notify",
-            "id": "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#notify@5.1.0",
             "keywords": [
                 "events",
                 "filesystem",
@@ -5009,7 +5009,7 @@
                 ]
             },
             "homepage": null,
-            "id": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.5.0",
             "keywords": [
                 "bytes",
                 "osstr",
@@ -5085,7 +5085,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -5538,7 +5538,7 @@
                 ]
             },
             "homepage": null,
-            "id": "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rustix@0.36.11",
             "keywords": [
                 "api",
                 "file",
@@ -5658,7 +5658,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/same-file",
-            "id": "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6",
             "keywords": [
                 "same",
                 "file",
@@ -5747,7 +5747,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/termcolor",
-            "id": "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.2.0",
             "keywords": [
                 "windows",
                 "win",
@@ -5835,7 +5835,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/walkdir",
-            "id": "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.3.3",
             "keywords": [
                 "directory",
                 "recursive",
@@ -5942,7 +5942,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1",
             "keywords": [
                 "webassembly",
                 "wasm"
@@ -6419,7 +6419,7 @@
                 "xinput": []
             },
             "homepage": null,
-            "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9",
             "keywords": [
                 "windows",
                 "ffi",
@@ -6498,7 +6498,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -6584,7 +6584,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/winapi-util",
-            "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5",
             "keywords": [
                 "windows",
                 "winapi",
@@ -6640,7 +6640,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -7805,7 +7805,7 @@
                 "deprecated": []
             },
             "homepage": null,
-            "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -8673,7 +8673,7 @@
                 "default": []
             },
             "homepage": null,
-            "id": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -8869,7 +8869,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.42.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -8912,7 +8912,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -8976,7 +8976,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -9040,7 +9040,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -9104,7 +9104,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -9168,7 +9168,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -9232,7 +9232,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -9296,7 +9296,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -9357,26 +9357,26 @@
                 "features": [
                     "default"
                 ],
-                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.79"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#clap_lex@0.3.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.2.0"
                 ],
                 "deps": [
                     {
@@ -9387,7 +9387,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -9397,7 +9397,7 @@
                             }
                         ],
                         "name": "clap_lex",
-                        "pkg": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@0.3.3"
                     },
                     {
                         "dep_kinds": [
@@ -9407,7 +9407,7 @@
                             }
                         ],
                         "name": "is_terminal",
-                        "pkg": "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.5"
                     },
                     {
                         "dep_kinds": [
@@ -9417,17 +9417,17 @@
                             }
                         ],
                         "name": "termcolor",
-                        "pkg": "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.2.0"
                     }
                 ],
                 "features": [
                     "color"
                 ],
-                "id": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#clap@4.1.1"
             },
             {
                 "dependencies": [
-                    "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.5.0"
                 ],
                 "deps": [
                     {
@@ -9438,16 +9438,16 @@
                             }
                         ],
                         "name": "os_str_bytes",
-                        "pkg": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.5.0"
                     }
                 ],
                 "features": [],
-                "id": "clap_lex 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#clap_lex@0.3.3"
             },
             {
                 "dependencies": [
-                    "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#clap@4.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#notify@5.1.0"
                 ],
                 "deps": [
                     {
@@ -9458,7 +9458,7 @@
                             }
                         ],
                         "name": "clap",
-                        "pkg": "clap 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#clap@4.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -9468,16 +9468,16 @@
                             }
                         ],
                         "name": "notify",
-                        "pkg": "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#notify@5.1.0"
                     }
                 ],
                 "features": [],
-                "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_enabled)"
+                "id": "path+file://{TEMP_DIR}/crate_optional_deps_enabled#crate-with-optional-deps@0.1.0"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.15"
                 ],
                 "deps": [
                     {
@@ -9488,7 +9488,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -9498,7 +9498,7 @@
                             }
                         ],
                         "name": "crossbeam_utils",
-                        "pkg": "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.15"
                     }
                 ],
                 "features": [
@@ -9506,11 +9506,11 @@
                     "default",
                     "std"
                 ],
-                "id": "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.7"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                 ],
                 "deps": [
                     {
@@ -9521,19 +9521,19 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     }
                 ],
                 "features": [
                     "std"
                 ],
-                "id": "crossbeam-utils 0.8.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.15"
             },
             {
                 "dependencies": [
-                    "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#errno-dragonfly@0.1.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -9544,7 +9544,7 @@
                             }
                         ],
                         "name": "errno_dragonfly",
-                        "pkg": "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#errno-dragonfly@0.1.2"
                     },
                     {
                         "dep_kinds": [
@@ -9562,7 +9562,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     },
                     {
                         "dep_kinds": [
@@ -9572,16 +9572,16 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [],
-                "id": "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#errno@0.2.8"
             },
             {
                 "dependencies": [
-                    "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.79",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                 ],
                 "deps": [
                     {
@@ -9592,7 +9592,7 @@
                             }
                         ],
                         "name": "cc",
-                        "pkg": "cc 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.79"
                     },
                     {
                         "dep_kinds": [
@@ -9602,18 +9602,18 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     }
                 ],
                 "features": [],
-                "id": "errno-dragonfly 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#errno-dragonfly@0.1.2"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140",
+                    "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                 ],
                 "deps": [
                     {
@@ -9624,7 +9624,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -9634,7 +9634,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     },
                     {
                         "dep_kinds": [
@@ -9644,7 +9644,7 @@
                             }
                         ],
                         "name": "syscall",
-                        "pkg": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16"
                     },
                     {
                         "dep_kinds": [
@@ -9654,15 +9654,15 @@
                             }
                         ],
                         "name": "windows_sys",
-                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                     }
                 ],
                 "features": [],
-                "id": "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.20"
             },
             {
                 "dependencies": [
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                 ],
                 "deps": [
                     {
@@ -9673,11 +9673,11 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     }
                 ],
                 "features": [],
-                "id": "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#fsevent-sys@4.1.0"
             },
             {
                 "dependencies": [],
@@ -9685,13 +9685,13 @@
                 "features": [
                     "default"
                 ],
-                "id": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.3.1"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#inotify-sys@0.1.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                 ],
                 "deps": [
                     {
@@ -9702,7 +9702,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -9712,7 +9712,7 @@
                             }
                         ],
                         "name": "inotify_sys",
-                        "pkg": "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#inotify-sys@0.1.5"
                     },
                     {
                         "dep_kinds": [
@@ -9722,15 +9722,15 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     }
                 ],
                 "features": [],
-                "id": "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#inotify@0.9.6"
             },
             {
                 "dependencies": [
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                 ],
                 "deps": [
                     {
@@ -9741,17 +9741,17 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     }
                 ],
                 "features": [],
-                "id": "inotify-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#inotify-sys@0.1.5"
             },
             {
                 "dependencies": [
-                    "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.3.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                 ],
                 "deps": [
                     {
@@ -9762,7 +9762,7 @@
                             }
                         ],
                         "name": "hermit_abi",
-                        "pkg": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.3.1"
                     },
                     {
                         "dep_kinds": [
@@ -9772,7 +9772,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     },
                     {
                         "dep_kinds": [
@@ -9782,7 +9782,7 @@
                             }
                         ],
                         "name": "windows_sys",
-                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                     }
                 ],
                 "features": [
@@ -9792,14 +9792,14 @@
                     "libc",
                     "windows-sys"
                 ],
-                "id": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#io-lifetimes@1.0.9"
             },
             {
                 "dependencies": [
-                    "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.3.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#io-lifetimes@1.0.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#rustix@0.36.11",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                 ],
                 "deps": [
                     {
@@ -9810,7 +9810,7 @@
                             }
                         ],
                         "name": "hermit_abi",
-                        "pkg": "hermit-abi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.3.1"
                     },
                     {
                         "dep_kinds": [
@@ -9820,7 +9820,7 @@
                             }
                         ],
                         "name": "io_lifetimes",
-                        "pkg": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#io-lifetimes@1.0.9"
                     },
                     {
                         "dep_kinds": [
@@ -9830,7 +9830,7 @@
                             }
                         ],
                         "name": "rustix",
-                        "pkg": "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rustix@0.36.11"
                     },
                     {
                         "dep_kinds": [
@@ -9840,16 +9840,16 @@
                             }
                         ],
                         "name": "windows_sys",
-                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                     }
                 ],
                 "features": [],
-                "id": "is-terminal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#is-terminal@0.4.5"
             },
             {
                 "dependencies": [
-                    "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#kqueue-sys@1.0.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                 ],
                 "deps": [
                     {
@@ -9860,7 +9860,7 @@
                             }
                         ],
                         "name": "kqueue_sys",
-                        "pkg": "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#kqueue-sys@1.0.3"
                     },
                     {
                         "dep_kinds": [
@@ -9870,16 +9870,16 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     }
                 ],
                 "features": [],
-                "id": "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#kqueue@1.0.7"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                 ],
                 "deps": [
                     {
@@ -9890,7 +9890,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -9900,11 +9900,11 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     }
                 ],
                 "features": [],
-                "id": "kqueue-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#kqueue-sys@1.0.3"
             },
             {
                 "dependencies": [],
@@ -9914,7 +9914,7 @@
                     "extra_traits",
                     "std"
                 ],
-                "id": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
             },
             {
                 "dependencies": [],
@@ -9925,11 +9925,11 @@
                     "ioctl",
                     "no_std"
                 ],
-                "id": "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.1.4"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                 ],
                 "deps": [
                     {
@@ -9940,18 +9940,18 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     }
                 ],
                 "features": [],
-                "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
             },
             {
                 "dependencies": [
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                 ],
                 "deps": [
                     {
@@ -9966,7 +9966,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     },
                     {
                         "dep_kinds": [
@@ -9976,7 +9976,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -9986,7 +9986,7 @@
                             }
                         ],
                         "name": "wasi",
-                        "pkg": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
                     },
                     {
                         "dep_kinds": [
@@ -9996,7 +9996,7 @@
                             }
                         ],
                         "name": "windows_sys",
-                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                     }
                 ],
                 "features": [
@@ -10004,20 +10004,20 @@
                     "os-ext",
                     "os-poll"
                 ],
-                "id": "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#mio@0.8.6"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.20",
+                    "registry+https://github.com/rust-lang/crates.io-index#fsevent-sys@4.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#inotify@0.9.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#kqueue@1.0.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140",
+                    "registry+https://github.com/rust-lang/crates.io-index#mio@0.8.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.3.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
                 ],
                 "deps": [
                     {
@@ -10028,7 +10028,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -10038,7 +10038,7 @@
                             }
                         ],
                         "name": "crossbeam_channel",
-                        "pkg": "crossbeam-channel 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.7"
                     },
                     {
                         "dep_kinds": [
@@ -10048,7 +10048,7 @@
                             }
                         ],
                         "name": "filetime",
-                        "pkg": "filetime 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#filetime@0.2.20"
                     },
                     {
                         "dep_kinds": [
@@ -10058,7 +10058,7 @@
                             }
                         ],
                         "name": "fsevent_sys",
-                        "pkg": "fsevent-sys 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#fsevent-sys@4.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -10068,7 +10068,7 @@
                             }
                         ],
                         "name": "inotify",
-                        "pkg": "inotify 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#inotify@0.9.6"
                     },
                     {
                         "dep_kinds": [
@@ -10078,7 +10078,7 @@
                             }
                         ],
                         "name": "kqueue",
-                        "pkg": "kqueue 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#kqueue@1.0.7"
                     },
                     {
                         "dep_kinds": [
@@ -10088,7 +10088,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     },
                     {
                         "dep_kinds": [
@@ -10102,7 +10102,7 @@
                             }
                         ],
                         "name": "mio",
-                        "pkg": "mio 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#mio@0.8.6"
                     },
                     {
                         "dep_kinds": [
@@ -10112,7 +10112,7 @@
                             }
                         ],
                         "name": "walkdir",
-                        "pkg": "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.3.3"
                     },
                     {
                         "dep_kinds": [
@@ -10122,7 +10122,7 @@
                             }
                         ],
                         "name": "windows_sys",
-                        "pkg": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
                     }
                 ],
                 "features": [
@@ -10131,7 +10131,7 @@
                     "fsevent-sys",
                     "macos_fsevent"
                 ],
-                "id": "notify 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#notify@5.1.0"
             },
             {
                 "dependencies": [],
@@ -10139,11 +10139,11 @@
                 "features": [
                     "raw_os_str"
                 ],
-                "id": "os_str_bytes 6.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#os_str_bytes@6.5.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                 ],
                 "deps": [
                     {
@@ -10154,20 +10154,20 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     }
                 ],
                 "features": [],
-                "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#errno@0.2.8",
+                    "registry+https://github.com/rust-lang/crates.io-index#io-lifetimes@1.0.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140",
+                    "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.1.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                 ],
                 "deps": [
                     {
@@ -10178,7 +10178,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -10188,7 +10188,7 @@
                             }
                         ],
                         "name": "libc_errno",
-                        "pkg": "errno 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#errno@0.2.8"
                     },
                     {
                         "dep_kinds": [
@@ -10198,7 +10198,7 @@
                             }
                         ],
                         "name": "io_lifetimes",
-                        "pkg": "io-lifetimes 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#io-lifetimes@1.0.9"
                     },
                     {
                         "dep_kinds": [
@@ -10212,7 +10212,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.140 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.140"
                     },
                     {
                         "dep_kinds": [
@@ -10226,7 +10226,7 @@
                             }
                         ],
                         "name": "linux_raw_sys",
-                        "pkg": "linux-raw-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.1.4"
                     },
                     {
                         "dep_kinds": [
@@ -10236,7 +10236,7 @@
                             }
                         ],
                         "name": "windows_sys",
-                        "pkg": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
                     }
                 ],
                 "features": [
@@ -10247,11 +10247,11 @@
                     "termios",
                     "use-libc-auxv"
                 ],
-                "id": "rustix 0.36.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rustix@0.36.11"
             },
             {
                 "dependencies": [
-                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                 ],
                 "deps": [
                     {
@@ -10262,15 +10262,15 @@
                             }
                         ],
                         "name": "winapi_util",
-                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                     }
                 ],
                 "features": [],
-                "id": "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6"
             },
             {
                 "dependencies": [
-                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                 ],
                 "deps": [
                     {
@@ -10281,16 +10281,16 @@
                             }
                         ],
                         "name": "winapi_util",
-                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                     }
                 ],
                 "features": [],
-                "id": "termcolor 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.2.0"
             },
             {
                 "dependencies": [
-                    "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                 ],
                 "deps": [
                     {
@@ -10301,7 +10301,7 @@
                             }
                         ],
                         "name": "same_file",
-                        "pkg": "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#same-file@1.0.6"
                     },
                     {
                         "dep_kinds": [
@@ -10311,11 +10311,11 @@
                             }
                         ],
                         "name": "winapi_util",
-                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                     }
                 ],
                 "features": [],
-                "id": "walkdir 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#walkdir@2.3.3"
             },
             {
                 "dependencies": [],
@@ -10324,12 +10324,12 @@
                     "default",
                     "std"
                 ],
-                "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
             },
             {
                 "dependencies": [
-                    "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                 ],
                 "deps": [
                     {
@@ -10340,7 +10340,7 @@
                             }
                         ],
                         "name": "winapi_i686_pc_windows_gnu",
-                        "pkg": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -10350,7 +10350,7 @@
                             }
                         ],
                         "name": "winapi_x86_64_pc_windows_gnu",
-                        "pkg": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                     }
                 ],
                 "features": [
@@ -10366,17 +10366,17 @@
                     "winerror",
                     "winnt"
                 ],
-                "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
             },
             {
                 "dependencies": [
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -10387,27 +10387,27 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [],
-                "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
             },
             {
                 "dependencies": [
-                    "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.2"
                 ],
                 "deps": [
                     {
@@ -10418,7 +10418,7 @@
                             }
                         ],
                         "name": "windows_aarch64_gnullvm",
-                        "pkg": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10432,7 +10432,7 @@
                             }
                         ],
                         "name": "windows_aarch64_msvc",
-                        "pkg": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10446,7 +10446,7 @@
                             }
                         ],
                         "name": "windows_i686_gnu",
-                        "pkg": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10460,7 +10460,7 @@
                             }
                         ],
                         "name": "windows_i686_msvc",
-                        "pkg": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10474,7 +10474,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnu",
-                        "pkg": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10484,7 +10484,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnullvm",
-                        "pkg": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10498,7 +10498,7 @@
                             }
                         ],
                         "name": "windows_x86_64_msvc",
-                        "pkg": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.2"
                     }
                 ],
                 "features": [
@@ -10513,11 +10513,11 @@
                     "Win32_System_WindowsProgramming",
                     "default"
                 ],
-                "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
             },
             {
                 "dependencies": [
-                    "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.42.2"
                 ],
                 "deps": [
                     {
@@ -10528,7 +10528,7 @@
                             }
                         ],
                         "name": "windows_targets",
-                        "pkg": "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.42.2"
                     }
                 ],
                 "features": [
@@ -10549,17 +10549,17 @@
                     "Win32_System_WindowsProgramming",
                     "default"
                 ],
-                "id": "windows-sys 0.45.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0"
             },
             {
                 "dependencies": [
-                    "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.2"
                 ],
                 "deps": [
                     {
@@ -10570,7 +10570,7 @@
                             }
                         ],
                         "name": "windows_aarch64_gnullvm",
-                        "pkg": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10584,7 +10584,7 @@
                             }
                         ],
                         "name": "windows_aarch64_msvc",
-                        "pkg": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10598,7 +10598,7 @@
                             }
                         ],
                         "name": "windows_i686_gnu",
-                        "pkg": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10612,7 +10612,7 @@
                             }
                         ],
                         "name": "windows_i686_msvc",
-                        "pkg": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10626,7 +10626,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnu",
-                        "pkg": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10636,7 +10636,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnullvm",
-                        "pkg": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.2"
                     },
                     {
                         "dep_kinds": [
@@ -10650,64 +10650,64 @@
                             }
                         ],
                         "name": "windows_x86_64_msvc",
-                        "pkg": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.2"
                     }
                 ],
                 "features": [],
-                "id": "windows-targets 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.42.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnu 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnullvm 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_msvc 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.2"
             }
         ],
-        "root": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_enabled)"
+        "root": "path+file://{TEMP_DIR}/crate_optional_deps_enabled#crate-with-optional-deps@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/crate_optional_deps_enabled/target",
     "version": 1,
     "workspace_default_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_enabled)"
+        "path+file://{TEMP_DIR}/crate_optional_deps_enabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_optional_deps_enabled)"
+        "path+file://{TEMP_DIR}/crate_optional_deps_enabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/crate_optional_deps_enabled"
 }

--- a/crate_universe/test_data/metadata/crate_renamed_optional_deps_disabled/metadata.json
+++ b/crate_universe/test_data/metadata/crate_renamed_optional_deps_disabled/metadata.json
@@ -28,7 +28,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "android-tzdata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#android-tzdata@0.1.1",
             "keywords": [
                 "parser",
                 "android",
@@ -88,7 +88,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/nical/android_system_properties",
-            "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
             "keywords": [
                 "android"
             ],
@@ -162,7 +162,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
             "keywords": [
                 "rustc",
                 "build",
@@ -204,6 +204,20 @@
                     "kind": [
                         "example"
                     ],
+                    "name": "integers",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/autocfg-1.1.0/examples/integers.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2015",
+                    "kind": [
+                        "example"
+                    ],
                     "name": "paths",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/autocfg-1.1.0/examples/paths.rs",
                     "test": false
@@ -220,20 +234,6 @@
                     ],
                     "name": "versions",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/autocfg-1.1.0/examples/versions.rs",
-                    "test": false
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2015",
-                    "kind": [
-                        "example"
-                    ],
-                    "name": "integers",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/autocfg-1.1.0/examples/integers.rs",
                     "test": false
                 },
                 {
@@ -365,7 +365,7 @@
                 ]
             },
             "homepage": null,
-            "id": "base64 0.21.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#base64@0.21.5",
             "keywords": [
                 "base64",
                 "utf8",
@@ -552,7 +552,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "bumpalo 3.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.14.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -678,7 +678,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/cc-rs",
-            "id": "cc 1.0.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.83",
             "keywords": [
                 "build-dependencies"
             ],
@@ -732,6 +732,20 @@
                     "kind": [
                         "test"
                     ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/cc-1.0.83/tests/test.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
                     "name": "cxxflags",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/cc-1.0.83/tests/cxxflags.rs",
                     "test": true
@@ -748,20 +762,6 @@
                     ],
                     "name": "cflags",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/cc-1.0.83/tests/cflags.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/cc-1.0.83/tests/test.rs",
                     "test": true
                 },
                 {
@@ -829,7 +829,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -1142,7 +1142,7 @@
                 ]
             },
             "homepage": "https://github.com/chronotope/chrono",
-            "id": "chrono 0.4.31 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.31",
             "keywords": [
                 "date",
                 "time",
@@ -1201,20 +1201,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "wasm",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/chrono-0.4.31/tests/wasm.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "win_bindings",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/chrono-0.4.31/tests/win_bindings.rs",
                     "test": true
@@ -1231,6 +1217,20 @@
                     ],
                     "name": "dateutils",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/chrono-0.4.31/tests/dateutils.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "wasm",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/chrono-0.4.31/tests/wasm.rs",
                     "test": true
                 }
             ],
@@ -1251,7 +1251,7 @@
                 "mac_os_10_8_features": []
             },
             "homepage": "https://github.com/servo/core-foundation-rs",
-            "id": "core-foundation-sys 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.4",
             "keywords": [],
             "license": "MIT / Apache-2.0",
             "license_file": null,
@@ -1311,7 +1311,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled)",
+            "id": "path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled#crate-with-optional-deps@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -1449,7 +1449,7 @@
                 ]
             },
             "homepage": null,
-            "id": "darling 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#darling@0.20.3",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -1487,8 +1487,22 @@
                     "kind": [
                         "example"
                     ],
-                    "name": "expr_with",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/examples/expr_with.rs",
+                    "name": "consume_fields",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/examples/consume_fields.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "example"
+                    ],
+                    "name": "automatic_bounds",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/examples/automatic_bounds.rs",
                     "test": false
                 },
                 {
@@ -1543,22 +1557,8 @@
                     "kind": [
                         "example"
                     ],
-                    "name": "automatic_bounds",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/examples/automatic_bounds.rs",
-                    "test": false
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "example"
-                    ],
-                    "name": "consume_fields",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/examples/consume_fields.rs",
+                    "name": "expr_with",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/examples/expr_with.rs",
                     "test": false
                 },
                 {
@@ -1585,50 +1585,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "computed_bound",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/computed_bound.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "hash_map",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/hash_map.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "from_type_param",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/from_type_param.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "enums_struct",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/enums_struct.rs",
                     "test": true
                 },
                 {
@@ -1655,64 +1613,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "suggestions",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/suggestions.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "from_type_param_default",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/from_type_param_default.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "accrue_errors",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/accrue_errors.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "unsupported_attributes",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/unsupported_attributes.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "from_meta",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/from_meta.rs",
                     "test": true
                 },
                 {
@@ -1739,48 +1641,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "split_declaration",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/split_declaration.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "defaults",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/defaults.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "enums_unit",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/enums_unit.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "error",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/error.rs",
                     "test": true
@@ -1795,36 +1655,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "custom_bound",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/custom_bound.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "compiletests",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/compiletests.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "happy_path",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/happy_path.rs",
+                    "name": "suggestions",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/suggestions.rs",
                     "test": true
                 },
                 {
@@ -1851,8 +1683,36 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "newtype",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/newtype.rs",
+                    "name": "happy_path",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/happy_path.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "custom_bound",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/custom_bound.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "enums_newtype",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/enums_newtype.rs",
                     "test": true
                 },
                 {
@@ -1879,6 +1739,20 @@
                     "kind": [
                         "test"
                     ],
+                    "name": "unsupported_attributes",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/unsupported_attributes.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
                     "name": "generics",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/generics.rs",
                     "test": true
@@ -1893,8 +1767,134 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "enums_newtype",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/enums_newtype.rs",
+                    "name": "newtype",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/newtype.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "hash_map",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/hash_map.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "accrue_errors",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/accrue_errors.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "enums_struct",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/enums_struct.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "compiletests",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/compiletests.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "defaults",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/defaults.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "split_declaration",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/split_declaration.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "computed_bound",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/computed_bound.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "enums_unit",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/enums_unit.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "from_meta",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/darling-0.20.3/tests/from_meta.rs",
                     "test": true
                 }
             ],
@@ -1996,7 +1996,7 @@
                 ]
             },
             "homepage": null,
-            "id": "darling_core 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.3",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -2076,7 +2076,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "darling_macro 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.3",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -2228,7 +2228,7 @@
                 ]
             },
             "homepage": null,
-            "id": "deranged 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.3.9",
             "keywords": [
                 "integer",
                 "int",
@@ -2289,7 +2289,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "equivalent 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.1",
             "keywords": [
                 "hashmap",
                 "no_std"
@@ -2340,7 +2340,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
             "keywords": [],
             "license": "Apache-2.0 / MIT",
             "license_file": null,
@@ -2585,7 +2585,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
             "keywords": [
                 "hash",
                 "no_std",
@@ -2639,6 +2639,20 @@
                     "kind": [
                         "test"
                     ],
+                    "name": "serde",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.12.3/tests/serde.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
                     "name": "rayon",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.12.3/tests/rayon.rs",
                     "test": true
@@ -2667,20 +2681,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "serde",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.12.3/tests/serde.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "hasher",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.12.3/tests/hasher.rs",
                     "test": true
@@ -2695,8 +2695,8 @@
                     "kind": [
                         "bench"
                     ],
-                    "name": "bench",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.12.3/benches/bench.rs",
+                    "name": "insert_unique_unchecked",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.12.3/benches/insert_unique_unchecked.rs",
                     "test": false
                 },
                 {
@@ -2709,8 +2709,8 @@
                     "kind": [
                         "bench"
                     ],
-                    "name": "insert_unique_unchecked",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.12.3/benches/insert_unique_unchecked.rs",
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.12.3/benches/bench.rs",
                     "test": false
                 }
             ],
@@ -2993,7 +2993,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hashbrown 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.2",
             "keywords": [
                 "hash",
                 "no_std",
@@ -3050,8 +3050,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "hasher",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/tests/hasher.rs",
+                    "name": "serde",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/tests/serde.rs",
                     "test": true
                 },
                 {
@@ -3066,6 +3066,20 @@
                     ],
                     "name": "rayon",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/tests/rayon.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "raw",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/tests/raw.rs",
                     "test": true
                 },
                 {
@@ -3106,37 +3120,9 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "serde",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/tests/serde.rs",
+                    "name": "hasher",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/tests/hasher.rs",
                     "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "raw",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/tests/raw.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "bench"
-                    ],
-                    "name": "bench",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/benches/bench.rs",
-                    "test": false
                 },
                 {
                     "crate_types": [
@@ -3150,6 +3136,20 @@
                     ],
                     "name": "insert_unique_unchecked",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/benches/insert_unique_unchecked.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "bench"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.2/benches/bench.rs",
                     "test": false
                 }
             ],
@@ -3280,7 +3280,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
             "keywords": [
                 "no_std",
                 "hex"
@@ -3471,7 +3471,7 @@
                 "fallback": []
             },
             "homepage": null,
-            "id": "iana-time-zone 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.58",
             "keywords": [
                 "IANA",
                 "time"
@@ -3562,7 +3562,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "iana-time-zone-haiku 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2",
             "keywords": [
                 "IANA",
                 "time"
@@ -3622,7 +3622,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -3861,7 +3861,7 @@
                 "test_low_transition_point": []
             },
             "homepage": null,
-            "id": "indexmap 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
             "keywords": [
                 "hashmap",
                 "no_std"
@@ -3917,34 +3917,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "tests",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-1.9.3/tests/tests.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "equivalent_trait",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-1.9.3/tests/equivalent_trait.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "quick",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-1.9.3/tests/quick.rs",
                     "test": true
@@ -3971,11 +3943,25 @@
                     "doctest": false,
                     "edition": "2021",
                     "kind": [
-                        "bench"
+                        "test"
                     ],
-                    "name": "bench",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-1.9.3/benches/bench.rs",
-                    "test": false
+                    "name": "equivalent_trait",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-1.9.3/tests/equivalent_trait.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-1.9.3/tests/tests.rs",
+                    "test": true
                 },
                 {
                     "crate_types": [
@@ -3989,6 +3975,20 @@
                     ],
                     "name": "faststring",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-1.9.3/benches/faststring.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "bench"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-1.9.3/benches/bench.rs",
                     "test": false
                 },
                 {
@@ -4215,7 +4215,7 @@
                 "test_debug": []
             },
             "homepage": null,
-            "id": "indexmap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.1.0",
             "keywords": [
                 "hashmap",
                 "no_std"
@@ -4275,22 +4275,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "tests",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-2.1.0/tests/tests.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "equivalent_trait",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-2.1.0/tests/equivalent_trait.rs",
+                    "name": "quick",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-2.1.0/tests/quick.rs",
                     "test": true
                 },
                 {
@@ -4317,8 +4303,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "quick",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-2.1.0/tests/quick.rs",
+                    "name": "equivalent_trait",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-2.1.0/tests/equivalent_trait.rs",
                     "test": true
                 },
                 {
@@ -4329,11 +4315,11 @@
                     "doctest": false,
                     "edition": "2021",
                     "kind": [
-                        "bench"
+                        "test"
                     ],
-                    "name": "bench",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-2.1.0/benches/bench.rs",
-                    "test": false
+                    "name": "tests",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-2.1.0/tests/tests.rs",
+                    "test": true
                 },
                 {
                     "crate_types": [
@@ -4347,6 +4333,20 @@
                     ],
                     "name": "faststring",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-2.1.0/benches/faststring.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "bench"
+                    ],
+                    "name": "bench",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/indexmap-2.1.0/benches/bench.rs",
                     "test": false
                 }
             ],
@@ -4385,7 +4385,7 @@
                 ]
             },
             "homepage": null,
-            "id": "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9",
             "keywords": [
                 "integer"
             ],
@@ -4524,7 +4524,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "js-sys 0.3.65 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.65",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -4630,7 +4630,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/libc",
-            "id": "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150",
             "keywords": [
                 "libc",
                 "ffi",
@@ -5000,7 +5000,7 @@
                 ]
             },
             "homepage": null,
-            "id": "log 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.20",
             "keywords": [
                 "logging"
             ],
@@ -5137,7 +5137,7 @@
                 "std": []
             },
             "homepage": "https://github.com/rust-num/num-traits",
-            "id": "num-traits 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.17",
             "keywords": [
                 "mathematics",
                 "numerics"
@@ -5310,7 +5310,7 @@
                 "unstable": []
             },
             "homepage": null,
-            "id": "once_cell 1.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.18.0",
             "keywords": [
                 "lazy",
                 "static"
@@ -5507,7 +5507,7 @@
                 ]
             },
             "homepage": null,
-            "id": "powerfmt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
             "keywords": [
                 "display",
                 "format",
@@ -5617,7 +5617,7 @@
                 "span-locations": []
             },
             "homepage": null,
-            "id": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
             "keywords": [
                 "macros",
                 "syn"
@@ -5682,34 +5682,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "comments",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/tests/comments.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_fmt",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/tests/test_fmt.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "features",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/tests/features.rs",
                     "test": true
@@ -5738,8 +5710,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "marker",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/tests/marker.rs",
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/tests/test_size.rs",
                     "test": true
                 },
                 {
@@ -5752,8 +5724,36 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "test_size",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/tests/test_size.rs",
+                    "name": "test_fmt",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/tests/test_fmt.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "comments",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/tests/comments.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "marker",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.69/tests/marker.rs",
                     "test": true
                 },
                 {
@@ -5833,7 +5833,7 @@
                 ]
             },
             "homepage": null,
-            "id": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
             "keywords": [
                 "macros",
                 "syn"
@@ -5885,8 +5885,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "compiletest",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.33/tests/compiletest.rs",
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.33/tests/test.rs",
                     "test": true
                 },
                 {
@@ -5899,8 +5899,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "test",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.33/tests/test.rs",
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.33/tests/compiletest.rs",
                     "test": true
                 }
             ],
@@ -5976,7 +5976,7 @@
                 "small": []
             },
             "homepage": null,
-            "id": "ryu 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.15",
             "keywords": [
                 "float"
             ],
@@ -6041,36 +6041,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "f2s_test",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/f2s_test.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "s2d_test",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/s2d_test.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "d2s_test",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/d2s_test.rs",
+                    "name": "d2s_table_test",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/d2s_table_test.rs",
                     "test": true
                 },
                 {
@@ -6097,6 +6069,34 @@
                     "kind": [
                         "test"
                     ],
+                    "name": "d2s_test",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/d2s_test.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "s2d_test",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/s2d_test.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
                     "name": "exhaustive",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/exhaustive.rs",
                     "test": true
@@ -6111,8 +6111,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "s2f_test",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/s2f_test.rs",
+                    "name": "f2s_test",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/f2s_test.rs",
                     "test": true
                 },
                 {
@@ -6125,8 +6125,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "d2s_table_test",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/d2s_table_test.rs",
+                    "name": "s2f_test",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/ryu-1.0.15/tests/s2f_test.rs",
                     "test": true
                 },
                 {
@@ -6214,7 +6214,7 @@
                 "unstable": []
             },
             "homepage": "https://serde.rs",
-            "id": "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192",
             "keywords": [
                 "serde",
                 "serialization",
@@ -6355,7 +6355,7 @@
                 "deserialize_in_place": []
             },
             "homepage": "https://serde.rs",
-            "id": "serde_derive 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.192",
             "keywords": [
                 "serde",
                 "serialization",
@@ -6601,7 +6601,7 @@
                 "unbounded_depth": []
             },
             "homepage": null,
-            "id": "serde_json 1.0.108 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.108",
             "keywords": [
                 "json",
                 "serde",
@@ -6665,8 +6665,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "map",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/map.rs",
+                    "name": "stream",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/stream.rs",
                     "test": true
                 },
                 {
@@ -6693,36 +6693,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "lexical",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/lexical.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "debug",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/debug.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "stream",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/stream.rs",
+                    "name": "regression",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/regression.rs",
                     "test": true
                 },
                 {
@@ -6749,8 +6721,36 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "regression",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/regression.rs",
+                    "name": "debug",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/debug.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "lexical",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/lexical.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "map",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_json-1.0.108/tests/map.rs",
                     "test": true
                 },
                 {
@@ -7194,7 +7194,7 @@
                 ]
             },
             "homepage": null,
-            "id": "serde_with 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.4.0",
             "keywords": [
                 "serde",
                 "utilities",
@@ -7656,7 +7656,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "serde_with_macros 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.4.0",
             "keywords": [
                 "serde",
                 "utilities",
@@ -7725,8 +7725,36 @@
                     "kind": [
                         "test"
                     ],
+                    "name": "serde_as_issue_267",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_with_macros-3.4.0/tests/serde_as_issue_267.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
                     "name": "serde_as_issue_538",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_with_macros-3.4.0/tests/serde_as_issue_538.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "compiler-messages",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_with_macros-3.4.0/tests/compiler-messages.rs",
                     "test": true
                 },
                 {
@@ -7767,34 +7795,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "serde_as_issue_267",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_with_macros-3.4.0/tests/serde_as_issue_267.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "compiler-messages",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_with_macros-3.4.0/tests/compiler-messages.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "version_numbers",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/serde_with_macros-3.4.0/tests/version_numbers.rs",
                     "test": true
@@ -7814,7 +7814,7 @@
             "edition": "2015",
             "features": {},
             "homepage": "https://github.com/dguo/strsim-rs",
-            "id": "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.10.0",
             "keywords": [
                 "string",
                 "similarity",
@@ -8118,7 +8118,7 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39",
             "keywords": [
                 "macros",
                 "syn"
@@ -8182,286 +8182,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "test_lit",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_lit.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_shebang",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_shebang.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_size",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_size.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_pat",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_pat.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "regression",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/regression.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_item",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_item.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_iterators",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_iterators.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "zzz_stable",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/zzz_stable.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_token_trees",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_token_trees.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_asyncness",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_asyncness.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_generics",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_generics.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_expr",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_expr.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_meta",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_meta.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_precedence",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_precedence.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_parse_stream",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_parse_stream.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_ty",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_ty.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_grouping",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_grouping.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_receiver",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_receiver.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_ident",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_ident.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_parse_buffer",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_parse_buffer.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "test_should_parse",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_should_parse.rs",
                     "test": true
@@ -8476,36 +8196,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "test_derive_input",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_derive_input.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_path",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_path.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "test_round_trip",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_round_trip.rs",
+                    "name": "test_visibility",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_visibility.rs",
                     "test": true
                 },
                 {
@@ -8532,8 +8224,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "test_attribute",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_attribute.rs",
+                    "name": "test_round_trip",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_round_trip.rs",
                     "test": true
                 },
                 {
@@ -8546,8 +8238,316 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "test_visibility",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_visibility.rs",
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_size.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_shebang",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_shebang.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_pat",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_pat.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_receiver",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_receiver.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_precedence",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_precedence.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_lit",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_lit.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "regression",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/regression.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_parse_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_parse_stream.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_grouping",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_grouping.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_ident",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_ident.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_iterators",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_iterators.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_parse_buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_parse_buffer.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_asyncness",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_asyncness.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_token_trees",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_token_trees.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_ty",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_ty.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "zzz_stable",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/zzz_stable.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_meta",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_meta.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_expr.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_item",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_item.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_path.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_derive_input",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_derive_input.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_generics.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_attribute",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.39/tests/test_attribute.rs",
                     "test": true
                 },
                 {
@@ -8921,7 +8921,7 @@
                 ]
             },
             "homepage": "https://time-rs.github.io",
-            "id": "time 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.30",
             "keywords": [
                 "date",
                 "time",
@@ -9014,7 +9014,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "time-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.2",
             "keywords": [
                 "date",
                 "time",
@@ -9091,7 +9091,7 @@
                 "serde": []
             },
             "homepage": null,
-            "id": "time-macros 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.15",
             "keywords": [
                 "date",
                 "time",
@@ -9226,7 +9226,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12",
             "keywords": [
                 "unicode",
                 "xid"
@@ -9278,8 +9278,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "compare",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/compare.rs",
+                    "name": "static_size",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/static_size.rs",
                     "test": true
                 },
                 {
@@ -9292,8 +9292,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "static_size",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/static_size.rs",
+                    "name": "compare",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/compare.rs",
                     "test": true
                 },
                 {
@@ -9480,7 +9480,7 @@
                 ]
             },
             "homepage": "https://rustwasm.github.io/",
-            "id": "wasm-bindgen 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.88",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -9526,48 +9526,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "headless",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/headless/main.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "must_use",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/must_use.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "worker",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/worker/main.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "wasm",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/wasm/main.rs",
                     "test": true
@@ -9596,8 +9554,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "unwrap_throw",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/unwrap_throw.rs",
+                    "name": "std-crate-no-std-dep",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/std-crate-no-std-dep.rs",
                     "test": true
                 },
                 {
@@ -9610,8 +9568,50 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "std-crate-no-std-dep",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/std-crate-no-std-dep.rs",
+                    "name": "must_use",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/must_use.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "headless",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/headless/main.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "worker",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/worker/main.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "unwrap_throw",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.88/tests/unwrap_throw.rs",
                     "test": true
                 },
                 {
@@ -9735,7 +9735,7 @@
                 "spans": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-backend 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.88",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -9861,7 +9861,7 @@
                 "xxx_debug_only_print_generated_code": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-macro 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.88",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -9990,7 +9990,7 @@
                 "strict-macro": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-macro-support 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.88",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10033,7 +10033,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-shared 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.88",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10108,7 +10108,7 @@
                 "implement": []
             },
             "homepage": null,
-            "id": "windows-core 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.51.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10243,7 +10243,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows-targets 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.48.5",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10286,7 +10286,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_gnullvm 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.48.5",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10350,7 +10350,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.48.5",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10414,7 +10414,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_gnu 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.48.5",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10478,7 +10478,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.48.5",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10542,7 +10542,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnu 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.48.5",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10606,7 +10606,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnullvm 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.48.5",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10670,7 +10670,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.48.5",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10729,11 +10729,11 @@
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "android-tzdata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#android-tzdata@0.1.1"
             },
             {
                 "dependencies": [
-                    "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150"
                 ],
                 "deps": [
                     {
@@ -10744,17 +10744,17 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150"
                     }
                 ],
                 "features": [],
-                "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
             },
             {
                 "dependencies": [],
@@ -10762,7 +10762,7 @@
                 "features": [
                     "alloc"
                 ],
-                "id": "base64 0.21.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#base64@0.21.5"
             },
             {
                 "dependencies": [],
@@ -10770,11 +10770,11 @@
                 "features": [
                     "default"
                 ],
-                "id": "bumpalo 3.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.14.0"
             },
             {
                 "dependencies": [
-                    "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150"
                 ],
                 "deps": [
                     {
@@ -10785,25 +10785,25 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150"
                     }
                 ],
                 "features": [],
-                "id": "cc 1.0.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.83"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [
-                    "android-tzdata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "iana-time-zone 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "num-traits 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-targets 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#android-tzdata@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.58",
+                    "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.48.5"
                 ],
                 "deps": [
                     {
@@ -10814,7 +10814,7 @@
                             }
                         ],
                         "name": "android_tzdata",
-                        "pkg": "android-tzdata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#android-tzdata@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -10824,7 +10824,7 @@
                             }
                         ],
                         "name": "iana_time_zone",
-                        "pkg": "iana-time-zone 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.58"
                     },
                     {
                         "dep_kinds": [
@@ -10834,7 +10834,7 @@
                             }
                         ],
                         "name": "num_traits",
-                        "pkg": "num-traits 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.17"
                     },
                     {
                         "dep_kinds": [
@@ -10844,7 +10844,7 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                     },
                     {
                         "dep_kinds": [
@@ -10854,7 +10854,7 @@
                             }
                         ],
                         "name": "windows_targets",
-                        "pkg": "windows-targets 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.48.5"
                     }
                 ],
                 "features": [
@@ -10867,17 +10867,17 @@
                     "winapi",
                     "windows-targets"
                 ],
-                "id": "chrono 0.4.31 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.31"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "core-foundation-sys 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.4"
             },
             {
                 "dependencies": [
-                    "serde_with 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.4.0"
                 ],
                 "deps": [
                     {
@@ -10888,16 +10888,16 @@
                             }
                         ],
                         "name": "serde_with",
-                        "pkg": "serde_with 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.4.0"
                     }
                 ],
                 "features": [],
-                "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled)"
+                "id": "path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled#crate-with-optional-deps@0.1.0"
             },
             {
                 "dependencies": [
-                    "darling_core 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "darling_macro 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.3"
                 ],
                 "deps": [
                     {
@@ -10908,7 +10908,7 @@
                             }
                         ],
                         "name": "darling_core",
-                        "pkg": "darling_core 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.3"
                     },
                     {
                         "dep_kinds": [
@@ -10918,23 +10918,23 @@
                             }
                         ],
                         "name": "darling_macro",
-                        "pkg": "darling_macro 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.3"
                     }
                 ],
                 "features": [
                     "default",
                     "suggestions"
                 ],
-                "id": "darling 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#darling@0.20.3"
             },
             {
                 "dependencies": [
-                    "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#strsim@0.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                 ],
                 "deps": [
                     {
@@ -10945,7 +10945,7 @@
                             }
                         ],
                         "name": "fnv",
-                        "pkg": "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7"
                     },
                     {
                         "dep_kinds": [
@@ -10955,7 +10955,7 @@
                             }
                         ],
                         "name": "ident_case",
-                        "pkg": "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1"
                     },
                     {
                         "dep_kinds": [
@@ -10965,7 +10965,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -10975,7 +10975,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -10985,7 +10985,7 @@
                             }
                         ],
                         "name": "strsim",
-                        "pkg": "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -10995,20 +10995,20 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                     }
                 ],
                 "features": [
                     "strsim",
                     "suggestions"
                 ],
-                "id": "darling_core 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.3"
             },
             {
                 "dependencies": [
-                    "darling_core 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                 ],
                 "deps": [
                     {
@@ -11019,7 +11019,7 @@
                             }
                         ],
                         "name": "darling_core",
-                        "pkg": "darling_core 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#darling_core@0.20.3"
                     },
                     {
                         "dep_kinds": [
@@ -11029,7 +11029,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -11039,16 +11039,16 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                     }
                 ],
                 "features": [],
-                "id": "darling_macro 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#darling_macro@0.20.3"
             },
             {
                 "dependencies": [
-                    "powerfmt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                 ],
                 "deps": [
                     {
@@ -11059,7 +11059,7 @@
                             }
                         ],
                         "name": "powerfmt",
-                        "pkg": "powerfmt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0"
                     },
                     {
                         "dep_kinds": [
@@ -11069,7 +11069,7 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                     }
                 ],
                 "features": [
@@ -11078,13 +11078,13 @@
                     "serde",
                     "std"
                 ],
-                "id": "deranged 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.3.9"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "equivalent 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.1"
             },
             {
                 "dependencies": [],
@@ -11093,7 +11093,7 @@
                     "default",
                     "std"
                 ],
-                "id": "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#fnv@1.0.7"
             },
             {
                 "dependencies": [],
@@ -11101,7 +11101,7 @@
                 "features": [
                     "raw"
                 ],
-                "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
             },
             {
                 "dependencies": [],
@@ -11109,7 +11109,7 @@
                 "features": [
                     "raw"
                 ],
-                "id": "hashbrown 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.2"
             },
             {
                 "dependencies": [],
@@ -11117,16 +11117,16 @@
                 "features": [
                     "alloc"
                 ],
-                "id": "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3"
             },
             {
                 "dependencies": [
-                    "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "core-foundation-sys 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "iana-time-zone-haiku 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js-sys 0.3.65 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-core 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.65",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.88",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.51.1"
                 ],
                 "deps": [
                     {
@@ -11137,7 +11137,7 @@
                             }
                         ],
                         "name": "android_system_properties",
-                        "pkg": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5"
                     },
                     {
                         "dep_kinds": [
@@ -11147,7 +11147,7 @@
                             }
                         ],
                         "name": "core_foundation_sys",
-                        "pkg": "core-foundation-sys 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.4"
                     },
                     {
                         "dep_kinds": [
@@ -11157,7 +11157,7 @@
                             }
                         ],
                         "name": "iana_time_zone_haiku",
-                        "pkg": "iana-time-zone-haiku 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2"
                     },
                     {
                         "dep_kinds": [
@@ -11167,7 +11167,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.65 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.65"
                     },
                     {
                         "dep_kinds": [
@@ -11177,7 +11177,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.88"
                     },
                     {
                         "dep_kinds": [
@@ -11187,17 +11187,17 @@
                             }
                         ],
                         "name": "windows_core",
-                        "pkg": "windows-core 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.51.1"
                     }
                 ],
                 "features": [
                     "fallback"
                 ],
-                "id": "iana-time-zone 0.1.58 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.58"
             },
             {
                 "dependencies": [
-                    "cc 1.0.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.83"
                 ],
                 "deps": [
                     {
@@ -11208,23 +11208,23 @@
                             }
                         ],
                         "name": "cc",
-                        "pkg": "cc 1.0.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.83"
                     }
                 ],
                 "features": [],
-                "id": "iana-time-zone-haiku 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ident_case@1.0.1"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                 ],
                 "deps": [
                     {
@@ -11235,7 +11235,7 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -11245,7 +11245,7 @@
                             }
                         ],
                         "name": "hashbrown",
-                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                     },
                     {
                         "dep_kinds": [
@@ -11255,7 +11255,7 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                     }
                 ],
                 "features": [
@@ -11263,13 +11263,13 @@
                     "serde-1",
                     "std"
                 ],
-                "id": "indexmap 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3"
             },
             {
                 "dependencies": [
-                    "equivalent 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hashbrown 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                 ],
                 "deps": [
                     {
@@ -11280,7 +11280,7 @@
                             }
                         ],
                         "name": "equivalent",
-                        "pkg": "equivalent 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#equivalent@1.0.1"
                     },
                     {
                         "dep_kinds": [
@@ -11290,7 +11290,7 @@
                             }
                         ],
                         "name": "hashbrown",
-                        "pkg": "hashbrown 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.14.2"
                     },
                     {
                         "dep_kinds": [
@@ -11300,24 +11300,24 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                     }
                 ],
                 "features": [
                     "serde",
                     "std"
                 ],
-                "id": "indexmap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.1.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9"
             },
             {
                 "dependencies": [
-                    "wasm-bindgen 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.88"
                 ],
                 "deps": [
                     {
@@ -11328,11 +11328,11 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.88"
                     }
                 ],
                 "features": [],
-                "id": "js-sys 0.3.65 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.65"
             },
             {
                 "dependencies": [],
@@ -11341,17 +11341,17 @@
                     "default",
                     "std"
                 ],
-                "id": "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "log 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.20"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                 ],
                 "deps": [
                     {
@@ -11362,11 +11362,11 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     }
                 ],
                 "features": [],
-                "id": "num-traits 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.17"
             },
             {
                 "dependencies": [],
@@ -11377,17 +11377,17 @@
                     "race",
                     "std"
                 ],
-                "id": "once_cell 1.18.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.18.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "powerfmt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0"
             },
             {
                 "dependencies": [
-                    "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                 ],
                 "deps": [
                     {
@@ -11398,18 +11398,18 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                 ],
                 "deps": [
                     {
@@ -11420,24 +11420,24 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "ryu 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.15"
             },
             {
                 "dependencies": [
-                    "serde_derive 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.192"
                 ],
                 "deps": [
                     {
@@ -11452,7 +11452,7 @@
                             }
                         ],
                         "name": "serde_derive",
-                        "pkg": "serde_derive 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.192"
                     }
                 ],
                 "features": [
@@ -11461,13 +11461,13 @@
                     "serde_derive",
                     "std"
                 ],
-                "id": "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                 ],
                 "deps": [
                     {
@@ -11478,7 +11478,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -11488,7 +11488,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -11498,19 +11498,19 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "serde_derive 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.192"
             },
             {
                 "dependencies": [
-                    "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ryu 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.15",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                 ],
                 "deps": [
                     {
@@ -11521,7 +11521,7 @@
                             }
                         ],
                         "name": "itoa",
-                        "pkg": "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9"
                     },
                     {
                         "dep_kinds": [
@@ -11531,7 +11531,7 @@
                             }
                         ],
                         "name": "ryu",
-                        "pkg": "ryu 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ryu@1.0.15"
                     },
                     {
                         "dep_kinds": [
@@ -11541,25 +11541,25 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                     }
                 ],
                 "features": [
                     "alloc"
                 ],
-                "id": "serde_json 1.0.108 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.108"
             },
             {
                 "dependencies": [
-                    "base64 0.21.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "chrono 0.4.31 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "indexmap 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "indexmap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde_json 1.0.108 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde_with_macros 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "time 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#base64@0.21.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.31",
+                    "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.108",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#time@0.3.30"
                 ],
                 "deps": [
                     {
@@ -11570,7 +11570,7 @@
                             }
                         ],
                         "name": "base64",
-                        "pkg": "base64 0.21.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#base64@0.21.5"
                     },
                     {
                         "dep_kinds": [
@@ -11580,7 +11580,7 @@
                             }
                         ],
                         "name": "chrono_0_4",
-                        "pkg": "chrono 0.4.31 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.31"
                     },
                     {
                         "dep_kinds": [
@@ -11590,7 +11590,7 @@
                             }
                         ],
                         "name": "hex",
-                        "pkg": "hex 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3"
                     },
                     {
                         "dep_kinds": [
@@ -11600,7 +11600,7 @@
                             }
                         ],
                         "name": "indexmap_1",
-                        "pkg": "indexmap 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.3"
                     },
                     {
                         "dep_kinds": [
@@ -11610,7 +11610,7 @@
                             }
                         ],
                         "name": "indexmap_2",
-                        "pkg": "indexmap 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -11620,7 +11620,7 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                     },
                     {
                         "dep_kinds": [
@@ -11630,7 +11630,7 @@
                             }
                         ],
                         "name": "serde_json",
-                        "pkg": "serde_json 1.0.108 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.108"
                     },
                     {
                         "dep_kinds": [
@@ -11640,7 +11640,7 @@
                             }
                         ],
                         "name": "serde_with_macros",
-                        "pkg": "serde_with_macros 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -11650,7 +11650,7 @@
                             }
                         ],
                         "name": "time_0_3",
-                        "pkg": "time 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.30"
                     }
                 ],
                 "features": [
@@ -11659,14 +11659,14 @@
                     "macros",
                     "std"
                 ],
-                "id": "serde_with 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_with@3.4.0"
             },
             {
                 "dependencies": [
-                    "darling 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#darling@0.20.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                 ],
                 "deps": [
                     {
@@ -11677,7 +11677,7 @@
                             }
                         ],
                         "name": "darling",
-                        "pkg": "darling 0.20.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#darling@0.20.3"
                     },
                     {
                         "dep_kinds": [
@@ -11687,7 +11687,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -11697,7 +11697,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -11707,23 +11707,23 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                     }
                 ],
                 "features": [],
-                "id": "serde_with_macros 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_with_macros@3.4.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#strsim@0.10.0"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                 ],
                 "deps": [
                     {
@@ -11734,7 +11734,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -11744,7 +11744,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -11754,7 +11754,7 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
                     }
                 ],
                 "features": [
@@ -11769,16 +11769,16 @@
                     "quote",
                     "visit"
                 ],
-                "id": "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
             },
             {
                 "dependencies": [
-                    "deranged 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "powerfmt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "time-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "time-macros 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#deranged@0.3.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192",
+                    "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.15"
                 ],
                 "deps": [
                     {
@@ -11789,7 +11789,7 @@
                             }
                         ],
                         "name": "deranged",
-                        "pkg": "deranged 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#deranged@0.3.9"
                     },
                     {
                         "dep_kinds": [
@@ -11799,7 +11799,7 @@
                             }
                         ],
                         "name": "itoa",
-                        "pkg": "itoa 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.9"
                     },
                     {
                         "dep_kinds": [
@@ -11809,7 +11809,7 @@
                             }
                         ],
                         "name": "powerfmt",
-                        "pkg": "powerfmt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0"
                     },
                     {
                         "dep_kinds": [
@@ -11819,7 +11819,7 @@
                             }
                         ],
                         "name": "serde",
-                        "pkg": "serde 1.0.192 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.192"
                     },
                     {
                         "dep_kinds": [
@@ -11829,7 +11829,7 @@
                             }
                         ],
                         "name": "time_core",
-                        "pkg": "time-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.2"
                     },
                     {
                         "dep_kinds": [
@@ -11839,7 +11839,7 @@
                             }
                         ],
                         "name": "time_macros",
-                        "pkg": "time-macros 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.15"
                     }
                 ],
                 "features": [
@@ -11850,17 +11850,17 @@
                     "serde-well-known",
                     "std"
                 ],
-                "id": "time 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#time@0.3.30"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "time-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.2"
             },
             {
                 "dependencies": [
-                    "time-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.2"
                 ],
                 "deps": [
                     {
@@ -11871,7 +11871,7 @@
                             }
                         ],
                         "name": "time_core",
-                        "pkg": "time-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#time-core@0.1.2"
                     }
                 ],
                 "features": [
@@ -11879,18 +11879,18 @@
                     "parsing",
                     "serde"
                 ],
-                "id": "time-macros 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#time-macros@0.2.15"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "unicode-ident 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-macro 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.88"
                 ],
                 "deps": [
                     {
@@ -11901,7 +11901,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -11911,7 +11911,7 @@
                             }
                         ],
                         "name": "wasm_bindgen_macro",
-                        "pkg": "wasm-bindgen-macro 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.88"
                     }
                 ],
                 "features": [
@@ -11919,17 +11919,17 @@
                     "spans",
                     "std"
                 ],
-                "id": "wasm-bindgen 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.88"
             },
             {
                 "dependencies": [
-                    "bumpalo 3.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "once_cell 1.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-shared 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.14.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.20",
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.18.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.88"
                 ],
                 "deps": [
                     {
@@ -11940,7 +11940,7 @@
                             }
                         ],
                         "name": "bumpalo",
-                        "pkg": "bumpalo 3.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.14.0"
                     },
                     {
                         "dep_kinds": [
@@ -11950,7 +11950,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.20"
                     },
                     {
                         "dep_kinds": [
@@ -11960,7 +11960,7 @@
                             }
                         ],
                         "name": "once_cell",
-                        "pkg": "once_cell 1.18.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.18.0"
                     },
                     {
                         "dep_kinds": [
@@ -11970,7 +11970,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -11980,7 +11980,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -11990,7 +11990,7 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                     },
                     {
                         "dep_kinds": [
@@ -12000,18 +12000,18 @@
                             }
                         ],
                         "name": "wasm_bindgen_shared",
-                        "pkg": "wasm-bindgen-shared 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.88"
                     }
                 ],
                 "features": [
                     "spans"
                 ],
-                "id": "wasm-bindgen-backend 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.88"
             },
             {
                 "dependencies": [
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-macro-support 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.88"
                 ],
                 "deps": [
                     {
@@ -12022,7 +12022,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -12032,21 +12032,21 @@
                             }
                         ],
                         "name": "wasm_bindgen_macro_support",
-                        "pkg": "wasm-bindgen-macro-support 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.88"
                     }
                 ],
                 "features": [
                     "spans"
                 ],
-                "id": "wasm-bindgen-macro 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.88"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-backend 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-shared 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.88",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.88"
                 ],
                 "deps": [
                     {
@@ -12057,7 +12057,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.69"
                     },
                     {
                         "dep_kinds": [
@@ -12067,7 +12067,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.33"
                     },
                     {
                         "dep_kinds": [
@@ -12077,7 +12077,7 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 2.0.39 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.39"
                     },
                     {
                         "dep_kinds": [
@@ -12087,7 +12087,7 @@
                             }
                         ],
                         "name": "wasm_bindgen_backend",
-                        "pkg": "wasm-bindgen-backend 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.88"
                     },
                     {
                         "dep_kinds": [
@@ -12097,23 +12097,23 @@
                             }
                         ],
                         "name": "wasm_bindgen_shared",
-                        "pkg": "wasm-bindgen-shared 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.88"
                     }
                 ],
                 "features": [
                     "spans"
                 ],
-                "id": "wasm-bindgen-macro-support 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.88"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "wasm-bindgen-shared 0.2.88 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.88"
             },
             {
                 "dependencies": [
-                    "windows-targets 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.48.5"
                 ],
                 "deps": [
                     {
@@ -12124,23 +12124,23 @@
                             }
                         ],
                         "name": "windows_targets",
-                        "pkg": "windows-targets 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.48.5"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "windows-core 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows-core@0.51.1"
             },
             {
                 "dependencies": [
-                    "windows_aarch64_gnullvm 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_aarch64_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_gnu 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnu 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnullvm 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.48.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.48.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.48.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.48.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.48.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.48.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.48.5"
                 ],
                 "deps": [
                     {
@@ -12151,7 +12151,7 @@
                             }
                         ],
                         "name": "windows_aarch64_gnullvm",
-                        "pkg": "windows_aarch64_gnullvm 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.48.5"
                     },
                     {
                         "dep_kinds": [
@@ -12161,7 +12161,7 @@
                             }
                         ],
                         "name": "windows_aarch64_msvc",
-                        "pkg": "windows_aarch64_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.48.5"
                     },
                     {
                         "dep_kinds": [
@@ -12171,7 +12171,7 @@
                             }
                         ],
                         "name": "windows_i686_gnu",
-                        "pkg": "windows_i686_gnu 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.48.5"
                     },
                     {
                         "dep_kinds": [
@@ -12181,7 +12181,7 @@
                             }
                         ],
                         "name": "windows_i686_msvc",
-                        "pkg": "windows_i686_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.48.5"
                     },
                     {
                         "dep_kinds": [
@@ -12191,7 +12191,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnu",
-                        "pkg": "windows_x86_64_gnu 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.48.5"
                     },
                     {
                         "dep_kinds": [
@@ -12201,7 +12201,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnullvm",
-                        "pkg": "windows_x86_64_gnullvm 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.48.5"
                     },
                     {
                         "dep_kinds": [
@@ -12211,64 +12211,64 @@
                             }
                         ],
                         "name": "windows_x86_64_msvc",
-                        "pkg": "windows_x86_64_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.48.5"
                     }
                 ],
                 "features": [],
-                "id": "windows-targets 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows-targets@0.48.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_gnullvm 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.48.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.48.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_gnu 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.48.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.48.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnu 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.48.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnullvm 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.48.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_msvc 0.48.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.48.5"
             }
         ],
-        "root": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled)"
+        "root": "path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled#crate-with-optional-deps@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/crate_renamed_optional_deps_disabled/target",
     "version": 1,
     "workspace_default_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled)"
+        "path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled)"
+        "path+file://{TEMP_DIR}/crate_renamed_optional_deps_disabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/crate_renamed_optional_deps_disabled"
 }

--- a/crate_universe/test_data/metadata/crate_renamed_optional_deps_enabled/metadata.json
+++ b/crate_universe/test_data/metadata/crate_renamed_optional_deps_enabled/metadata.json
@@ -23,7 +23,7 @@
                 ]
             },
             "homepage": null,
-            "id": "base16ct 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#base16ct@0.2.0",
             "keywords": [
                 "crypto",
                 "hex",
@@ -143,7 +143,7 @@
                 ]
             },
             "homepage": null,
-            "id": "base64ct 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.6.0",
             "keywords": [
                 "crypto",
                 "base64",
@@ -196,8 +196,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "crypt",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.6.0/tests/crypt.rs",
+                    "name": "standard",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.6.0/tests/standard.rs",
                     "test": true
                 },
                 {
@@ -224,20 +224,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "bcrypt",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.6.0/tests/bcrypt.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "shacrypt",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.6.0/tests/shacrypt.rs",
                     "test": true
@@ -252,8 +238,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "url",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.6.0/tests/url.rs",
+                    "name": "crypt",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.6.0/tests/crypt.rs",
                     "test": true
                 },
                 {
@@ -266,8 +252,22 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "standard",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.6.0/tests/standard.rs",
+                    "name": "bcrypt",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.6.0/tests/bcrypt.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "url",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.6.0/tests/url.rs",
                     "test": true
                 },
                 {
@@ -315,7 +315,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "block-buffer 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4",
             "keywords": [
                 "block",
                 "buffer"
@@ -411,7 +411,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -507,7 +507,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "const-oid 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.5",
             "keywords": [
                 "iso",
                 "iec",
@@ -631,7 +631,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "cpufeatures 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.11",
             "keywords": [
                 "cpuid",
                 "target-feature"
@@ -672,6 +672,20 @@
                     "kind": [
                         "test"
                     ],
+                    "name": "loongarch64",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/cpufeatures-0.2.11/tests/loongarch64.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
                     "name": "x86",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/cpufeatures-0.2.11/tests/x86.rs",
                     "test": true
@@ -688,20 +702,6 @@
                     ],
                     "name": "aarch64",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/cpufeatures-0.2.11/tests/aarch64.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2018",
-                    "kind": [
-                        "test"
-                    ],
-                    "name": "loongarch64",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/cpufeatures-0.2.11/tests/loongarch64.rs",
                     "test": true
                 }
             ],
@@ -730,7 +730,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled)",
+            "id": "path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled#crate-with-optional-deps@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -1005,7 +1005,7 @@
                 ]
             },
             "homepage": null,
-            "id": "crypto-bigint 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#crypto-bigint@0.5.4",
             "keywords": [
                 "arbitrary",
                 "crypto",
@@ -1073,8 +1073,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "const_residue",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/crypto-bigint-0.5.4/tests/const_residue.rs",
+                    "name": "proptests",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/crypto-bigint-0.5.4/tests/proptests.rs",
                     "test": true
                 },
                 {
@@ -1087,8 +1087,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "proptests",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/crypto-bigint-0.5.4/tests/proptests.rs",
+                    "name": "const_residue",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/crypto-bigint-0.5.4/tests/const_residue.rs",
                     "test": true
                 },
                 {
@@ -1170,7 +1170,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "crypto-common 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.6",
             "keywords": [
                 "crypto",
                 "traits"
@@ -1394,7 +1394,7 @@
                 ]
             },
             "homepage": null,
-            "id": "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8",
             "keywords": [
                 "asn1",
                 "crypto",
@@ -1461,8 +1461,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "datetime",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/der-0.7.8/tests/datetime.rs",
+                    "name": "set_of",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/der-0.7.8/tests/set_of.rs",
                     "test": true
                 },
                 {
@@ -1489,8 +1489,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "set_of",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/der-0.7.8/tests/set_of.rs",
+                    "name": "datetime",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/der-0.7.8/tests/datetime.rs",
                     "test": true
                 }
             ],
@@ -1608,7 +1608,7 @@
                 ]
             },
             "homepage": null,
-            "id": "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
             "keywords": [
                 "digest",
                 "crypto",
@@ -1881,7 +1881,7 @@
                 ]
             },
             "homepage": null,
-            "id": "ecdsa 0.16.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ecdsa@0.16.8",
             "keywords": [
                 "crypto",
                 "ecc",
@@ -2309,7 +2309,7 @@
                 ]
             },
             "homepage": null,
-            "id": "elliptic-curve 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#elliptic-curve@0.13.6",
             "keywords": [
                 "crypto",
                 "ecc",
@@ -2370,8 +2370,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "pkcs8",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/elliptic-curve-0.13.6/tests/pkcs8.rs",
+                    "name": "secret_key",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/elliptic-curve-0.13.6/tests/secret_key.rs",
                     "test": true
                 },
                 {
@@ -2384,8 +2384,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "secret_key",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/elliptic-curve-0.13.6/tests/secret_key.rs",
+                    "name": "pkcs8",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/elliptic-curve-0.13.6/tests/pkcs8.rs",
                     "test": true
                 }
             ],
@@ -2520,7 +2520,7 @@
                 ]
             },
             "homepage": "https://github.com/zkcrypto/ff",
-            "id": "ff 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ff@0.13.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -2675,7 +2675,7 @@
                 ]
             },
             "homepage": null,
-            "id": "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
             "keywords": [
                 "generic",
                 "array"
@@ -2871,7 +2871,7 @@
                 ]
             },
             "homepage": null,
-            "id": "getrandom 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.11",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3094,7 +3094,7 @@
                 ]
             },
             "homepage": "https://github.com/zkcrypto/group",
-            "id": "group 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#group@0.13.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -3234,7 +3234,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hmac 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hmac@0.12.1",
             "keywords": [
                 "crypto",
                 "mac",
@@ -3341,7 +3341,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/libc",
-            "id": "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150",
             "keywords": [
                 "libc",
                 "ffi",
@@ -3793,7 +3793,7 @@
                 ]
             },
             "homepage": null,
-            "id": "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#p256@0.13.2",
             "keywords": [
                 "crypto",
                 "ecc",
@@ -3847,6 +3847,20 @@
                     "kind": [
                         "test"
                     ],
+                    "name": "affine",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/p256-0.13.2/tests/affine.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
                     "name": "projective",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/p256-0.13.2/tests/projective.rs",
                     "test": true
@@ -3875,20 +3889,6 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "ecdsa",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/p256-0.13.2/tests/ecdsa.rs",
-                    "test": true
-                },
-                {
-                    "crate_types": [
-                        "bin"
-                    ],
-                    "doc": false,
-                    "doctest": false,
-                    "edition": "2021",
-                    "kind": [
-                        "test"
-                    ],
                     "name": "pkcs8",
                     "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/p256-0.13.2/tests/pkcs8.rs",
                     "test": true
@@ -3903,8 +3903,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "affine",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/p256-0.13.2/tests/affine.rs",
+                    "name": "ecdsa",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/p256-0.13.2/tests/ecdsa.rs",
                     "test": true
                 },
                 {
@@ -3980,7 +3980,7 @@
                 ]
             },
             "homepage": null,
-            "id": "pem-rfc7468 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0",
             "keywords": [
                 "crypto",
                 "key",
@@ -4206,7 +4206,7 @@
                 ]
             },
             "homepage": null,
-            "id": "pkcs8 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2",
             "keywords": [
                 "crypto",
                 "key",
@@ -4259,8 +4259,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "private_key",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/pkcs8-0.10.2/tests/private_key.rs",
+                    "name": "encrypted_private_key",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/pkcs8-0.10.2/tests/encrypted_private_key.rs",
                     "test": true
                 },
                 {
@@ -4273,8 +4273,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "encrypted_private_key",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/pkcs8-0.10.2/tests/encrypted_private_key.rs",
+                    "name": "private_key",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/pkcs8-0.10.2/tests/private_key.rs",
                     "test": true
                 },
                 {
@@ -4349,7 +4349,7 @@
                 ]
             },
             "homepage": null,
-            "id": "primeorder 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#primeorder@0.13.3",
             "keywords": [
                 "crypto",
                 "ecc"
@@ -4452,7 +4452,7 @@
                 ]
             },
             "homepage": "https://rust-random.github.io/book",
-            "id": "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4",
             "keywords": [
                 "random",
                 "rng"
@@ -4565,7 +4565,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "rfc6979 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rfc6979@0.4.0",
             "keywords": [
                 "dsa",
                 "ecdsa",
@@ -4785,7 +4785,7 @@
                 ]
             },
             "homepage": null,
-            "id": "sec1 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#sec1@0.7.3",
             "keywords": [
                 "crypto",
                 "key",
@@ -4838,8 +4838,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "traits",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/sec1-0.7.3/tests/traits.rs",
+                    "name": "private_key",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/sec1-0.7.3/tests/private_key.rs",
                     "test": true
                 },
                 {
@@ -4852,8 +4852,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "private_key",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/sec1-0.7.3/tests/private_key.rs",
+                    "name": "traits",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/sec1-0.7.3/tests/traits.rs",
                     "test": true
                 }
             ],
@@ -4971,7 +4971,7 @@
                 ]
             },
             "homepage": null,
-            "id": "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.8",
             "keywords": [
                 "crypto",
                 "sha2",
@@ -5135,7 +5135,7 @@
                 ]
             },
             "homepage": null,
-            "id": "signature 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#signature@2.1.0",
             "keywords": [
                 "crypto",
                 "ecdsa",
@@ -5317,7 +5317,7 @@
                 ]
             },
             "homepage": null,
-            "id": "spki 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#spki@0.7.2",
             "keywords": [
                 "crypto",
                 "x509"
@@ -5368,8 +5368,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "traits",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/spki-0.7.2/tests/traits.rs",
+                    "name": "spki",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/spki-0.7.2/tests/spki.rs",
                     "test": true
                 },
                 {
@@ -5382,8 +5382,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "spki",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/spki-0.7.2/tests/spki.rs",
+                    "name": "traits",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/spki-0.7.2/tests/traits.rs",
                     "test": true
                 }
             ],
@@ -5428,7 +5428,7 @@
                 "std": []
             },
             "homepage": "https://dalek.rs/",
-            "id": "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0",
             "keywords": [
                 "cryptography",
                 "crypto",
@@ -5518,7 +5518,7 @@
                 "strict": []
             },
             "homepage": null,
-            "id": "typenum 1.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.17.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -5608,7 +5608,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4",
             "keywords": [
                 "version",
                 "rustc",
@@ -5715,7 +5715,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1",
             "keywords": [
                 "webassembly",
                 "wasm"
@@ -5809,7 +5809,7 @@
                 ]
             },
             "homepage": null,
-            "id": "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0",
             "keywords": [
                 "memory",
                 "memset",
@@ -5863,8 +5863,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "zeroize_derive",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/zeroize-1.6.0/tests/zeroize_derive.rs",
+                    "name": "zeroize",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/zeroize-1.6.0/tests/zeroize.rs",
                     "test": true
                 },
                 {
@@ -5877,8 +5877,8 @@
                     "kind": [
                         "test"
                     ],
-                    "name": "zeroize",
-                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/zeroize-1.6.0/tests/zeroize.rs",
+                    "name": "zeroize_derive",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/zeroize-1.6.0/tests/zeroize_derive.rs",
                     "test": true
                 }
             ],
@@ -5893,7 +5893,7 @@
                 "features": [
                     "alloc"
                 ],
-                "id": "base16ct 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#base16ct@0.2.0"
             },
             {
                 "dependencies": [],
@@ -5901,11 +5901,11 @@
                 "features": [
                     "alloc"
                 ],
-                "id": "base64ct 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.6.0"
             },
             {
                 "dependencies": [
-                    "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
                 ],
                 "deps": [
                     {
@@ -5916,27 +5916,27 @@
                             }
                         ],
                         "name": "generic_array",
-                        "pkg": "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
                     }
                 ],
                 "features": [],
-                "id": "block-buffer 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "const-oid 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.5"
             },
             {
                 "dependencies": [
-                    "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150"
                 ],
                 "deps": [
                     {
@@ -5959,15 +5959,15 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150"
                     }
                 ],
                 "features": [],
-                "id": "cpufeatures 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.11"
             },
             {
                 "dependencies": [
-                    "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#p256@0.13.2"
                 ],
                 "deps": [
                     {
@@ -5978,18 +5978,18 @@
                             }
                         ],
                         "name": "p256",
-                        "pkg": "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#p256@0.13.2"
                     }
                 ],
                 "features": [],
-                "id": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled)"
+                "id": "path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled#crate-with-optional-deps@0.1.0"
             },
             {
                 "dependencies": [
-                    "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                 ],
                 "deps": [
                     {
@@ -6000,7 +6000,7 @@
                             }
                         ],
                         "name": "generic_array",
-                        "pkg": "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
                     },
                     {
                         "dep_kinds": [
@@ -6010,7 +6010,7 @@
                             }
                         ],
                         "name": "rand_core",
-                        "pkg": "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                     },
                     {
                         "dep_kinds": [
@@ -6020,7 +6020,7 @@
                             }
                         ],
                         "name": "subtle",
-                        "pkg": "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -6030,7 +6030,7 @@
                             }
                         ],
                         "name": "zeroize",
-                        "pkg": "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                     }
                 ],
                 "features": [
@@ -6038,12 +6038,12 @@
                     "rand_core",
                     "zeroize"
                 ],
-                "id": "crypto-bigint 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#crypto-bigint@0.5.4"
             },
             {
                 "dependencies": [
-                    "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "typenum 1.17.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#typenum@1.17.0"
                 ],
                 "deps": [
                     {
@@ -6054,7 +6054,7 @@
                             }
                         ],
                         "name": "generic_array",
-                        "pkg": "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
                     },
                     {
                         "dep_kinds": [
@@ -6064,17 +6064,17 @@
                             }
                         ],
                         "name": "typenum",
-                        "pkg": "typenum 1.17.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.17.0"
                     }
                 ],
                 "features": [],
-                "id": "crypto-common 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.6"
             },
             {
                 "dependencies": [
-                    "const-oid 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pem-rfc7468 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                 ],
                 "deps": [
                     {
@@ -6085,7 +6085,7 @@
                             }
                         ],
                         "name": "const_oid",
-                        "pkg": "const-oid 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.5"
                     },
                     {
                         "dep_kinds": [
@@ -6095,7 +6095,7 @@
                             }
                         ],
                         "name": "pem_rfc7468",
-                        "pkg": "pem-rfc7468 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0"
                     },
                     {
                         "dep_kinds": [
@@ -6105,7 +6105,7 @@
                             }
                         ],
                         "name": "zeroize",
-                        "pkg": "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                     }
                 ],
                 "features": [
@@ -6115,14 +6115,14 @@
                     "std",
                     "zeroize"
                 ],
-                "id": "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8"
             },
             {
                 "dependencies": [
-                    "block-buffer 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "const-oid 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crypto-common 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                 ],
                 "deps": [
                     {
@@ -6133,7 +6133,7 @@
                             }
                         ],
                         "name": "block_buffer",
-                        "pkg": "block-buffer 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4"
                     },
                     {
                         "dep_kinds": [
@@ -6143,7 +6143,7 @@
                             }
                         ],
                         "name": "const_oid",
-                        "pkg": "const-oid 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#const-oid@0.9.5"
                     },
                     {
                         "dep_kinds": [
@@ -6153,7 +6153,7 @@
                             }
                         ],
                         "name": "crypto_common",
-                        "pkg": "crypto-common 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crypto-common@0.1.6"
                     },
                     {
                         "dep_kinds": [
@@ -6163,7 +6163,7 @@
                             }
                         ],
                         "name": "subtle",
-                        "pkg": "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                     }
                 ],
                 "features": [
@@ -6175,16 +6175,16 @@
                     "oid",
                     "subtle"
                 ],
-                "id": "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
             },
             {
                 "dependencies": [
-                    "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "elliptic-curve 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rfc6979 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "signature 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "spki 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8",
+                    "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#elliptic-curve@0.13.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#rfc6979@0.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#signature@2.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#spki@0.7.2"
                 ],
                 "deps": [
                     {
@@ -6195,7 +6195,7 @@
                             }
                         ],
                         "name": "der",
-                        "pkg": "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8"
                     },
                     {
                         "dep_kinds": [
@@ -6205,7 +6205,7 @@
                             }
                         ],
                         "name": "digest",
-                        "pkg": "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
                     },
                     {
                         "dep_kinds": [
@@ -6215,7 +6215,7 @@
                             }
                         ],
                         "name": "elliptic_curve",
-                        "pkg": "elliptic-curve 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#elliptic-curve@0.13.6"
                     },
                     {
                         "dep_kinds": [
@@ -6225,7 +6225,7 @@
                             }
                         ],
                         "name": "rfc6979",
-                        "pkg": "rfc6979 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rfc6979@0.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -6235,7 +6235,7 @@
                             }
                         ],
                         "name": "signature",
-                        "pkg": "signature 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#signature@2.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -6245,7 +6245,7 @@
                             }
                         ],
                         "name": "spki",
-                        "pkg": "spki 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#spki@0.7.2"
                     }
                 ],
                 "features": [
@@ -6262,22 +6262,22 @@
                     "std",
                     "verifying"
                 ],
-                "id": "ecdsa 0.16.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ecdsa@0.16.8"
             },
             {
                 "dependencies": [
-                    "base16ct 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crypto-bigint 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ff 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "group 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pem-rfc7468 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pkcs8 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "sec1 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#base16ct@0.2.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#crypto-bigint@0.5.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#ff@0.13.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#group@0.13.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#sec1@0.7.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                 ],
                 "deps": [
                     {
@@ -6288,7 +6288,7 @@
                             }
                         ],
                         "name": "base16ct",
-                        "pkg": "base16ct 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#base16ct@0.2.0"
                     },
                     {
                         "dep_kinds": [
@@ -6298,7 +6298,7 @@
                             }
                         ],
                         "name": "crypto_bigint",
-                        "pkg": "crypto-bigint 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crypto-bigint@0.5.4"
                     },
                     {
                         "dep_kinds": [
@@ -6308,7 +6308,7 @@
                             }
                         ],
                         "name": "digest",
-                        "pkg": "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
                     },
                     {
                         "dep_kinds": [
@@ -6318,7 +6318,7 @@
                             }
                         ],
                         "name": "ff",
-                        "pkg": "ff 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ff@0.13.0"
                     },
                     {
                         "dep_kinds": [
@@ -6328,7 +6328,7 @@
                             }
                         ],
                         "name": "generic_array",
-                        "pkg": "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
                     },
                     {
                         "dep_kinds": [
@@ -6338,7 +6338,7 @@
                             }
                         ],
                         "name": "group",
-                        "pkg": "group 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#group@0.13.0"
                     },
                     {
                         "dep_kinds": [
@@ -6348,7 +6348,7 @@
                             }
                         ],
                         "name": "pem_rfc7468",
-                        "pkg": "pem-rfc7468 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0"
                     },
                     {
                         "dep_kinds": [
@@ -6358,7 +6358,7 @@
                             }
                         ],
                         "name": "pkcs8",
-                        "pkg": "pkcs8 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2"
                     },
                     {
                         "dep_kinds": [
@@ -6368,7 +6368,7 @@
                             }
                         ],
                         "name": "rand_core",
-                        "pkg": "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                     },
                     {
                         "dep_kinds": [
@@ -6378,7 +6378,7 @@
                             }
                         ],
                         "name": "sec1",
-                        "pkg": "sec1 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#sec1@0.7.3"
                     },
                     {
                         "dep_kinds": [
@@ -6388,7 +6388,7 @@
                             }
                         ],
                         "name": "subtle",
-                        "pkg": "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -6398,7 +6398,7 @@
                             }
                         ],
                         "name": "zeroize",
-                        "pkg": "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                     }
                 ],
                 "features": [
@@ -6413,12 +6413,12 @@
                     "sec1",
                     "std"
                 ],
-                "id": "elliptic-curve 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#elliptic-curve@0.13.6"
             },
             {
                 "dependencies": [
-                    "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                 ],
                 "deps": [
                     {
@@ -6429,7 +6429,7 @@
                             }
                         ],
                         "name": "rand_core",
-                        "pkg": "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                     },
                     {
                         "dep_kinds": [
@@ -6439,19 +6439,19 @@
                             }
                         ],
                         "name": "subtle",
-                        "pkg": "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                     }
                 ],
                 "features": [
                     "alloc"
                 ],
-                "id": "ff 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ff@0.13.0"
             },
             {
                 "dependencies": [
-                    "typenum 1.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#typenum@1.17.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                 ],
                 "deps": [
                     {
@@ -6462,7 +6462,7 @@
                             }
                         ],
                         "name": "typenum",
-                        "pkg": "typenum 1.17.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.17.0"
                     },
                     {
                         "dep_kinds": [
@@ -6472,7 +6472,7 @@
                             }
                         ],
                         "name": "version_check",
-                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                     },
                     {
                         "dep_kinds": [
@@ -6482,20 +6482,20 @@
                             }
                         ],
                         "name": "zeroize",
-                        "pkg": "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                     }
                 ],
                 "features": [
                     "more_lengths",
                     "zeroize"
                 ],
-                "id": "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
                 ],
                 "deps": [
                     {
@@ -6506,7 +6506,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -6516,7 +6516,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150"
                     },
                     {
                         "dep_kinds": [
@@ -6526,19 +6526,19 @@
                             }
                         ],
                         "name": "wasi",
-                        "pkg": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
                     }
                 ],
                 "features": [
                     "std"
                 ],
-                "id": "getrandom 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.11"
             },
             {
                 "dependencies": [
-                    "ff 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#ff@0.13.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                 ],
                 "deps": [
                     {
@@ -6549,7 +6549,7 @@
                             }
                         ],
                         "name": "ff",
-                        "pkg": "ff 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ff@0.13.0"
                     },
                     {
                         "dep_kinds": [
@@ -6559,7 +6559,7 @@
                             }
                         ],
                         "name": "rand_core",
-                        "pkg": "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                     },
                     {
                         "dep_kinds": [
@@ -6569,17 +6569,17 @@
                             }
                         ],
                         "name": "subtle",
-                        "pkg": "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                     }
                 ],
                 "features": [
                     "alloc"
                 ],
-                "id": "group 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#group@0.13.0"
             },
             {
                 "dependencies": [
-                    "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
                 ],
                 "deps": [
                     {
@@ -6590,13 +6590,13 @@
                             }
                         ],
                         "name": "digest",
-                        "pkg": "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
                     }
                 ],
                 "features": [
                     "reset"
                 ],
-                "id": "hmac 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hmac@0.12.1"
             },
             {
                 "dependencies": [],
@@ -6605,14 +6605,14 @@
                     "default",
                     "std"
                 ],
-                "id": "libc 0.2.150 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.150"
             },
             {
                 "dependencies": [
-                    "ecdsa 0.16.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "elliptic-curve 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "primeorder 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#ecdsa@0.16.8",
+                    "registry+https://github.com/rust-lang/crates.io-index#elliptic-curve@0.13.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#primeorder@0.13.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.8"
                 ],
                 "deps": [
                     {
@@ -6623,7 +6623,7 @@
                             }
                         ],
                         "name": "ecdsa_core",
-                        "pkg": "ecdsa 0.16.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ecdsa@0.16.8"
                     },
                     {
                         "dep_kinds": [
@@ -6633,7 +6633,7 @@
                             }
                         ],
                         "name": "elliptic_curve",
-                        "pkg": "elliptic-curve 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#elliptic-curve@0.13.6"
                     },
                     {
                         "dep_kinds": [
@@ -6643,7 +6643,7 @@
                             }
                         ],
                         "name": "primeorder",
-                        "pkg": "primeorder 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#primeorder@0.13.3"
                     },
                     {
                         "dep_kinds": [
@@ -6653,7 +6653,7 @@
                             }
                         ],
                         "name": "sha2",
-                        "pkg": "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.8"
                     }
                 ],
                 "features": [
@@ -6669,11 +6669,11 @@
                     "sha256",
                     "std"
                 ],
-                "id": "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#p256@0.13.2"
             },
             {
                 "dependencies": [
-                    "base64ct 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.6.0"
                 ],
                 "deps": [
                     {
@@ -6684,18 +6684,18 @@
                             }
                         ],
                         "name": "base64ct",
-                        "pkg": "base64ct 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.6.0"
                     }
                 ],
                 "features": [
                     "alloc"
                 ],
-                "id": "pem-rfc7468 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0"
             },
             {
                 "dependencies": [
-                    "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "spki 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8",
+                    "registry+https://github.com/rust-lang/crates.io-index#spki@0.7.2"
                 ],
                 "deps": [
                     {
@@ -6706,7 +6706,7 @@
                             }
                         ],
                         "name": "der",
-                        "pkg": "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8"
                     },
                     {
                         "dep_kinds": [
@@ -6716,7 +6716,7 @@
                             }
                         ],
                         "name": "spki",
-                        "pkg": "spki 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#spki@0.7.2"
                     }
                 ],
                 "features": [
@@ -6724,11 +6724,11 @@
                     "pem",
                     "std"
                 ],
-                "id": "pkcs8 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2"
             },
             {
                 "dependencies": [
-                    "elliptic-curve 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#elliptic-curve@0.13.6"
                 ],
                 "deps": [
                     {
@@ -6739,15 +6739,15 @@
                             }
                         ],
                         "name": "elliptic_curve",
-                        "pkg": "elliptic-curve 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#elliptic-curve@0.13.6"
                     }
                 ],
                 "features": [],
-                "id": "primeorder 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#primeorder@0.13.3"
             },
             {
                 "dependencies": [
-                    "getrandom 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.11"
                 ],
                 "deps": [
                     {
@@ -6758,7 +6758,7 @@
                             }
                         ],
                         "name": "getrandom",
-                        "pkg": "getrandom 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.11"
                     }
                 ],
                 "features": [
@@ -6766,12 +6766,12 @@
                     "getrandom",
                     "std"
                 ],
-                "id": "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
             },
             {
                 "dependencies": [
-                    "hmac 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#hmac@0.12.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                 ],
                 "deps": [
                     {
@@ -6782,7 +6782,7 @@
                             }
                         ],
                         "name": "hmac",
-                        "pkg": "hmac 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hmac@0.12.1"
                     },
                     {
                         "dep_kinds": [
@@ -6792,20 +6792,20 @@
                             }
                         ],
                         "name": "subtle",
-                        "pkg": "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                     }
                 ],
                 "features": [],
-                "id": "rfc6979 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rfc6979@0.4.0"
             },
             {
                 "dependencies": [
-                    "base16ct 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pkcs8 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#base16ct@0.2.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8",
+                    "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                 ],
                 "deps": [
                     {
@@ -6816,7 +6816,7 @@
                             }
                         ],
                         "name": "base16ct",
-                        "pkg": "base16ct 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#base16ct@0.2.0"
                     },
                     {
                         "dep_kinds": [
@@ -6826,7 +6826,7 @@
                             }
                         ],
                         "name": "der",
-                        "pkg": "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8"
                     },
                     {
                         "dep_kinds": [
@@ -6836,7 +6836,7 @@
                             }
                         ],
                         "name": "generic_array",
-                        "pkg": "generic-array 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7"
                     },
                     {
                         "dep_kinds": [
@@ -6846,7 +6846,7 @@
                             }
                         ],
                         "name": "pkcs8",
-                        "pkg": "pkcs8 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2"
                     },
                     {
                         "dep_kinds": [
@@ -6856,7 +6856,7 @@
                             }
                         ],
                         "name": "subtle",
-                        "pkg": "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -6866,7 +6866,7 @@
                             }
                         ],
                         "name": "zeroize",
-                        "pkg": "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
                     }
                 ],
                 "features": [
@@ -6880,13 +6880,13 @@
                     "subtle",
                     "zeroize"
                 ],
-                "id": "sec1 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#sec1@0.7.3"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "cpufeatures 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.11",
+                    "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
                 ],
                 "deps": [
                     {
@@ -6897,7 +6897,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -6907,7 +6907,7 @@
                             }
                         ],
                         "name": "cpufeatures",
-                        "pkg": "cpufeatures 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.11"
                     },
                     {
                         "dep_kinds": [
@@ -6917,16 +6917,16 @@
                             }
                         ],
                         "name": "digest",
-                        "pkg": "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
                     }
                 ],
                 "features": [],
-                "id": "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#sha2@0.10.8"
             },
             {
                 "dependencies": [
-                    "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                 ],
                 "deps": [
                     {
@@ -6937,7 +6937,7 @@
                             }
                         ],
                         "name": "digest",
-                        "pkg": "digest 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#digest@0.10.7"
                     },
                     {
                         "dep_kinds": [
@@ -6947,7 +6947,7 @@
                             }
                         ],
                         "name": "rand_core",
-                        "pkg": "rand_core 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rand_core@0.6.4"
                     }
                 ],
                 "features": [
@@ -6956,12 +6956,12 @@
                     "rand_core",
                     "std"
                 ],
-                "id": "signature 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#signature@2.1.0"
             },
             {
                 "dependencies": [
-                    "base64ct 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.6.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8"
                 ],
                 "deps": [
                     {
@@ -6972,7 +6972,7 @@
                             }
                         ],
                         "name": "base64ct",
-                        "pkg": "base64ct 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#base64ct@1.6.0"
                     },
                     {
                         "dep_kinds": [
@@ -6982,7 +6982,7 @@
                             }
                         ],
                         "name": "der",
-                        "pkg": "der 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#der@0.7.8"
                     }
                 ],
                 "features": [
@@ -6990,7 +6990,7 @@
                     "pem",
                     "std"
                 ],
-                "id": "spki 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#spki@0.7.2"
             },
             {
                 "dependencies": [],
@@ -6998,25 +6998,25 @@
                 "features": [
                     "i128"
                 ],
-                "id": "subtle 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#subtle@2.5.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "typenum 1.17.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#typenum@1.17.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
             },
             {
                 "dependencies": [],
@@ -7024,18 +7024,18 @@
                 "features": [
                     "alloc"
                 ],
-                "id": "zeroize 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#zeroize@1.6.0"
             }
         ],
-        "root": "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled)"
+        "root": "path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled#crate-with-optional-deps@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/crate_renamed_optional_deps_enabled/target",
     "version": 1,
     "workspace_default_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled)"
+        "path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_members": [
-        "crate-with-optional-deps 0.1.0 (path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled)"
+        "path+file://{TEMP_DIR}/crate_renamed_optional_deps_enabled#crate-with-optional-deps@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/crate_renamed_optional_deps_enabled"
 }

--- a/crate_universe/test_data/metadata/crate_types/metadata.json
+++ b/crate_universe/test_data/metadata/crate_types/metadata.json
@@ -15,7 +15,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.0.1",
             "keywords": [
                 "rustc",
                 "build",
@@ -244,7 +244,7 @@
                 ]
             },
             "homepage": "https://github.com/bitflags/bitflags",
-            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
             "keywords": [
                 "bit",
                 "bitmask",
@@ -364,7 +364,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -424,7 +424,7 @@
                 "mac_os_10_8_features": []
             },
             "homepage": "https://github.com/servo/core-foundation-rs",
-            "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3",
             "keywords": [],
             "license": "MIT / Apache-2.0",
             "license_file": null,
@@ -510,7 +510,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "crate-types 0.1.0 (path+file://{TEMP_DIR}/crate_types)",
+            "id": "path+file://{TEMP_DIR}/crate_types#crate-types@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -626,7 +626,7 @@
                 ]
             },
             "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel",
-            "id": "crossbeam-channel 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.2",
             "keywords": [
                 "channel",
                 "mpmc",
@@ -994,7 +994,7 @@
                 ]
             },
             "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-deque",
-            "id": "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.1",
             "keywords": [
                 "chase-lev",
                 "lock-free",
@@ -1224,7 +1224,7 @@
                 ]
             },
             "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-epoch",
-            "id": "crossbeam-epoch 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.6",
             "keywords": [
                 "lock-free",
                 "rcu",
@@ -1434,7 +1434,7 @@
                 ]
             },
             "homepage": "https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-utils",
-            "id": "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6",
             "keywords": [
                 "scoped",
                 "thread",
@@ -1632,7 +1632,7 @@
                 "use_std": []
             },
             "homepage": null,
-            "id": "either 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#either@1.6.1",
             "keywords": [
                 "data-structure",
                 "no_std"
@@ -1743,7 +1743,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.1.19",
             "keywords": [
                 "unikernel",
                 "libos"
@@ -1834,7 +1834,7 @@
                 ]
             },
             "homepage": null,
-            "id": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0",
             "keywords": [
                 "macro",
                 "lazy",
@@ -1944,7 +1944,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/libc",
-            "id": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112",
             "keywords": [
                 "libc",
                 "ffi",
@@ -2060,7 +2060,7 @@
                 "unstable_const": []
             },
             "homepage": null,
-            "id": "memoffset 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#memoffset@0.6.5",
             "keywords": [
                 "mem",
                 "offset",
@@ -2159,7 +2159,7 @@
                 "user": []
             },
             "homepage": null,
-            "id": "ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.3.6",
             "keywords": [
                 "windows",
                 "ffi",
@@ -2263,7 +2263,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "num_cpus 1.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.13.1",
             "keywords": [
                 "cpu",
                 "cpus",
@@ -2406,7 +2406,7 @@
                 "unstable": []
             },
             "homepage": null,
-            "id": "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.9.0",
             "keywords": [
                 "lazy",
                 "static"
@@ -2705,7 +2705,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "rayon 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rayon@1.5.1",
             "keywords": [
                 "parallel",
                 "thread",
@@ -3090,7 +3090,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "rayon-core 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.9.1",
             "keywords": [
                 "parallel",
                 "thread",
@@ -3245,7 +3245,7 @@
                 "use_std": []
             },
             "homepage": null,
-            "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0",
             "keywords": [
                 "scope-guard",
                 "defer",
@@ -3458,7 +3458,7 @@
                 "unknown-ci": []
             },
             "homepage": null,
-            "id": "sysinfo 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.22.5",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -4074,7 +4074,7 @@
                 "xinput": []
             },
             "homepage": null,
-            "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9",
             "keywords": [
                 "windows",
                 "ffi",
@@ -4153,7 +4153,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -4212,7 +4212,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -4266,7 +4266,7 @@
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.0.1"
             },
             {
                 "dependencies": [],
@@ -4274,24 +4274,24 @@
                 "features": [
                     "default"
                 ],
-                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "sysinfo 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.22.5"
                 ],
                 "deps": [
                     {
@@ -4302,7 +4302,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -4312,16 +4312,16 @@
                             }
                         ],
                         "name": "sysinfo",
-                        "pkg": "sysinfo 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.22.5"
                     }
                 ],
                 "features": [],
-                "id": "crate-types 0.1.0 (path+file://{TEMP_DIR}/crate_types)"
+                "id": "path+file://{TEMP_DIR}/crate_types#crate-types@0.1.0"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6"
                 ],
                 "deps": [
                     {
@@ -4332,7 +4332,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -4342,7 +4342,7 @@
                             }
                         ],
                         "name": "crossbeam_utils",
-                        "pkg": "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6"
                     }
                 ],
                 "features": [
@@ -4350,13 +4350,13 @@
                     "default",
                     "std"
                 ],
-                "id": "crossbeam-channel 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.2"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crossbeam-epoch 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6"
                 ],
                 "deps": [
                     {
@@ -4367,7 +4367,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -4377,7 +4377,7 @@
                             }
                         ],
                         "name": "crossbeam_epoch",
-                        "pkg": "crossbeam-epoch 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.6"
                     },
                     {
                         "dep_kinds": [
@@ -4387,7 +4387,7 @@
                             }
                         ],
                         "name": "crossbeam_utils",
-                        "pkg": "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6"
                     }
                 ],
                 "features": [
@@ -4396,15 +4396,15 @@
                     "default",
                     "std"
                 ],
-                "id": "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.1"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "memoffset 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#memoffset@0.6.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0"
                 ],
                 "deps": [
                     {
@@ -4415,7 +4415,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -4425,7 +4425,7 @@
                             }
                         ],
                         "name": "crossbeam_utils",
-                        "pkg": "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6"
                     },
                     {
                         "dep_kinds": [
@@ -4435,7 +4435,7 @@
                             }
                         ],
                         "name": "lazy_static",
-                        "pkg": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -4445,7 +4445,7 @@
                             }
                         ],
                         "name": "memoffset",
-                        "pkg": "memoffset 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#memoffset@0.6.5"
                     },
                     {
                         "dep_kinds": [
@@ -4455,7 +4455,7 @@
                             }
                         ],
                         "name": "scopeguard",
-                        "pkg": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0"
                     }
                 ],
                 "features": [
@@ -4463,12 +4463,12 @@
                     "lazy_static",
                     "std"
                 ],
-                "id": "crossbeam-epoch 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-epoch@0.9.6"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
                 ],
                 "deps": [
                     {
@@ -4479,7 +4479,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -4489,7 +4489,7 @@
                             }
                         ],
                         "name": "lazy_static",
-                        "pkg": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
                     }
                 ],
                 "features": [
@@ -4497,17 +4497,17 @@
                     "lazy_static",
                     "std"
                 ],
-                "id": "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "either 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#either@1.6.1"
             },
             {
                 "dependencies": [
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                 ],
                 "deps": [
                     {
@@ -4518,19 +4518,19 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.1.19"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
             },
             {
                 "dependencies": [],
@@ -4539,11 +4539,11 @@
                     "default",
                     "std"
                 ],
-                "id": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
             },
             {
                 "dependencies": [
-                    "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.0.1"
                 ],
                 "deps": [
                     {
@@ -4554,17 +4554,17 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.0.1"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "memoffset 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#memoffset@0.6.5"
             },
             {
                 "dependencies": [
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -4575,19 +4575,19 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [
                     "default",
                     "user"
                 ],
-                "id": "ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.3.6"
             },
             {
                 "dependencies": [
-                    "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.1.19",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                 ],
                 "deps": [
                     {
@@ -4598,7 +4598,7 @@
                             }
                         ],
                         "name": "hermit_abi",
-                        "pkg": "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hermit-abi@0.1.19"
                     },
                     {
                         "dep_kinds": [
@@ -4608,11 +4608,11 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     }
                 ],
                 "features": [],
-                "id": "num_cpus 1.13.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.13.1"
             },
             {
                 "dependencies": [],
@@ -4623,14 +4623,14 @@
                     "race",
                     "std"
                 ],
-                "id": "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.9.0"
             },
             {
                 "dependencies": [
-                    "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "either 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rayon-core 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.0.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#either@1.6.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.9.1"
                 ],
                 "deps": [
                     {
@@ -4641,7 +4641,7 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.0.1"
                     },
                     {
                         "dep_kinds": [
@@ -4651,7 +4651,7 @@
                             }
                         ],
                         "name": "crossbeam_deque",
-                        "pkg": "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.1"
                     },
                     {
                         "dep_kinds": [
@@ -4661,7 +4661,7 @@
                             }
                         ],
                         "name": "either",
-                        "pkg": "either 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#either@1.6.1"
                     },
                     {
                         "dep_kinds": [
@@ -4671,19 +4671,19 @@
                             }
                         ],
                         "name": "rayon_core",
-                        "pkg": "rayon-core 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.9.1"
                     }
                 ],
                 "features": [],
-                "id": "rayon 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rayon@1.5.1"
             },
             {
                 "dependencies": [
-                    "crossbeam-channel 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "num_cpus 1.13.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.13.1"
                 ],
                 "deps": [
                     {
@@ -4694,7 +4694,7 @@
                             }
                         ],
                         "name": "crossbeam_channel",
-                        "pkg": "crossbeam-channel 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.2"
                     },
                     {
                         "dep_kinds": [
@@ -4704,7 +4704,7 @@
                             }
                         ],
                         "name": "crossbeam_deque",
-                        "pkg": "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-deque@0.8.1"
                     },
                     {
                         "dep_kinds": [
@@ -4714,7 +4714,7 @@
                             }
                         ],
                         "name": "crossbeam_utils",
-                        "pkg": "crossbeam-utils 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.6"
                     },
                     {
                         "dep_kinds": [
@@ -4724,7 +4724,7 @@
                             }
                         ],
                         "name": "lazy_static",
-                        "pkg": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -4734,27 +4734,27 @@
                             }
                         ],
                         "name": "num_cpus",
-                        "pkg": "num_cpus 1.13.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.13.1"
                     }
                 ],
                 "features": [],
-                "id": "rayon-core 1.9.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rayon-core@1.9.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rayon 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112",
+                    "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.3.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.9.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#rayon@1.5.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -4765,7 +4765,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -4775,7 +4775,7 @@
                             }
                         ],
                         "name": "core_foundation_sys",
-                        "pkg": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3"
                     },
                     {
                         "dep_kinds": [
@@ -4785,7 +4785,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.112 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.112"
                     },
                     {
                         "dep_kinds": [
@@ -4795,7 +4795,7 @@
                             }
                         ],
                         "name": "ntapi",
-                        "pkg": "ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ntapi@0.3.6"
                     },
                     {
                         "dep_kinds": [
@@ -4805,7 +4805,7 @@
                             }
                         ],
                         "name": "once_cell",
-                        "pkg": "once_cell 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.9.0"
                     },
                     {
                         "dep_kinds": [
@@ -4815,7 +4815,7 @@
                             }
                         ],
                         "name": "rayon",
-                        "pkg": "rayon 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rayon@1.5.1"
                     },
                     {
                         "dep_kinds": [
@@ -4825,7 +4825,7 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [
@@ -4833,12 +4833,12 @@
                     "multithread",
                     "rayon"
                 ],
-                "id": "sysinfo 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#sysinfo@0.22.5"
             },
             {
                 "dependencies": [
-                    "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                 ],
                 "deps": [
                     {
@@ -4849,7 +4849,7 @@
                             }
                         ],
                         "name": "winapi_i686_pc_windows_gnu",
-                        "pkg": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -4859,7 +4859,7 @@
                             }
                         ],
                         "name": "winapi_x86_64_pc_windows_gnu",
-                        "pkg": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                     }
                 ],
                 "features": [
@@ -4897,30 +4897,30 @@
                     "winioctl",
                     "winnt"
                 ],
-                "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
             }
         ],
-        "root": "crate-types 0.1.0 (path+file://{TEMP_DIR}/crate_types)"
+        "root": "path+file://{TEMP_DIR}/crate_types#crate-types@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/crate_types/target",
     "version": 1,
     "workspace_default_members": [
-        "crate-types 0.1.0 (path+file://{TEMP_DIR}/crate_types)"
+        "path+file://{TEMP_DIR}/crate_types#crate-types@0.1.0"
     ],
     "workspace_members": [
-        "crate-types 0.1.0 (path+file://{TEMP_DIR}/crate_types)"
+        "path+file://{TEMP_DIR}/crate_types#crate-types@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/crate_types"
 }

--- a/crate_universe/test_data/metadata/example_proc_macro_dep/metadata.json
+++ b/crate_universe/test_data/metadata/example_proc_macro_dep/metadata.json
@@ -1,2033 +1,2033 @@
 {
-  "packages": [
-    {
-      "name": "example-proc-macro-dep",
-      "version": "0.1.0",
-      "id": "example-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/example-proc-macro-dep)",
-      "license": null,
-      "license_file": null,
-      "description": null,
-      "source": null,
-      "dependencies": [
+    "metadata": null,
+    "packages": [
         {
-          "name": "proc-macro-rules",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "=0.4.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "example-proc-macro-dep",
-          "src_path": "{TEMP_DIR}/example_proc_macro_dep/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "{TEMP_DIR}/example_proc_macro_dep/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": null,
-      "homepage": null,
-      "documentation": null,
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "once_cell",
-      "version": "1.19.0",
-      "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.19.0",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Single assignment cells and lazy values.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "critical-section",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "parking_lot_core",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.9.3",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "portable-atomic",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "critical-section",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.1.1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "std"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "regex",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.2.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "once_cell",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "bench",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/bench.rs",
-          "edition": "2021",
-          "required-features": [
-            "std"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "bench_acquire",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/bench_acquire.rs",
-          "edition": "2021",
-          "required-features": [
-            "std"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "lazy_static",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/lazy_static.rs",
-          "edition": "2021",
-          "required-features": [
-            "std"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "reentrant_init_deadlocks",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/reentrant_init_deadlocks.rs",
-          "edition": "2021",
-          "required-features": [
-            "std"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "regex",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/regex.rs",
-          "edition": "2021",
-          "required-features": [
-            "std"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_synchronization",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/test_synchronization.rs",
-          "edition": "2021",
-          "required-features": [
-            "std"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "it",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/tests/it/main.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        }
-      ],
-      "features": {
-        "alloc": [
-          "race"
-        ],
-        "atomic-polyfill": [
-          "critical-section"
-        ],
-        "critical-section": [
-          "dep:critical-section",
-          "portable-atomic"
-        ],
-        "default": [
-          "std"
-        ],
-        "parking_lot": [
-          "dep:parking_lot_core"
-        ],
-        "portable-atomic": [
-          "dep:portable-atomic"
-        ],
-        "race": [],
-        "std": [
-          "alloc"
-        ],
-        "unstable": []
-      },
-      "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "all-features": true,
-            "rustdoc-args": [
-              "--generate-link-to-definition"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "Aleksey Kladov <aleksey.kladov@gmail.com>"
-      ],
-      "categories": [
-        "rust-patterns",
-        "memory-management"
-      ],
-      "keywords": [
-        "lazy",
-        "static"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/matklad/once_cell",
-      "homepage": null,
-      "documentation": "https://docs.rs/once_cell",
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.60"
-    },
-    {
-      "name": "proc-macro-rules",
-      "version": "0.4.0",
-      "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules@0.4.0",
-      "license": "Apache-2.0/MIT",
-      "license_file": null,
-      "description": "Emulate macro-rules pattern matching in procedural macros",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "proc-macro-rules-macros",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "proc-macro2",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.56",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "syn",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^2.0.15",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "full",
-            "extra-traits"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "quote",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.26",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "proc-macro-rules",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-0.4.0/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "example"
-          ],
-          "crate_types": [
-            "proc-macro"
-          ],
-          "name": "macro_rules",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-0.4.0/examples/macro_rules.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-0.4.0/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Nick Cameron <nrc@ncameron.org>"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": "README.md",
-      "repository": "https://github.com/nrc/proc-macro-rules",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "proc-macro-rules-macros",
-      "version": "0.4.0",
-      "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules-macros@0.4.0",
-      "license": "Apache-2.0/MIT",
-      "license_file": null,
-      "description": "Emulate macro-rules pattern matching in procedural macros",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "once_cell",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.17.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "proc-macro2",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.56",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "quote",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.26",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "syn",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^2.0.15",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "full",
-            "extra-traits"
-          ],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "proc-macro"
-          ],
-          "crate_types": [
-            "proc-macro"
-          ],
-          "name": "proc-macro-rules-macros",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-macros-0.4.0/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-macros-0.4.0/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [
-        "Nick Cameron <nrc@ncameron.org>"
-      ],
-      "categories": [],
-      "keywords": [],
-      "readme": "README.md",
-      "repository": "https://github.com/nrc/proc-macro-rules",
-      "homepage": null,
-      "documentation": null,
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
-    },
-    {
-      "name": "proc-macro2",
-      "version": "1.0.79",
-      "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "unicode-ident",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "flate2",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "quote",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rayon",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustversion",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tar",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "proc-macro2",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "comments",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/comments.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/test.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_fmt",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/test_fmt.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "features",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/features.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "marker",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/marker.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_size",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/test_size.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "custom-build"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "build-script-build",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/build.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "default": [
-          "proc-macro"
-        ],
-        "nightly": [],
-        "proc-macro": [],
-        "span-locations": []
-      },
-      "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "rustc-args": [
-              "--cfg",
-              "procmacro2_semver_exempt"
+            "authors": [],
+            "categories": [],
+            "default_run": null,
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "proc-macro-rules",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "=0.4.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
             ],
-            "rustdoc-args": [
-              "--cfg",
-              "procmacro2_semver_exempt",
-              "--cfg",
-              "doc_cfg",
-              "--generate-link-to-definition"
-            ],
+            "description": null,
+            "documentation": null,
+            "edition": "2018",
+            "features": {},
+            "homepage": null,
+            "id": "path+file://{TEMP_DIR}/example_proc_macro_dep#example-proc-macro-dep@0.1.0",
+            "keywords": [],
+            "license": null,
+            "license_file": null,
+            "links": null,
+            "manifest_path": "{TEMP_DIR}/example_proc_macro_dep/Cargo.toml",
+            "metadata": null,
+            "name": "example-proc-macro-dep",
+            "publish": null,
+            "readme": null,
+            "repository": null,
+            "rust_version": null,
+            "source": null,
             "targets": [
-              "x86_64-unknown-linux-gnu"
-            ]
-          }
-        },
-        "playground": {
-          "features": [
-            "span-locations"
-          ]
-        }
-      },
-      "publish": null,
-      "authors": [
-        "David Tolnay <dtolnay@gmail.com>",
-        "Alex Crichton <alex@alexcrichton.com>"
-      ],
-      "categories": [
-        "development-tools::procedural-macro-helpers"
-      ],
-      "keywords": [
-        "macros",
-        "syn"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/dtolnay/proc-macro2",
-      "homepage": null,
-      "documentation": "https://docs.rs/proc-macro2",
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.56"
-    },
-    {
-      "name": "quote",
-      "version": "1.0.35",
-      "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Quasi-quoting macro quote!(...)",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "proc-macro2",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.74",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustversion",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "trybuild",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.66",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "diff"
-          ],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "quote",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/tests/test.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "compiletest",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/tests/compiletest.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        }
-      ],
-      "features": {
-        "default": [
-          "proc-macro"
-        ],
-        "proc-macro": [
-          "proc-macro2/proc-macro"
-        ]
-      },
-      "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "rustdoc-args": [
-              "--generate-link-to-definition"
+                {
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2018",
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "example-proc-macro-dep",
+                    "src_path": "{TEMP_DIR}/example_proc_macro_dep/lib.rs",
+                    "test": true
+                }
             ],
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "David Tolnay <dtolnay@gmail.com>"
-      ],
-      "categories": [
-        "development-tools::procedural-macro-helpers"
-      ],
-      "keywords": [
-        "macros",
-        "syn"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/dtolnay/quote",
-      "homepage": null,
-      "documentation": "https://docs.rs/quote/",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.56"
-    },
-    {
-      "name": "syn",
-      "version": "2.0.57",
-      "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57",
-      "license": "MIT OR Apache-2.0",
-      "license_file": null,
-      "description": "Parser for Rust source code",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "proc-macro2",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.75",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
+            "version": "0.1.0"
         },
         {
-          "name": "quote",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1.0.35",
-          "kind": null,
-          "rename": null,
-          "optional": true,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "unicode-ident",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "anyhow",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "automod",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "flate2",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "insta",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rayon",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "ref-cast",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "reqwest",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.12",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "blocking"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rustversion",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "syn-test-suite",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "tar",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4.16",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "termcolor",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "walkdir",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^2.3.2",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "syn",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/src/lib.rs",
-          "edition": "2021",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_parse_stream",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_parse_stream.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_generics",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_generics.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_visibility",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_visibility.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_round_trip",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_round_trip.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_shebang",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_shebang.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_asyncness",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_asyncness.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_ty",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_ty.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_pat",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_pat.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_derive_input",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_derive_input.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_item",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_item.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_stmt",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_stmt.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_parse_quote",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_parse_quote.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "regression",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/regression.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_precedence",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_precedence.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_path",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_path.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_meta",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_meta.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_receiver",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_receiver.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_iterators",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_iterators.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_expr",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_expr.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_should_parse",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_should_parse.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_attribute",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_attribute.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "zzz_stable",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/zzz_stable.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_lit",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_lit.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_ident",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_ident.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_grouping",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_grouping.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_token_trees",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_token_trees.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_parse_buffer",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_parse_buffer.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "test_size",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_size.rs",
-          "edition": "2021",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "bench"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "rust",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/benches/rust.rs",
-          "edition": "2021",
-          "required-features": [
-            "full",
-            "parsing"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        },
-        {
-          "kind": [
-            "bench"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "file",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/benches/file.rs",
-          "edition": "2021",
-          "required-features": [
-            "full",
-            "parsing"
-          ],
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {
-        "clone-impls": [],
-        "default": [
-          "derive",
-          "parsing",
-          "printing",
-          "clone-impls",
-          "proc-macro"
-        ],
-        "derive": [],
-        "extra-traits": [],
-        "fold": [],
-        "full": [],
-        "parsing": [],
-        "printing": [
-          "dep:quote"
-        ],
-        "proc-macro": [
-          "proc-macro2/proc-macro",
-          "quote?/proc-macro"
-        ],
-        "test": [
-          "syn-test-suite/all-features"
-        ],
-        "visit": [],
-        "visit-mut": []
-      },
-      "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "all-features": true,
-            "rustdoc-args": [
-              "--cfg",
-              "doc_cfg",
-              "--generate-link-to-definition"
+            "authors": [
+                "Aleksey Kladov <aleksey.kladov@gmail.com>"
             ],
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ]
-          }
-        },
-        "playground": {
-          "features": [
-            "full",
-            "visit",
-            "visit-mut",
-            "fold",
-            "extra-traits"
-          ]
-        }
-      },
-      "publish": null,
-      "authors": [
-        "David Tolnay <dtolnay@gmail.com>"
-      ],
-      "categories": [
-        "development-tools::procedural-macro-helpers",
-        "parser-implementations"
-      ],
-      "keywords": [
-        "macros",
-        "syn"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/dtolnay/syn",
-      "homepage": null,
-      "documentation": "https://docs.rs/syn",
-      "edition": "2021",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.60"
-    },
-    {
-      "name": "unicode-ident",
-      "version": "1.0.12",
-      "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12",
-      "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
-      "license_file": null,
-      "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [
-        {
-          "name": "criterion",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.5",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "fst",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.4",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "rand",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.8",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [
-            "small_rng"
-          ],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "roaring",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.10",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "ucd-trie",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.1",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": false,
-          "features": [],
-          "target": null,
-          "registry": null
-        },
-        {
-          "name": "unicode-xid",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.2.4",
-          "kind": "dev",
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "unicode-ident",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/src/lib.rs",
-          "edition": "2018",
-          "doc": true,
-          "doctest": true,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "static_size",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/static_size.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "test"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "compare",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/compare.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": true
-        },
-        {
-          "kind": [
-            "bench"
-          ],
-          "crate_types": [
-            "bin"
-          ],
-          "name": "xid",
-          "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/benches/xid.rs",
-          "edition": "2018",
-          "doc": false,
-          "doctest": false,
-          "test": false
-        }
-      ],
-      "features": {},
-      "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/Cargo.toml",
-      "metadata": {
-        "docs": {
-          "rs": {
-            "rustdoc-args": [
-              "--generate-link-to-definition"
+            "categories": [
+                "rust-patterns",
+                "memory-management"
             ],
-            "targets": [
-              "x86_64-unknown-linux-gnu"
-            ]
-          }
-        }
-      },
-      "publish": null,
-      "authors": [
-        "David Tolnay <dtolnay@gmail.com>"
-      ],
-      "categories": [
-        "development-tools::procedural-macro-helpers",
-        "no-std",
-        "no-std::no-alloc"
-      ],
-      "keywords": [
-        "unicode",
-        "xid"
-      ],
-      "readme": "README.md",
-      "repository": "https://github.com/dtolnay/unicode-ident",
-      "homepage": null,
-      "documentation": "https://docs.rs/unicode-ident",
-      "edition": "2018",
-      "links": null,
-      "default_run": null,
-      "rust_version": "1.31"
-    }
-  ],
-  "workspace_members": [
-    "example-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/example-proc-macro-dep)"
-  ],
-  "workspace_default_members": [
-    "example-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/example-proc-macro-dep)"
-  ],
-  "resolve": {
-    "nodes": [
-      {
-        "id": "example-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/example-proc-macro-dep)",
-        "dependencies": [
-          "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules@0.4.0"
-        ],
-        "deps": [
-          {
-            "name": "proc_macro_rules",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules@0.4.0",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.19.0",
-        "dependencies": [],
-        "deps": [],
-        "features": [
-          "alloc",
-          "default",
-          "race",
-          "std"
-        ]
-      },
-      {
-        "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules@0.4.0",
-        "dependencies": [
-          "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules-macros@0.4.0",
-          "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
-          "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57"
-        ],
-        "deps": [
-          {
-            "name": "proc_macro_rules_macros",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules-macros@0.4.0",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "proc_macro2",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "syn",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules-macros@0.4.0",
-        "dependencies": [
-          "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.19.0",
-          "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
-          "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
-          "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57"
-        ],
-        "deps": [
-          {
+            "default_run": null,
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "critical-section",
+                    "optional": true,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "parking_lot_core",
+                    "optional": true,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.9.3",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "portable-atomic",
+                    "optional": true,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [
+                        "std"
+                    ],
+                    "kind": "dev",
+                    "name": "critical-section",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.1.1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "regex",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.2.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "description": "Single assignment cells and lazy values.",
+            "documentation": "https://docs.rs/once_cell",
+            "edition": "2021",
+            "features": {
+                "alloc": [
+                    "race"
+                ],
+                "atomic-polyfill": [
+                    "critical-section"
+                ],
+                "critical-section": [
+                    "dep:critical-section",
+                    "portable-atomic"
+                ],
+                "default": [
+                    "std"
+                ],
+                "parking_lot": [
+                    "dep:parking_lot_core"
+                ],
+                "portable-atomic": [
+                    "dep:portable-atomic"
+                ],
+                "race": [],
+                "std": [
+                    "alloc"
+                ],
+                "unstable": []
+            },
+            "homepage": null,
+            "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.19.0",
+            "keywords": [
+                "lazy",
+                "static"
+            ],
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "links": null,
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--generate-link-to-definition"
+                        ]
+                    }
+                }
+            },
             "name": "once_cell",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.19.0",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "proc_macro2",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
+            "publish": null,
+            "readme": "README.md",
+            "repository": "https://github.com/matklad/once_cell",
+            "rust_version": "1.60",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2021",
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "once_cell",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/src/lib.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "example"
+                    ],
+                    "name": "bench",
+                    "required-features": [
+                        "std"
+                    ],
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/bench.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "example"
+                    ],
+                    "name": "bench_acquire",
+                    "required-features": [
+                        "std"
+                    ],
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/bench_acquire.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "example"
+                    ],
+                    "name": "lazy_static",
+                    "required-features": [
+                        "std"
+                    ],
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/lazy_static.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "example"
+                    ],
+                    "name": "reentrant_init_deadlocks",
+                    "required-features": [
+                        "std"
+                    ],
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/reentrant_init_deadlocks.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "example"
+                    ],
+                    "name": "regex",
+                    "required-features": [
+                        "std"
+                    ],
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/regex.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "example"
+                    ],
+                    "name": "test_synchronization",
+                    "required-features": [
+                        "std"
+                    ],
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/examples/test_synchronization.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "it",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/once_cell-1.19.0/tests/it/main.rs",
+                    "test": true
+                }
+            ],
+            "version": "1.19.0"
+        },
+        {
+            "authors": [
+                "Nick Cameron <nrc@ncameron.org>"
+            ],
+            "categories": [],
+            "default_run": null,
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "proc-macro-rules-macros",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.4",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "proc-macro2",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0.56",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [
+                        "full",
+                        "extra-traits"
+                    ],
+                    "kind": null,
+                    "name": "syn",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^2.0.15",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "quote",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0.26",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "description": "Emulate macro-rules pattern matching in procedural macros",
+            "documentation": null,
+            "edition": "2021",
+            "features": {},
+            "homepage": null,
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules@0.4.0",
+            "keywords": [],
+            "license": "Apache-2.0/MIT",
+            "license_file": null,
+            "links": null,
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-0.4.0/Cargo.toml",
+            "metadata": null,
+            "name": "proc-macro-rules",
+            "publish": null,
+            "readme": "README.md",
+            "repository": "https://github.com/nrc/proc-macro-rules",
+            "rust_version": null,
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2021",
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "proc-macro-rules",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-0.4.0/src/lib.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "example"
+                    ],
+                    "name": "macro_rules",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-0.4.0/examples/macro_rules.rs",
+                    "test": false
+                }
+            ],
+            "version": "0.4.0"
+        },
+        {
+            "authors": [
+                "Nick Cameron <nrc@ncameron.org>"
+            ],
+            "categories": [],
+            "default_run": null,
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "once_cell",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.17.1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "proc-macro2",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0.56",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "quote",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0.26",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [
+                        "full",
+                        "extra-traits"
+                    ],
+                    "kind": null,
+                    "name": "syn",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^2.0.15",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "description": "Emulate macro-rules pattern matching in procedural macros",
+            "documentation": null,
+            "edition": "2021",
+            "features": {},
+            "homepage": null,
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules-macros@0.4.0",
+            "keywords": [],
+            "license": "Apache-2.0/MIT",
+            "license_file": null,
+            "links": null,
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-macros-0.4.0/Cargo.toml",
+            "metadata": null,
+            "name": "proc-macro-rules-macros",
+            "publish": null,
+            "readme": "README.md",
+            "repository": "https://github.com/nrc/proc-macro-rules",
+            "rust_version": null,
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "crate_types": [
+                        "proc-macro"
+                    ],
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2021",
+                    "kind": [
+                        "proc-macro"
+                    ],
+                    "name": "proc-macro-rules-macros",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-rules-macros-0.4.0/src/lib.rs",
+                    "test": true
+                }
+            ],
+            "version": "0.4.0"
+        },
+        {
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>",
+                "Alex Crichton <alex@alexcrichton.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "default_run": null,
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "unicode-ident",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "flate2",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "quote",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "rayon",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "rustversion",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "tar",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.4",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "description": "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
+            "documentation": "https://docs.rs/proc-macro2",
+            "edition": "2021",
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "nightly": [],
+                "proc-macro": [],
+                "span-locations": []
+            },
+            "homepage": null,
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "links": null,
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt"
+                        ],
+                        "rustdoc-args": [
+                            "--cfg",
+                            "procmacro2_semver_exempt",
+                            "--cfg",
+                            "doc_cfg",
+                            "--generate-link-to-definition"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "span-locations"
+                    ]
+                }
+            },
+            "name": "proc-macro2",
+            "publish": null,
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/proc-macro2",
+            "rust_version": "1.56",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2021",
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "proc-macro2",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/src/lib.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "features",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/features.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/test.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/test_size.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_fmt",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/test_fmt.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "comments",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/comments.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "marker",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/tests/marker.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "custom-build"
+                    ],
+                    "name": "build-script-build",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.79/build.rs",
+                    "test": false
+                }
+            ],
+            "version": "1.0.79"
+        },
+        {
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers"
+            ],
+            "default_run": null,
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "proc-macro2",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0.74",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "rustversion",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [
+                        "diff"
+                    ],
+                    "kind": "dev",
+                    "name": "trybuild",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0.66",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "description": "Quasi-quoting macro quote!(...)",
+            "documentation": "https://docs.rs/quote/",
+            "edition": "2018",
+            "features": {
+                "default": [
+                    "proc-macro"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro"
+                ]
+            },
+            "homepage": null,
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "links": null,
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustdoc-args": [
+                            "--generate-link-to-definition"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
             "name": "quote",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
+            "publish": null,
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/quote",
+            "rust_version": "1.56",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2018",
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "quote",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/src/lib.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/tests/test.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "compiletest",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/quote-1.0.35/tests/compiletest.rs",
+                    "test": true
+                }
+            ],
+            "version": "1.0.35"
+        },
+        {
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "parser-implementations"
+            ],
+            "default_run": null,
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "proc-macro2",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0.75",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "quote",
+                    "optional": true,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1.0.35",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": null,
+                    "name": "unicode-ident",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "anyhow",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "automod",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "flate2",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "insta",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "rayon",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "ref-cast",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [
+                        "blocking"
+                    ],
+                    "kind": "dev",
+                    "name": "reqwest",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.12",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "rustversion",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "syn-test-suite",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "tar",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.4.16",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "termcolor",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "walkdir",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^2.3.2",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "description": "Parser for Rust source code",
+            "documentation": "https://docs.rs/syn",
+            "edition": "2021",
+            "features": {
+                "clone-impls": [],
+                "default": [
+                    "derive",
+                    "parsing",
+                    "printing",
+                    "clone-impls",
+                    "proc-macro"
+                ],
+                "derive": [],
+                "extra-traits": [],
+                "fold": [],
+                "full": [],
+                "parsing": [],
+                "printing": [
+                    "dep:quote"
+                ],
+                "proc-macro": [
+                    "proc-macro2/proc-macro",
+                    "quote?/proc-macro"
+                ],
+                "test": [
+                    "syn-test-suite/all-features"
+                ],
+                "visit": [],
+                "visit-mut": []
+            },
+            "homepage": null,
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57",
+            "keywords": [
+                "macros",
+                "syn"
+            ],
+            "license": "MIT OR Apache-2.0",
+            "license_file": null,
+            "links": null,
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "all-features": true,
+                        "rustdoc-args": [
+                            "--cfg",
+                            "doc_cfg",
+                            "--generate-link-to-definition"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                },
+                "playground": {
+                    "features": [
+                        "full",
+                        "visit",
+                        "visit-mut",
+                        "fold",
+                        "extra-traits"
+                    ]
+                }
+            },
             "name": "syn",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
-        "dependencies": [
-          "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
-        ],
-        "deps": [
-          {
-            "name": "unicode_ident",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": [
-          "default",
-          "proc-macro"
-        ]
-      },
-      {
-        "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
-        "dependencies": [
-          "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
-        ],
-        "deps": [
-          {
-            "name": "proc_macro2",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": [
-          "default",
-          "proc-macro"
-        ]
-      },
-      {
-        "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57",
-        "dependencies": [
-          "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
-          "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
-          "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
-        ],
-        "deps": [
-          {
-            "name": "proc_macro2",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "quote",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          },
-          {
-            "name": "unicode_ident",
-            "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": [
-          "clone-impls",
-          "default",
-          "derive",
-          "extra-traits",
-          "full",
-          "parsing",
-          "printing",
-          "proc-macro"
-        ]
-      },
-      {
-        "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      }
+            "publish": null,
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/syn",
+            "rust_version": "1.60",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2021",
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "syn",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/src/lib.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_should_parse",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_should_parse.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_visibility",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_visibility.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_stmt",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_stmt.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_round_trip",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_round_trip.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_size",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_size.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_shebang",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_shebang.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_pat",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_pat.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_receiver",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_receiver.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_precedence",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_precedence.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_lit",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_lit.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "regression",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/regression.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_parse_stream",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_parse_stream.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_grouping",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_grouping.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_ident",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_ident.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_iterators",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_iterators.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_parse_buffer",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_parse_buffer.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_asyncness",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_asyncness.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_token_trees",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_token_trees.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_ty",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_ty.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "zzz_stable",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/zzz_stable.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_parse_quote",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_parse_quote.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_meta",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_meta.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_expr",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_expr.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_item",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_item.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_path",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_path.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_derive_input",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_derive_input.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_generics",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_generics.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "test_attribute",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/tests/test_attribute.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "bench"
+                    ],
+                    "name": "rust",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/benches/rust.rs",
+                    "test": false
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2021",
+                    "kind": [
+                        "bench"
+                    ],
+                    "name": "file",
+                    "required-features": [
+                        "full",
+                        "parsing"
+                    ],
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.57/benches/file.rs",
+                    "test": false
+                }
+            ],
+            "version": "2.0.57"
+        },
+        {
+            "authors": [
+                "David Tolnay <dtolnay@gmail.com>"
+            ],
+            "categories": [
+                "development-tools::procedural-macro-helpers",
+                "no-std",
+                "no-std::no-alloc"
+            ],
+            "default_run": null,
+            "dependencies": [
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "criterion",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.5",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "fst",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.4",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [
+                        "small_rng"
+                    ],
+                    "kind": "dev",
+                    "name": "rand",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.8",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "roaring",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.10",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "ucd-trie",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.1",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": false
+                },
+                {
+                    "features": [],
+                    "kind": "dev",
+                    "name": "unicode-xid",
+                    "optional": false,
+                    "registry": null,
+                    "rename": null,
+                    "req": "^0.2.4",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "target": null,
+                    "uses_default_features": true
+                }
+            ],
+            "description": "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31",
+            "documentation": "https://docs.rs/unicode-ident",
+            "edition": "2018",
+            "features": {},
+            "homepage": null,
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12",
+            "keywords": [
+                "unicode",
+                "xid"
+            ],
+            "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
+            "license_file": null,
+            "links": null,
+            "manifest_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/Cargo.toml",
+            "metadata": {
+                "docs": {
+                    "rs": {
+                        "rustdoc-args": [
+                            "--generate-link-to-definition"
+                        ],
+                        "targets": [
+                            "x86_64-unknown-linux-gnu"
+                        ]
+                    }
+                }
+            },
+            "name": "unicode-ident",
+            "publish": null,
+            "readme": "README.md",
+            "repository": "https://github.com/dtolnay/unicode-ident",
+            "rust_version": "1.31",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "targets": [
+                {
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2018",
+                    "kind": [
+                        "lib"
+                    ],
+                    "name": "unicode-ident",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/src/lib.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "static_size",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/static_size.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "test"
+                    ],
+                    "name": "compare",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/tests/compare.rs",
+                    "test": true
+                },
+                {
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "doc": false,
+                    "doctest": false,
+                    "edition": "2018",
+                    "kind": [
+                        "bench"
+                    ],
+                    "name": "xid",
+                    "src_path": "{CARGO_HOME}/registry/src/index.crates.io-6f17d22bba15001f/unicode-ident-1.0.12/benches/xid.rs",
+                    "test": false
+                }
+            ],
+            "version": "1.0.12"
+        }
     ],
-    "root": "example-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/example-proc-macro-dep)"
-  },
-  "target_directory": "{TEMP_DIR}/example_proc_macro_dep/target",
-  "version": 1,
-  "workspace_root": "{TEMP_DIR}/example_proc_macro_dep",
-  "metadata": null
+    "resolve": {
+        "nodes": [
+            {
+                "dependencies": [
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules@0.4.0"
+                ],
+                "deps": [
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "proc_macro_rules",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules@0.4.0"
+                    }
+                ],
+                "features": [],
+                "id": "path+file://{TEMP_DIR}/example_proc_macro_dep#example-proc-macro-dep@0.1.0"
+            },
+            {
+                "dependencies": [],
+                "deps": [],
+                "features": [
+                    "alloc",
+                    "default",
+                    "race",
+                    "std"
+                ],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.19.0"
+            },
+            {
+                "dependencies": [
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules-macros@0.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57"
+                ],
+                "deps": [
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "proc_macro_rules_macros",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules-macros@0.4.0"
+                    },
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "proc_macro2",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
+                    },
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "syn",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57"
+                    }
+                ],
+                "features": [],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules@0.4.0"
+            },
+            {
+                "dependencies": [
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.19.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57"
+                ],
+                "deps": [
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "once_cell",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.19.0"
+                    },
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "proc_macro2",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
+                    },
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "quote",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35"
+                    },
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "syn",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57"
+                    }
+                ],
+                "features": [],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro-rules-macros@0.4.0"
+            },
+            {
+                "dependencies": [
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
+                ],
+                "deps": [
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "unicode_ident",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
+            },
+            {
+                "dependencies": [
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
+                ],
+                "deps": [
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "proc_macro2",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
+                    }
+                ],
+                "features": [
+                    "default",
+                    "proc-macro"
+                ],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35"
+            },
+            {
+                "dependencies": [
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
+                ],
+                "deps": [
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "proc_macro2",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.79"
+                    },
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "quote",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.35"
+                    },
+                    {
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ],
+                        "name": "unicode_ident",
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
+                    }
+                ],
+                "features": [
+                    "clone-impls",
+                    "default",
+                    "derive",
+                    "extra-traits",
+                    "full",
+                    "parsing",
+                    "printing",
+                    "proc-macro"
+                ],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@2.0.57"
+            },
+            {
+                "dependencies": [],
+                "deps": [],
+                "features": [],
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.12"
+            }
+        ],
+        "root": "path+file://{TEMP_DIR}/example_proc_macro_dep#example-proc-macro-dep@0.1.0"
+    },
+    "target_directory": "{TEMP_DIR}/example_proc_macro_dep/target",
+    "version": 1,
+    "workspace_default_members": [
+        "path+file://{TEMP_DIR}/example_proc_macro_dep#example-proc-macro-dep@0.1.0"
+    ],
+    "workspace_members": [
+        "path+file://{TEMP_DIR}/example_proc_macro_dep#example-proc-macro-dep@0.1.0"
+    ],
+    "workspace_root": "{TEMP_DIR}/example_proc_macro_dep"
 }

--- a/crate_universe/test_data/metadata/git_repos/metadata.json
+++ b/crate_universe/test_data/metadata/git_repos/metadata.json
@@ -49,7 +49,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -117,7 +117,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "git-repos 0.1.0 (path+file://{TEMP_DIR}/git_repos)",
+            "id": "path+file://{TEMP_DIR}/git_repos#git-repos@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -196,7 +196,7 @@
                 ]
             },
             "homepage": null,
-            "id": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0",
             "keywords": [
                 "macro",
                 "lazy",
@@ -321,7 +321,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "pin-project-lite 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.8",
             "keywords": [
                 "pin",
                 "macros"
@@ -494,7 +494,7 @@
                 "span-locations": []
             },
             "homepage": null,
-            "id": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.36",
             "keywords": [
                 "macros"
             ],
@@ -694,7 +694,7 @@
                 ]
             },
             "homepage": null,
-            "id": "quote 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.14",
             "keywords": [
                 "syn"
             ],
@@ -989,7 +989,7 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.85",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -1647,7 +1647,7 @@
                 ]
             },
             "homepage": "https://tokio.rs",
-            "id": "tracing 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)",
+            "id": "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing@0.2.0",
             "keywords": [
                 "logging",
                 "tracing",
@@ -2001,7 +2001,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://tokio.rs",
-            "id": "tracing-attributes 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)",
+            "id": "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing-attributes@0.2.0",
             "keywords": [
                 "logging",
                 "tracing",
@@ -2205,7 +2205,7 @@
                 ]
             },
             "homepage": "https://tokio.rs",
-            "id": "tracing-core 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)",
+            "id": "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing-core@0.2.0",
             "keywords": [
                 "logging",
                 "tracing",
@@ -2323,7 +2323,7 @@
                 "no_std": []
             },
             "homepage": "https://github.com/unicode-rs/unicode-xid",
-            "id": "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.2",
             "keywords": [
                 "text",
                 "unicode",
@@ -2393,11 +2393,11 @@
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [
-                    "tracing 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)"
+                    "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing@0.2.0"
                 ],
                 "deps": [
                     {
@@ -2408,27 +2408,27 @@
                             }
                         ],
                         "name": "tracing",
-                        "pkg": "tracing 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)"
+                        "pkg": "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing@0.2.0"
                     }
                 ],
                 "features": [],
-                "id": "git-repos 0.1.0 (path+file://{TEMP_DIR}/git_repos)"
+                "id": "path+file://{TEMP_DIR}/git_repos#git-repos@0.1.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "pin-project-lite 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.8"
             },
             {
                 "dependencies": [
-                    "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.2"
                 ],
                 "deps": [
                     {
@@ -2439,18 +2439,18 @@
                             }
                         ],
                         "name": "unicode_xid",
-                        "pkg": "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.2"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.36"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.36"
                 ],
                 "deps": [
                     {
@@ -2461,20 +2461,20 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.36"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "quote 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.14"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.36",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.14",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.2"
                 ],
                 "deps": [
                     {
@@ -2485,7 +2485,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.36"
                     },
                     {
                         "dep_kinds": [
@@ -2495,7 +2495,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.14"
                     },
                     {
                         "dep_kinds": [
@@ -2505,7 +2505,7 @@
                             }
                         ],
                         "name": "unicode_xid",
-                        "pkg": "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.2"
                     }
                 ],
                 "features": [
@@ -2519,14 +2519,14 @@
                     "visit",
                     "visit-mut"
                 ],
-                "id": "syn 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.85"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pin-project-lite 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "tracing-attributes 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)",
-                    "tracing-core 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.8",
+                    "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing-attributes@0.2.0",
+                    "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing-core@0.2.0"
                 ],
                 "deps": [
                     {
@@ -2537,7 +2537,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -2547,7 +2547,7 @@
                             }
                         ],
                         "name": "pin_project_lite",
-                        "pkg": "pin-project-lite 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.8"
                     },
                     {
                         "dep_kinds": [
@@ -2557,7 +2557,7 @@
                             }
                         ],
                         "name": "tracing_attributes",
-                        "pkg": "tracing-attributes 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)"
+                        "pkg": "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing-attributes@0.2.0"
                     },
                     {
                         "dep_kinds": [
@@ -2567,7 +2567,7 @@
                             }
                         ],
                         "name": "tracing_core",
-                        "pkg": "tracing-core 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)"
+                        "pkg": "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing-core@0.2.0"
                     }
                 ],
                 "features": [
@@ -2577,13 +2577,13 @@
                     "std",
                     "tracing-attributes"
                 ],
-                "id": "tracing 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)"
+                "id": "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing@0.2.0"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.36",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.14",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.85"
                 ],
                 "deps": [
                     {
@@ -2594,7 +2594,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.36"
                     },
                     {
                         "dep_kinds": [
@@ -2604,7 +2604,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.14"
                     },
                     {
                         "dep_kinds": [
@@ -2614,15 +2614,15 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.85"
                     }
                 ],
                 "features": [],
-                "id": "tracing-attributes 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)"
+                "id": "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing-attributes@0.2.0"
             },
             {
                 "dependencies": [
-                    "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
                 ],
                 "deps": [
                     {
@@ -2633,7 +2633,7 @@
                             }
                         ],
                         "name": "lazy_static",
-                        "pkg": "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.4.0"
                     }
                 ],
                 "features": [
@@ -2641,7 +2641,7 @@
                     "lazy_static",
                     "std"
                 ],
-                "id": "tracing-core 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0)"
+                "id": "git+https://github.com/tokio-rs/tracing.git?branch=master#tracing-core@0.2.0"
             },
             {
                 "dependencies": [],
@@ -2649,18 +2649,18 @@
                 "features": [
                     "default"
                 ],
-                "id": "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.2"
             }
         ],
-        "root": "git-repos 0.1.0 (path+file://{TEMP_DIR}/git_repos)"
+        "root": "path+file://{TEMP_DIR}/git_repos#git-repos@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/git_repos/target",
     "version": 1,
     "workspace_default_members": [
-        "git-repos 0.1.0 (path+file://{TEMP_DIR}/git_repos)"
+        "path+file://{TEMP_DIR}/git_repos#git-repos@0.1.0"
     ],
     "workspace_members": [
-        "git-repos 0.1.0 (path+file://{TEMP_DIR}/git_repos)"
+        "path+file://{TEMP_DIR}/git_repos#git-repos@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/git_repos"
 }

--- a/crate_universe/test_data/metadata/has_package_metadata/metadata.json
+++ b/crate_universe/test_data/metadata/has_package_metadata/metadata.json
@@ -11,7 +11,7 @@
             "edition": "2021",
             "features": {},
             "homepage": null,
-            "id": "has_package_metadata 0.0.0 (path+file://{TEMP_DIR}/has_package_metadata)",
+            "id": "path+file://{TEMP_DIR}/has_package_metadata#0.0.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -56,18 +56,18 @@
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "has_package_metadata 0.0.0 (path+file://{TEMP_DIR}/has_package_metadata)"
+                "id": "path+file://{TEMP_DIR}/has_package_metadata#0.0.0"
             }
         ],
-        "root": "has_package_metadata 0.0.0 (path+file://{TEMP_DIR}/has_package_metadata)"
+        "root": "path+file://{TEMP_DIR}/has_package_metadata#0.0.0"
     },
     "target_directory": "{TEMP_DIR}/has_package_metadata/target",
     "version": 1,
     "workspace_default_members": [
-        "has_package_metadata 0.0.0 (path+file://{TEMP_DIR}/has_package_metadata)"
+        "path+file://{TEMP_DIR}/has_package_metadata#0.0.0"
     ],
     "workspace_members": [
-        "has_package_metadata 0.0.0 (path+file://{TEMP_DIR}/has_package_metadata)"
+        "path+file://{TEMP_DIR}/has_package_metadata#0.0.0"
     ],
     "workspace_root": "{TEMP_DIR}/has_package_metadata"
 }

--- a/crate_universe/test_data/metadata/multi_cfg_dep/metadata.json
+++ b/crate_universe/test_data/metadata/multi_cfg_dep/metadata.json
@@ -53,7 +53,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "cpufeatures 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.7",
             "keywords": [
                 "cpuid",
                 "target-feature"
@@ -162,7 +162,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/libc",
-            "id": "libc 0.2.117 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.117",
             "keywords": [
                 "libc",
                 "ffi",
@@ -259,7 +259,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "multi_cfg_dep 0.1.0 (path+file://{TEMP_DIR}/multi_cfg_dep)",
+            "id": "path+file://{TEMP_DIR}/multi_cfg_dep#0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -295,7 +295,7 @@
         "nodes": [
             {
                 "dependencies": [
-                    "libc 0.2.117 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.117"
                 ],
                 "deps": [
                     {
@@ -314,11 +314,11 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.117 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.117"
                     }
                 ],
                 "features": [],
-                "id": "cpufeatures 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.7"
             },
             {
                 "dependencies": [],
@@ -327,11 +327,11 @@
                     "default",
                     "std"
                 ],
-                "id": "libc 0.2.117 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.117"
             },
             {
                 "dependencies": [
-                    "cpufeatures 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.7"
                 ],
                 "deps": [
                     {
@@ -342,22 +342,22 @@
                             }
                         ],
                         "name": "cpufeatures",
-                        "pkg": "cpufeatures 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.7"
                     }
                 ],
                 "features": [],
-                "id": "multi_cfg_dep 0.1.0 (path+file://{TEMP_DIR}/multi_cfg_dep)"
+                "id": "path+file://{TEMP_DIR}/multi_cfg_dep#0.1.0"
             }
         ],
-        "root": "multi_cfg_dep 0.1.0 (path+file://{TEMP_DIR}/multi_cfg_dep)"
+        "root": "path+file://{TEMP_DIR}/multi_cfg_dep#0.1.0"
     },
     "target_directory": "{TEMP_DIR}/multi_cfg_dep/target",
     "version": 1,
     "workspace_default_members": [
-        "multi_cfg_dep 0.1.0 (path+file://{TEMP_DIR}/multi_cfg_dep)"
+        "path+file://{TEMP_DIR}/multi_cfg_dep#0.1.0"
     ],
     "workspace_members": [
-        "multi_cfg_dep 0.1.0 (path+file://{TEMP_DIR}/multi_cfg_dep)"
+        "path+file://{TEMP_DIR}/multi_cfg_dep#0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/multi_cfg_dep"
 }

--- a/crate_universe/test_data/metadata/multi_kind_proc_macro_dep/metadata.json
+++ b/crate_universe/test_data/metadata/multi_kind_proc_macro_dep/metadata.json
@@ -36,7 +36,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "multi-kind-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/multi_kind_proc_macro_dep)",
+            "id": "path+file://{TEMP_DIR}/multi_kind_proc_macro_dep#multi-kind-proc-macro-dep@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -122,7 +122,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#paste@1.0.14",
             "keywords": [
                 "macros"
             ],
@@ -255,7 +255,7 @@
         "nodes": [
             {
                 "dependencies": [
-                    "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#paste@1.0.14"
                 ],
                 "deps": [
                     {
@@ -270,28 +270,28 @@
                             }
                         ],
                         "name": "paste",
-                        "pkg": "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#paste@1.0.14"
                     }
                 ],
                 "features": [],
-                "id": "multi-kind-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/multi_kind_proc_macro_dep)"
+                "id": "path+file://{TEMP_DIR}/multi_kind_proc_macro_dep#multi-kind-proc-macro-dep@0.1.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "paste 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#paste@1.0.14"
             }
         ],
-        "root": "multi-kind-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/multi_kind_proc_macro_dep)"
+        "root": "path+file://{TEMP_DIR}/multi_kind_proc_macro_dep#multi-kind-proc-macro-dep@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/multi_kind_proc_macro_dep/target",
     "version": 1,
     "workspace_default_members": [
-        "multi-kind-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/multi_kind_proc_macro_dep)"
+        "path+file://{TEMP_DIR}/multi_kind_proc_macro_dep#multi-kind-proc-macro-dep@0.1.0"
     ],
     "workspace_members": [
-        "multi-kind-proc-macro-dep 0.1.0 (path+file://{TEMP_DIR}/multi_kind_proc_macro_dep)"
+        "path+file://{TEMP_DIR}/multi_kind_proc_macro_dep#multi-kind-proc-macro-dep@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/multi_kind_proc_macro_dep"
 }

--- a/crate_universe/test_data/metadata/no_deps/metadata.json
+++ b/crate_universe/test_data/metadata/no_deps/metadata.json
@@ -11,7 +11,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "no-deps 0.1.0 (path+file://{TEMP_DIR}/no_deps)",
+            "id": "path+file://{TEMP_DIR}/no_deps#no-deps@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -49,18 +49,18 @@
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "no-deps 0.1.0 (path+file://{TEMP_DIR}/no_deps)"
+                "id": "path+file://{TEMP_DIR}/no_deps#no-deps@0.1.0"
             }
         ],
-        "root": "no-deps 0.1.0 (path+file://{TEMP_DIR}/no_deps)"
+        "root": "path+file://{TEMP_DIR}/no_deps#no-deps@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/no_deps/target",
     "version": 1,
     "workspace_default_members": [
-        "no-deps 0.1.0 (path+file://{TEMP_DIR}/no_deps)"
+        "path+file://{TEMP_DIR}/no_deps#no-deps@0.1.0"
     ],
     "workspace_members": [
-        "no-deps 0.1.0 (path+file://{TEMP_DIR}/no_deps)"
+        "path+file://{TEMP_DIR}/no_deps#no-deps@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/no_deps"
 }

--- a/crate_universe/test_data/metadata/target_cfg_features/metadata.json
+++ b/crate_universe/test_data/metadata/target_cfg_features/metadata.json
@@ -15,7 +15,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
             "keywords": [
                 "rustc",
                 "build",
@@ -170,7 +170,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.9",
             "keywords": [
                 "pin",
                 "macros"
@@ -333,7 +333,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "target_cfg_features 0.1.0 (path+file://{TEMP_DIR}/target_cfg_features)",
+            "id": "path+file://{TEMP_DIR}/target_cfg_features#0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -848,7 +848,7 @@
                 ]
             },
             "homepage": "https://tokio.rs",
-            "id": "tokio 1.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.25.0",
             "keywords": [
                 "io",
                 "async",
@@ -3676,7 +3676,7 @@
                 "deprecated": []
             },
             "homepage": null,
-            "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3727,7 +3727,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3791,7 +3791,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3855,7 +3855,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3919,7 +3919,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3983,7 +3983,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -4047,7 +4047,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -4111,7 +4111,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.1",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -4170,17 +4170,17 @@
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.9"
             },
             {
                 "dependencies": [
-                    "tokio 1.25.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#tokio@1.25.0"
                 ],
                 "deps": [
                     {
@@ -4195,17 +4195,17 @@
                             }
                         ],
                         "name": "tokio",
-                        "pkg": "tokio 1.25.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.25.0"
                     }
                 ],
                 "features": [],
-                "id": "target_cfg_features 0.1.0 (path+file://{TEMP_DIR}/target_cfg_features)"
+                "id": "path+file://{TEMP_DIR}/target_cfg_features#0.1.0"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
                 ],
                 "deps": [
                     {
@@ -4216,7 +4216,7 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -4226,7 +4226,7 @@
                             }
                         ],
                         "name": "pin_project_lite",
-                        "pkg": "pin-project-lite 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.9"
                     },
                     {
                         "dep_kinds": [
@@ -4236,24 +4236,24 @@
                             }
                         ],
                         "name": "windows_sys",
-                        "pkg": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
                     }
                 ],
                 "features": [
                     "default",
                     "fs"
                 ],
-                "id": "tokio 1.25.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.25.0"
             },
             {
                 "dependencies": [
-                    "windows_aarch64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_aarch64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.1"
                 ],
                 "deps": [
                     {
@@ -4264,7 +4264,7 @@
                             }
                         ],
                         "name": "windows_aarch64_gnullvm",
-                        "pkg": "windows_aarch64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.1"
                     },
                     {
                         "dep_kinds": [
@@ -4278,7 +4278,7 @@
                             }
                         ],
                         "name": "windows_aarch64_msvc",
-                        "pkg": "windows_aarch64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.1"
                     },
                     {
                         "dep_kinds": [
@@ -4292,7 +4292,7 @@
                             }
                         ],
                         "name": "windows_i686_gnu",
-                        "pkg": "windows_i686_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.1"
                     },
                     {
                         "dep_kinds": [
@@ -4306,7 +4306,7 @@
                             }
                         ],
                         "name": "windows_i686_msvc",
-                        "pkg": "windows_i686_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.1"
                     },
                     {
                         "dep_kinds": [
@@ -4320,7 +4320,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnu",
-                        "pkg": "windows_x86_64_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.1"
                     },
                     {
                         "dep_kinds": [
@@ -4330,7 +4330,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnullvm",
-                        "pkg": "windows_x86_64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.1"
                     },
                     {
                         "dep_kinds": [
@@ -4344,7 +4344,7 @@
                             }
                         ],
                         "name": "windows_x86_64_msvc",
-                        "pkg": "windows_x86_64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.1"
                     }
                 ],
                 "features": [
@@ -4354,60 +4354,60 @@
                     "Win32_Security_Authorization",
                     "default"
                 ],
-                "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnu 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnullvm 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_msvc 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.1"
             }
         ],
-        "root": "target_cfg_features 0.1.0 (path+file://{TEMP_DIR}/target_cfg_features)"
+        "root": "path+file://{TEMP_DIR}/target_cfg_features#0.1.0"
     },
     "target_directory": "{TEMP_DIR}/target_cfg_features/target",
     "version": 1,
     "workspace_default_members": [
-        "target_cfg_features 0.1.0 (path+file://{TEMP_DIR}/target_cfg_features)"
+        "path+file://{TEMP_DIR}/target_cfg_features#0.1.0"
     ],
     "workspace_members": [
-        "target_cfg_features 0.1.0 (path+file://{TEMP_DIR}/target_cfg_features)"
+        "path+file://{TEMP_DIR}/target_cfg_features#0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/target_cfg_features"
 }

--- a/crate_universe/test_data/metadata/target_features/metadata.json
+++ b/crate_universe/test_data/metadata/target_features/metadata.json
@@ -214,7 +214,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.6",
             "keywords": [
                 "hash",
                 "hasher",
@@ -376,7 +376,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/nical/android_system_properties",
-            "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
             "keywords": [
                 "android"
             ],
@@ -508,7 +508,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2",
             "keywords": [
                 "stack",
                 "vector",
@@ -653,7 +653,7 @@
                 ]
             },
             "homepage": null,
-            "id": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ash@0.37.1+1.3.235",
             "keywords": [
                 "vulkan",
                 "graphic"
@@ -756,7 +756,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
             "keywords": [
                 "rustc",
                 "build",
@@ -905,7 +905,7 @@
                 ]
             },
             "homepage": "https://github.com/contain-rs/bit-set",
-            "id": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3",
             "keywords": [
                 "data-structures",
                 "bitset"
@@ -1017,7 +1017,7 @@
                 "std": []
             },
             "homepage": "https://github.com/contain-rs/bit-vec",
-            "id": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3",
             "keywords": [
                 "data-structures",
                 "bitvec",
@@ -1192,7 +1192,7 @@
                 ]
             },
             "homepage": "https://github.com/bitflags/bitflags",
-            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
             "keywords": [
                 "bit",
                 "bitmask",
@@ -1289,7 +1289,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6",
             "keywords": [
                 "blocks",
                 "osx",
@@ -1383,7 +1383,7 @@
                 "default": []
             },
             "homepage": null,
-            "id": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.11.1",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -1498,7 +1498,7 @@
                 "std": []
             },
             "homepage": "https://github.com/BurntSushi/byteorder",
-            "id": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#byteorder@1.4.3",
             "keywords": [
                 "byte",
                 "endian",
@@ -1595,7 +1595,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/cc-rs",
-            "id": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.77",
             "keywords": [
                 "build-dependencies"
             ],
@@ -1746,7 +1746,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -1806,7 +1806,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/katharostech/cfg_aliases",
-            "id": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.1.1",
             "keywords": [
                 "cfg",
                 "alias",
@@ -1987,7 +1987,7 @@
                 ]
             },
             "homepage": "https://github.com/brendanzab/codespan",
-            "id": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1",
             "keywords": [],
             "license": "Apache-2.0",
             "license_file": null,
@@ -2184,7 +2184,7 @@
                 ]
             },
             "homepage": "https://github.com/servo/core-foundation-rs",
-            "id": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.3",
             "keywords": [
                 "macos",
                 "framework",
@@ -2254,7 +2254,7 @@
                 "mac_os_10_8_features": []
             },
             "homepage": "https://github.com/servo/core-foundation-rs",
-            "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3",
             "keywords": [],
             "license": "MIT / Apache-2.0",
             "license_file": null,
@@ -2366,7 +2366,7 @@
             "edition": "2015",
             "features": {},
             "homepage": "https://github.com/servo/core-foundation-rs",
-            "id": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1",
             "keywords": [],
             "license": "MIT / Apache-2.0",
             "license_file": null,
@@ -2419,7 +2419,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cty@0.2.2",
             "keywords": [
                 "c",
                 "types",
@@ -2528,7 +2528,7 @@
                 ]
             },
             "homepage": null,
-            "id": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#d3d12@0.5.0",
             "keywords": [
                 "windows",
                 "graphics"
@@ -2593,7 +2593,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -2636,7 +2636,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -2718,7 +2718,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1",
             "keywords": [
                 "hash"
             ],
@@ -2904,7 +2904,7 @@
                 ]
             },
             "homepage": null,
-            "id": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.8",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3116,7 +3116,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/grovesNL/glow.git",
-            "id": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#glow@0.11.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3242,7 +3242,7 @@
                 ]
             },
             "homepage": "https://github.com/zakarumych/gpu-alloc",
-            "id": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc@0.5.3",
             "keywords": [
                 "gpu",
                 "vulkan",
@@ -3303,7 +3303,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/zakarumych/gpu-alloc",
-            "id": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc-types@0.2.0",
             "keywords": [
                 "gpu",
                 "vulkan",
@@ -3425,7 +3425,7 @@
                 ]
             },
             "homepage": "https://github.com/zakarumych/gpu-descriptor",
-            "id": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor@0.2.3",
             "keywords": [
                 "gpu",
                 "vulkan",
@@ -3485,7 +3485,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/zakarumych/gpu-descriptor",
-            "id": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor-types@0.1.1",
             "keywords": [
                 "gpu",
                 "vulkan",
@@ -3735,7 +3735,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
             "keywords": [
                 "hash",
                 "no_std",
@@ -3878,7 +3878,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/lifthrasiir/hexf",
-            "id": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hexf-parse@0.2.1",
             "keywords": [],
             "license": "CC0-1.0",
             "license_file": null,
@@ -4117,7 +4117,7 @@
                 "test_low_transition_point": []
             },
             "homepage": null,
-            "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2",
             "keywords": [
                 "hashmap",
                 "no_std"
@@ -4331,7 +4331,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -4523,7 +4523,7 @@
                 ]
             },
             "homepage": null,
-            "id": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#khronos-egl@4.1.0",
             "keywords": [
                 "egl",
                 "gl",
@@ -4672,7 +4672,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/libc",
-            "id": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137",
             "keywords": [
                 "libc",
                 "ffi",
@@ -4812,7 +4812,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4",
             "keywords": [
                 "dlopen",
                 "load",
@@ -5001,7 +5001,7 @@
                 ]
             },
             "homepage": null,
-            "id": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.9",
             "keywords": [
                 "mutex",
                 "rwlock",
@@ -5221,7 +5221,7 @@
                 ]
             },
             "homepage": null,
-            "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
             "keywords": [
                 "logging"
             ],
@@ -5347,7 +5347,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#malloc_buf@0.0.6",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -5544,7 +5544,7 @@
                 "private": []
             },
             "homepage": "https://github.com/gfx-rs/metal-rs",
-            "id": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#metal@0.24.0",
             "keywords": [
                 "metal",
                 "graphics",
@@ -6190,7 +6190,7 @@
                 "wgsl-out": []
             },
             "homepage": "https://github.com/gfx-rs/naga",
-            "id": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0",
             "keywords": [
                 "shader",
                 "SPIR-V",
@@ -6296,7 +6296,7 @@
                 "std": []
             },
             "homepage": "https://github.com/rust-num/num-traits",
-            "id": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15",
             "keywords": [
                 "mathematics",
                 "numerics"
@@ -6411,7 +6411,7 @@
                 "verify_message": []
             },
             "homepage": null,
-            "id": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7",
             "keywords": [
                 "objective-c",
                 "osx",
@@ -6487,7 +6487,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#objc_exception@0.1.2",
             "keywords": [
                 "objective-c",
                 "osx",
@@ -6669,7 +6669,7 @@
                 "unstable": []
             },
             "homepage": null,
-            "id": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0",
             "keywords": [
                 "lazy",
                 "static"
@@ -6925,7 +6925,7 @@
                 ]
             },
             "homepage": null,
-            "id": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1",
             "keywords": [
                 "mutex",
                 "condvar",
@@ -7108,7 +7108,7 @@
                 ]
             },
             "homepage": null,
-            "id": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.4",
             "keywords": [
                 "mutex",
                 "condvar",
@@ -7184,7 +7184,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.26",
             "keywords": [
                 "build-dependencies"
             ],
@@ -7278,7 +7278,7 @@
                 "span-locations": []
             },
             "homepage": null,
-            "id": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
             "keywords": [
                 "macros",
                 "syn"
@@ -7699,7 +7699,7 @@
                 "type-check": []
             },
             "homepage": "https://github.com/aclysma/profiling",
-            "id": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7",
             "keywords": [
                 "performance",
                 "profiling"
@@ -7825,7 +7825,7 @@
                 ]
             },
             "homepage": null,
-            "id": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
             "keywords": [
                 "macros",
                 "syn"
@@ -7923,7 +7923,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/gfx-rs/gfx",
-            "id": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#range-alloc@0.1.2",
             "keywords": [
                 "allocator"
             ],
@@ -7983,7 +7983,7 @@
                 "alloc": []
             },
             "homepage": null,
-            "id": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0",
             "keywords": [
                 "windowing"
             ],
@@ -8051,7 +8051,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -8094,7 +8094,7 @@
             "edition": "2015",
             "features": {},
             "homepage": "https://github.com/ebkalderon/renderdoc-rs/tree/master/renderdoc-sys",
-            "id": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#renderdoc-sys@0.7.1",
             "keywords": [
                 "ffi",
                 "renderdoc"
@@ -8145,7 +8145,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0",
             "keywords": [
                 "hash",
                 "fxhash",
@@ -8200,7 +8200,7 @@
                 "use_std": []
             },
             "homepage": null,
-            "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0",
             "keywords": [
                 "scope-guard",
                 "defer",
@@ -8367,7 +8367,7 @@
                 "unstable": []
             },
             "homepage": null,
-            "id": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#slotmap@1.0.6",
             "keywords": [
                 "slotmap",
                 "storage",
@@ -8537,7 +8537,7 @@
                 "write": []
             },
             "homepage": null,
-            "id": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
             "keywords": [
                 "small",
                 "vec",
@@ -8690,7 +8690,7 @@
                 ]
             },
             "homepage": null,
-            "id": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#spirv@0.2.0+1.5.4",
             "keywords": [
                 "spirv",
                 "definition",
@@ -8744,7 +8744,7 @@
                 "nightly": []
             },
             "homepage": "https://github.com/nvzqz/static-assertions-rs",
-            "id": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0",
             "keywords": [
                 "assert",
                 "static",
@@ -9006,7 +9006,7 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104",
             "keywords": [
                 "macros",
                 "syn"
@@ -9513,7 +9513,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "target_features 0.1.0 (path+file://{TEMP_DIR}/target_features)",
+            "id": "path+file://{TEMP_DIR}/target_features#0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -9569,7 +9569,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/termcolor",
-            "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3",
             "keywords": [
                 "windows",
                 "win",
@@ -9683,7 +9683,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37",
             "keywords": [
                 "error",
                 "error-handling",
@@ -9971,7 +9971,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.37",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10100,7 +10100,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5",
             "keywords": [
                 "unicode",
                 "xid"
@@ -10252,7 +10252,7 @@
                 ]
             },
             "homepage": "https://github.com/unicode-rs/unicode-width",
-            "id": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.10",
             "keywords": [
                 "text",
                 "width",
@@ -10318,7 +10318,7 @@
                 "no_std": []
             },
             "homepage": "https://github.com/unicode-rs/unicode-xid",
-            "id": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.4",
             "keywords": [
                 "text",
                 "unicode",
@@ -10393,7 +10393,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4",
             "keywords": [
                 "version",
                 "rustc",
@@ -10500,7 +10500,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1",
             "keywords": [
                 "webassembly",
                 "wasm"
@@ -10698,7 +10698,7 @@
                 ]
             },
             "homepage": "https://rustwasm.github.io/",
-            "id": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -10939,7 +10939,7 @@
                 "spans": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -11089,7 +11089,7 @@
                 ]
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.33",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -11215,7 +11215,7 @@
                 "xxx_debug_only_print_generated_code": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -11344,7 +11344,7 @@
                 "strict-macro": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -11387,7 +11387,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -14432,7 +14432,7 @@
                 "gpu_texture_usage": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/web-sys/index.html",
-            "id": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -15117,7 +15117,7 @@
                 ]
             },
             "homepage": "https://wgpu.rs/",
-            "id": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu@0.14.0",
             "keywords": [
                 "graphics"
             ],
@@ -15749,7 +15749,7 @@
                 ]
             },
             "homepage": "https://github.com/gfx-rs/wgpu",
-            "id": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-core@0.14.0",
             "keywords": [
                 "graphics"
             ],
@@ -16349,7 +16349,7 @@
                 ]
             },
             "homepage": "https://github.com/gfx-rs/wgpu",
-            "id": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1",
             "keywords": [
                 "graphics"
             ],
@@ -16491,7 +16491,7 @@
                 ]
             },
             "homepage": "https://github.com/gfx-rs/wgpu",
-            "id": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1",
             "keywords": [
                 "graphics"
             ],
@@ -16967,7 +16967,7 @@
                 "xinput": []
             },
             "homepage": null,
-            "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9",
             "keywords": [
                 "windows",
                 "ffi",
@@ -17046,7 +17046,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -17132,7 +17132,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/winapi-util",
-            "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5",
             "keywords": [
                 "windows",
                 "winapi",
@@ -17188,7 +17188,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -18353,7 +18353,7 @@
                 "deprecated": []
             },
             "homepage": null,
-            "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18404,7 +18404,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18468,7 +18468,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18532,7 +18532,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18596,7 +18596,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18660,7 +18660,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18724,7 +18724,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18788,7 +18788,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18845,9 +18845,9 @@
         "nodes": [
             {
                 "dependencies": [
-                    "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.8",
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                 ],
                 "deps": [
                     {
@@ -18858,7 +18858,7 @@
                             }
                         ],
                         "name": "getrandom",
-                        "pkg": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.8"
                     },
                     {
                         "dep_kinds": [
@@ -18868,7 +18868,7 @@
                             }
                         ],
                         "name": "once_cell",
-                        "pkg": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0"
                     },
                     {
                         "dep_kinds": [
@@ -18878,15 +18878,15 @@
                             }
                         ],
                         "name": "version_check",
-                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                     }
                 ],
                 "features": [],
-                "id": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.6"
             },
             {
                 "dependencies": [
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                 ],
                 "deps": [
                     {
@@ -18897,11 +18897,11 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     }
                 ],
                 "features": [],
-                "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5"
             },
             {
                 "dependencies": [],
@@ -18910,11 +18910,11 @@
                     "default",
                     "std"
                 ],
-                "id": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2"
             },
             {
                 "dependencies": [
-                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                 ],
                 "deps": [
                     {
@@ -18925,7 +18925,7 @@
                             }
                         ],
                         "name": "libloading",
-                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                     }
                 ],
                 "features": [
@@ -18934,17 +18934,17 @@
                     "libloading",
                     "loaded"
                 ],
-                "id": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ash@0.37.1+1.3.235"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
             },
             {
                 "dependencies": [
-                    "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3"
                 ],
                 "deps": [
                     {
@@ -18955,14 +18955,14 @@
                             }
                         ],
                         "name": "bit_vec",
-                        "pkg": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3"
             },
             {
                 "dependencies": [],
@@ -18971,7 +18971,7 @@
                     "default",
                     "std"
                 ],
-                "id": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3"
             },
             {
                 "dependencies": [],
@@ -18979,13 +18979,13 @@
                 "features": [
                     "default"
                 ],
-                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6"
             },
             {
                 "dependencies": [],
@@ -18993,7 +18993,7 @@
                 "features": [
                     "default"
                 ],
-                "id": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.11.1"
             },
             {
                 "dependencies": [],
@@ -19002,30 +19002,30 @@
                     "default",
                     "std"
                 ],
-                "id": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#byteorder@1.4.3"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.77"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.1.1"
             },
             {
                 "dependencies": [
-                    "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.10"
                 ],
                 "deps": [
                     {
@@ -19036,7 +19036,7 @@
                             }
                         ],
                         "name": "termcolor",
-                        "pkg": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3"
                     },
                     {
                         "dep_kinds": [
@@ -19046,16 +19046,16 @@
                             }
                         ],
                         "name": "unicode_width",
-                        "pkg": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.10"
                     }
                 ],
                 "features": [],
-                "id": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1"
             },
             {
                 "dependencies": [
-                    "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                 ],
                 "deps": [
                     {
@@ -19066,7 +19066,7 @@
                             }
                         ],
                         "name": "core_foundation_sys",
-                        "pkg": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3"
                     },
                     {
                         "dep_kinds": [
@@ -19076,24 +19076,24 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     }
                 ],
                 "features": [],
-                "id": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.3"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                 ],
                 "deps": [
                     {
@@ -19104,7 +19104,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19114,7 +19114,7 @@
                             }
                         ],
                         "name": "core_foundation",
-                        "pkg": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.3"
                     },
                     {
                         "dep_kinds": [
@@ -19124,7 +19124,7 @@
                             }
                         ],
                         "name": "foreign_types",
-                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19134,23 +19134,23 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     }
                 ],
                 "features": [],
-                "id": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cty@0.2.2"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -19161,7 +19161,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19171,7 +19171,7 @@
                             }
                         ],
                         "name": "libloading",
-                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                     },
                     {
                         "dep_kinds": [
@@ -19181,17 +19181,17 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [
                     "libloading"
                 ],
-                "id": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#d3d12@0.5.0"
             },
             {
                 "dependencies": [
-                    "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
                 ],
                 "deps": [
                     {
@@ -19202,21 +19202,21 @@
                             }
                         ],
                         "name": "foreign_types_shared",
-                        "pkg": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
                     }
                 ],
                 "features": [],
-                "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
             },
             {
                 "dependencies": [
-                    "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#byteorder@1.4.3"
                 ],
                 "deps": [
                     {
@@ -19227,17 +19227,17 @@
                             }
                         ],
                         "name": "byteorder",
-                        "pkg": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#byteorder@1.4.3"
                     }
                 ],
                 "features": [],
-                "id": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
                 ],
                 "deps": [
                     {
@@ -19248,7 +19248,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -19258,7 +19258,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     },
                     {
                         "dep_kinds": [
@@ -19268,18 +19268,18 @@
                             }
                         ],
                         "name": "wasi",
-                        "pkg": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
                     }
                 ],
                 "features": [],
-                "id": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.8"
             },
             {
                 "dependencies": [
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#slotmap@1.0.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                 ],
                 "deps": [
                     {
@@ -19290,7 +19290,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -19300,7 +19300,7 @@
                             }
                         ],
                         "name": "slotmap",
-                        "pkg": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#slotmap@1.0.6"
                     },
                     {
                         "dep_kinds": [
@@ -19310,7 +19310,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -19320,16 +19320,16 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     }
                 ],
                 "features": [],
-                "id": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#glow@0.11.2"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc-types@0.2.0"
                 ],
                 "deps": [
                     {
@@ -19340,7 +19340,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19350,18 +19350,18 @@
                             }
                         ],
                         "name": "gpu_alloc_types",
-                        "pkg": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc-types@0.2.0"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc@0.5.3"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                 ],
                 "deps": [
                     {
@@ -19372,17 +19372,17 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     }
                 ],
                 "features": [],
-                "id": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc-types@0.2.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor-types@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                 ],
                 "deps": [
                     {
@@ -19393,7 +19393,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19403,7 +19403,7 @@
                             }
                         ],
                         "name": "gpu_descriptor_types",
-                        "pkg": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor-types@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -19413,18 +19413,18 @@
                             }
                         ],
                         "name": "hashbrown",
-                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor@0.2.3"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                 ],
                 "deps": [
                     {
@@ -19435,15 +19435,15 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     }
                 ],
                 "features": [],
-                "id": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor-types@0.1.1"
             },
             {
                 "dependencies": [
-                    "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.6"
                 ],
                 "deps": [
                     {
@@ -19454,7 +19454,7 @@
                             }
                         ],
                         "name": "ahash",
-                        "pkg": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.6"
                     }
                 ],
                 "features": [
@@ -19463,18 +19463,18 @@
                     "inline-more",
                     "raw"
                 ],
-                "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hexf-parse@0.2.1"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                 ],
                 "deps": [
                     {
@@ -19485,7 +19485,7 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -19495,17 +19495,17 @@
                             }
                         ],
                         "name": "hashbrown",
-                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                     }
                 ],
                 "features": [
                     "std"
                 ],
-                "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2"
             },
             {
                 "dependencies": [
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                 ],
                 "deps": [
                     {
@@ -19516,17 +19516,17 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     }
                 ],
                 "features": [],
-                "id": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
             },
             {
                 "dependencies": [
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137",
+                    "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.26"
                 ],
                 "deps": [
                     {
@@ -19537,7 +19537,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     },
                     {
                         "dep_kinds": [
@@ -19547,7 +19547,7 @@
                             }
                         ],
                         "name": "libloading",
-                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                     },
                     {
                         "dep_kinds": [
@@ -19557,7 +19557,7 @@
                             }
                         ],
                         "name": "pkg_config",
-                        "pkg": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.26"
                     }
                 ],
                 "features": [
@@ -19574,7 +19574,7 @@
                     "pkg-config",
                     "static"
                 ],
-                "id": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#khronos-egl@4.1.0"
             },
             {
                 "dependencies": [],
@@ -19583,12 +19583,12 @@
                     "default",
                     "std"
                 ],
-                "id": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -19599,7 +19599,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -19609,16 +19609,16 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [],
-                "id": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0"
                 ],
                 "deps": [
                     {
@@ -19629,7 +19629,7 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -19639,15 +19639,15 @@
                             }
                         ],
                         "name": "scopeguard",
-                        "pkg": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0"
                     }
                 ],
                 "features": [],
-                "id": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.9"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                 ],
                 "deps": [
                     {
@@ -19658,15 +19658,15 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     }
                 ],
                 "features": [],
-                "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
             },
             {
                 "dependencies": [
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                 ],
                 "deps": [
                     {
@@ -19677,20 +19677,20 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     }
                 ],
                 "features": [],
-                "id": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#malloc_buf@0.0.6"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7"
                 ],
                 "deps": [
                     {
@@ -19701,7 +19701,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19711,7 +19711,7 @@
                             }
                         ],
                         "name": "block",
-                        "pkg": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6"
                     },
                     {
                         "dep_kinds": [
@@ -19721,7 +19721,7 @@
                             }
                         ],
                         "name": "core_graphics_types",
-                        "pkg": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -19731,7 +19731,7 @@
                             }
                         ],
                         "name": "foreign_types",
-                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19741,7 +19741,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -19751,28 +19751,28 @@
                             }
                         ],
                         "name": "objc",
-                        "pkg": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#metal@0.24.0"
             },
             {
                 "dependencies": [
-                    "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#hexf-parse@0.2.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15",
+                    "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#spirv@0.2.0+1.5.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.4"
                 ],
                 "deps": [
                     {
@@ -19783,7 +19783,7 @@
                             }
                         ],
                         "name": "bit_set",
-                        "pkg": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3"
                     },
                     {
                         "dep_kinds": [
@@ -19793,7 +19793,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19803,7 +19803,7 @@
                             }
                         ],
                         "name": "codespan_reporting",
-                        "pkg": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1"
                     },
                     {
                         "dep_kinds": [
@@ -19813,7 +19813,7 @@
                             }
                         ],
                         "name": "hexf_parse",
-                        "pkg": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hexf-parse@0.2.1"
                     },
                     {
                         "dep_kinds": [
@@ -19823,7 +19823,7 @@
                             }
                         ],
                         "name": "indexmap",
-                        "pkg": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2"
                     },
                     {
                         "dep_kinds": [
@@ -19833,7 +19833,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -19843,7 +19843,7 @@
                             }
                         ],
                         "name": "num_traits",
-                        "pkg": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15"
                     },
                     {
                         "dep_kinds": [
@@ -19853,7 +19853,7 @@
                             }
                         ],
                         "name": "rustc_hash",
-                        "pkg": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -19863,7 +19863,7 @@
                             }
                         ],
                         "name": "spirv",
-                        "pkg": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#spirv@0.2.0+1.5.4"
                     },
                     {
                         "dep_kinds": [
@@ -19873,7 +19873,7 @@
                             }
                         ],
                         "name": "termcolor",
-                        "pkg": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3"
                     },
                     {
                         "dep_kinds": [
@@ -19883,7 +19883,7 @@
                             }
                         ],
                         "name": "thiserror",
-                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37"
                     },
                     {
                         "dep_kinds": [
@@ -19893,7 +19893,7 @@
                             }
                         ],
                         "name": "unicode_xid",
-                        "pkg": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.4"
                     }
                 ],
                 "features": [
@@ -19913,11 +19913,11 @@
                     "wgsl-in",
                     "wgsl-out"
                 ],
-                "id": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                 ],
                 "deps": [
                     {
@@ -19928,19 +19928,19 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15"
             },
             {
                 "dependencies": [
-                    "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#malloc_buf@0.0.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#objc_exception@0.1.2"
                 ],
                 "deps": [
                     {
@@ -19951,7 +19951,7 @@
                             }
                         ],
                         "name": "malloc_buf",
-                        "pkg": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#malloc_buf@0.0.6"
                     },
                     {
                         "dep_kinds": [
@@ -19961,17 +19961,17 @@
                             }
                         ],
                         "name": "objc_exception",
-                        "pkg": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#objc_exception@0.1.2"
                     }
                 ],
                 "features": [
                     "objc_exception"
                 ],
-                "id": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7"
             },
             {
                 "dependencies": [
-                    "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.77"
                 ],
                 "deps": [
                     {
@@ -19982,11 +19982,11 @@
                             }
                         ],
                         "name": "cc",
-                        "pkg": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.77"
                     }
                 ],
                 "features": [],
-                "id": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#objc_exception@0.1.2"
             },
             {
                 "dependencies": [],
@@ -19997,12 +19997,12 @@
                     "race",
                     "std"
                 ],
-                "id": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0"
             },
             {
                 "dependencies": [
-                    "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.4"
                 ],
                 "deps": [
                     {
@@ -20013,7 +20013,7 @@
                             }
                         ],
                         "name": "lock_api",
-                        "pkg": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.9"
                     },
                     {
                         "dep_kinds": [
@@ -20023,21 +20023,21 @@
                             }
                         ],
                         "name": "parking_lot_core",
-                        "pkg": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.4"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137",
+                    "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16",
+                    "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
                 ],
                 "deps": [
                     {
@@ -20048,7 +20048,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -20058,7 +20058,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     },
                     {
                         "dep_kinds": [
@@ -20068,7 +20068,7 @@
                             }
                         ],
                         "name": "syscall",
-                        "pkg": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16"
                     },
                     {
                         "dep_kinds": [
@@ -20078,7 +20078,7 @@
                             }
                         ],
                         "name": "smallvec",
-                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -20088,21 +20088,21 @@
                             }
                         ],
                         "name": "windows_sys",
-                        "pkg": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
                     }
                 ],
                 "features": [],
-                "id": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.26"
             },
             {
                 "dependencies": [
-                    "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
                 ],
                 "deps": [
                     {
@@ -20113,24 +20113,24 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                 ],
                 "deps": [
                     {
@@ -20141,24 +20141,24 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#range-alloc@0.1.2"
             },
             {
                 "dependencies": [
-                    "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cty@0.2.2"
                 ],
                 "deps": [
                     {
@@ -20169,15 +20169,15 @@
                             }
                         ],
                         "name": "cty",
-                        "pkg": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cty@0.2.2"
                     }
                 ],
                 "features": [],
-                "id": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                 ],
                 "deps": [
                     {
@@ -20188,17 +20188,17 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     }
                 ],
                 "features": [],
-                "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#renderdoc-sys@0.7.1"
             },
             {
                 "dependencies": [],
@@ -20207,17 +20207,17 @@
                     "default",
                     "std"
                 ],
-                "id": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0"
             },
             {
                 "dependencies": [
-                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                 ],
                 "deps": [
                     {
@@ -20228,14 +20228,14 @@
                             }
                         ],
                         "name": "version_check",
-                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#slotmap@1.0.6"
             },
             {
                 "dependencies": [],
@@ -20243,12 +20243,12 @@
                 "features": [
                     "union"
                 ],
-                "id": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15"
                 ],
                 "deps": [
                     {
@@ -20259,7 +20259,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -20269,23 +20269,23 @@
                             }
                         ],
                         "name": "num_traits",
-                        "pkg": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15"
                     }
                 ],
                 "features": [],
-                "id": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#spirv@0.2.0+1.5.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
                 ],
                 "deps": [
                     {
@@ -20296,7 +20296,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     },
                     {
                         "dep_kinds": [
@@ -20306,7 +20306,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20316,7 +20316,7 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
                     }
                 ],
                 "features": [
@@ -20330,11 +20330,11 @@
                     "quote",
                     "visit"
                 ],
-                "id": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
             },
             {
                 "dependencies": [
-                    "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu@0.14.0"
                 ],
                 "deps": [
                     {
@@ -20345,15 +20345,15 @@
                             }
                         ],
                         "name": "wgpu",
-                        "pkg": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu@0.14.0"
                     }
                 ],
                 "features": [],
-                "id": "target_features 0.1.0 (path+file://{TEMP_DIR}/target_features)"
+                "id": "path+file://{TEMP_DIR}/target_features#0.1.0"
             },
             {
                 "dependencies": [
-                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                 ],
                 "deps": [
                     {
@@ -20364,15 +20364,15 @@
                             }
                         ],
                         "name": "winapi_util",
-                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                     }
                 ],
                 "features": [],
-                "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3"
             },
             {
                 "dependencies": [
-                    "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.37"
                 ],
                 "deps": [
                     {
@@ -20383,17 +20383,17 @@
                             }
                         ],
                         "name": "thiserror_impl",
-                        "pkg": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.37"
                     }
                 ],
                 "features": [],
-                "id": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
                 ],
                 "deps": [
                     {
@@ -20404,7 +20404,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     },
                     {
                         "dep_kinds": [
@@ -20414,7 +20414,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20424,17 +20424,17 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
                     }
                 ],
                 "features": [],
-                "id": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.37"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
             },
             {
                 "dependencies": [],
@@ -20442,7 +20442,7 @@
                 "features": [
                     "default"
                 ],
-                "id": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.10"
             },
             {
                 "dependencies": [],
@@ -20450,13 +20450,13 @@
                 "features": [
                     "default"
                 ],
-                "id": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
             },
             {
                 "dependencies": [],
@@ -20465,12 +20465,12 @@
                     "default",
                     "std"
                 ],
-                "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20481,7 +20481,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -20491,7 +20491,7 @@
                             }
                         ],
                         "name": "wasm_bindgen_macro",
-                        "pkg": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.83"
                     }
                 ],
                 "features": [
@@ -20499,17 +20499,17 @@
                     "spans",
                     "std"
                 ],
-                "id": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
             },
             {
                 "dependencies": [
-                    "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.11.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20520,7 +20520,7 @@
                             }
                         ],
                         "name": "bumpalo",
-                        "pkg": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.11.1"
                     },
                     {
                         "dep_kinds": [
@@ -20530,7 +20530,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -20540,7 +20540,7 @@
                             }
                         ],
                         "name": "once_cell",
-                        "pkg": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0"
                     },
                     {
                         "dep_kinds": [
@@ -20550,7 +20550,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     },
                     {
                         "dep_kinds": [
@@ -20560,7 +20560,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20570,7 +20570,7 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
                     },
                     {
                         "dep_kinds": [
@@ -20580,20 +20580,20 @@
                             }
                         ],
                         "name": "wasm_bindgen_shared",
-                        "pkg": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
                     }
                 ],
                 "features": [
                     "spans"
                 ],
-                "id": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.83"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                 ],
                 "deps": [
                     {
@@ -20604,7 +20604,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -20614,7 +20614,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -20624,7 +20624,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -20634,16 +20634,16 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     }
                 ],
                 "features": [],
-                "id": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.33"
             },
             {
                 "dependencies": [
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20654,7 +20654,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20664,21 +20664,21 @@
                             }
                         ],
                         "name": "wasm_bindgen_macro_support",
-                        "pkg": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.83"
                     }
                 ],
                 "features": [
                     "spans"
                 ],
-                "id": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.83"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20689,7 +20689,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     },
                     {
                         "dep_kinds": [
@@ -20699,7 +20699,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20709,7 +20709,7 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
                     },
                     {
                         "dep_kinds": [
@@ -20719,7 +20719,7 @@
                             }
                         ],
                         "name": "wasm_bindgen_backend",
-                        "pkg": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -20729,24 +20729,24 @@
                             }
                         ],
                         "name": "wasm_bindgen_shared",
-                        "pkg": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
                     }
                 ],
                 "features": [
                     "spans"
                 ],
-                "id": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.83"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
             },
             {
                 "dependencies": [
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20757,7 +20757,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -20767,7 +20767,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     }
                 ],
                 "features": [
@@ -20947,24 +20947,24 @@
                     "Worker",
                     "gpu_map_mode"
                 ],
-                "id": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
             },
             {
                 "dependencies": [
-                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-core@0.14.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                 ],
                 "deps": [
                     {
@@ -20975,7 +20975,7 @@
                             }
                         ],
                         "name": "arrayvec",
-                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2"
                     },
                     {
                         "dep_kinds": [
@@ -20985,7 +20985,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -20995,7 +20995,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -21005,7 +21005,7 @@
                             }
                         ],
                         "name": "naga",
-                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21019,7 +21019,7 @@
                             }
                         ],
                         "name": "parking_lot",
-                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1"
                     },
                     {
                         "dep_kinds": [
@@ -21029,7 +21029,7 @@
                             }
                         ],
                         "name": "raw_window_handle",
-                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -21039,7 +21039,7 @@
                             }
                         ],
                         "name": "smallvec",
-                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21049,7 +21049,7 @@
                             }
                         ],
                         "name": "static_assertions",
-                        "pkg": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -21059,7 +21059,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -21069,7 +21069,7 @@
                             }
                         ],
                         "name": "wasm_bindgen_futures",
-                        "pkg": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.33"
                     },
                     {
                         "dep_kinds": [
@@ -21079,7 +21079,7 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -21089,7 +21089,7 @@
                             }
                         ],
                         "name": "wgc",
-                        "pkg": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-core@0.14.0"
                     },
                     {
                         "dep_kinds": [
@@ -21099,7 +21099,7 @@
                             }
                         ],
                         "name": "hal",
-                        "pkg": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1"
                     },
                     {
                         "dep_kinds": [
@@ -21109,32 +21109,32 @@
                             }
                         ],
                         "name": "wgt",
-                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu@0.14.0"
             },
             {
                 "dependencies": [
-                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                 ],
                 "deps": [
                     {
@@ -21145,7 +21145,7 @@
                             }
                         ],
                         "name": "arrayvec",
-                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2"
                     },
                     {
                         "dep_kinds": [
@@ -21155,7 +21155,7 @@
                             }
                         ],
                         "name": "bit_vec",
-                        "pkg": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3"
                     },
                     {
                         "dep_kinds": [
@@ -21165,7 +21165,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -21175,7 +21175,7 @@
                             }
                         ],
                         "name": "cfg_aliases",
-                        "pkg": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -21185,7 +21185,7 @@
                             }
                         ],
                         "name": "codespan_reporting",
-                        "pkg": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1"
                     },
                     {
                         "dep_kinds": [
@@ -21195,7 +21195,7 @@
                             }
                         ],
                         "name": "fxhash",
-                        "pkg": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1"
                     },
                     {
                         "dep_kinds": [
@@ -21205,7 +21205,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -21215,7 +21215,7 @@
                             }
                         ],
                         "name": "naga",
-                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21225,7 +21225,7 @@
                             }
                         ],
                         "name": "parking_lot",
-                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1"
                     },
                     {
                         "dep_kinds": [
@@ -21235,7 +21235,7 @@
                             }
                         ],
                         "name": "profiling",
-                        "pkg": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7"
                     },
                     {
                         "dep_kinds": [
@@ -21245,7 +21245,7 @@
                             }
                         ],
                         "name": "raw_window_handle",
-                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -21255,7 +21255,7 @@
                             }
                         ],
                         "name": "smallvec",
-                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21265,7 +21265,7 @@
                             }
                         ],
                         "name": "thiserror",
-                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37"
                     },
                     {
                         "dep_kinds": [
@@ -21275,7 +21275,7 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -21305,7 +21305,7 @@
                             }
                         ],
                         "name": "hal",
-                        "pkg": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1"
                     },
                     {
                         "dep_kinds": [
@@ -21315,48 +21315,48 @@
                             }
                         ],
                         "name": "wgt",
-                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                     }
                 ],
                 "features": [
                     "default",
                     "raw-window-handle"
                 ],
-                "id": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-core@0.14.0"
             },
             {
                 "dependencies": [
-                    "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#ash@0.37.1+1.3.235",
+                    "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#d3d12@0.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#glow@0.11.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc@0.5.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor@0.2.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#khronos-egl@4.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#metal@0.24.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#range-alloc@0.1.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#renderdoc-sys@0.7.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -21367,7 +21367,7 @@
                             }
                         ],
                         "name": "android_system_properties",
-                        "pkg": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5"
                     },
                     {
                         "dep_kinds": [
@@ -21377,7 +21377,7 @@
                             }
                         ],
                         "name": "arrayvec",
-                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2"
                     },
                     {
                         "dep_kinds": [
@@ -21387,7 +21387,7 @@
                             }
                         ],
                         "name": "ash",
-                        "pkg": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ash@0.37.1+1.3.235"
                     },
                     {
                         "dep_kinds": [
@@ -21397,7 +21397,7 @@
                             }
                         ],
                         "name": "bit_set",
-                        "pkg": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3"
                     },
                     {
                         "dep_kinds": [
@@ -21407,7 +21407,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -21417,7 +21417,7 @@
                             }
                         ],
                         "name": "block",
-                        "pkg": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6"
                     },
                     {
                         "dep_kinds": [
@@ -21427,7 +21427,7 @@
                             }
                         ],
                         "name": "core_graphics_types",
-                        "pkg": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -21437,7 +21437,7 @@
                             }
                         ],
                         "name": "native",
-                        "pkg": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#d3d12@0.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -21447,7 +21447,7 @@
                             }
                         ],
                         "name": "foreign_types",
-                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -21457,7 +21457,7 @@
                             }
                         ],
                         "name": "fxhash",
-                        "pkg": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1"
                     },
                     {
                         "dep_kinds": [
@@ -21467,7 +21467,7 @@
                             }
                         ],
                         "name": "glow",
-                        "pkg": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#glow@0.11.2"
                     },
                     {
                         "dep_kinds": [
@@ -21477,7 +21477,7 @@
                             }
                         ],
                         "name": "gpu_alloc",
-                        "pkg": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc@0.5.3"
                     },
                     {
                         "dep_kinds": [
@@ -21487,7 +21487,7 @@
                             }
                         ],
                         "name": "gpu_descriptor",
-                        "pkg": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor@0.2.3"
                     },
                     {
                         "dep_kinds": [
@@ -21497,7 +21497,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -21511,7 +21511,7 @@
                             }
                         ],
                         "name": "egl",
-                        "pkg": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#khronos-egl@4.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -21525,7 +21525,7 @@
                             }
                         ],
                         "name": "libloading",
-                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                     },
                     {
                         "dep_kinds": [
@@ -21535,7 +21535,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -21545,7 +21545,7 @@
                             }
                         ],
                         "name": "mtl",
-                        "pkg": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#metal@0.24.0"
                     },
                     {
                         "dep_kinds": [
@@ -21555,7 +21555,7 @@
                             }
                         ],
                         "name": "naga",
-                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21565,7 +21565,7 @@
                             }
                         ],
                         "name": "objc",
-                        "pkg": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7"
                     },
                     {
                         "dep_kinds": [
@@ -21575,7 +21575,7 @@
                             }
                         ],
                         "name": "parking_lot",
-                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1"
                     },
                     {
                         "dep_kinds": [
@@ -21585,7 +21585,7 @@
                             }
                         ],
                         "name": "profiling",
-                        "pkg": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7"
                     },
                     {
                         "dep_kinds": [
@@ -21595,7 +21595,7 @@
                             }
                         ],
                         "name": "range_alloc",
-                        "pkg": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#range-alloc@0.1.2"
                     },
                     {
                         "dep_kinds": [
@@ -21605,7 +21605,7 @@
                             }
                         ],
                         "name": "raw_window_handle",
-                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -21615,7 +21615,7 @@
                             }
                         ],
                         "name": "renderdoc_sys",
-                        "pkg": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#renderdoc-sys@0.7.1"
                     },
                     {
                         "dep_kinds": [
@@ -21625,7 +21625,7 @@
                             }
                         ],
                         "name": "smallvec",
-                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21635,7 +21635,7 @@
                             }
                         ],
                         "name": "thiserror",
-                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37"
                     },
                     {
                         "dep_kinds": [
@@ -21645,7 +21645,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -21655,7 +21655,7 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -21665,7 +21665,7 @@
                             }
                         ],
                         "name": "wgt",
-                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                     },
                     {
                         "dep_kinds": [
@@ -21675,7 +21675,7 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [
@@ -21701,11 +21701,11 @@
                     "smallvec",
                     "vulkan"
                 ],
-                "id": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                 ],
                 "deps": [
                     {
@@ -21716,16 +21716,16 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     }
                 ],
                 "features": [],
-                "id": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
             },
             {
                 "dependencies": [
-                    "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                 ],
                 "deps": [
                     {
@@ -21736,7 +21736,7 @@
                             }
                         ],
                         "name": "winapi_i686_pc_windows_gnu",
-                        "pkg": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -21746,7 +21746,7 @@
                             }
                         ],
                         "name": "winapi_x86_64_pc_windows_gnu",
-                        "pkg": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                     }
                 ],
                 "features": [
@@ -21782,17 +21782,17 @@
                     "winnt",
                     "winuser"
                 ],
-                "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
             },
             {
                 "dependencies": [
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -21803,27 +21803,27 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [],
-                "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
             },
             {
                 "dependencies": [
-                    "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.0"
                 ],
                 "deps": [
                     {
@@ -21834,7 +21834,7 @@
                             }
                         ],
                         "name": "windows_aarch64_gnullvm",
-                        "pkg": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21848,7 +21848,7 @@
                             }
                         ],
                         "name": "windows_aarch64_msvc",
-                        "pkg": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21862,7 +21862,7 @@
                             }
                         ],
                         "name": "windows_i686_gnu",
-                        "pkg": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21876,7 +21876,7 @@
                             }
                         ],
                         "name": "windows_i686_msvc",
-                        "pkg": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21890,7 +21890,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnu",
-                        "pkg": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21900,7 +21900,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnullvm",
-                        "pkg": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21914,7 +21914,7 @@
                             }
                         ],
                         "name": "windows_x86_64_msvc",
-                        "pkg": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.0"
                     }
                 ],
                 "features": [
@@ -21926,60 +21926,60 @@
                     "Win32_System_WindowsProgramming",
                     "default"
                 ],
-                "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.0"
             }
         ],
-        "root": "target_features 0.1.0 (path+file://{TEMP_DIR}/target_features)"
+        "root": "path+file://{TEMP_DIR}/target_features#0.1.0"
     },
     "target_directory": "{TEMP_DIR}/target_features/target",
     "version": 1,
     "workspace_default_members": [
-        "target_features 0.1.0 (path+file://{TEMP_DIR}/target_features)"
+        "path+file://{TEMP_DIR}/target_features#0.1.0"
     ],
     "workspace_members": [
-        "target_features 0.1.0 (path+file://{TEMP_DIR}/target_features)"
+        "path+file://{TEMP_DIR}/target_features#0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/target_features"
 }

--- a/crate_universe/test_data/metadata/workspace/metadata.json
+++ b/crate_universe/test_data/metadata/workspace/metadata.json
@@ -214,7 +214,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.6",
             "keywords": [
                 "hash",
                 "hasher",
@@ -376,7 +376,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/nical/android_system_properties",
-            "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
             "keywords": [
                 "android"
             ],
@@ -508,7 +508,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2",
             "keywords": [
                 "stack",
                 "vector",
@@ -653,7 +653,7 @@
                 ]
             },
             "homepage": null,
-            "id": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#ash@0.37.1+1.3.235",
             "keywords": [
                 "vulkan",
                 "graphic"
@@ -756,7 +756,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
             "keywords": [
                 "rustc",
                 "build",
@@ -905,7 +905,7 @@
                 ]
             },
             "homepage": "https://github.com/contain-rs/bit-set",
-            "id": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3",
             "keywords": [
                 "data-structures",
                 "bitset"
@@ -1017,7 +1017,7 @@
                 "std": []
             },
             "homepage": "https://github.com/contain-rs/bit-vec",
-            "id": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3",
             "keywords": [
                 "data-structures",
                 "bitvec",
@@ -1192,7 +1192,7 @@
                 ]
             },
             "homepage": "https://github.com/bitflags/bitflags",
-            "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
             "keywords": [
                 "bit",
                 "bitmask",
@@ -1289,7 +1289,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6",
             "keywords": [
                 "blocks",
                 "osx",
@@ -1383,7 +1383,7 @@
                 "default": []
             },
             "homepage": null,
-            "id": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.11.1",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -1498,7 +1498,7 @@
                 "std": []
             },
             "homepage": "https://github.com/BurntSushi/byteorder",
-            "id": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#byteorder@1.4.3",
             "keywords": [
                 "byte",
                 "endian",
@@ -1595,7 +1595,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/cc-rs",
-            "id": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.77",
             "keywords": [
                 "build-dependencies"
             ],
@@ -1746,7 +1746,7 @@
                 ]
             },
             "homepage": "https://github.com/alexcrichton/cfg-if",
-            "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -1806,7 +1806,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/katharostech/cfg_aliases",
-            "id": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.1.1",
             "keywords": [
                 "cfg",
                 "alias",
@@ -1866,7 +1866,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "child 0.1.0 (path+file://{TEMP_DIR}/workspace/child)",
+            "id": "path+file://{TEMP_DIR}/workspace/child#0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -2041,7 +2041,7 @@
                 ]
             },
             "homepage": "https://github.com/brendanzab/codespan",
-            "id": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1",
             "keywords": [],
             "license": "Apache-2.0",
             "license_file": null,
@@ -2238,7 +2238,7 @@
                 ]
             },
             "homepage": "https://github.com/servo/core-foundation-rs",
-            "id": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.3",
             "keywords": [
                 "macos",
                 "framework",
@@ -2308,7 +2308,7 @@
                 "mac_os_10_8_features": []
             },
             "homepage": "https://github.com/servo/core-foundation-rs",
-            "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3",
             "keywords": [],
             "license": "MIT / Apache-2.0",
             "license_file": null,
@@ -2420,7 +2420,7 @@
             "edition": "2015",
             "features": {},
             "homepage": "https://github.com/servo/core-foundation-rs",
-            "id": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1",
             "keywords": [],
             "license": "MIT / Apache-2.0",
             "license_file": null,
@@ -2473,7 +2473,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#cty@0.2.2",
             "keywords": [
                 "c",
                 "types",
@@ -2582,7 +2582,7 @@
                 ]
             },
             "homepage": null,
-            "id": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#d3d12@0.5.0",
             "keywords": [
                 "windows",
                 "graphics"
@@ -2647,7 +2647,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -2690,7 +2690,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -2772,7 +2772,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1",
             "keywords": [
                 "hash"
             ],
@@ -2958,7 +2958,7 @@
                 ]
             },
             "homepage": null,
-            "id": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.8",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3170,7 +3170,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/grovesNL/glow.git",
-            "id": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#glow@0.11.2",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -3296,7 +3296,7 @@
                 ]
             },
             "homepage": "https://github.com/zakarumych/gpu-alloc",
-            "id": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc@0.5.3",
             "keywords": [
                 "gpu",
                 "vulkan",
@@ -3357,7 +3357,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/zakarumych/gpu-alloc",
-            "id": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc-types@0.2.0",
             "keywords": [
                 "gpu",
                 "vulkan",
@@ -3479,7 +3479,7 @@
                 ]
             },
             "homepage": "https://github.com/zakarumych/gpu-descriptor",
-            "id": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor@0.2.3",
             "keywords": [
                 "gpu",
                 "vulkan",
@@ -3539,7 +3539,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/zakarumych/gpu-descriptor",
-            "id": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor-types@0.1.1",
             "keywords": [
                 "gpu",
                 "vulkan",
@@ -3789,7 +3789,7 @@
                 ]
             },
             "homepage": null,
-            "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3",
             "keywords": [
                 "hash",
                 "no_std",
@@ -3932,7 +3932,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/lifthrasiir/hexf",
-            "id": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#hexf-parse@0.2.1",
             "keywords": [],
             "license": "CC0-1.0",
             "license_file": null,
@@ -4171,7 +4171,7 @@
                 "test_low_transition_point": []
             },
             "homepage": null,
-            "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2",
             "keywords": [
                 "hashmap",
                 "no_std"
@@ -4385,7 +4385,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -4577,7 +4577,7 @@
                 ]
             },
             "homepage": null,
-            "id": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#khronos-egl@4.1.0",
             "keywords": [
                 "egl",
                 "gl",
@@ -4726,7 +4726,7 @@
                 ]
             },
             "homepage": "https://github.com/rust-lang/libc",
-            "id": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137",
             "keywords": [
                 "libc",
                 "ffi",
@@ -4866,7 +4866,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4",
             "keywords": [
                 "dlopen",
                 "load",
@@ -5055,7 +5055,7 @@
                 ]
             },
             "homepage": null,
-            "id": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.9",
             "keywords": [
                 "mutex",
                 "rwlock",
@@ -5275,7 +5275,7 @@
                 ]
             },
             "homepage": null,
-            "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
             "keywords": [
                 "logging"
             ],
@@ -5401,7 +5401,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#malloc_buf@0.0.6",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -5598,7 +5598,7 @@
                 "private": []
             },
             "homepage": "https://github.com/gfx-rs/metal-rs",
-            "id": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#metal@0.24.0",
             "keywords": [
                 "metal",
                 "graphics",
@@ -6244,7 +6244,7 @@
                 "wgsl-out": []
             },
             "homepage": "https://github.com/gfx-rs/naga",
-            "id": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0",
             "keywords": [
                 "shader",
                 "SPIR-V",
@@ -6350,7 +6350,7 @@
                 "std": []
             },
             "homepage": "https://github.com/rust-num/num-traits",
-            "id": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15",
             "keywords": [
                 "mathematics",
                 "numerics"
@@ -6465,7 +6465,7 @@
                 "verify_message": []
             },
             "homepage": null,
-            "id": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7",
             "keywords": [
                 "objective-c",
                 "osx",
@@ -6541,7 +6541,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#objc_exception@0.1.2",
             "keywords": [
                 "objective-c",
                 "osx",
@@ -6723,7 +6723,7 @@
                 "unstable": []
             },
             "homepage": null,
-            "id": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0",
             "keywords": [
                 "lazy",
                 "static"
@@ -6906,7 +6906,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "parent 0.1.0 (path+file://{TEMP_DIR}/workspace)",
+            "id": "path+file://{TEMP_DIR}/workspace#parent@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -7020,7 +7020,7 @@
                 ]
             },
             "homepage": null,
-            "id": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1",
             "keywords": [
                 "mutex",
                 "condvar",
@@ -7203,7 +7203,7 @@
                 ]
             },
             "homepage": null,
-            "id": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.4",
             "keywords": [
                 "mutex",
                 "condvar",
@@ -7279,7 +7279,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.26",
             "keywords": [
                 "build-dependencies"
             ],
@@ -7373,7 +7373,7 @@
                 "span-locations": []
             },
             "homepage": null,
-            "id": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
             "keywords": [
                 "macros",
                 "syn"
@@ -7794,7 +7794,7 @@
                 "type-check": []
             },
             "homepage": "https://github.com/aclysma/profiling",
-            "id": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7",
             "keywords": [
                 "performance",
                 "profiling"
@@ -7920,7 +7920,7 @@
                 ]
             },
             "homepage": null,
-            "id": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
             "keywords": [
                 "macros",
                 "syn"
@@ -8018,7 +8018,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/gfx-rs/gfx",
-            "id": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#range-alloc@0.1.2",
             "keywords": [
                 "allocator"
             ],
@@ -8078,7 +8078,7 @@
                 "alloc": []
             },
             "homepage": null,
-            "id": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0",
             "keywords": [
                 "windowing"
             ],
@@ -8146,7 +8146,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16",
             "keywords": [],
             "license": "MIT",
             "license_file": null,
@@ -8189,7 +8189,7 @@
             "edition": "2015",
             "features": {},
             "homepage": "https://github.com/ebkalderon/renderdoc-rs/tree/master/renderdoc-sys",
-            "id": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#renderdoc-sys@0.7.1",
             "keywords": [
                 "ffi",
                 "renderdoc"
@@ -8240,7 +8240,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0",
             "keywords": [
                 "hash",
                 "fxhash",
@@ -8295,7 +8295,7 @@
                 "use_std": []
             },
             "homepage": null,
-            "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0",
             "keywords": [
                 "scope-guard",
                 "defer",
@@ -8462,7 +8462,7 @@
                 "unstable": []
             },
             "homepage": null,
-            "id": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#slotmap@1.0.6",
             "keywords": [
                 "slotmap",
                 "storage",
@@ -8632,7 +8632,7 @@
                 "write": []
             },
             "homepage": null,
-            "id": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
             "keywords": [
                 "small",
                 "vec",
@@ -8785,7 +8785,7 @@
                 ]
             },
             "homepage": null,
-            "id": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#spirv@0.2.0+1.5.4",
             "keywords": [
                 "spirv",
                 "definition",
@@ -8839,7 +8839,7 @@
                 "nightly": []
             },
             "homepage": "https://github.com/nvzqz/static-assertions-rs",
-            "id": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0",
             "keywords": [
                 "assert",
                 "static",
@@ -9101,7 +9101,7 @@
                 "visit-mut": []
             },
             "homepage": null,
-            "id": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104",
             "keywords": [
                 "macros",
                 "syn"
@@ -9610,7 +9610,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/termcolor",
-            "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3",
             "keywords": [
                 "windows",
                 "win",
@@ -9724,7 +9724,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37",
             "keywords": [
                 "error",
                 "error-handling",
@@ -10012,7 +10012,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.37",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -10141,7 +10141,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5",
             "keywords": [
                 "unicode",
                 "xid"
@@ -10293,7 +10293,7 @@
                 ]
             },
             "homepage": "https://github.com/unicode-rs/unicode-width",
-            "id": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.10",
             "keywords": [
                 "text",
                 "width",
@@ -10359,7 +10359,7 @@
                 "no_std": []
             },
             "homepage": "https://github.com/unicode-rs/unicode-xid",
-            "id": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.4",
             "keywords": [
                 "text",
                 "unicode",
@@ -10434,7 +10434,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4",
             "keywords": [
                 "version",
                 "rustc",
@@ -10541,7 +10541,7 @@
                 "std": []
             },
             "homepage": null,
-            "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1",
             "keywords": [
                 "webassembly",
                 "wasm"
@@ -10739,7 +10739,7 @@
                 ]
             },
             "homepage": "https://rustwasm.github.io/",
-            "id": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -10980,7 +10980,7 @@
                 "spans": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -11130,7 +11130,7 @@
                 ]
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.33",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -11256,7 +11256,7 @@
                 "xxx_debug_only_print_generated_code": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -11385,7 +11385,7 @@
                 "strict-macro": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -11428,7 +11428,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://rustwasm.github.io/wasm-bindgen/",
-            "id": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -14473,7 +14473,7 @@
                 "gpu_texture_usage": []
             },
             "homepage": "https://rustwasm.github.io/wasm-bindgen/web-sys/index.html",
-            "id": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60",
             "keywords": [],
             "license": "MIT/Apache-2.0",
             "license_file": null,
@@ -15158,7 +15158,7 @@
                 ]
             },
             "homepage": "https://wgpu.rs/",
-            "id": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu@0.14.0",
             "keywords": [
                 "graphics"
             ],
@@ -15790,7 +15790,7 @@
                 ]
             },
             "homepage": "https://github.com/gfx-rs/wgpu",
-            "id": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-core@0.14.0",
             "keywords": [
                 "graphics"
             ],
@@ -16390,7 +16390,7 @@
                 ]
             },
             "homepage": "https://github.com/gfx-rs/wgpu",
-            "id": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1",
             "keywords": [
                 "graphics"
             ],
@@ -16532,7 +16532,7 @@
                 ]
             },
             "homepage": "https://github.com/gfx-rs/wgpu",
-            "id": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1",
             "keywords": [
                 "graphics"
             ],
@@ -17008,7 +17008,7 @@
                 "xinput": []
             },
             "homepage": null,
-            "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9",
             "keywords": [
                 "windows",
                 "ffi",
@@ -17087,7 +17087,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -17173,7 +17173,7 @@
             "edition": "2018",
             "features": {},
             "homepage": "https://github.com/BurntSushi/winapi-util",
-            "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5",
             "keywords": [
                 "windows",
                 "winapi",
@@ -17229,7 +17229,7 @@
             "edition": "2015",
             "features": {},
             "homepage": null,
-            "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0",
             "keywords": [
                 "windows"
             ],
@@ -18394,7 +18394,7 @@
                 "deprecated": []
             },
             "homepage": null,
-            "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18445,7 +18445,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18509,7 +18509,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18573,7 +18573,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18637,7 +18637,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18701,7 +18701,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18765,7 +18765,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18829,7 +18829,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.0",
             "keywords": [],
             "license": "MIT OR Apache-2.0",
             "license_file": null,
@@ -18886,9 +18886,9 @@
         "nodes": [
             {
                 "dependencies": [
-                    "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.8",
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                 ],
                 "deps": [
                     {
@@ -18899,7 +18899,7 @@
                             }
                         ],
                         "name": "getrandom",
-                        "pkg": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.8"
                     },
                     {
                         "dep_kinds": [
@@ -18909,7 +18909,7 @@
                             }
                         ],
                         "name": "once_cell",
-                        "pkg": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0"
                     },
                     {
                         "dep_kinds": [
@@ -18919,15 +18919,15 @@
                             }
                         ],
                         "name": "version_check",
-                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                     }
                 ],
                 "features": [],
-                "id": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.6"
             },
             {
                 "dependencies": [
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                 ],
                 "deps": [
                     {
@@ -18938,11 +18938,11 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     }
                 ],
                 "features": [],
-                "id": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5"
             },
             {
                 "dependencies": [],
@@ -18951,11 +18951,11 @@
                     "default",
                     "std"
                 ],
-                "id": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2"
             },
             {
                 "dependencies": [
-                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                 ],
                 "deps": [
                     {
@@ -18966,7 +18966,7 @@
                             }
                         ],
                         "name": "libloading",
-                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                     }
                 ],
                 "features": [
@@ -18975,17 +18975,17 @@
                     "libloading",
                     "loaded"
                 ],
-                "id": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#ash@0.37.1+1.3.235"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
             },
             {
                 "dependencies": [
-                    "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3"
                 ],
                 "deps": [
                     {
@@ -18996,14 +18996,14 @@
                             }
                         ],
                         "name": "bit_vec",
-                        "pkg": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3"
             },
             {
                 "dependencies": [],
@@ -19012,7 +19012,7 @@
                     "default",
                     "std"
                 ],
-                "id": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3"
             },
             {
                 "dependencies": [],
@@ -19020,13 +19020,13 @@
                 "features": [
                     "default"
                 ],
-                "id": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6"
             },
             {
                 "dependencies": [],
@@ -19034,7 +19034,7 @@
                 "features": [
                     "default"
                 ],
-                "id": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.11.1"
             },
             {
                 "dependencies": [],
@@ -19043,29 +19043,29 @@
                     "default",
                     "std"
                 ],
-                "id": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#byteorder@1.4.3"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.77"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.1.1"
             },
             {
                 "dependencies": [
-                    "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu@0.14.0"
                 ],
                 "deps": [
                     {
@@ -19076,16 +19076,16 @@
                             }
                         ],
                         "name": "wgpu",
-                        "pkg": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu@0.14.0"
                     }
                 ],
                 "features": [],
-                "id": "child 0.1.0 (path+file://{TEMP_DIR}/workspace/child)"
+                "id": "path+file://{TEMP_DIR}/workspace/child#0.1.0"
             },
             {
                 "dependencies": [
-                    "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.10"
                 ],
                 "deps": [
                     {
@@ -19096,7 +19096,7 @@
                             }
                         ],
                         "name": "termcolor",
-                        "pkg": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3"
                     },
                     {
                         "dep_kinds": [
@@ -19106,16 +19106,16 @@
                             }
                         ],
                         "name": "unicode_width",
-                        "pkg": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.10"
                     }
                 ],
                 "features": [],
-                "id": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1"
             },
             {
                 "dependencies": [
-                    "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                 ],
                 "deps": [
                     {
@@ -19126,7 +19126,7 @@
                             }
                         ],
                         "name": "core_foundation_sys",
-                        "pkg": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3"
                     },
                     {
                         "dep_kinds": [
@@ -19136,24 +19136,24 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     }
                 ],
                 "features": [],
-                "id": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.3"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.3"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                 ],
                 "deps": [
                     {
@@ -19164,7 +19164,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19174,7 +19174,7 @@
                             }
                         ],
                         "name": "core_foundation",
-                        "pkg": "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-foundation@0.9.3"
                     },
                     {
                         "dep_kinds": [
@@ -19184,7 +19184,7 @@
                             }
                         ],
                         "name": "foreign_types",
-                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19194,23 +19194,23 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     }
                 ],
                 "features": [],
-                "id": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#cty@0.2.2"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -19221,7 +19221,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19231,7 +19231,7 @@
                             }
                         ],
                         "name": "libloading",
-                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                     },
                     {
                         "dep_kinds": [
@@ -19241,17 +19241,17 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [
                     "libloading"
                 ],
-                "id": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#d3d12@0.5.0"
             },
             {
                 "dependencies": [
-                    "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
                 ],
                 "deps": [
                     {
@@ -19262,21 +19262,21 @@
                             }
                         ],
                         "name": "foreign_types_shared",
-                        "pkg": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
                     }
                 ],
                 "features": [],
-                "id": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.1.1"
             },
             {
                 "dependencies": [
-                    "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#byteorder@1.4.3"
                 ],
                 "deps": [
                     {
@@ -19287,17 +19287,17 @@
                             }
                         ],
                         "name": "byteorder",
-                        "pkg": "byteorder 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#byteorder@1.4.3"
                     }
                 ],
                 "features": [],
-                "id": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
                 ],
                 "deps": [
                     {
@@ -19308,7 +19308,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -19318,7 +19318,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     },
                     {
                         "dep_kinds": [
@@ -19328,18 +19328,18 @@
                             }
                         ],
                         "name": "wasi",
-                        "pkg": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
                     }
                 ],
                 "features": [],
-                "id": "getrandom 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#getrandom@0.2.8"
             },
             {
                 "dependencies": [
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#slotmap@1.0.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                 ],
                 "deps": [
                     {
@@ -19350,7 +19350,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -19360,7 +19360,7 @@
                             }
                         ],
                         "name": "slotmap",
-                        "pkg": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#slotmap@1.0.6"
                     },
                     {
                         "dep_kinds": [
@@ -19370,7 +19370,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -19380,16 +19380,16 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     }
                 ],
                 "features": [],
-                "id": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#glow@0.11.2"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc-types@0.2.0"
                 ],
                 "deps": [
                     {
@@ -19400,7 +19400,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19410,18 +19410,18 @@
                             }
                         ],
                         "name": "gpu_alloc_types",
-                        "pkg": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc-types@0.2.0"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc@0.5.3"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                 ],
                 "deps": [
                     {
@@ -19432,17 +19432,17 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     }
                 ],
                 "features": [],
-                "id": "gpu-alloc-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc-types@0.2.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor-types@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                 ],
                 "deps": [
                     {
@@ -19453,7 +19453,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19463,7 +19463,7 @@
                             }
                         ],
                         "name": "gpu_descriptor_types",
-                        "pkg": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor-types@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -19473,18 +19473,18 @@
                             }
                         ],
                         "name": "hashbrown",
-                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor@0.2.3"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                 ],
                 "deps": [
                     {
@@ -19495,15 +19495,15 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     }
                 ],
                 "features": [],
-                "id": "gpu-descriptor-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor-types@0.1.1"
             },
             {
                 "dependencies": [
-                    "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.6"
                 ],
                 "deps": [
                     {
@@ -19514,7 +19514,7 @@
                             }
                         ],
                         "name": "ahash",
-                        "pkg": "ahash 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ahash@0.7.6"
                     }
                 ],
                 "features": [
@@ -19523,18 +19523,18 @@
                     "inline-more",
                     "raw"
                 ],
-                "id": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#hexf-parse@0.2.1"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                 ],
                 "deps": [
                     {
@@ -19545,7 +19545,7 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -19555,17 +19555,17 @@
                             }
                         ],
                         "name": "hashbrown",
-                        "pkg": "hashbrown 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3"
                     }
                 ],
                 "features": [
                     "std"
                 ],
-                "id": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2"
             },
             {
                 "dependencies": [
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                 ],
                 "deps": [
                     {
@@ -19576,17 +19576,17 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     }
                 ],
                 "features": [],
-                "id": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
             },
             {
                 "dependencies": [
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137",
+                    "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.26"
                 ],
                 "deps": [
                     {
@@ -19597,7 +19597,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     },
                     {
                         "dep_kinds": [
@@ -19607,7 +19607,7 @@
                             }
                         ],
                         "name": "libloading",
-                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                     },
                     {
                         "dep_kinds": [
@@ -19617,7 +19617,7 @@
                             }
                         ],
                         "name": "pkg_config",
-                        "pkg": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.26"
                     }
                 ],
                 "features": [
@@ -19634,7 +19634,7 @@
                     "pkg-config",
                     "static"
                 ],
-                "id": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#khronos-egl@4.1.0"
             },
             {
                 "dependencies": [],
@@ -19643,12 +19643,12 @@
                     "default",
                     "std"
                 ],
-                "id": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -19659,7 +19659,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -19669,16 +19669,16 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [],
-                "id": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0"
                 ],
                 "deps": [
                     {
@@ -19689,7 +19689,7 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -19699,15 +19699,15 @@
                             }
                         ],
                         "name": "scopeguard",
-                        "pkg": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0"
                     }
                 ],
                 "features": [],
-                "id": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.9"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                 ],
                 "deps": [
                     {
@@ -19718,15 +19718,15 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     }
                 ],
                 "features": [],
-                "id": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
             },
             {
                 "dependencies": [
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                 ],
                 "deps": [
                     {
@@ -19737,20 +19737,20 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     }
                 ],
                 "features": [],
-                "id": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#malloc_buf@0.0.6"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7"
                 ],
                 "deps": [
                     {
@@ -19761,7 +19761,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19771,7 +19771,7 @@
                             }
                         ],
                         "name": "block",
-                        "pkg": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6"
                     },
                     {
                         "dep_kinds": [
@@ -19781,7 +19781,7 @@
                             }
                         ],
                         "name": "core_graphics_types",
-                        "pkg": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -19791,7 +19791,7 @@
                             }
                         ],
                         "name": "foreign_types",
-                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19801,7 +19801,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -19811,28 +19811,28 @@
                             }
                         ],
                         "name": "objc",
-                        "pkg": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#metal@0.24.0"
             },
             {
                 "dependencies": [
-                    "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#hexf-parse@0.2.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15",
+                    "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#spirv@0.2.0+1.5.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.4"
                 ],
                 "deps": [
                     {
@@ -19843,7 +19843,7 @@
                             }
                         ],
                         "name": "bit_set",
-                        "pkg": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3"
                     },
                     {
                         "dep_kinds": [
@@ -19853,7 +19853,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -19863,7 +19863,7 @@
                             }
                         ],
                         "name": "codespan_reporting",
-                        "pkg": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1"
                     },
                     {
                         "dep_kinds": [
@@ -19873,7 +19873,7 @@
                             }
                         ],
                         "name": "hexf_parse",
-                        "pkg": "hexf-parse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#hexf-parse@0.2.1"
                     },
                     {
                         "dep_kinds": [
@@ -19883,7 +19883,7 @@
                             }
                         ],
                         "name": "indexmap",
-                        "pkg": "indexmap 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#indexmap@1.9.2"
                     },
                     {
                         "dep_kinds": [
@@ -19893,7 +19893,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -19903,7 +19903,7 @@
                             }
                         ],
                         "name": "num_traits",
-                        "pkg": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15"
                     },
                     {
                         "dep_kinds": [
@@ -19913,7 +19913,7 @@
                             }
                         ],
                         "name": "rustc_hash",
-                        "pkg": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -19923,7 +19923,7 @@
                             }
                         ],
                         "name": "spirv",
-                        "pkg": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#spirv@0.2.0+1.5.4"
                     },
                     {
                         "dep_kinds": [
@@ -19933,7 +19933,7 @@
                             }
                         ],
                         "name": "termcolor",
-                        "pkg": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3"
                     },
                     {
                         "dep_kinds": [
@@ -19943,7 +19943,7 @@
                             }
                         ],
                         "name": "thiserror",
-                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37"
                     },
                     {
                         "dep_kinds": [
@@ -19953,7 +19953,7 @@
                             }
                         ],
                         "name": "unicode_xid",
-                        "pkg": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.4"
                     }
                 ],
                 "features": [
@@ -19973,11 +19973,11 @@
                     "wgsl-in",
                     "wgsl-out"
                 ],
-                "id": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0"
             },
             {
                 "dependencies": [
-                    "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                 ],
                 "deps": [
                     {
@@ -19988,19 +19988,19 @@
                             }
                         ],
                         "name": "autocfg",
-                        "pkg": "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#autocfg@1.1.0"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15"
             },
             {
                 "dependencies": [
-                    "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#malloc_buf@0.0.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#objc_exception@0.1.2"
                 ],
                 "deps": [
                     {
@@ -20011,7 +20011,7 @@
                             }
                         ],
                         "name": "malloc_buf",
-                        "pkg": "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#malloc_buf@0.0.6"
                     },
                     {
                         "dep_kinds": [
@@ -20021,17 +20021,17 @@
                             }
                         ],
                         "name": "objc_exception",
-                        "pkg": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#objc_exception@0.1.2"
                     }
                 ],
                 "features": [
                     "objc_exception"
                 ],
-                "id": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7"
             },
             {
                 "dependencies": [
-                    "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.77"
                 ],
                 "deps": [
                     {
@@ -20042,11 +20042,11 @@
                             }
                         ],
                         "name": "cc",
-                        "pkg": "cc 1.0.77 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cc@1.0.77"
                     }
                 ],
                 "features": [],
-                "id": "objc_exception 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#objc_exception@0.1.2"
             },
             {
                 "dependencies": [],
@@ -20057,18 +20057,18 @@
                     "race",
                     "std"
                 ],
-                "id": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "parent 0.1.0 (path+file://{TEMP_DIR}/workspace)"
+                "id": "path+file://{TEMP_DIR}/workspace#parent@0.1.0"
             },
             {
                 "dependencies": [
-                    "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.9",
+                    "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.4"
                 ],
                 "deps": [
                     {
@@ -20079,7 +20079,7 @@
                             }
                         ],
                         "name": "lock_api",
-                        "pkg": "lock_api 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#lock_api@0.4.9"
                     },
                     {
                         "dep_kinds": [
@@ -20089,21 +20089,21 @@
                             }
                         ],
                         "name": "parking_lot_core",
-                        "pkg": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.4"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137",
+                    "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16",
+                    "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
                 ],
                 "deps": [
                     {
@@ -20114,7 +20114,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -20124,7 +20124,7 @@
                             }
                         ],
                         "name": "libc",
-                        "pkg": "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.137"
                     },
                     {
                         "dep_kinds": [
@@ -20134,7 +20134,7 @@
                             }
                         ],
                         "name": "syscall",
-                        "pkg": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16"
                     },
                     {
                         "dep_kinds": [
@@ -20144,7 +20144,7 @@
                             }
                         ],
                         "name": "smallvec",
-                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -20154,21 +20154,21 @@
                             }
                         ],
                         "name": "windows_sys",
-                        "pkg": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
                     }
                 ],
                 "features": [],
-                "id": "parking_lot_core 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "pkg-config 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pkg-config@0.3.26"
             },
             {
                 "dependencies": [
-                    "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
                 ],
                 "deps": [
                     {
@@ -20179,24 +20179,24 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                 ],
                 "deps": [
                     {
@@ -20207,24 +20207,24 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     }
                 ],
                 "features": [
                     "default",
                     "proc-macro"
                 ],
-                "id": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#range-alloc@0.1.2"
             },
             {
                 "dependencies": [
-                    "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cty@0.2.2"
                 ],
                 "deps": [
                     {
@@ -20235,15 +20235,15 @@
                             }
                         ],
                         "name": "cty",
-                        "pkg": "cty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cty@0.2.2"
                     }
                 ],
                 "features": [],
-                "id": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                 ],
                 "deps": [
                     {
@@ -20254,17 +20254,17 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     }
                 ],
                 "features": [],
-                "id": "redox_syscall 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#redox_syscall@0.2.16"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#renderdoc-sys@0.7.1"
             },
             {
                 "dependencies": [],
@@ -20273,17 +20273,17 @@
                     "default",
                     "std"
                 ],
-                "id": "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#rustc-hash@1.1.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#scopeguard@1.1.0"
             },
             {
                 "dependencies": [
-                    "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                 ],
                 "deps": [
                     {
@@ -20294,14 +20294,14 @@
                             }
                         ],
                         "name": "version_check",
-                        "pkg": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
                     }
                 ],
                 "features": [
                     "default",
                     "std"
                 ],
-                "id": "slotmap 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#slotmap@1.0.6"
             },
             {
                 "dependencies": [],
@@ -20309,12 +20309,12 @@
                 "features": [
                     "union"
                 ],
-                "id": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15"
                 ],
                 "deps": [
                     {
@@ -20325,7 +20325,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -20335,23 +20335,23 @@
                             }
                         ],
                         "name": "num_traits",
-                        "pkg": "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.15"
                     }
                 ],
                 "features": [],
-                "id": "spirv 0.2.0+1.5.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#spirv@0.2.0+1.5.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
                 ],
                 "deps": [
                     {
@@ -20362,7 +20362,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     },
                     {
                         "dep_kinds": [
@@ -20372,7 +20372,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20382,7 +20382,7 @@
                             }
                         ],
                         "name": "unicode_ident",
-                        "pkg": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
                     }
                 ],
                 "features": [
@@ -20396,11 +20396,11 @@
                     "quote",
                     "visit"
                 ],
-                "id": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
             },
             {
                 "dependencies": [
-                    "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                 ],
                 "deps": [
                     {
@@ -20411,15 +20411,15 @@
                             }
                         ],
                         "name": "winapi_util",
-                        "pkg": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
                     }
                 ],
                 "features": [],
-                "id": "termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#termcolor@1.1.3"
             },
             {
                 "dependencies": [
-                    "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.37"
                 ],
                 "deps": [
                     {
@@ -20430,17 +20430,17 @@
                             }
                         ],
                         "name": "thiserror_impl",
-                        "pkg": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.37"
                     }
                 ],
                 "features": [],
-                "id": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
                 ],
                 "deps": [
                     {
@@ -20451,7 +20451,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     },
                     {
                         "dep_kinds": [
@@ -20461,7 +20461,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20471,17 +20471,17 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
                     }
                 ],
                 "features": [],
-                "id": "thiserror-impl 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.37"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.5"
             },
             {
                 "dependencies": [],
@@ -20489,7 +20489,7 @@
                 "features": [
                     "default"
                 ],
-                "id": "unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-width@0.1.10"
             },
             {
                 "dependencies": [],
@@ -20497,13 +20497,13 @@
                 "features": [
                     "default"
                 ],
-                "id": "unicode-xid 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#unicode-xid@0.2.4"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#version_check@0.9.4"
             },
             {
                 "dependencies": [],
@@ -20512,12 +20512,12 @@
                     "default",
                     "std"
                 ],
-                "id": "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasi@0.11.0+wasi-snapshot-preview1"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20528,7 +20528,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -20538,7 +20538,7 @@
                             }
                         ],
                         "name": "wasm_bindgen_macro",
-                        "pkg": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.83"
                     }
                 ],
                 "features": [
@@ -20546,17 +20546,17 @@
                     "spans",
                     "std"
                 ],
-                "id": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
             },
             {
                 "dependencies": [
-                    "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.11.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20567,7 +20567,7 @@
                             }
                         ],
                         "name": "bumpalo",
-                        "pkg": "bumpalo 3.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bumpalo@3.11.1"
                     },
                     {
                         "dep_kinds": [
@@ -20577,7 +20577,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -20587,7 +20587,7 @@
                             }
                         ],
                         "name": "once_cell",
-                        "pkg": "once_cell 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#once_cell@1.16.0"
                     },
                     {
                         "dep_kinds": [
@@ -20597,7 +20597,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     },
                     {
                         "dep_kinds": [
@@ -20607,7 +20607,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20617,7 +20617,7 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
                     },
                     {
                         "dep_kinds": [
@@ -20627,20 +20627,20 @@
                             }
                         ],
                         "name": "wasm_bindgen_shared",
-                        "pkg": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
                     }
                 ],
                 "features": [
                     "spans"
                 ],
-                "id": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.83"
             },
             {
                 "dependencies": [
-                    "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                 ],
                 "deps": [
                     {
@@ -20651,7 +20651,7 @@
                             }
                         ],
                         "name": "cfg_if",
-                        "pkg": "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.0"
                     },
                     {
                         "dep_kinds": [
@@ -20661,7 +20661,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -20671,7 +20671,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -20681,16 +20681,16 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     }
                 ],
                 "features": [],
-                "id": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.33"
             },
             {
                 "dependencies": [
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20701,7 +20701,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20711,21 +20711,21 @@
                             }
                         ],
                         "name": "wasm_bindgen_macro_support",
-                        "pkg": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.83"
                     }
                 ],
                 "features": [
                     "spans"
                 ],
-                "id": "wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.83"
             },
             {
                 "dependencies": [
-                    "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47",
+                    "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21",
+                    "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20736,7 +20736,7 @@
                             }
                         ],
                         "name": "proc_macro2",
-                        "pkg": "proc-macro2 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.47"
                     },
                     {
                         "dep_kinds": [
@@ -20746,7 +20746,7 @@
                             }
                         ],
                         "name": "quote",
-                        "pkg": "quote 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#quote@1.0.21"
                     },
                     {
                         "dep_kinds": [
@@ -20756,7 +20756,7 @@
                             }
                         ],
                         "name": "syn",
-                        "pkg": "syn 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#syn@1.0.104"
                     },
                     {
                         "dep_kinds": [
@@ -20766,7 +20766,7 @@
                             }
                         ],
                         "name": "wasm_bindgen_backend",
-                        "pkg": "wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -20776,24 +20776,24 @@
                             }
                         ],
                         "name": "wasm_bindgen_shared",
-                        "pkg": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
                     }
                 ],
                 "features": [
                     "spans"
                 ],
-                "id": "wasm-bindgen-macro-support 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.83"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "wasm-bindgen-shared 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.83"
             },
             {
                 "dependencies": [
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                 ],
                 "deps": [
                     {
@@ -20804,7 +20804,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -20814,7 +20814,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     }
                 ],
                 "features": [
@@ -20994,24 +20994,24 @@
                     "Worker",
                     "gpu_map_mode"
                 ],
-                "id": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
             },
             {
                 "dependencies": [
-                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.33",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-core@0.14.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                 ],
                 "deps": [
                     {
@@ -21022,7 +21022,7 @@
                             }
                         ],
                         "name": "arrayvec",
-                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2"
                     },
                     {
                         "dep_kinds": [
@@ -21032,7 +21032,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -21042,7 +21042,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -21052,7 +21052,7 @@
                             }
                         ],
                         "name": "naga",
-                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21066,7 +21066,7 @@
                             }
                         ],
                         "name": "parking_lot",
-                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1"
                     },
                     {
                         "dep_kinds": [
@@ -21076,7 +21076,7 @@
                             }
                         ],
                         "name": "raw_window_handle",
-                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -21086,7 +21086,7 @@
                             }
                         ],
                         "name": "smallvec",
-                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21096,7 +21096,7 @@
                             }
                         ],
                         "name": "static_assertions",
-                        "pkg": "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -21106,7 +21106,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -21116,7 +21116,7 @@
                             }
                         ],
                         "name": "wasm_bindgen_futures",
-                        "pkg": "wasm-bindgen-futures 0.4.33 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.33"
                     },
                     {
                         "dep_kinds": [
@@ -21126,7 +21126,7 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -21136,7 +21136,7 @@
                             }
                         ],
                         "name": "wgc",
-                        "pkg": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-core@0.14.0"
                     },
                     {
                         "dep_kinds": [
@@ -21146,7 +21146,7 @@
                             }
                         ],
                         "name": "hal",
-                        "pkg": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1"
                     },
                     {
                         "dep_kinds": [
@@ -21156,32 +21156,32 @@
                             }
                         ],
                         "name": "wgt",
-                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                     }
                 ],
                 "features": [
                     "default"
                 ],
-                "id": "wgpu 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu@0.14.0"
             },
             {
                 "dependencies": [
-                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                 ],
                 "deps": [
                     {
@@ -21192,7 +21192,7 @@
                             }
                         ],
                         "name": "arrayvec",
-                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2"
                     },
                     {
                         "dep_kinds": [
@@ -21202,7 +21202,7 @@
                             }
                         ],
                         "name": "bit_vec",
-                        "pkg": "bit-vec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3"
                     },
                     {
                         "dep_kinds": [
@@ -21212,7 +21212,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -21222,7 +21222,7 @@
                             }
                         ],
                         "name": "cfg_aliases",
-                        "pkg": "cfg_aliases 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg_aliases@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -21232,7 +21232,7 @@
                             }
                         ],
                         "name": "codespan_reporting",
-                        "pkg": "codespan-reporting 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#codespan-reporting@0.11.1"
                     },
                     {
                         "dep_kinds": [
@@ -21242,7 +21242,7 @@
                             }
                         ],
                         "name": "fxhash",
-                        "pkg": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1"
                     },
                     {
                         "dep_kinds": [
@@ -21252,7 +21252,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -21262,7 +21262,7 @@
                             }
                         ],
                         "name": "naga",
-                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21272,7 +21272,7 @@
                             }
                         ],
                         "name": "parking_lot",
-                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1"
                     },
                     {
                         "dep_kinds": [
@@ -21282,7 +21282,7 @@
                             }
                         ],
                         "name": "profiling",
-                        "pkg": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7"
                     },
                     {
                         "dep_kinds": [
@@ -21292,7 +21292,7 @@
                             }
                         ],
                         "name": "raw_window_handle",
-                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -21302,7 +21302,7 @@
                             }
                         ],
                         "name": "smallvec",
-                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21312,7 +21312,7 @@
                             }
                         ],
                         "name": "thiserror",
-                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37"
                     },
                     {
                         "dep_kinds": [
@@ -21322,7 +21322,7 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -21352,7 +21352,7 @@
                             }
                         ],
                         "name": "hal",
-                        "pkg": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1"
                     },
                     {
                         "dep_kinds": [
@@ -21362,48 +21362,48 @@
                             }
                         ],
                         "name": "wgt",
-                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                     }
                 ],
                 "features": [
                     "default",
                     "raw-window-handle"
                 ],
-                "id": "wgpu-core 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-core@0.14.0"
             },
             {
                 "dependencies": [
-                    "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5",
+                    "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#ash@0.37.1+1.3.235",
+                    "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6",
+                    "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#d3d12@0.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#glow@0.11.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc@0.5.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor@0.2.3",
+                    "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#khronos-egl@4.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4",
+                    "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17",
+                    "registry+https://github.com/rust-lang/crates.io-index#metal@0.24.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7",
+                    "registry+https://github.com/rust-lang/crates.io-index#range-alloc@0.1.2",
+                    "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#renderdoc-sys@0.7.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37",
+                    "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83",
+                    "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60",
+                    "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -21414,7 +21414,7 @@
                             }
                         ],
                         "name": "android_system_properties",
-                        "pkg": "android_system_properties 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5"
                     },
                     {
                         "dep_kinds": [
@@ -21424,7 +21424,7 @@
                             }
                         ],
                         "name": "arrayvec",
-                        "pkg": "arrayvec 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#arrayvec@0.7.2"
                     },
                     {
                         "dep_kinds": [
@@ -21434,7 +21434,7 @@
                             }
                         ],
                         "name": "ash",
-                        "pkg": "ash 0.37.1+1.3.235 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#ash@0.37.1+1.3.235"
                     },
                     {
                         "dep_kinds": [
@@ -21444,7 +21444,7 @@
                             }
                         ],
                         "name": "bit_set",
-                        "pkg": "bit-set 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bit-set@0.5.3"
                     },
                     {
                         "dep_kinds": [
@@ -21454,7 +21454,7 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -21464,7 +21464,7 @@
                             }
                         ],
                         "name": "block",
-                        "pkg": "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#block@0.1.6"
                     },
                     {
                         "dep_kinds": [
@@ -21474,7 +21474,7 @@
                             }
                         ],
                         "name": "core_graphics_types",
-                        "pkg": "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#core-graphics-types@0.1.1"
                     },
                     {
                         "dep_kinds": [
@@ -21484,7 +21484,7 @@
                             }
                         ],
                         "name": "native",
-                        "pkg": "d3d12 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#d3d12@0.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -21494,7 +21494,7 @@
                             }
                         ],
                         "name": "foreign_types",
-                        "pkg": "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#foreign-types@0.3.2"
                     },
                     {
                         "dep_kinds": [
@@ -21504,7 +21504,7 @@
                             }
                         ],
                         "name": "fxhash",
-                        "pkg": "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#fxhash@0.2.1"
                     },
                     {
                         "dep_kinds": [
@@ -21514,7 +21514,7 @@
                             }
                         ],
                         "name": "glow",
-                        "pkg": "glow 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#glow@0.11.2"
                     },
                     {
                         "dep_kinds": [
@@ -21524,7 +21524,7 @@
                             }
                         ],
                         "name": "gpu_alloc",
-                        "pkg": "gpu-alloc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#gpu-alloc@0.5.3"
                     },
                     {
                         "dep_kinds": [
@@ -21534,7 +21534,7 @@
                             }
                         ],
                         "name": "gpu_descriptor",
-                        "pkg": "gpu-descriptor 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#gpu-descriptor@0.2.3"
                     },
                     {
                         "dep_kinds": [
@@ -21544,7 +21544,7 @@
                             }
                         ],
                         "name": "js_sys",
-                        "pkg": "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#js-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -21558,7 +21558,7 @@
                             }
                         ],
                         "name": "egl",
-                        "pkg": "khronos-egl 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#khronos-egl@4.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -21572,7 +21572,7 @@
                             }
                         ],
                         "name": "libloading",
-                        "pkg": "libloading 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#libloading@0.7.4"
                     },
                     {
                         "dep_kinds": [
@@ -21582,7 +21582,7 @@
                             }
                         ],
                         "name": "log",
-                        "pkg": "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#log@0.4.17"
                     },
                     {
                         "dep_kinds": [
@@ -21592,7 +21592,7 @@
                             }
                         ],
                         "name": "mtl",
-                        "pkg": "metal 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#metal@0.24.0"
                     },
                     {
                         "dep_kinds": [
@@ -21602,7 +21602,7 @@
                             }
                         ],
                         "name": "naga",
-                        "pkg": "naga 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#naga@0.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21612,7 +21612,7 @@
                             }
                         ],
                         "name": "objc",
-                        "pkg": "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#objc@0.2.7"
                     },
                     {
                         "dep_kinds": [
@@ -21622,7 +21622,7 @@
                             }
                         ],
                         "name": "parking_lot",
-                        "pkg": "parking_lot 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#parking_lot@0.12.1"
                     },
                     {
                         "dep_kinds": [
@@ -21632,7 +21632,7 @@
                             }
                         ],
                         "name": "profiling",
-                        "pkg": "profiling 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#profiling@1.0.7"
                     },
                     {
                         "dep_kinds": [
@@ -21642,7 +21642,7 @@
                             }
                         ],
                         "name": "range_alloc",
-                        "pkg": "range-alloc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#range-alloc@0.1.2"
                     },
                     {
                         "dep_kinds": [
@@ -21652,7 +21652,7 @@
                             }
                         ],
                         "name": "raw_window_handle",
-                        "pkg": "raw-window-handle 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#raw-window-handle@0.5.0"
                     },
                     {
                         "dep_kinds": [
@@ -21662,7 +21662,7 @@
                             }
                         ],
                         "name": "renderdoc_sys",
-                        "pkg": "renderdoc-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#renderdoc-sys@0.7.1"
                     },
                     {
                         "dep_kinds": [
@@ -21672,7 +21672,7 @@
                             }
                         ],
                         "name": "smallvec",
-                        "pkg": "smallvec 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.10.0"
                     },
                     {
                         "dep_kinds": [
@@ -21682,7 +21682,7 @@
                             }
                         ],
                         "name": "thiserror",
-                        "pkg": "thiserror 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#thiserror@1.0.37"
                     },
                     {
                         "dep_kinds": [
@@ -21692,7 +21692,7 @@
                             }
                         ],
                         "name": "wasm_bindgen",
-                        "pkg": "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.83"
                     },
                     {
                         "dep_kinds": [
@@ -21702,7 +21702,7 @@
                             }
                         ],
                         "name": "web_sys",
-                        "pkg": "web-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#web-sys@0.3.60"
                     },
                     {
                         "dep_kinds": [
@@ -21712,7 +21712,7 @@
                             }
                         ],
                         "name": "wgt",
-                        "pkg": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
                     },
                     {
                         "dep_kinds": [
@@ -21722,7 +21722,7 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [
@@ -21748,11 +21748,11 @@
                     "smallvec",
                     "vulkan"
                 ],
-                "id": "wgpu-hal 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-hal@0.14.1"
             },
             {
                 "dependencies": [
-                    "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                 ],
                 "deps": [
                     {
@@ -21763,16 +21763,16 @@
                             }
                         ],
                         "name": "bitflags",
-                        "pkg": "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bitflags@1.3.2"
                     }
                 ],
                 "features": [],
-                "id": "wgpu-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#wgpu-types@0.14.1"
             },
             {
                 "dependencies": [
-                    "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                 ],
                 "deps": [
                     {
@@ -21783,7 +21783,7 @@
                             }
                         ],
                         "name": "winapi_i686_pc_windows_gnu",
-                        "pkg": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
                     },
                     {
                         "dep_kinds": [
@@ -21793,7 +21793,7 @@
                             }
                         ],
                         "name": "winapi_x86_64_pc_windows_gnu",
-                        "pkg": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
                     }
                 ],
                 "features": [
@@ -21829,17 +21829,17 @@
                     "winnt",
                     "winuser"
                 ],
-                "id": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0"
             },
             {
                 "dependencies": [
-                    "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                 ],
                 "deps": [
                     {
@@ -21850,27 +21850,27 @@
                             }
                         ],
                         "name": "winapi",
-                        "pkg": "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.3.9"
                     }
                 ],
                 "features": [],
-                "id": "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-util@0.1.5"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0"
             },
             {
                 "dependencies": [
-                    "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.0"
                 ],
                 "deps": [
                     {
@@ -21881,7 +21881,7 @@
                             }
                         ],
                         "name": "windows_aarch64_gnullvm",
-                        "pkg": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21895,7 +21895,7 @@
                             }
                         ],
                         "name": "windows_aarch64_msvc",
-                        "pkg": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21909,7 +21909,7 @@
                             }
                         ],
                         "name": "windows_i686_gnu",
-                        "pkg": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21923,7 +21923,7 @@
                             }
                         ],
                         "name": "windows_i686_msvc",
-                        "pkg": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21937,7 +21937,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnu",
-                        "pkg": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21947,7 +21947,7 @@
                             }
                         ],
                         "name": "windows_x86_64_gnullvm",
-                        "pkg": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.0"
                     },
                     {
                         "dep_kinds": [
@@ -21961,7 +21961,7 @@
                             }
                         ],
                         "name": "windows_x86_64_msvc",
-                        "pkg": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.0"
                     }
                 ],
                 "features": [
@@ -21973,61 +21973,61 @@
                     "Win32_System_WindowsProgramming",
                     "default"
                 ],
-                "id": "windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows-sys@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_aarch64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_i686_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnu 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_gnullvm 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "windows_x86_64_msvc 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.0"
             }
         ],
-        "root": "parent 0.1.0 (path+file://{TEMP_DIR}/workspace)"
+        "root": "path+file://{TEMP_DIR}/workspace#parent@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/workspace/target",
     "version": 1,
     "workspace_default_members": [
-        "parent 0.1.0 (path+file://{TEMP_DIR}/workspace)"
+        "path+file://{TEMP_DIR}/workspace#parent@0.1.0"
     ],
     "workspace_members": [
-        "child 0.1.0 (path+file://{TEMP_DIR}/workspace/child)",
-        "parent 0.1.0 (path+file://{TEMP_DIR}/workspace)"
+        "path+file://{TEMP_DIR}/workspace/child#0.1.0",
+        "path+file://{TEMP_DIR}/workspace#parent@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/workspace"
 }

--- a/crate_universe/test_data/metadata/workspace_path/metadata.json
+++ b/crate_universe/test_data/metadata/workspace_path/metadata.json
@@ -11,7 +11,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "child_a 0.1.0 (path+file://{TEMP_DIR}/workspace_path/child_a)",
+            "id": "path+file://{TEMP_DIR}/workspace_path/child_a#0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -66,7 +66,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "child_b 0.1.0 (path+file://{TEMP_DIR}/workspace_path/child_b)",
+            "id": "path+file://{TEMP_DIR}/workspace_path/child_b#0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -107,7 +107,7 @@
             "edition": "2018",
             "features": {},
             "homepage": null,
-            "id": "parent 0.1.0 (path+file://{TEMP_DIR}/workspace_path)",
+            "id": "path+file://{TEMP_DIR}/workspace_path#parent@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -145,11 +145,11 @@
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "child_a 0.1.0 (path+file://{TEMP_DIR}/workspace_path/child_a)"
+                "id": "path+file://{TEMP_DIR}/workspace_path/child_a#0.1.0"
             },
             {
                 "dependencies": [
-                    "child_a 0.1.0 (path+file://{TEMP_DIR}/workspace_path/child_a)"
+                    "path+file://{TEMP_DIR}/workspace_path/child_a#0.1.0"
                 ],
                 "deps": [
                     {
@@ -160,30 +160,30 @@
                             }
                         ],
                         "name": "child_a",
-                        "pkg": "child_a 0.1.0 (path+file://{TEMP_DIR}/workspace_path/child_a)"
+                        "pkg": "path+file://{TEMP_DIR}/workspace_path/child_a#0.1.0"
                     }
                 ],
                 "features": [],
-                "id": "child_b 0.1.0 (path+file://{TEMP_DIR}/workspace_path/child_b)"
+                "id": "path+file://{TEMP_DIR}/workspace_path/child_b#0.1.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "parent 0.1.0 (path+file://{TEMP_DIR}/workspace_path)"
+                "id": "path+file://{TEMP_DIR}/workspace_path#parent@0.1.0"
             }
         ],
-        "root": "parent 0.1.0 (path+file://{TEMP_DIR}/workspace_path)"
+        "root": "path+file://{TEMP_DIR}/workspace_path#parent@0.1.0"
     },
     "target_directory": "{TEMP_DIR}/workspace_path/target",
     "version": 1,
     "workspace_default_members": [
-        "parent 0.1.0 (path+file://{TEMP_DIR}/workspace_path)"
+        "path+file://{TEMP_DIR}/workspace_path#parent@0.1.0"
     ],
     "workspace_members": [
-        "child_a 0.1.0 (path+file://{TEMP_DIR}/workspace_path/child_a)",
-        "child_b 0.1.0 (path+file://{TEMP_DIR}/workspace_path/child_b)",
-        "parent 0.1.0 (path+file://{TEMP_DIR}/workspace_path)"
+        "path+file://{TEMP_DIR}/workspace_path/child_a#0.1.0",
+        "path+file://{TEMP_DIR}/workspace_path/child_b#0.1.0",
+        "path+file://{TEMP_DIR}/workspace_path#parent@0.1.0"
     ],
     "workspace_root": "{TEMP_DIR}/workspace_path"
 }


### PR DESCRIPTION
This change also updates tests to account for the change in registry reprs in Cargo.lock files. E.g.
```
tracing 0.2.0 (git+https://github.com/tokio-rs/tracing.git?branch=master#1e09e50e8d15580b5929adbade9c782a6833e4a0
```
to
```
git+https://github.com/tokio-rs/tracing.git?branch=master#tracing@0.2.0
```