### PR TITLE
Keep default_features parity from bzlmod to workspace

### DIFF
--- a/crate_universe/extension.bzl
+++ b/crate_universe/extension.bzl
@@ -224,7 +224,7 @@ def _package_to_json(p):
     return json.encode({
         k: v
         for k, v in structs.to_dict(p).items()
-        if v
+        if v or type(v) == "bool"
     })
 
 def _get_generator(module_ctx):
@@ -515,6 +515,7 @@ _spec = tag_class(
         ),
         default_features = attr.bool(
             doc = "Maps to the `default-features` flag.",
+            default = True,
         ),
         features = attr.string_list(
             doc = "A list of features to use for the crate.",

--- a/crate_universe/extension.bzl
+++ b/crate_universe/extension.bzl
@@ -224,7 +224,7 @@ def _package_to_json(p):
     return json.encode({
         k: v
         for k, v in structs.to_dict(p).items()
-        if v or type(v) == "bool"
+        if v or k == "default_features"
     })
 
 def _get_generator(module_ctx):

--- a/examples/bzlmod/hello_world_no_cargo/BUILD.bazel
+++ b/examples/bzlmod/hello_world_no_cargo/BUILD.bazel
@@ -7,5 +7,6 @@ rust_binary(
     srcs = ["src/main.rs"],
     deps = [
         "@crates//:anyhow",
+        "@crates//:uuid",
     ],
 )

--- a/examples/bzlmod/hello_world_no_cargo/MODULE.bazel
+++ b/examples/bzlmod/hello_world_no_cargo/MODULE.bazel
@@ -22,5 +22,13 @@ crate.spec(
     package = "anyhow",
     version = "1.0.77",
 )
+crate.spec(
+    # NOTE: v4 is not available in no-std and by default, std is enabled in uuid
+    # so if this fails to build, then default_features default value is False
+    # see https://docs.rs/uuid/1.8.0/uuid/#embedded
+    features = ["v4"],
+    package = "uuid",
+    version = "1.8.0",
+)
 crate.from_specs()
 use_repo(crate, "crates")

--- a/examples/bzlmod/hello_world_no_cargo/src/main.rs
+++ b/examples/bzlmod/hello_world_no_cargo/src/main.rs
@@ -14,5 +14,6 @@
 
 fn main() -> anyhow::Result<()> {
     println!("Hello, world!");
+    println!("{}", uuid::Uuid::new_v4());
     Ok(())
 }


### PR DESCRIPTION
This PR contains two changes:
1. Set the default value of `crate.spec` `default_features` to `True` as `WORKSPACE` handles it.
2. Prevent filtering out `default_features` during package json encoding as both truthy and falsy values for booleans are significant.