### PR TITLE
Fix rust module extension for Bazel pre-7.1

### DIFF
--- a/examples/bzlmod/hello_world/MODULE.bazel.lock
+++ b/examples/bzlmod/hello_world/MODULE.bazel.lock
@@ -13,7 +13,7 @@
     "compatibilityMode": "ERROR"
   },
   "localOverrideHashes": {
-    "rules_rust": "56475a7f828566bdf555201daddb14a5715fd1a7ac2cc8fa2d4f799daab22344",
+    "rules_rust": "b01d8fa2d0cadc2b4b427e5008dfef525aa9e17ddb781848b17f0af39e09c076",
     "bazel_tools": "1ae69322ac3823527337acf02016e8ee95813d8d356f47060255b8956fa642f0"
   },
   "moduleDepGraph": {
@@ -196,7 +196,7 @@
     },
     "rules_rust@_": {
       "name": "rules_rust",
-      "version": "0.41.1",
+      "version": "0.42.0",
       "key": "rules_rust@_",
       "repoName": "rules_rust",
       "executionPlatformsToRegister": [],
@@ -2072,7 +2072,7 @@
     },
     "@@rules_rust~//crate_universe/private/module_extensions:cargo_bazel_bootstrap.bzl%cargo_bazel_bootstrap": {
       "general": {
-        "bzlTransitiveDigest": "Df2Y27xShS852nGbsclIrZvcOvzlpSuFnXEwT4SCc4A=",
+        "bzlTransitiveDigest": "zFgJRyUaZ1w/hZaKm5My/VV8ctiOIVx9211GvlUmOt4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2131,7 +2131,7 @@
               "binary": "cargo-bazel",
               "cargo_lockfile": "@@rules_rust~//crate_universe:Cargo.lock",
               "cargo_toml": "@@rules_rust~//crate_universe:Cargo.toml",
-              "version": "1.77.0",
+              "version": "1.77.2",
               "timeout": 900,
               "rust_toolchain_cargo_template": "@rust_host_tools//:bin/{tool}",
               "rust_toolchain_rustc_template": "@rust_host_tools//:bin/{tool}"
@@ -2159,7 +2159,7 @@
     },
     "@@rules_rust~//rust:extensions.bzl%rust": {
       "general": {
-        "bzlTransitiveDigest": "7N6Kxf2YsvfZ6kQJr3++b0u7nl0qm+uaqjzhp5IhQcg=",
+        "bzlTransitiveDigest": "fc5384f0cxBOMkpjo3iXF+BV2bz6qjpFTzUqS8we/JM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2172,9 +2172,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-unknown-linux-gnu",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2196,8 +2196,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2219,8 +2219,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2242,8 +2242,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2265,8 +2265,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2321,8 +2321,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2335,6 +2335,20 @@
               "auth": {}
             }
           },
+          "rustfmt_nightly-2024-04-09__x86_64-unknown-freebsd": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-04-09__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:freebsd"
+              ],
+              "target_compatible_with": []
+            }
+          },
           "rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
@@ -2344,8 +2358,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-pc-windows-msvc",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2400,8 +2414,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-pc-windows-msvc",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2422,9 +2436,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2435,6 +2449,20 @@
                 "https://static.rust-lang.org/dist/{}.tar.xz"
               ],
               "auth": {}
+            }
+          },
+          "rustfmt_nightly-2024-04-09__x86_64-unknown-freebsd_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-04-09",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "exec_triple": "x86_64-unknown-freebsd"
             }
           },
           "rust_linux_x86_64__wasm32-unknown-unknown__nightly": {
@@ -2540,9 +2568,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-pc-windows-msvc",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2583,8 +2611,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2595,6 +2623,20 @@
                 "https://static.rust-lang.org/dist/{}.tar.xz"
               ],
               "auth": {}
+            }
+          },
+          "rustfmt_nightly-2024-04-09__x86_64-pc-windows-msvc_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-04-09",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "exec_triple": "x86_64-pc-windows-msvc"
             }
           },
           "rust_linux_aarch64__wasm32-wasi__stable": {
@@ -2616,17 +2658,13 @@
               ]
             }
           },
-          "rustfmt_nightly-2024-03-21__x86_64-pc-windows-msvc": {
+          "rust_analyzer_1.77.2": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-03-21__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:windows"
-              ],
+              "toolchain": "@rust_analyzer_1.77.2_tools//:rust_analyzer_toolchain",
+              "toolchain_type": "@rules_rust//rust/rust_analyzer:toolchain_type",
+              "exec_compatible_with": [],
               "target_compatible_with": []
             }
           },
@@ -2638,9 +2676,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-apple-darwin",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2653,30 +2691,6 @@
               "auth": {}
             }
           },
-          "rustfmt_nightly-2024-03-21__x86_64-pc-windows-msvc_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-03-21",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "exec_triple": "x86_64-pc-windows-msvc"
-            }
-          },
-          "rust_analyzer_1.77.0": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rust_analyzer_1.77.0_tools//:rust_analyzer_toolchain",
-              "toolchain_type": "@rules_rust//rust/rust_analyzer:toolchain_type",
-              "exec_compatible_with": [],
-              "target_compatible_with": []
-            }
-          },
           "rust_linux_x86_64__wasm32-unknown-unknown__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
@@ -2686,8 +2700,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2727,9 +2741,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2750,9 +2764,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2774,8 +2788,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2821,20 +2835,6 @@
               ]
             }
           },
-          "rustfmt_nightly-2024-03-21__x86_64-unknown-linux-gnu_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-03-21",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "exec_triple": "x86_64-unknown-linux-gnu"
-            }
-          },
           "rust_windows_x86_64__wasm32-unknown-unknown__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
@@ -2862,9 +2862,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2896,6 +2896,20 @@
               ]
             }
           },
+          "rustfmt_nightly-2024-04-09__aarch64-unknown-linux-gnu": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-04-09__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
+            }
+          },
           "rust_windows_x86_64__wasm32-wasi__nightly_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
@@ -2904,9 +2918,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -2936,20 +2950,6 @@
                 "@platforms//cpu:x86_64",
                 "@platforms//os:windows"
               ]
-            }
-          },
-          "rustfmt_nightly-2024-03-21__x86_64-unknown-freebsd_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-03-21",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "exec_triple": "x86_64-unknown-freebsd"
             }
           },
           "rust_linux_x86_64__wasm32-wasi__stable": {
@@ -2998,9 +2998,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-apple-darwin",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -3022,8 +3022,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-apple-darwin",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -3045,26 +3045,13 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
               "extra_exec_rustc_flags": [],
               "opt_level": {},
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {}
-            }
-          },
-          "rust_analyzer_1.77.0_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rust_analyzer_toolchain_tools_repository",
-            "attributes": {
-              "version": "1.77.0",
-              "iso_date": "",
               "sha256s": {},
               "urls": [
                 "https://static.rust-lang.org/dist/{}.tar.xz"
@@ -3080,9 +3067,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-unknown-linux-gnu",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -3112,6 +3099,20 @@
                 "@platforms//cpu:wasm32",
                 "@platforms//os:wasi"
               ]
+            }
+          },
+          "rustfmt_nightly-2024-04-09__aarch64-pc-windows-msvc_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-04-09",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "exec_triple": "aarch64-pc-windows-msvc"
             }
           },
           "rust_windows_aarch64__wasm32-unknown-unknown__stable": {
@@ -3193,9 +3194,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-unknown-freebsd",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -3227,6 +3228,34 @@
               ]
             }
           },
+          "rustfmt_nightly-2024-04-09__x86_64-pc-windows-msvc": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-04-09__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rustfmt_nightly-2024-04-09__x86_64-unknown-linux-gnu_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-04-09",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "exec_triple": "x86_64-unknown-linux-gnu"
+            }
+          },
           "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
@@ -3244,20 +3273,6 @@
                 "@platforms//cpu:aarch64",
                 "@platforms//os:windows"
               ]
-            }
-          },
-          "rustfmt_nightly-2024-03-21__aarch64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-03-21__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": []
             }
           },
           "rust_darwin_aarch64__aarch64-apple-darwin__nightly": {
@@ -3287,9 +3302,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -3302,182 +3317,168 @@
               "auth": {}
             }
           },
-          "rustfmt_nightly-2024-03-21__x86_64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-03-21__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:linux"
-              ],
-              "target_compatible_with": []
-            }
-          },
           "rust_toolchains": {
             "bzlFile": "@@rules_rust~//rust/private:repository_utils.bzl",
             "ruleClassName": "toolchain_repository_hub",
             "attributes": {
               "toolchain_names": [
-                "rust_analyzer_1.77.0",
+                "rust_analyzer_1.77.2",
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable",
                 "rust_darwin_aarch64__aarch64-apple-darwin__nightly",
                 "rust_darwin_aarch64__wasm32-unknown-unknown__stable",
                 "rust_darwin_aarch64__wasm32-unknown-unknown__nightly",
                 "rust_darwin_aarch64__wasm32-wasi__stable",
                 "rust_darwin_aarch64__wasm32-wasi__nightly",
-                "rustfmt_nightly-2024-03-21__aarch64-apple-darwin",
+                "rustfmt_nightly-2024-04-09__aarch64-apple-darwin",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly",
                 "rust_windows_aarch64__wasm32-unknown-unknown__stable",
                 "rust_windows_aarch64__wasm32-unknown-unknown__nightly",
                 "rust_windows_aarch64__wasm32-wasi__stable",
                 "rust_windows_aarch64__wasm32-wasi__nightly",
-                "rustfmt_nightly-2024-03-21__aarch64-pc-windows-msvc",
+                "rustfmt_nightly-2024-04-09__aarch64-pc-windows-msvc",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly",
                 "rust_linux_aarch64__wasm32-unknown-unknown__stable",
                 "rust_linux_aarch64__wasm32-unknown-unknown__nightly",
                 "rust_linux_aarch64__wasm32-wasi__stable",
                 "rust_linux_aarch64__wasm32-wasi__nightly",
-                "rustfmt_nightly-2024-03-21__aarch64-unknown-linux-gnu",
+                "rustfmt_nightly-2024-04-09__aarch64-unknown-linux-gnu",
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable",
                 "rust_darwin_x86_64__x86_64-apple-darwin__nightly",
                 "rust_darwin_x86_64__wasm32-unknown-unknown__stable",
                 "rust_darwin_x86_64__wasm32-unknown-unknown__nightly",
                 "rust_darwin_x86_64__wasm32-wasi__stable",
                 "rust_darwin_x86_64__wasm32-wasi__nightly",
-                "rustfmt_nightly-2024-03-21__x86_64-apple-darwin",
+                "rustfmt_nightly-2024-04-09__x86_64-apple-darwin",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly",
                 "rust_windows_x86_64__wasm32-unknown-unknown__stable",
                 "rust_windows_x86_64__wasm32-unknown-unknown__nightly",
                 "rust_windows_x86_64__wasm32-wasi__stable",
                 "rust_windows_x86_64__wasm32-wasi__nightly",
-                "rustfmt_nightly-2024-03-21__x86_64-pc-windows-msvc",
+                "rustfmt_nightly-2024-04-09__x86_64-pc-windows-msvc",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly",
                 "rust_freebsd_x86_64__wasm32-unknown-unknown__stable",
                 "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly",
                 "rust_freebsd_x86_64__wasm32-wasi__stable",
                 "rust_freebsd_x86_64__wasm32-wasi__nightly",
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-freebsd",
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-freebsd",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly",
                 "rust_linux_x86_64__wasm32-unknown-unknown__stable",
                 "rust_linux_x86_64__wasm32-unknown-unknown__nightly",
                 "rust_linux_x86_64__wasm32-wasi__stable",
                 "rust_linux_x86_64__wasm32-wasi__nightly",
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-linux-gnu"
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-linux-gnu"
               ],
               "toolchain_labels": {
-                "rust_analyzer_1.77.0": "@rust_analyzer_1.77.0_tools//:rust_analyzer_toolchain",
+                "rust_analyzer_1.77.2": "@rust_analyzer_1.77.2_tools//:rust_analyzer_toolchain",
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rust_darwin_aarch64__aarch64-apple-darwin__stable_tools//:rust_toolchain",
                 "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rust_darwin_aarch64__aarch64-apple-darwin__nightly_tools//:rust_toolchain",
                 "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rust_darwin_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": "@rust_darwin_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
                 "rust_darwin_aarch64__wasm32-wasi__stable": "@rust_darwin_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
                 "rust_darwin_aarch64__wasm32-wasi__nightly": "@rust_darwin_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-03-21__aarch64-apple-darwin": "@rustfmt_nightly-2024-03-21__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-04-09__aarch64-apple-darwin": "@rustfmt_nightly-2024-04-09__aarch64-apple-darwin_tools//:rustfmt_toolchain",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rust_windows_aarch64__aarch64-pc-windows-msvc__stable_tools//:rust_toolchain",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rust_windows_aarch64__aarch64-pc-windows-msvc__nightly_tools//:rust_toolchain",
                 "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rust_windows_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_windows_aarch64__wasm32-unknown-unknown__nightly": "@rust_windows_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
                 "rust_windows_aarch64__wasm32-wasi__stable": "@rust_windows_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
                 "rust_windows_aarch64__wasm32-wasi__nightly": "@rust_windows_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-03-21__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-03-21__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-04-09__aarch64-pc-windows-msvc": "@rustfmt_nightly-2024-04-09__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
                 "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rust_linux_aarch64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_linux_aarch64__wasm32-unknown-unknown__nightly": "@rust_linux_aarch64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
                 "rust_linux_aarch64__wasm32-wasi__stable": "@rust_linux_aarch64__wasm32-wasi__stable_tools//:rust_toolchain",
                 "rust_linux_aarch64__wasm32-wasi__nightly": "@rust_linux_aarch64__wasm32-wasi__nightly_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-03-21__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-03-21__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-04-09__aarch64-unknown-linux-gnu": "@rustfmt_nightly-2024-04-09__aarch64-unknown-linux-gnu_tools//:rustfmt_toolchain",
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rust_darwin_x86_64__x86_64-apple-darwin__stable_tools//:rust_toolchain",
                 "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rust_darwin_x86_64__x86_64-apple-darwin__nightly_tools//:rust_toolchain",
                 "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rust_darwin_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": "@rust_darwin_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
                 "rust_darwin_x86_64__wasm32-wasi__stable": "@rust_darwin_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
                 "rust_darwin_x86_64__wasm32-wasi__nightly": "@rust_darwin_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-03-21__x86_64-apple-darwin": "@rustfmt_nightly-2024-03-21__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-04-09__x86_64-apple-darwin": "@rustfmt_nightly-2024-04-09__x86_64-apple-darwin_tools//:rustfmt_toolchain",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rust_windows_x86_64__x86_64-pc-windows-msvc__stable_tools//:rust_toolchain",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rust_windows_x86_64__x86_64-pc-windows-msvc__nightly_tools//:rust_toolchain",
                 "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rust_windows_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_windows_x86_64__wasm32-unknown-unknown__nightly": "@rust_windows_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
                 "rust_windows_x86_64__wasm32-wasi__stable": "@rust_windows_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
                 "rust_windows_x86_64__wasm32-wasi__nightly": "@rust_windows_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-03-21__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-03-21__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-04-09__x86_64-pc-windows-msvc": "@rustfmt_nightly-2024-04-09__x86_64-pc-windows-msvc_tools//:rustfmt_toolchain",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__stable_tools//:rust_toolchain",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly_tools//:rust_toolchain",
                 "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rust_freebsd_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": "@rust_freebsd_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
                 "rust_freebsd_x86_64__wasm32-wasi__stable": "@rust_freebsd_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
                 "rust_freebsd_x86_64__wasm32-wasi__nightly": "@rust_freebsd_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-03-21__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-freebsd": "@rustfmt_nightly-2024-04-09__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools//:rust_toolchain",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly_tools//:rust_toolchain",
                 "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rust_linux_x86_64__wasm32-unknown-unknown__stable_tools//:rust_toolchain",
                 "rust_linux_x86_64__wasm32-unknown-unknown__nightly": "@rust_linux_x86_64__wasm32-unknown-unknown__nightly_tools//:rust_toolchain",
                 "rust_linux_x86_64__wasm32-wasi__stable": "@rust_linux_x86_64__wasm32-wasi__stable_tools//:rust_toolchain",
                 "rust_linux_x86_64__wasm32-wasi__nightly": "@rust_linux_x86_64__wasm32-wasi__nightly_tools//:rust_toolchain",
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-03-21__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-linux-gnu": "@rustfmt_nightly-2024-04-09__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain"
               },
               "toolchain_types": {
-                "rust_analyzer_1.77.0": "@rules_rust//rust/rust_analyzer:toolchain_type",
+                "rust_analyzer_1.77.2": "@rules_rust//rust/rust_analyzer:toolchain_type",
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_aarch64__aarch64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
                 "rust_darwin_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
                 "rust_darwin_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-03-21__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-04-09__aarch64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
                 "rust_windows_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
                 "rust_windows_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-03-21__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-04-09__aarch64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
                 "rust_linux_aarch64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_aarch64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
                 "rust_linux_aarch64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_aarch64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-03-21__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-04-09__aarch64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_x86_64__x86_64-apple-darwin__nightly": "@rules_rust//rust:toolchain",
                 "rust_darwin_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
                 "rust_darwin_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
                 "rust_darwin_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-03-21__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-04-09__x86_64-apple-darwin": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__nightly": "@rules_rust//rust:toolchain",
                 "rust_windows_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
                 "rust_windows_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
                 "rust_windows_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-03-21__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-04-09__x86_64-pc-windows-msvc": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": "@rules_rust//rust:toolchain",
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": "@rules_rust//rust:toolchain",
                 "rust_freebsd_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_freebsd_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
                 "rust_freebsd_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
                 "rust_freebsd_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-freebsd": "@rules_rust//rust/rustfmt:toolchain_type",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__nightly": "@rules_rust//rust:toolchain",
                 "rust_linux_x86_64__wasm32-unknown-unknown__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_x86_64__wasm32-unknown-unknown__nightly": "@rules_rust//rust:toolchain",
                 "rust_linux_x86_64__wasm32-wasi__stable": "@rules_rust//rust:toolchain",
                 "rust_linux_x86_64__wasm32-wasi__nightly": "@rules_rust//rust:toolchain",
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-linux-gnu": "@rules_rust//rust/rustfmt:toolchain_type"
               },
               "exec_compatible_with": {
-                "rust_analyzer_1.77.0": [],
+                "rust_analyzer_1.77.2": [],
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
@@ -3502,7 +3503,7 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
-                "rustfmt_nightly-2024-03-21__aarch64-apple-darwin": [
+                "rustfmt_nightly-2024-04-09__aarch64-apple-darwin": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
                 ],
@@ -3530,7 +3531,7 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
-                "rustfmt_nightly-2024-03-21__aarch64-pc-windows-msvc": [
+                "rustfmt_nightly-2024-04-09__aarch64-pc-windows-msvc": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
                 ],
@@ -3558,7 +3559,7 @@
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
-                "rustfmt_nightly-2024-03-21__aarch64-unknown-linux-gnu": [
+                "rustfmt_nightly-2024-04-09__aarch64-unknown-linux-gnu": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
                 ],
@@ -3586,7 +3587,7 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
-                "rustfmt_nightly-2024-03-21__x86_64-apple-darwin": [
+                "rustfmt_nightly-2024-04-09__x86_64-apple-darwin": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
                 ],
@@ -3614,7 +3615,7 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
-                "rustfmt_nightly-2024-03-21__x86_64-pc-windows-msvc": [
+                "rustfmt_nightly-2024-04-09__x86_64-pc-windows-msvc": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
                 ],
@@ -3642,7 +3643,7 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-freebsd": [
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-freebsd": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
                 ],
@@ -3670,13 +3671,13 @@
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ],
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-linux-gnu": [
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-linux-gnu": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
                 ]
               },
               "target_compatible_with": {
-                "rust_analyzer_1.77.0": [],
+                "rust_analyzer_1.77.2": [],
                 "rust_darwin_aarch64__aarch64-apple-darwin__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:osx"
@@ -3701,7 +3702,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-03-21__aarch64-apple-darwin": [],
+                "rustfmt_nightly-2024-04-09__aarch64-apple-darwin": [],
                 "rust_windows_aarch64__aarch64-pc-windows-msvc__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:windows"
@@ -3726,7 +3727,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-03-21__aarch64-pc-windows-msvc": [],
+                "rustfmt_nightly-2024-04-09__aarch64-pc-windows-msvc": [],
                 "rust_linux_aarch64__aarch64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:aarch64",
                   "@platforms//os:linux"
@@ -3751,7 +3752,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-03-21__aarch64-unknown-linux-gnu": [],
+                "rustfmt_nightly-2024-04-09__aarch64-unknown-linux-gnu": [],
                 "rust_darwin_x86_64__x86_64-apple-darwin__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:osx"
@@ -3776,7 +3777,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-03-21__x86_64-apple-darwin": [],
+                "rustfmt_nightly-2024-04-09__x86_64-apple-darwin": [],
                 "rust_windows_x86_64__x86_64-pc-windows-msvc__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:windows"
@@ -3801,7 +3802,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-03-21__x86_64-pc-windows-msvc": [],
+                "rustfmt_nightly-2024-04-09__x86_64-pc-windows-msvc": [],
                 "rust_freebsd_x86_64__x86_64-unknown-freebsd__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:freebsd"
@@ -3826,7 +3827,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-freebsd": [],
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-freebsd": [],
                 "rust_linux_x86_64__x86_64-unknown-linux-gnu__stable": [
                   "@platforms//cpu:x86_64",
                   "@platforms//os:linux"
@@ -3851,7 +3852,7 @@
                   "@platforms//cpu:wasm32",
                   "@platforms//os:wasi"
                 ],
-                "rustfmt_nightly-2024-03-21__x86_64-unknown-linux-gnu": []
+                "rustfmt_nightly-2024-04-09__x86_64-unknown-linux-gnu": []
               }
             }
           },
@@ -3864,8 +3865,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -3887,8 +3888,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-apple-darwin",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -3929,8 +3930,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -3970,9 +3971,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4023,11 +4024,24 @@
               ]
             }
           },
-          "rustfmt_nightly-2024-03-21__aarch64-apple-darwin": {
+          "rust_analyzer_1.77.2_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rust_analyzer_toolchain_tools_repository",
+            "attributes": {
+              "version": "1.77.2",
+              "iso_date": "",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {}
+            }
+          },
+          "rustfmt_nightly-2024-04-09__aarch64-apple-darwin": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
             "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-03-21__aarch64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain": "@rustfmt_nightly-2024-04-09__aarch64-apple-darwin_tools//:rustfmt_toolchain",
               "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
               "target_settings": [],
               "exec_compatible_with": [
@@ -4046,8 +4060,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-unknown-linux-gnu",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4068,9 +4082,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4091,9 +4105,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4134,8 +4148,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "x86_64-unknown-freebsd",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4194,9 +4208,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4217,9 +4231,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4230,34 +4244,6 @@
                 "https://static.rust-lang.org/dist/{}.tar.xz"
               ],
               "auth": {}
-            }
-          },
-          "rustfmt_nightly-2024-03-21__x86_64-apple-darwin": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-03-21__x86_64-apple-darwin_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:osx"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rustfmt_nightly-2024-03-21__aarch64-pc-windows-msvc": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-03-21__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:aarch64",
-                "@platforms//os:windows"
-              ],
-              "target_compatible_with": []
             }
           },
           "rust_darwin_x86_64": {
@@ -4282,9 +4268,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4306,8 +4292,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4329,8 +4315,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4357,12 +4343,12 @@
               ]
             }
           },
-          "rustfmt_nightly-2024-03-21__aarch64-apple-darwin_tools": {
+          "rustfmt_nightly-2024-04-09__aarch64-apple-darwin_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rustfmt_toolchain_tools_repository",
             "attributes": {
               "version": "nightly",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "sha256s": {},
               "urls": [
                 "https://static.rust-lang.org/dist/{}.tar.xz"
@@ -4418,8 +4404,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4430,20 +4416,6 @@
                 "https://static.rust-lang.org/dist/{}.tar.xz"
               ],
               "auth": {}
-            }
-          },
-          "rustfmt_nightly-2024-03-21__aarch64-unknown-linux-gnu_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-03-21",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "exec_triple": "aarch64-unknown-linux-gnu"
             }
           },
           "rust_linux_x86_64": {
@@ -4460,20 +4432,6 @@
               ]
             }
           },
-          "rustfmt_nightly-2024-03-21__x86_64-apple-darwin_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-03-21",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "exec_triple": "x86_64-apple-darwin"
-            }
-          },
           "rust_windows_aarch64__wasm32-unknown-unknown__stable_tools": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "rust_toolchain_tools_repository",
@@ -4483,8 +4441,8 @@
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
               "iso_date": "",
-              "version": "1.77.0",
-              "rustfmt_version": "nightly/2024-03-21",
+              "version": "1.77.2",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4554,6 +4512,48 @@
               ]
             }
           },
+          "rustfmt_nightly-2024-04-09__aarch64-pc-windows-msvc": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-04-09__aarch64-pc-windows-msvc_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:aarch64",
+                "@platforms//os:windows"
+              ],
+              "target_compatible_with": []
+            }
+          },
+          "rustfmt_nightly-2024-04-09__aarch64-unknown-linux-gnu_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-04-09",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "exec_triple": "aarch64-unknown-linux-gnu"
+            }
+          },
+          "rustfmt_nightly-2024-04-09__x86_64-apple-darwin": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-04-09__x86_64-apple-darwin_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:osx"
+              ],
+              "target_compatible_with": []
+            }
+          },
           "rust_windows_x86_64__wasm32-unknown-unknown__nightly": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
@@ -4592,6 +4592,20 @@
               ]
             }
           },
+          "rustfmt_nightly-2024-04-09__x86_64-apple-darwin_tools": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "rustfmt_toolchain_tools_repository",
+            "attributes": {
+              "version": "nightly",
+              "iso_date": "2024-04-09",
+              "sha256s": {},
+              "urls": [
+                "https://static.rust-lang.org/dist/{}.tar.xz"
+              ],
+              "auth": {},
+              "exec_triple": "x86_64-apple-darwin"
+            }
+          },
           "rust_linux_aarch64__aarch64-unknown-linux-gnu__nightly": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
@@ -4609,6 +4623,20 @@
                 "@platforms//cpu:aarch64",
                 "@platforms//os:linux"
               ]
+            }
+          },
+          "rustfmt_nightly-2024-04-09__x86_64-unknown-linux-gnu": {
+            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
+            "ruleClassName": "toolchain_repository_proxy",
+            "attributes": {
+              "toolchain": "@rustfmt_nightly-2024-04-09__x86_64-unknown-linux-gnu_tools//:rustfmt_toolchain",
+              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
+              "target_settings": [],
+              "exec_compatible_with": [
+                "@platforms//cpu:x86_64",
+                "@platforms//os:linux"
+              ],
+              "target_compatible_with": []
             }
           },
           "rust_darwin_aarch64__wasm32-wasi__stable": {
@@ -4657,9 +4685,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "aarch64-pc-windows-msvc",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4680,9 +4708,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-wasi",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4714,34 +4742,6 @@
               ]
             }
           },
-          "rustfmt_nightly-2024-03-21__x86_64-unknown-freebsd": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "toolchain_repository_proxy",
-            "attributes": {
-              "toolchain": "@rustfmt_nightly-2024-03-21__x86_64-unknown-freebsd_tools//:rustfmt_toolchain",
-              "toolchain_type": "@rules_rust//rust/rustfmt:toolchain_type",
-              "target_settings": [],
-              "exec_compatible_with": [
-                "@platforms//cpu:x86_64",
-                "@platforms//os:freebsd"
-              ],
-              "target_compatible_with": []
-            }
-          },
-          "rustfmt_nightly-2024-03-21__aarch64-pc-windows-msvc_tools": {
-            "bzlFile": "@@rules_rust~//rust:repositories.bzl",
-            "ruleClassName": "rustfmt_toolchain_tools_repository",
-            "attributes": {
-              "version": "nightly",
-              "iso_date": "2024-03-21",
-              "sha256s": {},
-              "urls": [
-                "https://static.rust-lang.org/dist/{}.tar.xz"
-              ],
-              "auth": {},
-              "exec_triple": "aarch64-pc-windows-msvc"
-            }
-          },
           "rust_freebsd_x86_64__x86_64-unknown-freebsd__nightly": {
             "bzlFile": "@@rules_rust~//rust:repositories.bzl",
             "ruleClassName": "toolchain_repository_proxy",
@@ -4769,9 +4769,9 @@
               "allocator_library": "@rules_rust//ffi/cc/allocator_library",
               "global_allocator_library": "@rules_rust//ffi/cc/global_allocator_library",
               "target_triple": "wasm32-unknown-unknown",
-              "iso_date": "2024-03-21",
+              "iso_date": "2024-04-09",
               "version": "nightly",
-              "rustfmt_version": "nightly/2024-03-21",
+              "rustfmt_version": "nightly/2024-04-09",
               "edition": "2021",
               "dev_components": false,
               "extra_rustc_flags": [],
@@ -4786,6 +4786,21 @@
           }
         },
         "recordedRepoMappingEntries": [
+          [
+            "bazel_features~",
+            "bazel_features_globals",
+            "bazel_features~~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~",
+            "bazel_features_version",
+            "bazel_features~~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_rust~",
+            "bazel_features",
+            "bazel_features~"
+          ],
           [
             "rules_rust~",
             "bazel_skylib",
@@ -4806,7 +4821,7 @@
     },
     "@@rules_rust~//rust/private:extensions.bzl%i": {
       "general": {
-        "bzlTransitiveDigest": "44Hrm4d+4jGxghOa3R1w+y2isNsqHQ9M7xqDu2sAMzo=",
+        "bzlTransitiveDigest": "u5P1ixtNkztQlYF0vDyDV+Irt+Ffx3D8WaDD9fTrNy0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -4818,7 +4833,7 @@
               "sha256": "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tracing/0.1.37/download"
+                "https://static.crates.io/crates/tracing/0.1.37/download"
               ],
               "strip_prefix": "tracing-0.1.37",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-0.1.37.bazel"
@@ -4831,7 +4846,7 @@
               "sha256": "2c03529cd0c4400a2449f640d2f27cd1b48c3065226d15e26d98e4429ab0adb7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/walrus/0.20.3/download"
+                "https://static.crates.io/crates/walrus/0.20.3/download"
               ],
               "strip_prefix": "walrus-0.20.3",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.walrus-0.20.3.bazel"
@@ -4844,7 +4859,7 @@
               "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-bidi/0.3.13/download"
+                "https://static.crates.io/crates/unicode-bidi/0.3.13/download"
               ],
               "strip_prefix": "unicode-bidi-0.3.13",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
@@ -4857,7 +4872,7 @@
               "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnu-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
@@ -4870,7 +4885,7 @@
               "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustix/0.37.23/download"
+                "https://static.crates.io/crates/rustix/0.37.23/download"
               ],
               "strip_prefix": "rustix-0.37.23",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
@@ -4883,7 +4898,7 @@
               "sha256": "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fuchsia-cprng/0.1.1/download"
+                "https://static.crates.io/crates/fuchsia-cprng/0.1.1/download"
               ],
               "strip_prefix": "fuchsia-cprng-0.1.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fuchsia-cprng-0.1.1.bazel"
@@ -4896,7 +4911,7 @@
               "sha256": "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/url/2.4.0/download"
+                "https://static.crates.io/crates/url/2.4.0/download"
               ],
               "strip_prefix": "url-2.4.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.url-2.4.0.bazel"
@@ -4909,7 +4924,7 @@
               "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ryu/1.0.14/download"
+                "https://static.crates.io/crates/ryu/1.0.14/download"
               ],
               "strip_prefix": "ryu-1.0.14",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
@@ -4928,7 +4943,7 @@
               "sha256": "a81e3a9bb429fec47008b209896f0b9ab99fbcbc1c3733b385d43fbfd64dd2ca",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/protoc-gen-prost/0.2.2/download"
+                "https://static.crates.io/crates/protoc-gen-prost/0.2.2/download"
               ],
               "strip_prefix": "protoc-gen-prost-0.2.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-prost-0.2.2.bazel"
@@ -4941,7 +4956,7 @@
               "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cfg-if/1.0.0/download"
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
               ],
               "strip_prefix": "cfg-if-1.0.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
@@ -4954,7 +4969,7 @@
               "sha256": "725a07a704f9cf7a956b302c21d81b5516ed5ee6cfbbf827edb69beeaae6cc30",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/protoc-gen-tonic/0.2.2/download"
+                "https://static.crates.io/crates/protoc-gen-tonic/0.2.2/download"
               ],
               "strip_prefix": "protoc-gen-tonic-0.2.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-tonic-0.2.2.bazel"
@@ -4967,7 +4982,7 @@
               "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/iana-time-zone-haiku/0.1.2/download"
+                "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download"
               ],
               "strip_prefix": "iana-time-zone-haiku-0.1.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.iana-time-zone-haiku-0.1.2.bazel"
@@ -4980,7 +4995,7 @@
               "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
@@ -4993,7 +5008,7 @@
               "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/percent-encoding/2.3.0/download"
+                "https://static.crates.io/crates/percent-encoding/2.3.0/download"
               ],
               "strip_prefix": "percent-encoding-2.3.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.percent-encoding-2.3.0.bazel"
@@ -5006,7 +5021,7 @@
               "sha256": "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fastrand/2.0.1/download"
+                "https://static.crates.io/crates/fastrand/2.0.1/download"
               ],
               "strip_prefix": "fastrand-2.0.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fastrand-2.0.1.bazel"
@@ -5019,7 +5034,7 @@
               "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/flate2/1.0.28/download"
+                "https://static.crates.io/crates/flate2/1.0.28/download"
               ],
               "strip_prefix": "flate2-1.0.28",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
@@ -5032,7 +5047,7 @@
               "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cc/1.0.79/download"
+                "https://static.crates.io/crates/cc/1.0.79/download"
               ],
               "strip_prefix": "cc-1.0.79",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.cc-1.0.79.bazel"
@@ -5045,7 +5060,7 @@
               "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi/0.3.9/download"
+                "https://static.crates.io/crates/winapi/0.3.9/download"
               ],
               "strip_prefix": "winapi-0.3.9",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
@@ -5058,7 +5073,7 @@
               "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-targets/0.48.1/download"
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
               ],
               "strip_prefix": "windows-targets-0.48.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
@@ -5071,7 +5086,7 @@
               "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ppv-lite86/0.2.17/download"
+                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
               ],
               "strip_prefix": "ppv-lite86-0.2.17",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
@@ -5084,7 +5099,7 @@
               "sha256": "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/smawk/0.3.1/download"
+                "https://static.crates.io/crates/smawk/0.3.1/download"
               ],
               "strip_prefix": "smawk-0.3.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smawk-0.3.1.bazel"
@@ -5097,7 +5112,7 @@
               "sha256": "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/heck/0.3.3/download"
+                "https://static.crates.io/crates/heck/0.3.3/download"
               ],
               "strip_prefix": "heck-0.3.3",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.heck-0.3.3.bazel"
@@ -5110,7 +5125,7 @@
               "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-ident/1.0.10/download"
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
               ],
               "strip_prefix": "unicode-ident-1.0.10",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
@@ -5123,7 +5138,7 @@
               "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_derive/4.3.2/download"
+                "https://static.crates.io/crates/clap_derive/4.3.2/download"
               ],
               "strip_prefix": "clap_derive-4.3.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
@@ -5136,7 +5151,7 @@
               "sha256": "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/libm/0.2.7/download"
+                "https://static.crates.io/crates/libm/0.2.7/download"
               ],
               "strip_prefix": "libm-0.2.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.libm-0.2.7.bazel"
@@ -5149,7 +5164,7 @@
               "sha256": "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/deranged/0.3.9/download"
+                "https://static.crates.io/crates/deranged/0.3.9/download"
               ],
               "strip_prefix": "deranged-0.3.9",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.deranged-0.3.9.bazel"
@@ -5162,7 +5177,7 @@
               "sha256": "6f1697bf9911c6d1b8d709b9e6ef718cb5ea5821a1b7991520125a8134448004",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-negotiate/0.8.0/download"
+                "https://static.crates.io/crates/gix-negotiate/0.8.0/download"
               ],
               "strip_prefix": "gix-negotiate-0.8.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-negotiate-0.8.0.bazel"
@@ -5175,7 +5190,7 @@
               "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/autocfg/1.1.0/download"
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
               ],
               "strip_prefix": "autocfg-1.1.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
@@ -5188,7 +5203,7 @@
               "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/io-lifetimes/1.0.11/download"
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
               ],
               "strip_prefix": "io-lifetimes-1.0.11",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
@@ -5201,7 +5216,7 @@
               "sha256": "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cfg-if/0.1.10/download"
+                "https://static.crates.io/crates/cfg-if/0.1.10/download"
               ],
               "strip_prefix": "cfg-if-0.1.10",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cfg-if-0.1.10.bazel"
@@ -5214,7 +5229,7 @@
               "sha256": "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/proc-macro2/1.0.60/download"
+                "https://static.crates.io/crates/proc-macro2/1.0.60/download"
               ],
               "strip_prefix": "proc-macro2-1.0.60",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.proc-macro2-1.0.60.bazel"
@@ -5227,7 +5242,7 @@
               "sha256": "7f6b5c519bab3ea61843a7923d074b04245624bb84a64a8c150f5deb014e388b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_complete/4.3.1/download"
+                "https://static.crates.io/crates/clap_complete/4.3.1/download"
               ],
               "strip_prefix": "clap_complete-4.3.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_complete-4.3.1.bazel"
@@ -5240,7 +5255,7 @@
               "sha256": "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/time-core/0.1.1/download"
+                "https://static.crates.io/crates/time-core/0.1.1/download"
               ],
               "strip_prefix": "time-core-0.1.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.time-core-0.1.1.bazel"
@@ -5253,7 +5268,7 @@
               "sha256": "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num/0.1.42/download"
+                "https://static.crates.io/crates/num/0.1.42/download"
               ],
               "strip_prefix": "num-0.1.42",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-0.1.42.bazel"
@@ -5266,7 +5281,7 @@
               "sha256": "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tiny_http/0.12.0/download"
+                "https://static.crates.io/crates/tiny_http/0.12.0/download"
               ],
               "strip_prefix": "tiny_http-0.12.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tiny_http-0.12.0.bazel"
@@ -5279,7 +5294,7 @@
               "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-sys/0.48.0/download"
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
               ],
               "strip_prefix": "windows-sys-0.48.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
@@ -5292,7 +5307,7 @@
               "sha256": "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/libc/0.2.146/download"
+                "https://static.crates.io/crates/libc/0.2.146/download"
               ],
               "strip_prefix": "libc-0.2.146",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.libc-0.2.146.bazel"
@@ -5305,7 +5320,7 @@
               "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/iana-time-zone-haiku/0.1.2/download"
+                "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download"
               ],
               "strip_prefix": "iana-time-zone-haiku-0.1.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-haiku-0.1.2.bazel"
@@ -5318,7 +5333,7 @@
               "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/memchr/2.5.0/download"
+                "https://static.crates.io/crates/memchr/2.5.0/download"
               ],
               "strip_prefix": "memchr-2.5.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
@@ -5331,7 +5346,7 @@
               "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/getrandom/0.2.10/download"
+                "https://static.crates.io/crates/getrandom/0.2.10/download"
               ],
               "strip_prefix": "getrandom-0.2.10",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
@@ -5344,7 +5359,7 @@
               "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bitflags/1.3.2/download"
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
               ],
               "strip_prefix": "bitflags-1.3.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
@@ -5357,7 +5372,7 @@
               "sha256": "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/sha1_smol/1.0.0/download"
+                "https://static.crates.io/crates/sha1_smol/1.0.0/download"
               ],
               "strip_prefix": "sha1_smol-1.0.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
@@ -5382,7 +5397,7 @@
               "sha256": "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/iovec/0.1.4/download"
+                "https://static.crates.io/crates/iovec/0.1.4/download"
               ],
               "strip_prefix": "iovec-0.1.4",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.iovec-0.1.4.bazel"
@@ -5395,7 +5410,7 @@
               "sha256": "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/byteorder/1.4.3/download"
+                "https://static.crates.io/crates/byteorder/1.4.3/download"
               ],
               "strip_prefix": "byteorder-1.4.3",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.byteorder-1.4.3.bazel"
@@ -5408,7 +5423,7 @@
               "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/chrono/0.4.26/download"
+                "https://static.crates.io/crates/chrono/0.4.26/download"
               ],
               "strip_prefix": "chrono-0.4.26",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
@@ -5421,7 +5436,7 @@
               "sha256": "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/redox_syscall/0.1.57/download"
+                "https://static.crates.io/crates/redox_syscall/0.1.57/download"
               ],
               "strip_prefix": "redox_syscall-0.1.57",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.redox_syscall-0.1.57.bazel"
@@ -5434,7 +5449,7 @@
               "sha256": "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/proc-macro2/1.0.60/download"
+                "https://static.crates.io/crates/proc-macro2/1.0.60/download"
               ],
               "strip_prefix": "proc-macro2-1.0.60",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.60.bazel"
@@ -5447,7 +5462,7 @@
               "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_msvc-0.48.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
@@ -5460,7 +5475,7 @@
               "sha256": "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/overload/0.1.1/download"
+                "https://static.crates.io/crates/overload/0.1.1/download"
               ],
               "strip_prefix": "overload-0.1.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.overload-0.1.1.bazel"
@@ -5473,7 +5488,7 @@
               "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_derive/4.3.2/download"
+                "https://static.crates.io/crates/clap_derive/4.3.2/download"
               ],
               "strip_prefix": "clap_derive-4.3.2",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
@@ -5486,7 +5501,7 @@
               "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstream/0.3.2/download"
+                "https://static.crates.io/crates/anstream/0.3.2/download"
               ],
               "strip_prefix": "anstream-0.3.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
@@ -5499,7 +5514,7 @@
               "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bitflags/1.3.2/download"
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
               ],
               "strip_prefix": "bitflags-1.3.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
@@ -5512,7 +5527,7 @@
               "sha256": "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/smallvec/1.10.0/download"
+                "https://static.crates.io/crates/smallvec/1.10.0/download"
               ],
               "strip_prefix": "smallvec-1.10.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.smallvec-1.10.0.bazel"
@@ -5525,7 +5540,7 @@
               "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnu-0.48.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
@@ -5538,7 +5553,7 @@
               "sha256": "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/atty/0.2.14/download"
+                "https://static.crates.io/crates/atty/0.2.14/download"
               ],
               "strip_prefix": "atty-0.2.14",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.atty-0.2.14.bazel"
@@ -5551,7 +5566,7 @@
               "sha256": "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/walkdir/2.3.3/download"
+                "https://static.crates.io/crates/walkdir/2.3.3/download"
               ],
               "strip_prefix": "walkdir-2.3.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.walkdir-2.3.3.bazel"
@@ -5564,7 +5579,7 @@
               "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/aho-corasick/1.0.2/download"
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
               ],
               "strip_prefix": "aho-corasick-1.0.2",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
@@ -5577,7 +5592,7 @@
               "sha256": "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustls/0.21.8/download"
+                "https://static.crates.io/crates/rustls/0.21.8/download"
               ],
               "strip_prefix": "rustls-0.21.8",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustls-0.21.8.bazel"
@@ -5590,7 +5605,7 @@
               "sha256": "0895cb7b1e70f3c3bd4550c329e9f5caf2975f97fcd4238e05754e72208ef61e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-refspec/0.18.0/download"
+                "https://static.crates.io/crates/gix-refspec/0.18.0/download"
               ],
               "strip_prefix": "gix-refspec-0.18.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-refspec-0.18.0.bazel"
@@ -5603,7 +5618,7 @@
               "sha256": "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/semver/1.0.20/download"
+                "https://static.crates.io/crates/semver/1.0.20/download"
               ],
               "strip_prefix": "semver-1.0.20",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.semver-1.0.20.bazel"
@@ -5616,7 +5631,7 @@
               "sha256": "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num_cpus/1.15.0/download"
+                "https://static.crates.io/crates/num_cpus/1.15.0/download"
               ],
               "strip_prefix": "num_cpus-1.15.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.num_cpus-1.15.0.bazel"
@@ -5629,7 +5644,7 @@
               "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/humantime/2.1.0/download"
+                "https://static.crates.io/crates/humantime/2.1.0/download"
               ],
               "strip_prefix": "humantime-2.1.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
@@ -5642,7 +5657,7 @@
               "sha256": "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bitflags/2.4.1/download"
+                "https://static.crates.io/crates/bitflags/2.4.1/download"
               ],
               "strip_prefix": "bitflags-2.4.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bitflags-2.4.1.bazel"
@@ -5655,7 +5670,7 @@
               "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-syntax/0.7.4/download"
+                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
               ],
               "strip_prefix": "regex-syntax-0.7.4",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
@@ -5668,7 +5683,7 @@
               "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/autocfg/1.1.0/download"
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
               ],
               "strip_prefix": "autocfg-1.1.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
@@ -5681,7 +5696,7 @@
               "sha256": "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/sct/0.7.1/download"
+                "https://static.crates.io/crates/sct/0.7.1/download"
               ],
               "strip_prefix": "sct-0.7.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.sct-0.7.1.bazel"
@@ -5694,7 +5709,7 @@
               "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-util/0.1.5/download"
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
               ],
               "strip_prefix": "winapi-util-0.1.5",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
@@ -5707,7 +5722,7 @@
               "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/strsim/0.10.0/download"
+                "https://static.crates.io/crates/strsim/0.10.0/download"
               ],
               "strip_prefix": "strsim-0.10.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
@@ -5720,7 +5735,7 @@
               "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/untrusted/0.9.0/download"
+                "https://static.crates.io/crates/untrusted/0.9.0/download"
               ],
               "strip_prefix": "untrusted-0.9.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.untrusted-0.9.0.bazel"
@@ -5733,7 +5748,7 @@
               "sha256": "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/slab/0.4.7/download"
+                "https://static.crates.io/crates/slab/0.4.7/download"
               ],
               "strip_prefix": "slab-0.4.7",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.slab-0.4.7.bazel"
@@ -5746,7 +5761,7 @@
               "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-epoch/0.9.15/download"
+                "https://static.crates.io/crates/crossbeam-epoch/0.9.15/download"
               ],
               "strip_prefix": "crossbeam-epoch-0.9.15",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-epoch-0.9.15.bazel"
@@ -5759,7 +5774,7 @@
               "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/termcolor/1.2.0/download"
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
               ],
               "strip_prefix": "termcolor-1.2.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
@@ -5772,7 +5787,7 @@
               "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno/0.3.1/download"
+                "https://static.crates.io/crates/errno/0.3.1/download"
               ],
               "strip_prefix": "errno-0.3.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.errno-0.3.1.bazel"
@@ -5785,7 +5800,7 @@
               "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-width/0.1.10/download"
+                "https://static.crates.io/crates/unicode-width/0.1.10/download"
               ],
               "strip_prefix": "unicode-width-0.1.10",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.unicode-width-0.1.10.bazel"
@@ -5798,7 +5813,7 @@
               "sha256": "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-queue/0.2.3/download"
+                "https://static.crates.io/crates/crossbeam-queue/0.2.3/download"
               ],
               "strip_prefix": "crossbeam-queue-0.2.3",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-queue-0.2.3.bazel"
@@ -5811,7 +5826,7 @@
               "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-deque/0.8.3/download"
+                "https://static.crates.io/crates/crossbeam-deque/0.8.3/download"
               ],
               "strip_prefix": "crossbeam-deque-0.8.3",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-deque-0.8.3.bazel"
@@ -5824,7 +5839,7 @@
               "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
               ],
               "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
@@ -5837,7 +5852,7 @@
               "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/colorchoice/1.0.0/download"
+                "https://static.crates.io/crates/colorchoice/1.0.0/download"
               ],
               "strip_prefix": "colorchoice-1.0.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
@@ -5850,7 +5865,7 @@
               "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex/1.9.1/download"
+                "https://static.crates.io/crates/regex/1.9.1/download"
               ],
               "strip_prefix": "regex-1.9.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-1.9.1.bazel"
@@ -5863,7 +5878,7 @@
               "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
@@ -5876,7 +5891,7 @@
               "sha256": "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/slab/0.4.8/download"
+                "https://static.crates.io/crates/slab/0.4.8/download"
               ],
               "strip_prefix": "slab-0.4.8",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.slab-0.4.8.bazel"
@@ -5889,7 +5904,7 @@
               "sha256": "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap/4.3.11/download"
+                "https://static.crates.io/crates/clap/4.3.11/download"
               ],
               "strip_prefix": "clap-4.3.11",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap-4.3.11.bazel"
@@ -5902,7 +5917,7 @@
               "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/adler/1.0.2/download"
+                "https://static.crates.io/crates/adler/1.0.2/download"
               ],
               "strip_prefix": "adler-1.0.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.adler-1.0.2.bazel"
@@ -5926,7 +5941,7 @@
               "sha256": "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustix/0.37.20/download"
+                "https://static.crates.io/crates/rustix/0.37.20/download"
               ],
               "strip_prefix": "rustix-0.37.20",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustix-0.37.20.bazel"
@@ -5939,7 +5954,7 @@
               "sha256": "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-macro-support-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.91.bazel"
@@ -5952,7 +5967,7 @@
               "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fnv/1.0.7/download"
+                "https://static.crates.io/crates/fnv/1.0.7/download"
               ],
               "strip_prefix": "fnv-1.0.7",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
@@ -5965,7 +5980,7 @@
               "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_msvc-0.48.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
@@ -5978,7 +5993,7 @@
               "sha256": "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/jwalk/0.8.1/download"
+                "https://static.crates.io/crates/jwalk/0.8.1/download"
               ],
               "strip_prefix": "jwalk-0.8.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.jwalk-0.8.1.bazel"
@@ -5991,7 +6006,7 @@
               "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/getrandom/0.2.10/download"
+                "https://static.crates.io/crates/getrandom/0.2.10/download"
               ],
               "strip_prefix": "getrandom-0.2.10",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
@@ -6004,7 +6019,7 @@
               "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/redox_syscall/0.2.16/download"
+                "https://static.crates.io/crates/redox_syscall/0.2.16/download"
               ],
               "strip_prefix": "redox_syscall-0.2.16",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.2.16.bazel"
@@ -6017,7 +6032,7 @@
               "sha256": "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/httpdate/1.0.2/download"
+                "https://static.crates.io/crates/httpdate/1.0.2/download"
               ],
               "strip_prefix": "httpdate-1.0.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.httpdate-1.0.2.bazel"
@@ -6042,7 +6057,7 @@
               "sha256": "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cargo_toml/0.19.2/download"
+                "https://static.crates.io/crates/cargo_toml/0.19.2/download"
               ],
               "strip_prefix": "cargo_toml-0.19.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo_toml-0.19.2.bazel"
@@ -6055,7 +6070,7 @@
               "sha256": "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num_cpus/1.15.0/download"
+                "https://static.crates.io/crates/num_cpus/1.15.0/download"
               ],
               "strip_prefix": "num_cpus-1.15.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.num_cpus-1.15.0.bazel"
@@ -6068,7 +6083,7 @@
               "sha256": "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/lazycell/1.3.0/download"
+                "https://static.crates.io/crates/lazycell/1.3.0/download"
               ],
               "strip_prefix": "lazycell-1.3.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.lazycell-1.3.0.bazel"
@@ -6081,7 +6096,7 @@
               "sha256": "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tracing-subscriber/0.3.17/download"
+                "https://static.crates.io/crates/tracing-subscriber/0.3.17/download"
               ],
               "strip_prefix": "tracing-subscriber-0.3.17",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-subscriber-0.3.17.bazel"
@@ -6094,7 +6109,7 @@
               "sha256": "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bytes/1.4.0/download"
+                "https://static.crates.io/crates/bytes/1.4.0/download"
               ],
               "strip_prefix": "bytes-1.4.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.bytes-1.4.0.bazel"
@@ -6107,7 +6122,7 @@
               "sha256": "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/mime_guess/2.0.4/download"
+                "https://static.crates.io/crates/mime_guess/2.0.4/download"
               ],
               "strip_prefix": "mime_guess-2.0.4",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.mime_guess-2.0.4.bazel"
@@ -6120,7 +6135,7 @@
               "sha256": "3d74b9cbbf2ac9a7169c85a3714ec16c51ee9ec7cfd511549527e9a7df720795",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/protobuf-codegen/2.8.2/download"
+                "https://static.crates.io/crates/protobuf-codegen/2.8.2/download"
               ],
               "strip_prefix": "protobuf-codegen-2.8.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.protobuf-codegen-2.8.2.bazel"
@@ -6133,7 +6148,7 @@
               "sha256": "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-encoder/0.29.0/download"
+                "https://static.crates.io/crates/wasm-encoder/0.29.0/download"
               ],
               "strip_prefix": "wasm-encoder-0.29.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-encoder-0.29.0.bazel"
@@ -6146,7 +6161,7 @@
               "sha256": "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-syntax/0.8.2/download"
+                "https://static.crates.io/crates/regex-syntax/0.8.2/download"
               ],
               "strip_prefix": "regex-syntax-0.8.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-syntax-0.8.2.bazel"
@@ -6159,7 +6174,7 @@
               "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_lex/0.5.0/download"
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
               ],
               "strip_prefix": "clap_lex-0.5.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
@@ -6172,7 +6187,7 @@
               "sha256": "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/http-body/0.4.5/download"
+                "https://static.crates.io/crates/http-body/0.4.5/download"
               ],
               "strip_prefix": "http-body-0.4.5",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-body-0.4.5.bazel"
@@ -6185,7 +6200,7 @@
               "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/utf8parse/0.2.1/download"
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
               ],
               "strip_prefix": "utf8parse-0.2.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
@@ -6198,7 +6213,7 @@
               "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/lazy_static/1.4.0/download"
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
               ],
               "strip_prefix": "lazy_static-1.4.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
@@ -6211,7 +6226,7 @@
               "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
@@ -6224,7 +6239,7 @@
               "sha256": "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fixedbitset/0.4.2/download"
+                "https://static.crates.io/crates/fixedbitset/0.4.2/download"
               ],
               "strip_prefix": "fixedbitset-0.4.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.fixedbitset-0.4.2.bazel"
@@ -6237,7 +6252,7 @@
               "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
@@ -6250,7 +6265,7 @@
               "sha256": "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex/1.8.4/download"
+                "https://static.crates.io/crates/regex/1.8.4/download"
               ],
               "strip_prefix": "regex-1.8.4",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-1.8.4.bazel"
@@ -6263,7 +6278,7 @@
               "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi/0.3.9/download"
+                "https://static.crates.io/crates/winapi/0.3.9/download"
               ],
               "strip_prefix": "winapi-0.3.9",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
@@ -6276,7 +6291,7 @@
               "sha256": "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/syn/2.0.32/download"
+                "https://static.crates.io/crates/syn/2.0.32/download"
               ],
               "strip_prefix": "syn-2.0.32",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.syn-2.0.32.bazel"
@@ -6289,7 +6304,7 @@
               "sha256": "12b6ac5fca1d0992d2328147488169ea166bfe899c88f8ad06cf583f4c492fcf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-externref-xform/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-externref-xform/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-externref-xform-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-externref-xform-0.2.91.bazel"
@@ -6302,7 +6317,7 @@
               "sha256": "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustversion/1.0.12/download"
+                "https://static.crates.io/crates/rustversion/1.0.12/download"
               ],
               "strip_prefix": "rustversion-1.0.12",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rustversion-1.0.12.bazel"
@@ -6315,7 +6330,7 @@
               "sha256": "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-macros/2.1.0/download"
+                "https://static.crates.io/crates/tokio-macros/2.1.0/download"
               ],
               "strip_prefix": "tokio-macros-2.1.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-macros-2.1.0.bazel"
@@ -6328,7 +6343,7 @@
               "sha256": "b76cb909fe3d9b0de58cee1f4072247e680ff5cc1558ccad2790a9de14a23993",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasmprinter/0.2.60/download"
+                "https://static.crates.io/crates/wasmprinter/0.2.60/download"
               ],
               "strip_prefix": "wasmprinter-0.2.60",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmprinter-0.2.60.bazel"
@@ -6341,7 +6356,7 @@
               "sha256": "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/scoped-tls/0.1.2/download"
+                "https://static.crates.io/crates/scoped-tls/0.1.2/download"
               ],
               "strip_prefix": "scoped-tls-0.1.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.scoped-tls-0.1.2.bazel"
@@ -6354,7 +6369,7 @@
               "sha256": "9d8acb5ee668d55f0f2d19a320a3f9ef67a6999ad483e11135abcc2464ed18b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-macros/0.1.0/download"
+                "https://static.crates.io/crates/gix-macros/0.1.0/download"
               ],
               "strip_prefix": "gix-macros-0.1.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-macros-0.1.0.bazel"
@@ -6367,7 +6382,7 @@
               "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ryu/1.0.14/download"
+                "https://static.crates.io/crates/ryu/1.0.14/download"
               ],
               "strip_prefix": "ryu-1.0.14",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
@@ -6380,7 +6395,7 @@
               "sha256": "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde/1.0.171/download"
+                "https://static.crates.io/crates/serde/1.0.171/download"
               ],
               "strip_prefix": "serde-1.0.171",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde-1.0.171.bazel"
@@ -6393,7 +6408,7 @@
               "sha256": "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/lock_api/0.4.10/download"
+                "https://static.crates.io/crates/lock_api/0.4.10/download"
               ],
               "strip_prefix": "lock_api-0.4.10",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.lock_api-0.4.10.bazel"
@@ -6406,7 +6421,7 @@
               "sha256": "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/glob/0.3.1/download"
+                "https://static.crates.io/crates/glob/0.3.1/download"
               ],
               "strip_prefix": "glob-0.3.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.glob-0.3.1.bazel"
@@ -6419,7 +6434,7 @@
               "sha256": "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/itertools/0.10.5/download"
+                "https://static.crates.io/crates/itertools/0.10.5/download"
               ],
               "strip_prefix": "itertools-0.10.5",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.itertools-0.10.5.bazel"
@@ -6432,7 +6447,7 @@
               "sha256": "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/redox_syscall/0.4.1/download"
+                "https://static.crates.io/crates/redox_syscall/0.4.1/download"
               ],
               "strip_prefix": "redox_syscall-0.4.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.4.1.bazel"
@@ -6445,7 +6460,7 @@
               "sha256": "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/id-arena/2.2.1/download"
+                "https://static.crates.io/crates/id-arena/2.2.1/download"
               ],
               "strip_prefix": "id-arena-2.2.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.id-arena-2.2.1.bazel"
@@ -6458,7 +6473,7 @@
               "sha256": "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/normpath/1.1.1/download"
+                "https://static.crates.io/crates/normpath/1.1.1/download"
               ],
               "strip_prefix": "normpath-1.1.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.normpath-1.1.1.bazel"
@@ -6471,7 +6486,7 @@
               "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/lazy_static/1.4.0/download"
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
               ],
               "strip_prefix": "lazy_static-1.4.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
@@ -6484,7 +6499,7 @@
               "sha256": "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/axum/0.6.18/download"
+                "https://static.crates.io/crates/axum/0.6.18/download"
               ],
               "strip_prefix": "axum-0.6.18",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.axum-0.6.18.bazel"
@@ -6497,7 +6512,7 @@
               "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/parking_lot/0.12.1/download"
+                "https://static.crates.io/crates/parking_lot/0.12.1/download"
               ],
               "strip_prefix": "parking_lot-0.12.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.parking_lot-0.12.1.bazel"
@@ -6510,7 +6525,7 @@
               "sha256": "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cargo-platform/0.1.4/download"
+                "https://static.crates.io/crates/cargo-platform/0.1.4/download"
               ],
               "strip_prefix": "cargo-platform-0.1.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo-platform-0.1.4.bazel"
@@ -6523,7 +6538,7 @@
               "sha256": "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/slug/0.1.4/download"
+                "https://static.crates.io/crates/slug/0.1.4/download"
               ],
               "strip_prefix": "slug-0.1.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.slug-0.1.4.bazel"
@@ -6536,7 +6551,7 @@
               "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno-dragonfly/0.1.2/download"
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
               ],
               "strip_prefix": "errno-dragonfly-0.1.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
@@ -6549,7 +6564,7 @@
               "sha256": "6125ecf46e8c68bf7202da6cad239831daebf0247ffbab30210d72f3856e420f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-url/0.24.0/download"
+                "https://static.crates.io/crates/gix-url/0.24.0/download"
               ],
               "strip_prefix": "gix-url-0.24.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-url-0.24.0.bazel"
@@ -6562,7 +6577,7 @@
               "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/percent-encoding/2.3.0/download"
+                "https://static.crates.io/crates/percent-encoding/2.3.0/download"
               ],
               "strip_prefix": "percent-encoding-2.3.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.percent-encoding-2.3.0.bazel"
@@ -6575,7 +6590,7 @@
               "sha256": "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_builder/4.3.11/download"
+                "https://static.crates.io/crates/clap_builder/4.3.11/download"
               ],
               "strip_prefix": "clap_builder-4.3.11",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap_builder-4.3.11.bazel"
@@ -6588,7 +6603,7 @@
               "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tracing-core/0.1.32/download"
+                "https://static.crates.io/crates/tracing-core/0.1.32/download"
               ],
               "strip_prefix": "tracing-core-0.1.32",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-core-0.1.32.bazel"
@@ -6601,7 +6616,7 @@
               "sha256": "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fuchsia-zircon-sys/0.3.3/download"
+                "https://static.crates.io/crates/fuchsia-zircon-sys/0.3.3/download"
               ],
               "strip_prefix": "fuchsia-zircon-sys-0.3.3",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-sys-0.3.3.bazel"
@@ -6614,7 +6629,7 @@
               "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/safemem/0.3.3/download"
+                "https://static.crates.io/crates/safemem/0.3.3/download"
               ],
               "strip_prefix": "safemem-0.3.3",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
@@ -6627,7 +6642,7 @@
               "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnu-0.48.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
@@ -6640,7 +6655,7 @@
               "sha256": "08c60e982c5290897122d4e2622447f014a2dadd5a18cb73d50bb91b31645e27",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-actor/0.27.0/download"
+                "https://static.crates.io/crates/gix-actor/0.27.0/download"
               ],
               "strip_prefix": "gix-actor-0.27.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-actor-0.27.0.bazel"
@@ -6653,7 +6668,7 @@
               "sha256": "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unic-ucd-version/0.9.0/download"
+                "https://static.crates.io/crates/unic-ucd-version/0.9.0/download"
               ],
               "strip_prefix": "unic-ucd-version-0.9.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-ucd-version-0.9.0.bazel"
@@ -6677,7 +6692,7 @@
               "sha256": "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/either/1.9.0/download"
+                "https://static.crates.io/crates/either/1.9.0/download"
               ],
               "strip_prefix": "either-1.9.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.either-1.9.0.bazel"
@@ -6690,7 +6705,7 @@
               "sha256": "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gimli/0.26.2/download"
+                "https://static.crates.io/crates/gimli/0.26.2/download"
               ],
               "strip_prefix": "gimli-0.26.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.gimli-0.26.2.bazel"
@@ -6703,7 +6718,7 @@
               "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/parking_lot/0.12.1/download"
+                "https://static.crates.io/crates/parking_lot/0.12.1/download"
               ],
               "strip_prefix": "parking_lot-0.12.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.parking_lot-0.12.1.bazel"
@@ -6716,7 +6731,7 @@
               "sha256": "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/globwalk/0.8.1/download"
+                "https://static.crates.io/crates/globwalk/0.8.1/download"
               ],
               "strip_prefix": "globwalk-0.8.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.globwalk-0.8.1.bazel"
@@ -6729,7 +6744,7 @@
               "sha256": "682940195a701dbf887f20017418b8cac916a37b3f91ededec33226619e973c1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-wasm-interpreter/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-wasm-interpreter/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-wasm-interpreter-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-interpreter-0.2.91.bazel"
@@ -6742,7 +6757,7 @@
               "sha256": "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ring/0.17.5/download"
+                "https://static.crates.io/crates/ring/0.17.5/download"
               ],
               "strip_prefix": "ring-0.17.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ring-0.17.5.bazel"
@@ -6755,7 +6770,7 @@
               "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/memchr/2.5.0/download"
+                "https://static.crates.io/crates/memchr/2.5.0/download"
               ],
               "strip_prefix": "memchr-2.5.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
@@ -6768,7 +6783,7 @@
               "sha256": "33bc10579ea08741ae173928194b6c42c90b295d51ddd0d18238eaf15502ac87",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crates-index/2.2.0/download"
+                "https://static.crates.io/crates/crates-index/2.2.0/download"
               ],
               "strip_prefix": "crates-index-2.2.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crates-index-2.2.0.bazel"
@@ -6781,7 +6796,7 @@
               "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi/0.3.9/download"
+                "https://static.crates.io/crates/winapi/0.3.9/download"
               ],
               "strip_prefix": "winapi-0.3.9",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
@@ -6794,7 +6809,7 @@
               "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-channel/0.5.8/download"
+                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
               ],
               "strip_prefix": "crossbeam-channel-0.5.8",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
@@ -6807,7 +6822,7 @@
               "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-sys/0.48.0/download"
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
               ],
               "strip_prefix": "windows-sys-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
@@ -6820,7 +6835,7 @@
               "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/flate2/1.0.28/download"
+                "https://static.crates.io/crates/flate2/1.0.28/download"
               ],
               "strip_prefix": "flate2-1.0.28",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
@@ -6833,7 +6848,7 @@
               "sha256": "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/semver/0.9.0/download"
+                "https://static.crates.io/crates/semver/0.9.0/download"
               ],
               "strip_prefix": "semver-0.9.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.semver-0.9.0.bazel"
@@ -6846,7 +6861,7 @@
               "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/scopeguard/1.1.0/download"
+                "https://static.crates.io/crates/scopeguard/1.1.0/download"
               ],
               "strip_prefix": "scopeguard-1.1.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
@@ -6859,7 +6874,7 @@
               "sha256": "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fastrand/1.9.0/download"
+                "https://static.crates.io/crates/fastrand/1.9.0/download"
               ],
               "strip_prefix": "fastrand-1.9.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.fastrand-1.9.0.bazel"
@@ -6872,7 +6887,7 @@
               "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num_threads/0.1.6/download"
+                "https://static.crates.io/crates/num_threads/0.1.6/download"
               ],
               "strip_prefix": "num_threads-0.1.6",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num_threads-0.1.6.bazel"
@@ -6885,7 +6900,7 @@
               "sha256": "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rayon-core/1.12.0/download"
+                "https://static.crates.io/crates/rayon-core/1.12.0/download"
               ],
               "strip_prefix": "rayon-core-1.12.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rayon-core-1.12.0.bazel"
@@ -6898,7 +6913,7 @@
               "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/lazy_static/1.4.0/download"
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
               ],
               "strip_prefix": "lazy_static-1.4.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
@@ -6911,7 +6926,7 @@
               "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/thread_local/1.1.4/download"
+                "https://static.crates.io/crates/thread_local/1.1.4/download"
               ],
               "strip_prefix": "thread_local-1.1.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thread_local-1.1.4.bazel"
@@ -6924,7 +6939,7 @@
               "sha256": "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/threadpool/1.8.1/download"
+                "https://static.crates.io/crates/threadpool/1.8.1/download"
               ],
               "strip_prefix": "threadpool-1.8.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.threadpool-1.8.1.bazel"
@@ -6937,7 +6952,7 @@
               "sha256": "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/linux-raw-sys/0.4.10/download"
+                "https://static.crates.io/crates/linux-raw-sys/0.4.10/download"
               ],
               "strip_prefix": "linux-raw-sys-0.4.10",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.4.10.bazel"
@@ -6950,7 +6965,7 @@
               "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle-wincon/1.0.1/download"
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
               ],
               "strip_prefix": "anstyle-wincon-1.0.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
@@ -6963,7 +6978,7 @@
               "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_msvc-0.48.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
@@ -6976,7 +6991,7 @@
               "sha256": "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand_core/0.3.1/download"
+                "https://static.crates.io/crates/rand_core/0.3.1/download"
               ],
               "strip_prefix": "rand_core-0.3.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_core-0.3.1.bazel"
@@ -6989,7 +7004,7 @@
               "sha256": "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rayon/1.8.0/download"
+                "https://static.crates.io/crates/rayon/1.8.0/download"
               ],
               "strip_prefix": "rayon-1.8.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rayon-1.8.0.bazel"
@@ -7002,7 +7017,7 @@
               "sha256": "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tempfile/3.8.1/download"
+                "https://static.crates.io/crates/tempfile/3.8.1/download"
               ],
               "strip_prefix": "tempfile-3.8.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tempfile-3.8.1.bazel"
@@ -7015,7 +7030,7 @@
               "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_msvc-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
@@ -7028,7 +7043,7 @@
               "sha256": "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/multipart/0.18.0/download"
+                "https://static.crates.io/crates/multipart/0.18.0/download"
               ],
               "strip_prefix": "multipart-0.18.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.multipart-0.18.0.bazel"
@@ -7041,7 +7056,7 @@
               "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/android_system_properties/0.1.5/download"
+                "https://static.crates.io/crates/android_system_properties/0.1.5/download"
               ],
               "strip_prefix": "android_system_properties-0.1.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.android_system_properties-0.1.5.bazel"
@@ -7054,7 +7069,7 @@
               "sha256": "22e6b749660b613641769edc1954132eb8071a13c32224891686091bef078de4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-ref/0.37.0/download"
+                "https://static.crates.io/crates/gix-ref/0.37.0/download"
               ],
               "strip_prefix": "gix-ref-0.37.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-ref-0.37.0.bazel"
@@ -7067,7 +7082,7 @@
               "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand/0.8.5/download"
+                "https://static.crates.io/crates/rand/0.8.5/download"
               ],
               "strip_prefix": "rand-0.8.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand-0.8.5.bazel"
@@ -7080,7 +7095,7 @@
               "sha256": "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num-integer/0.1.45/download"
+                "https://static.crates.io/crates/num-integer/0.1.45/download"
               ],
               "strip_prefix": "num-integer-0.1.45",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-integer-0.1.45.bazel"
@@ -7093,7 +7108,7 @@
               "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle-query/1.0.0/download"
+                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
               ],
               "strip_prefix": "anstyle-query-1.0.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
@@ -7106,7 +7121,7 @@
               "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hermit-abi/0.3.2/download"
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
               ],
               "strip_prefix": "hermit-abi-0.3.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
@@ -7119,7 +7134,7 @@
               "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/getrandom/0.2.10/download"
+                "https://static.crates.io/crates/getrandom/0.2.10/download"
               ],
               "strip_prefix": "getrandom-0.2.10",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
@@ -7132,7 +7147,7 @@
               "sha256": "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/smallvec/0.6.14/download"
+                "https://static.crates.io/crates/smallvec/0.6.14/download"
               ],
               "strip_prefix": "smallvec-0.6.14",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.smallvec-0.6.14.bazel"
@@ -7145,7 +7160,7 @@
               "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/httparse/1.8.0/download"
+                "https://static.crates.io/crates/httparse/1.8.0/download"
               ],
               "strip_prefix": "httparse-1.8.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.httparse-1.8.0.bazel"
@@ -7158,7 +7173,7 @@
               "sha256": "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/shlex/1.1.0/download"
+                "https://static.crates.io/crates/shlex/1.1.0/download"
               ],
               "strip_prefix": "shlex-1.1.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.shlex-1.1.0.bazel"
@@ -7171,7 +7186,7 @@
               "sha256": "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/predicates/1.0.8/download"
+                "https://static.crates.io/crates/predicates/1.0.8/download"
               ],
               "strip_prefix": "predicates-1.0.8",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-1.0.8.bazel"
@@ -7184,7 +7199,7 @@
               "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/scopeguard/1.1.0/download"
+                "https://static.crates.io/crates/scopeguard/1.1.0/download"
               ],
               "strip_prefix": "scopeguard-1.1.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
@@ -7197,7 +7212,7 @@
               "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-targets/0.48.1/download"
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
               ],
               "strip_prefix": "windows-targets-0.48.1",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
@@ -7210,7 +7225,7 @@
               "sha256": "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde_json/1.0.102/download"
+                "https://static.crates.io/crates/serde_json/1.0.102/download"
               ],
               "strip_prefix": "serde_json-1.0.102",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
@@ -7223,7 +7238,7 @@
               "sha256": "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_builder/4.3.11/download"
+                "https://static.crates.io/crates/clap_builder/4.3.11/download"
               ],
               "strip_prefix": "clap_builder-4.3.11",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_builder-4.3.11.bazel"
@@ -7236,7 +7251,7 @@
               "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-sys/0.48.0/download"
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
               ],
               "strip_prefix": "windows-sys-0.48.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
@@ -7249,7 +7264,7 @@
               "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_gnu-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
@@ -7262,7 +7277,7 @@
               "sha256": "47fc96fa8b6b6d33555021907c81eb3b27635daecf6e630630bdad44f8feaa95",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-lock/10.0.0/download"
+                "https://static.crates.io/crates/gix-lock/10.0.0/download"
               ],
               "strip_prefix": "gix-lock-10.0.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-lock-10.0.0.bazel"
@@ -7275,7 +7290,7 @@
               "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/indexmap/1.9.3/download"
+                "https://static.crates.io/crates/indexmap/1.9.3/download"
               ],
               "strip_prefix": "indexmap-1.9.3",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
@@ -7288,7 +7303,7 @@
               "sha256": "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num-iter/0.1.43/download"
+                "https://static.crates.io/crates/num-iter/0.1.43/download"
               ],
               "strip_prefix": "num-iter-0.1.43",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-iter-0.1.43.bazel"
@@ -7301,7 +7316,7 @@
               "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ryu/1.0.14/download"
+                "https://static.crates.io/crates/ryu/1.0.14/download"
               ],
               "strip_prefix": "ryu-1.0.14",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
@@ -7314,7 +7329,7 @@
               "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/lazy_static/1.4.0/download"
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
               ],
               "strip_prefix": "lazy_static-1.4.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
@@ -7327,7 +7342,7 @@
               "sha256": "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/multimap/0.8.3/download"
+                "https://static.crates.io/crates/multimap/0.8.3/download"
               ],
               "strip_prefix": "multimap-0.8.3",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.multimap-0.8.3.bazel"
@@ -7340,7 +7355,7 @@
               "sha256": "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/difference/2.0.0/download"
+                "https://static.crates.io/crates/difference/2.0.0/download"
               ],
               "strip_prefix": "difference-2.0.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.difference-2.0.0.bazel"
@@ -7353,7 +7368,7 @@
               "sha256": "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-segmentation/1.10.1/download"
+                "https://static.crates.io/crates/unicode-segmentation/1.10.1/download"
               ],
               "strip_prefix": "unicode-segmentation-1.10.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-segmentation-1.10.1.bazel"
@@ -7366,7 +7381,7 @@
               "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/proc-macro2/1.0.64/download"
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
               ],
               "strip_prefix": "proc-macro2-1.0.64",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
@@ -7379,7 +7394,7 @@
               "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cc/1.0.79/download"
+                "https://static.crates.io/crates/cc/1.0.79/download"
               ],
               "strip_prefix": "cc-1.0.79",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.cc-1.0.79.bazel"
@@ -7392,7 +7407,7 @@
               "sha256": "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustls-webpki/0.101.7/download"
+                "https://static.crates.io/crates/rustls-webpki/0.101.7/download"
               ],
               "strip_prefix": "rustls-webpki-0.101.7",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustls-webpki-0.101.7.bazel"
@@ -7413,7 +7428,7 @@
               "sha256": "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/quote/1.0.28/download"
+                "https://static.crates.io/crates/quote/1.0.28/download"
               ],
               "strip_prefix": "quote-1.0.28",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.quote-1.0.28.bazel"
@@ -7426,7 +7441,7 @@
               "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle-query/1.0.0/download"
+                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
               ],
               "strip_prefix": "anstyle-query-1.0.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
@@ -7439,7 +7454,7 @@
               "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bumpalo/3.13.0/download"
+                "https://static.crates.io/crates/bumpalo/3.13.0/download"
               ],
               "strip_prefix": "bumpalo-3.13.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
@@ -7452,7 +7467,7 @@
               "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cfg-if/1.0.0/download"
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
               ],
               "strip_prefix": "cfg-if-1.0.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
@@ -7465,7 +7480,7 @@
               "sha256": "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle-parse/0.2.0/download"
+                "https://static.crates.io/crates/anstyle-parse/0.2.0/download"
               ],
               "strip_prefix": "anstyle-parse-0.2.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-parse-0.2.0.bazel"
@@ -7478,7 +7493,7 @@
               "sha256": "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bindgen/0.69.1/download"
+                "https://static.crates.io/crates/bindgen/0.69.1/download"
               ],
               "strip_prefix": "bindgen-0.69.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bindgen-0.69.1.bazel"
@@ -7491,7 +7506,7 @@
               "sha256": "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num-complex/0.1.43/download"
+                "https://static.crates.io/crates/num-complex/0.1.43/download"
               ],
               "strip_prefix": "num-complex-0.1.43",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-complex-0.1.43.bazel"
@@ -7504,7 +7519,7 @@
               "sha256": "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pin-project/1.1.0/download"
+                "https://static.crates.io/crates/pin-project/1.1.0/download"
               ],
               "strip_prefix": "pin-project-1.1.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-1.1.0.bazel"
@@ -7517,7 +7532,7 @@
               "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/quote/1.0.29/download"
+                "https://static.crates.io/crates/quote/1.0.29/download"
               ],
               "strip_prefix": "quote-1.0.29",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.quote-1.0.29.bazel"
@@ -7530,7 +7545,7 @@
               "sha256": "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/parse-zoneinfo/0.3.0/download"
+                "https://static.crates.io/crates/parse-zoneinfo/0.3.0/download"
               ],
               "strip_prefix": "parse-zoneinfo-0.3.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.parse-zoneinfo-0.3.0.bazel"
@@ -7543,7 +7558,7 @@
               "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-bidi/0.3.13/download"
+                "https://static.crates.io/crates/unicode-bidi/0.3.13/download"
               ],
               "strip_prefix": "unicode-bidi-0.3.13",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
@@ -7556,7 +7571,7 @@
               "sha256": "22ef04ab3643acba289b5cedd25d6f53c0430770b1d689d1d654511e6fb81ba0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-traverse/0.33.0/download"
+                "https://static.crates.io/crates/gix-traverse/0.33.0/download"
               ],
               "strip_prefix": "gix-traverse-0.33.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-traverse-0.33.0.bazel"
@@ -7569,7 +7584,7 @@
               "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/stable_deref_trait/1.2.0/download"
+                "https://static.crates.io/crates/stable_deref_trait/1.2.0/download"
               ],
               "strip_prefix": "stable_deref_trait-1.2.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.stable_deref_trait-1.2.0.bazel"
@@ -7582,7 +7597,7 @@
               "sha256": "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ws2_32-sys/0.2.1/download"
+                "https://static.crates.io/crates/ws2_32-sys/0.2.1/download"
               ],
               "strip_prefix": "ws2_32-sys-0.2.1",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.ws2_32-sys-0.2.1.bazel"
@@ -7595,7 +7610,7 @@
               "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/miniz_oxide/0.7.1/download"
+                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
               ],
               "strip_prefix": "miniz_oxide-0.7.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
@@ -7608,7 +7623,7 @@
               "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/io-lifetimes/1.0.11/download"
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
               ],
               "strip_prefix": "io-lifetimes-1.0.11",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
@@ -7621,7 +7636,7 @@
               "sha256": "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unic-char-range/0.9.0/download"
+                "https://static.crates.io/crates/unic-char-range/0.9.0/download"
               ],
               "strip_prefix": "unic-char-range-0.9.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-char-range-0.9.0.bazel"
@@ -7634,7 +7649,7 @@
               "sha256": "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/leb128/0.2.5/download"
+                "https://static.crates.io/crates/leb128/0.2.5/download"
               ],
               "strip_prefix": "leb128-0.2.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.leb128-0.2.5.bazel"
@@ -7647,7 +7662,7 @@
               "sha256": "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/predicates-core/1.0.6/download"
+                "https://static.crates.io/crates/predicates-core/1.0.6/download"
               ],
               "strip_prefix": "predicates-core-1.0.6",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-core-1.0.6.bazel"
@@ -7660,7 +7675,7 @@
               "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_msvc-0.48.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
@@ -7673,7 +7688,7 @@
               "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle/1.0.1/download"
+                "https://static.crates.io/crates/anstyle/1.0.1/download"
               ],
               "strip_prefix": "anstyle-1.0.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
@@ -7686,7 +7701,7 @@
               "sha256": "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-0.2.91.bazel"
@@ -7699,7 +7714,7 @@
               "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
@@ -7712,7 +7727,7 @@
               "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-automata/0.3.3/download"
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
               ],
               "strip_prefix": "regex-automata-0.3.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
@@ -7725,7 +7740,7 @@
               "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_msvc-0.48.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
@@ -7738,7 +7753,7 @@
               "sha256": "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/which/4.4.0/download"
+                "https://static.crates.io/crates/which/4.4.0/download"
               ],
               "strip_prefix": "which-4.4.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.which-4.4.0.bazel"
@@ -7751,7 +7766,7 @@
               "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle-wincon/1.0.1/download"
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
               ],
               "strip_prefix": "anstyle-wincon-1.0.1",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
@@ -7764,7 +7779,7 @@
               "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/adler/1.0.2/download"
+                "https://static.crates.io/crates/adler/1.0.2/download"
               ],
               "strip_prefix": "adler-1.0.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.adler-1.0.2.bazel"
@@ -7777,7 +7792,7 @@
               "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/log/0.4.19/download"
+                "https://static.crates.io/crates/log/0.4.19/download"
               ],
               "strip_prefix": "log-0.4.19",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.log-0.4.19.bazel"
@@ -7790,7 +7805,7 @@
               "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/heck/0.4.1/download"
+                "https://static.crates.io/crates/heck/0.4.1/download"
               ],
               "strip_prefix": "heck-0.4.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.heck-0.4.1.bazel"
@@ -7803,7 +7818,7 @@
               "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/digest/0.10.7/download"
+                "https://static.crates.io/crates/digest/0.10.7/download"
               ],
               "strip_prefix": "digest-0.10.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.digest-0.10.7.bazel"
@@ -7816,7 +7831,7 @@
               "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/equivalent/1.0.1/download"
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
               ],
               "strip_prefix": "equivalent-1.0.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
@@ -7837,7 +7852,7 @@
               "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/memchr/2.5.0/download"
+                "https://static.crates.io/crates/memchr/2.5.0/download"
               ],
               "strip_prefix": "memchr-2.5.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
@@ -7850,7 +7865,7 @@
               "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/once_cell/1.18.0/download"
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
               ],
               "strip_prefix": "once_cell-1.18.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
@@ -7863,7 +7878,7 @@
               "sha256": "68d0e040d5b1f4cfca70ec4f371229886a5de5bb554d272a4a8da73004a7b2c9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-tls-api/0.1.22/download"
+                "https://static.crates.io/crates/tokio-tls-api/0.1.22/download"
               ],
               "strip_prefix": "tokio-tls-api-0.1.22",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-tls-api-0.1.22.bazel"
@@ -7876,7 +7891,7 @@
               "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/is-terminal/0.4.7/download"
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
               ],
               "strip_prefix": "is-terminal-0.4.7",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
@@ -7889,7 +7904,7 @@
               "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/autocfg/1.1.0/download"
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
               ],
               "strip_prefix": "autocfg-1.1.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
@@ -7902,7 +7917,7 @@
               "sha256": "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-util/0.7.8/download"
+                "https://static.crates.io/crates/tokio-util/0.7.8/download"
               ],
               "strip_prefix": "tokio-util-0.7.8",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-util-0.7.8.bazel"
@@ -7915,7 +7930,7 @@
               "sha256": "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-io-timeout/1.2.0/download"
+                "https://static.crates.io/crates/tokio-io-timeout/1.2.0/download"
               ],
               "strip_prefix": "tokio-io-timeout-1.2.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-io-timeout-1.2.0.bazel"
@@ -7928,7 +7943,7 @@
               "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num-traits/0.2.15/download"
+                "https://static.crates.io/crates/num-traits/0.2.15/download"
               ],
               "strip_prefix": "num-traits-0.2.15",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-traits-0.2.15.bazel"
@@ -7941,7 +7956,7 @@
               "sha256": "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-build/0.1.1/download"
+                "https://static.crates.io/crates/winapi-build/0.1.1/download"
               ],
               "strip_prefix": "winapi-build-0.1.1",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-build-0.1.1.bazel"
@@ -7954,7 +7969,7 @@
               "sha256": "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/base64/0.13.1/download"
+                "https://static.crates.io/crates/base64/0.13.1/download"
               ],
               "strip_prefix": "base64-0.13.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.base64-0.13.1.bazel"
@@ -7967,7 +7982,7 @@
               "sha256": "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/parking_lot/0.9.0/download"
+                "https://static.crates.io/crates/parking_lot/0.9.0/download"
               ],
               "strip_prefix": "parking_lot-0.9.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.parking_lot-0.9.0.bazel"
@@ -7980,7 +7995,7 @@
               "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/humantime/2.1.0/download"
+                "https://static.crates.io/crates/humantime/2.1.0/download"
               ],
               "strip_prefix": "humantime-2.1.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
@@ -7993,7 +8008,7 @@
               "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand_chacha/0.3.1/download"
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
               ],
               "strip_prefix": "rand_chacha-0.3.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
@@ -8006,7 +8021,7 @@
               "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/strsim/0.10.0/download"
+                "https://static.crates.io/crates/strsim/0.10.0/download"
               ],
               "strip_prefix": "strsim-0.10.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
@@ -8019,7 +8034,7 @@
               "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
@@ -8032,7 +8047,7 @@
               "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cfg-if/1.0.0/download"
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
               ],
               "strip_prefix": "cfg-if-1.0.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
@@ -8045,7 +8060,7 @@
               "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno-dragonfly/0.1.2/download"
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
               ],
               "strip_prefix": "errno-dragonfly-0.1.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
@@ -8058,7 +8073,7 @@
               "sha256": "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-syntax/0.7.2/download"
+                "https://static.crates.io/crates/regex-syntax/0.7.2/download"
               ],
               "strip_prefix": "regex-syntax-0.7.2",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-syntax-0.7.2.bazel"
@@ -8071,7 +8086,7 @@
               "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/proc-macro2/1.0.64/download"
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
               ],
               "strip_prefix": "proc-macro2-1.0.64",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
@@ -8084,7 +8099,7 @@
               "sha256": "5c9a913769516f5e9d937afac206fb76428e3d7238e538845842887fda584678",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-prompt/0.7.0/download"
+                "https://static.crates.io/crates/gix-prompt/0.7.0/download"
               ],
               "strip_prefix": "gix-prompt-0.7.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-prompt-0.7.0.bazel"
@@ -8097,7 +8112,7 @@
               "sha256": "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/thiserror-impl/1.0.50/download"
+                "https://static.crates.io/crates/thiserror-impl/1.0.50/download"
               ],
               "strip_prefix": "thiserror-impl-1.0.50",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thiserror-impl-1.0.50.bazel"
@@ -8110,7 +8125,7 @@
               "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/either/1.8.1/download"
+                "https://static.crates.io/crates/either/1.8.1/download"
               ],
               "strip_prefix": "either-1.8.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.either-1.8.1.bazel"
@@ -8136,7 +8151,7 @@
               "sha256": "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/thiserror/1.0.50/download"
+                "https://static.crates.io/crates/thiserror/1.0.50/download"
               ],
               "strip_prefix": "thiserror-1.0.50",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.thiserror-1.0.50.bazel"
@@ -8149,7 +8164,7 @@
               "sha256": "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/mio-uds/0.6.8/download"
+                "https://static.crates.io/crates/mio-uds/0.6.8/download"
               ],
               "strip_prefix": "mio-uds-0.6.8",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.mio-uds-0.6.8.bazel"
@@ -8162,7 +8177,7 @@
               "sha256": "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-fs/0.1.7/download"
+                "https://static.crates.io/crates/tokio-fs/0.1.7/download"
               ],
               "strip_prefix": "tokio-fs-0.1.7",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-fs-0.1.7.bazel"
@@ -8175,7 +8190,7 @@
               "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/linux-raw-sys/0.3.8/download"
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
               ],
               "strip_prefix": "linux-raw-sys-0.3.8",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
@@ -8188,7 +8203,7 @@
               "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-automata/0.3.3/download"
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
               ],
               "strip_prefix": "regex-automata-0.3.3",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
@@ -8201,7 +8216,7 @@
               "sha256": "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/typenum/1.16.0/download"
+                "https://static.crates.io/crates/typenum/1.16.0/download"
               ],
               "strip_prefix": "typenum-1.16.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.typenum-1.16.0.bazel"
@@ -8214,7 +8229,7 @@
               "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand/0.8.5/download"
+                "https://static.crates.io/crates/rand/0.8.5/download"
               ],
               "strip_prefix": "rand-0.8.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand-0.8.5.bazel"
@@ -8227,7 +8242,7 @@
               "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno/0.3.1/download"
+                "https://static.crates.io/crates/errno/0.3.1/download"
               ],
               "strip_prefix": "errno-0.3.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.errno-0.3.1.bazel"
@@ -8240,7 +8255,7 @@
               "sha256": "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num-rational/0.1.42/download"
+                "https://static.crates.io/crates/num-rational/0.1.42/download"
               ],
               "strip_prefix": "num-rational-0.1.42",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-rational-0.1.42.bazel"
@@ -8253,7 +8268,7 @@
               "sha256": "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/difflib/0.4.0/download"
+                "https://static.crates.io/crates/difflib/0.4.0/download"
               ],
               "strip_prefix": "difflib-0.4.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.difflib-0.4.0.bazel"
@@ -8266,7 +8281,7 @@
               "sha256": "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/sha2/0.10.8/download"
+                "https://static.crates.io/crates/sha2/0.10.8/download"
               ],
               "strip_prefix": "sha2-0.10.8",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sha2-0.10.8.bazel"
@@ -8279,7 +8294,7 @@
               "sha256": "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clru/0.6.1/download"
+                "https://static.crates.io/crates/clru/0.6.1/download"
               ],
               "strip_prefix": "clru-0.6.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clru-0.6.1.bazel"
@@ -8292,7 +8307,7 @@
               "sha256": "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand/0.4.6/download"
+                "https://static.crates.io/crates/rand/0.4.6/download"
               ],
               "strip_prefix": "rand-0.4.6",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand-0.4.6.bazel"
@@ -8305,7 +8320,7 @@
               "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/io-lifetimes/1.0.11/download"
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
               ],
               "strip_prefix": "io-lifetimes-1.0.11",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
@@ -8318,7 +8333,7 @@
               "sha256": "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/phf_shared/0.11.2/download"
+                "https://static.crates.io/crates/phf_shared/0.11.2/download"
               ],
               "strip_prefix": "phf_shared-0.11.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf_shared-0.11.2.bazel"
@@ -8331,7 +8346,7 @@
               "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bitflags/1.3.2/download"
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
               ],
               "strip_prefix": "bitflags-1.3.2",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
@@ -8344,7 +8359,7 @@
               "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/redox_syscall/0.3.5/download"
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
               ],
               "strip_prefix": "redox_syscall-0.3.5",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
@@ -8357,7 +8372,7 @@
               "sha256": "7d8395f7501c84d6a1fe902035fdfd8cd86d89e2dd6be0200ec1a72fd3c92d39",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-packetline-blocking/0.16.6/download"
+                "https://static.crates.io/crates/gix-packetline-blocking/0.16.6/download"
               ],
               "strip_prefix": "gix-packetline-blocking-0.16.6",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-packetline-blocking-0.16.6.bazel"
@@ -8370,7 +8385,7 @@
               "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fnv/1.0.7/download"
+                "https://static.crates.io/crates/fnv/1.0.7/download"
               ],
               "strip_prefix": "fnv-1.0.7",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
@@ -8383,7 +8398,7 @@
               "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
@@ -8396,7 +8411,7 @@
               "sha256": "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tracing-core/0.1.31/download"
+                "https://static.crates.io/crates/tracing-core/0.1.31/download"
               ],
               "strip_prefix": "tracing-core-0.1.31",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-core-0.1.31.bazel"
@@ -8409,7 +8424,7 @@
               "sha256": "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/env_logger/0.10.0/download"
+                "https://static.crates.io/crates/env_logger/0.10.0/download"
               ],
               "strip_prefix": "env_logger-0.10.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.env_logger-0.10.0.bazel"
@@ -8422,7 +8437,7 @@
               "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/aho-corasick/1.0.2/download"
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
               ],
               "strip_prefix": "aho-corasick-1.0.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
@@ -8435,7 +8450,7 @@
               "sha256": "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/time/0.3.30/download"
+                "https://static.crates.io/crates/time/0.3.30/download"
               ],
               "strip_prefix": "time-0.3.30",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-0.3.30.bazel"
@@ -8448,7 +8463,7 @@
               "sha256": "2aaf1d741fe6f3413f1f9f71b99f5e4e26776d563475a8a53ce53a73a8534c1d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/grpc/0.6.2/download"
+                "https://static.crates.io/crates/grpc/0.6.2/download"
               ],
               "strip_prefix": "grpc-0.6.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.grpc-0.6.2.bazel"
@@ -8461,7 +8476,7 @@
               "sha256": "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-ident/1.0.9/download"
+                "https://static.crates.io/crates/unicode-ident/1.0.9/download"
               ],
               "strip_prefix": "unicode-ident-1.0.9",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.9.bazel"
@@ -8474,7 +8489,7 @@
               "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/log/0.4.19/download"
+                "https://static.crates.io/crates/log/0.4.19/download"
               ],
               "strip_prefix": "log-0.4.19",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.log-0.4.19.bazel"
@@ -8487,7 +8502,7 @@
               "sha256": "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ucd-trie/0.1.6/download"
+                "https://static.crates.io/crates/ucd-trie/0.1.6/download"
               ],
               "strip_prefix": "ucd-trie-0.1.6",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ucd-trie-0.1.6.bazel"
@@ -8500,7 +8515,7 @@
               "sha256": "7536203a45b31e1bc5694bbf90ba8da1b736c77040dd6a520db369f371eb1ab3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-pack/0.43.0/download"
+                "https://static.crates.io/crates/gix-pack/0.43.0/download"
               ],
               "strip_prefix": "gix-pack-0.43.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-pack-0.43.0.bazel"
@@ -8513,7 +8528,7 @@
               "sha256": "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/prettyplease/0.1.25/download"
+                "https://static.crates.io/crates/prettyplease/0.1.25/download"
               ],
               "strip_prefix": "prettyplease-0.1.25",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prettyplease-0.1.25.bazel"
@@ -8526,7 +8541,7 @@
               "sha256": "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/toml/0.7.6/download"
+                "https://static.crates.io/crates/toml/0.7.6/download"
               ],
               "strip_prefix": "toml-0.7.6",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml-0.7.6.bazel"
@@ -8539,7 +8554,7 @@
               "sha256": "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tempfile/3.6.0/download"
+                "https://static.crates.io/crates/tempfile/3.6.0/download"
               ],
               "strip_prefix": "tempfile-3.6.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tempfile-3.6.0.bazel"
@@ -8552,7 +8567,7 @@
               "sha256": "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-stream/0.1.14/download"
+                "https://static.crates.io/crates/tokio-stream/0.1.14/download"
               ],
               "strip_prefix": "tokio-stream-0.1.14",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-stream-0.1.14.bazel"
@@ -8565,7 +8580,7 @@
               "sha256": "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unic-ucd-segment/0.9.0/download"
+                "https://static.crates.io/crates/unic-ucd-segment/0.9.0/download"
               ],
               "strip_prefix": "unic-ucd-segment-0.9.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-ucd-segment-0.9.0.bazel"
@@ -8578,7 +8593,7 @@
               "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/android-tzdata/0.1.1/download"
+                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
               ],
               "strip_prefix": "android-tzdata-0.1.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
@@ -8596,7 +8611,7 @@
               "sha256": "dd0150e82e9282d3f2ab2dd57a22f9f6c3447b9d9856e5321ac92d38e3e0e2b7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-submodule/0.4.0/download"
+                "https://static.crates.io/crates/gix-submodule/0.4.0/download"
               ],
               "strip_prefix": "gix-submodule-0.4.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-submodule-0.4.0.bazel"
@@ -8609,7 +8624,7 @@
               "sha256": "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde_spanned/0.6.5/download"
+                "https://static.crates.io/crates/serde_spanned/0.6.5/download"
               ],
               "strip_prefix": "serde_spanned-0.6.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_spanned-0.6.5.bazel"
@@ -8622,7 +8637,7 @@
               "sha256": "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/kernel32-sys/0.2.2/download"
+                "https://static.crates.io/crates/kernel32-sys/0.2.2/download"
               ],
               "strip_prefix": "kernel32-sys-0.2.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.kernel32-sys-0.2.2.bazel"
@@ -8635,7 +8650,7 @@
               "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/mime/0.3.17/download"
+                "https://static.crates.io/crates/mime/0.3.17/download"
               ],
               "strip_prefix": "mime-0.3.17",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.mime-0.3.17.bazel"
@@ -8648,7 +8663,7 @@
               "sha256": "475c86a97dd0127ba4465fbb239abac9ea10e68301470c9791a6dd5351cdc905",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-quote/0.4.7/download"
+                "https://static.crates.io/crates/gix-quote/0.4.7/download"
               ],
               "strip_prefix": "gix-quote-0.4.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-quote-0.4.7.bazel"
@@ -8661,7 +8676,7 @@
               "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/linux-raw-sys/0.3.8/download"
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
               ],
               "strip_prefix": "linux-raw-sys-0.3.8",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
@@ -8674,7 +8689,7 @@
               "sha256": "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/memmap2/0.7.1/download"
+                "https://static.crates.io/crates/memmap2/0.7.1/download"
               ],
               "strip_prefix": "memmap2-0.7.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memmap2-0.7.1.bazel"
@@ -8687,7 +8702,7 @@
               "sha256": "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-reactor/0.1.12/download"
+                "https://static.crates.io/crates/tokio-reactor/0.1.12/download"
               ],
               "strip_prefix": "tokio-reactor-0.1.12",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-reactor-0.1.12.bazel"
@@ -8700,7 +8715,7 @@
               "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/equivalent/1.0.1/download"
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
               ],
               "strip_prefix": "equivalent-1.0.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
@@ -8713,7 +8728,7 @@
               "sha256": "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fallible-iterator/0.2.0/download"
+                "https://static.crates.io/crates/fallible-iterator/0.2.0/download"
               ],
               "strip_prefix": "fallible-iterator-0.2.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.fallible-iterator-0.2.0.bazel"
@@ -8726,7 +8741,7 @@
               "sha256": "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pest_derive/2.7.0/download"
+                "https://static.crates.io/crates/pest_derive/2.7.0/download"
               ],
               "strip_prefix": "pest_derive-2.7.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_derive-2.7.0.bazel"
@@ -8739,7 +8754,7 @@
               "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/once_cell/1.18.0/download"
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
               ],
               "strip_prefix": "once_cell-1.18.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
@@ -8752,7 +8767,7 @@
               "sha256": "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fuchsia-zircon/0.3.3/download"
+                "https://static.crates.io/crates/fuchsia-zircon/0.3.3/download"
               ],
               "strip_prefix": "fuchsia-zircon-0.3.3",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-0.3.3.bazel"
@@ -8765,7 +8780,7 @@
               "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hermit-abi/0.3.2/download"
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
               ],
               "strip_prefix": "hermit-abi-0.3.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
@@ -8778,7 +8793,7 @@
               "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-syntax/0.7.4/download"
+                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
               ],
               "strip_prefix": "regex-syntax-0.7.4",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
@@ -8791,7 +8806,7 @@
               "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno-dragonfly/0.1.2/download"
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
               ],
               "strip_prefix": "errno-dragonfly-0.1.2",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
@@ -8804,7 +8819,7 @@
               "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/miniz_oxide/0.7.1/download"
+                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
               ],
               "strip_prefix": "miniz_oxide-0.7.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
@@ -8817,7 +8832,7 @@
               "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
@@ -8830,7 +8845,7 @@
               "sha256": "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/syn/2.0.18/download"
+                "https://static.crates.io/crates/syn/2.0.18/download"
               ],
               "strip_prefix": "syn-2.0.18",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.syn-2.0.18.bazel"
@@ -8843,7 +8858,7 @@
               "sha256": "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-io/0.1.13/download"
+                "https://static.crates.io/crates/tokio-io/0.1.13/download"
               ],
               "strip_prefix": "tokio-io-0.1.13",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-io-0.1.13.bazel"
@@ -8856,7 +8871,7 @@
               "sha256": "b85d89dc728613e26e0ed952a19583744e7f5240fcd4aa30d6c824ffd8b52f0f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-utils/0.1.5/download"
+                "https://static.crates.io/crates/gix-utils/0.1.5/download"
               ],
               "strip_prefix": "gix-utils-0.1.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-utils-0.1.5.bazel"
@@ -8869,7 +8884,7 @@
               "sha256": "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicase/2.6.0/download"
+                "https://static.crates.io/crates/unicase/2.6.0/download"
               ],
               "strip_prefix": "unicase-2.6.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicase-2.6.0.bazel"
@@ -8882,7 +8897,7 @@
               "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cc/1.0.79/download"
+                "https://static.crates.io/crates/cc/1.0.79/download"
               ],
               "strip_prefix": "cc-1.0.79",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.cc-1.0.79.bazel"
@@ -8895,7 +8910,7 @@
               "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-ident/1.0.10/download"
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
               ],
               "strip_prefix": "unicode-ident-1.0.10",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
@@ -8908,7 +8923,7 @@
               "sha256": "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-epoch/0.8.2/download"
+                "https://static.crates.io/crates/crossbeam-epoch/0.8.2/download"
               ],
               "strip_prefix": "crossbeam-epoch-0.8.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-epoch-0.8.2.bazel"
@@ -8921,7 +8936,7 @@
               "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_lex/0.5.0/download"
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
               ],
               "strip_prefix": "clap_lex-0.5.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
@@ -8934,7 +8949,7 @@
               "sha256": "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/indexmap/2.1.0/download"
+                "https://static.crates.io/crates/indexmap/2.1.0/download"
               ],
               "strip_prefix": "indexmap-2.1.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.indexmap-2.1.0.bazel"
@@ -8947,7 +8962,7 @@
               "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hex/0.4.3/download"
+                "https://static.crates.io/crates/hex/0.4.3/download"
               ],
               "strip_prefix": "hex-0.4.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hex-0.4.3.bazel"
@@ -8960,7 +8975,7 @@
               "sha256": "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/quote/1.0.28/download"
+                "https://static.crates.io/crates/quote/1.0.28/download"
               ],
               "strip_prefix": "quote-1.0.28",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.quote-1.0.28.bazel"
@@ -8973,7 +8988,7 @@
               "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows/0.48.0/download"
+                "https://static.crates.io/crates/windows/0.48.0/download"
               ],
               "strip_prefix": "windows-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-0.48.0.bazel"
@@ -8986,7 +9001,7 @@
               "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bitflags/1.3.2/download"
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
               ],
               "strip_prefix": "bitflags-1.3.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
@@ -8999,7 +9014,7 @@
               "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-normalization/0.1.22/download"
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
               ],
               "strip_prefix": "unicode-normalization-0.1.22",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
@@ -9024,7 +9039,7 @@
               "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anyhow/1.0.71/download"
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
               ],
               "strip_prefix": "anyhow-1.0.71",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
@@ -9037,7 +9052,7 @@
               "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/memchr/2.5.0/download"
+                "https://static.crates.io/crates/memchr/2.5.0/download"
               ],
               "strip_prefix": "memchr-2.5.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
@@ -9050,7 +9065,7 @@
               "sha256": "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/parking_lot_core/0.9.8/download"
+                "https://static.crates.io/crates/parking_lot_core/0.9.8/download"
               ],
               "strip_prefix": "parking_lot_core-0.9.8",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.parking_lot_core-0.9.8.bazel"
@@ -9063,7 +9078,7 @@
               "sha256": "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bytes/0.4.12/download"
+                "https://static.crates.io/crates/bytes/0.4.12/download"
               ],
               "strip_prefix": "bytes-0.4.12",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.bytes-0.4.12.bazel"
@@ -9076,7 +9091,7 @@
               "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/iana-time-zone/0.1.57/download"
+                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
               ],
               "strip_prefix": "iana-time-zone-0.1.57",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
@@ -9089,7 +9104,7 @@
               "sha256": "5f8751d9c1b03c6500c387e96f81f815a4f8e72d142d2d4a9ffa6fedd51ddee7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/toml_edit/0.19.13/download"
+                "https://static.crates.io/crates/toml_edit/0.19.13/download"
               ],
               "strip_prefix": "toml_edit-0.19.13",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_edit-0.19.13.bazel"
@@ -9102,7 +9117,7 @@
               "sha256": "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/matchit/0.7.0/download"
+                "https://static.crates.io/crates/matchit/0.7.0/download"
               ],
               "strip_prefix": "matchit-0.7.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.matchit-0.7.0.bazel"
@@ -9115,7 +9130,7 @@
               "sha256": "5b42ea64420f7994000130328f3c7a2038f639120518870436d31b8bde704493",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-chunk/0.4.4/download"
+                "https://static.crates.io/crates/gix-chunk/0.4.4/download"
               ],
               "strip_prefix": "gix-chunk-0.4.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-chunk-0.4.4.bazel"
@@ -9128,7 +9143,7 @@
               "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/sync_wrapper/0.1.2/download"
+                "https://static.crates.io/crates/sync_wrapper/0.1.2/download"
               ],
               "strip_prefix": "sync_wrapper-0.1.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-0.1.2.bazel"
@@ -9141,7 +9156,7 @@
               "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/idna/0.4.0/download"
+                "https://static.crates.io/crates/idna/0.4.0/download"
               ],
               "strip_prefix": "idna-0.4.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.idna-0.4.0.bazel"
@@ -9154,7 +9169,7 @@
               "sha256": "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-macro-support/0.2.87/download"
+                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.87/download"
               ],
               "strip_prefix": "wasm-bindgen-macro-support-0.2.87",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.87.bazel"
@@ -9167,7 +9182,7 @@
               "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno-dragonfly/0.1.2/download"
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
               ],
               "strip_prefix": "errno-dragonfly-0.1.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
@@ -9180,7 +9195,7 @@
               "sha256": "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hyper-timeout/0.4.1/download"
+                "https://static.crates.io/crates/hyper-timeout/0.4.1/download"
               ],
               "strip_prefix": "hyper-timeout-0.4.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-timeout-0.4.1.bazel"
@@ -9193,7 +9208,7 @@
               "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustc-hash/1.1.0/download"
+                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
               ],
               "strip_prefix": "rustc-hash-1.1.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
@@ -9206,7 +9221,7 @@
               "sha256": "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/http/0.2.9/download"
+                "https://static.crates.io/crates/http/0.2.9/download"
               ],
               "strip_prefix": "http-0.2.9",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.http-0.2.9.bazel"
@@ -9219,7 +9234,7 @@
               "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-epoch/0.9.15/download"
+                "https://static.crates.io/crates/crossbeam-epoch/0.9.15/download"
               ],
               "strip_prefix": "crossbeam-epoch-0.9.15",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-epoch-0.9.15.bazel"
@@ -9232,7 +9247,7 @@
               "sha256": "ea7505b97f4d8e7933e29735a568ba2f86d8de466669d9f0e8321384f9972f47",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-config-value/0.14.0/download"
+                "https://static.crates.io/crates/gix-config-value/0.14.0/download"
               ],
               "strip_prefix": "gix-config-value-0.14.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-config-value-0.14.0.bazel"
@@ -9245,7 +9260,7 @@
               "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/chrono/0.4.26/download"
+                "https://static.crates.io/crates/chrono/0.4.26/download"
               ],
               "strip_prefix": "chrono-0.4.26",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
@@ -9258,7 +9273,7 @@
               "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/same-file/1.0.6/download"
+                "https://static.crates.io/crates/same-file/1.0.6/download"
               ],
               "strip_prefix": "same-file-1.0.6",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.same-file-1.0.6.bazel"
@@ -9271,7 +9286,7 @@
               "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/linux-raw-sys/0.3.8/download"
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
               ],
               "strip_prefix": "linux-raw-sys-0.3.8",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
@@ -9284,7 +9299,7 @@
               "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/termcolor/1.2.0/download"
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
               ],
               "strip_prefix": "termcolor-1.2.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
@@ -9297,7 +9312,7 @@
               "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand_core/0.6.4/download"
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
               ],
               "strip_prefix": "rand_core-0.6.4",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
@@ -9310,7 +9325,7 @@
               "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-channel/0.5.8/download"
+                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
               ],
               "strip_prefix": "crossbeam-channel-0.5.8",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
@@ -9323,7 +9338,7 @@
               "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cc/1.0.79/download"
+                "https://static.crates.io/crates/cc/1.0.79/download"
               ],
               "strip_prefix": "cc-1.0.79",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cc-1.0.79.bazel"
@@ -9336,7 +9351,7 @@
               "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand/0.8.5/download"
+                "https://static.crates.io/crates/rand/0.8.5/download"
               ],
               "strip_prefix": "rand-0.8.5",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand-0.8.5.bazel"
@@ -9349,7 +9364,7 @@
               "sha256": "e05cab2b03a45b866156e052aa38619f4ece4adcb2f79978bfc249bc3b21b8c5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-validate/0.8.0/download"
+                "https://static.crates.io/crates/gix-validate/0.8.0/download"
               ],
               "strip_prefix": "gix-validate-0.8.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-validate-0.8.0.bazel"
@@ -9362,7 +9377,7 @@
               "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anyhow/1.0.71/download"
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
               ],
               "strip_prefix": "anyhow-1.0.71",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
@@ -9375,7 +9390,7 @@
               "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/is-terminal/0.4.7/download"
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
               ],
               "strip_prefix": "is-terminal-0.4.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
@@ -9388,7 +9403,7 @@
               "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-width/0.1.10/download"
+                "https://static.crates.io/crates/unicode-width/0.1.10/download"
               ],
               "strip_prefix": "unicode-width-0.1.10",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-width-0.1.10.bazel"
@@ -9401,7 +9416,7 @@
               "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/humantime/2.1.0/download"
+                "https://static.crates.io/crates/humantime/2.1.0/download"
               ],
               "strip_prefix": "humantime-2.1.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
@@ -9414,7 +9429,7 @@
               "sha256": "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/libc/0.2.150/download"
+                "https://static.crates.io/crates/libc/0.2.150/download"
               ],
               "strip_prefix": "libc-0.2.150",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.libc-0.2.150.bazel"
@@ -9427,7 +9442,7 @@
               "sha256": "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/env_logger/0.10.0/download"
+                "https://static.crates.io/crates/env_logger/0.10.0/download"
               ],
               "strip_prefix": "env_logger-0.10.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.env_logger-0.10.0.bazel"
@@ -9440,7 +9455,7 @@
               "sha256": "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/toml/0.8.10/download"
+                "https://static.crates.io/crates/toml/0.8.10/download"
               ],
               "strip_prefix": "toml-0.8.10",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml-0.8.10.bazel"
@@ -9453,7 +9468,7 @@
               "sha256": "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tracing-attributes/0.1.26/download"
+                "https://static.crates.io/crates/tracing-attributes/0.1.26/download"
               ],
               "strip_prefix": "tracing-attributes-0.1.26",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tracing-attributes-0.1.26.bazel"
@@ -9466,7 +9481,7 @@
               "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/instant/0.1.12/download"
+                "https://static.crates.io/crates/instant/0.1.12/download"
               ],
               "strip_prefix": "instant-0.1.12",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.instant-0.1.12.bazel"
@@ -9479,7 +9494,7 @@
               "sha256": "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/indexmap/2.0.0/download"
+                "https://static.crates.io/crates/indexmap/2.0.0/download"
               ],
               "strip_prefix": "indexmap-2.0.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.indexmap-2.0.0.bazel"
@@ -9492,7 +9507,7 @@
               "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_gnu-0.48.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
@@ -9505,7 +9520,7 @@
               "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/proc-macro2/1.0.64/download"
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
               ],
               "strip_prefix": "proc-macro2-1.0.64",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
@@ -9518,7 +9533,7 @@
               "sha256": "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/predicates-tree/1.0.9/download"
+                "https://static.crates.io/crates/predicates-tree/1.0.9/download"
               ],
               "strip_prefix": "predicates-tree-1.0.9",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-tree-1.0.9.bazel"
@@ -9531,7 +9546,7 @@
               "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno/0.3.1/download"
+                "https://static.crates.io/crates/errno/0.3.1/download"
               ],
               "strip_prefix": "errno-0.3.1",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.errno-0.3.1.bazel"
@@ -9544,7 +9559,7 @@
               "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num_threads/0.1.6/download"
+                "https://static.crates.io/crates/num_threads/0.1.6/download"
               ],
               "strip_prefix": "num_threads-0.1.6",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num_threads-0.1.6.bazel"
@@ -9557,7 +9572,7 @@
               "sha256": "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/arc-swap/1.6.0/download"
+                "https://static.crates.io/crates/arc-swap/1.6.0/download"
               ],
               "strip_prefix": "arc-swap-1.6.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.arc-swap-1.6.0.bazel"
@@ -9570,7 +9585,7 @@
               "sha256": "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-uds/0.2.7/download"
+                "https://static.crates.io/crates/tokio-uds/0.2.7/download"
               ],
               "strip_prefix": "tokio-uds-0.2.7",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.2.7.bazel"
@@ -9583,7 +9598,7 @@
               "sha256": "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/webpki-roots/0.25.2/download"
+                "https://static.crates.io/crates/webpki-roots/0.25.2/download"
               ],
               "strip_prefix": "webpki-roots-0.25.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.webpki-roots-0.25.2.bazel"
@@ -9596,7 +9611,7 @@
               "sha256": "9b9ff423ae4983f762659040d13dd7a5defbd54b6a04ac3cc7347741cec828cd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-features/0.35.0/download"
+                "https://static.crates.io/crates/gix-features/0.35.0/download"
               ],
               "strip_prefix": "gix-features-0.35.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-features-0.35.0.bazel"
@@ -9609,7 +9624,7 @@
               "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/lock_api/0.4.11/download"
+                "https://static.crates.io/crates/lock_api/0.4.11/download"
               ],
               "strip_prefix": "lock_api-0.4.11",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.lock_api-0.4.11.bazel"
@@ -9622,7 +9637,7 @@
               "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/android-tzdata/0.1.1/download"
+                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
               ],
               "strip_prefix": "android-tzdata-0.1.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
@@ -9635,7 +9650,7 @@
               "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
@@ -9648,7 +9663,7 @@
               "sha256": "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/futures-task/0.3.28/download"
+                "https://static.crates.io/crates/futures-task/0.3.28/download"
               ],
               "strip_prefix": "futures-task-0.3.28",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-task-0.3.28.bazel"
@@ -9661,7 +9676,7 @@
               "sha256": "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde/1.0.190/download"
+                "https://static.crates.io/crates/serde/1.0.190/download"
               ],
               "strip_prefix": "serde-1.0.190",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde-1.0.190.bazel"
@@ -9674,7 +9689,7 @@
               "sha256": "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ascii/1.1.0/download"
+                "https://static.crates.io/crates/ascii/1.1.0/download"
               ],
               "strip_prefix": "ascii-1.1.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ascii-1.1.0.bazel"
@@ -9687,7 +9702,7 @@
               "sha256": "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/prost-types/0.11.9/download"
+                "https://static.crates.io/crates/prost-types/0.11.9/download"
               ],
               "strip_prefix": "prost-types-0.11.9",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-types-0.11.9.bazel"
@@ -9700,7 +9715,7 @@
               "sha256": "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bstr/0.2.17/download"
+                "https://static.crates.io/crates/bstr/0.2.17/download"
               ],
               "strip_prefix": "bstr-0.2.17",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bstr-0.2.17.bazel"
@@ -9713,7 +9728,7 @@
               "sha256": "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustc_version/0.2.3/download"
+                "https://static.crates.io/crates/rustc_version/0.2.3/download"
               ],
               "strip_prefix": "rustc_version-0.2.3",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.rustc_version-0.2.3.bazel"
@@ -9726,7 +9741,7 @@
               "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/aho-corasick/1.0.2/download"
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
               ],
               "strip_prefix": "aho-corasick-1.0.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
@@ -9739,7 +9754,7 @@
               "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tinyvec/1.6.0/download"
+                "https://static.crates.io/crates/tinyvec/1.6.0/download"
               ],
               "strip_prefix": "tinyvec-1.6.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
@@ -9752,7 +9767,7 @@
               "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_msvc-0.48.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
@@ -9765,7 +9780,7 @@
               "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
@@ -9778,7 +9793,7 @@
               "sha256": "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winnow/0.5.18/download"
+                "https://static.crates.io/crates/winnow/0.5.18/download"
               ],
               "strip_prefix": "winnow-0.5.18",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winnow-0.5.18.bazel"
@@ -9791,7 +9806,7 @@
               "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-utils/0.8.16/download"
+                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
               ],
               "strip_prefix": "crossbeam-utils-0.8.16",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
@@ -9804,7 +9819,7 @@
               "sha256": "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/memchr/2.6.4/download"
+                "https://static.crates.io/crates/memchr/2.6.4/download"
               ],
               "strip_prefix": "memchr-2.6.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memchr-2.6.4.bazel"
@@ -9817,7 +9832,7 @@
               "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde_derive/1.0.171/download"
+                "https://static.crates.io/crates/serde_derive/1.0.171/download"
               ],
               "strip_prefix": "serde_derive-1.0.171",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
@@ -9830,7 +9845,7 @@
               "sha256": "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bitflags/2.4.1/download"
+                "https://static.crates.io/crates/bitflags/2.4.1/download"
               ],
               "strip_prefix": "bitflags-2.4.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bitflags-2.4.1.bazel"
@@ -9843,7 +9858,7 @@
               "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
@@ -9856,7 +9871,7 @@
               "sha256": "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pin-project-lite/0.2.9/download"
+                "https://static.crates.io/crates/pin-project-lite/0.2.9/download"
               ],
               "strip_prefix": "pin-project-lite-0.2.9",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-lite-0.2.9.bazel"
@@ -9869,7 +9884,7 @@
               "sha256": "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/void/1.0.2/download"
+                "https://static.crates.io/crates/void/1.0.2/download"
               ],
               "strip_prefix": "void-1.0.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.void-1.0.2.bazel"
@@ -9882,7 +9897,7 @@
               "sha256": "806a045c4ec4ef7c3ad86dc27bcb641b84d9eeb3846200f56d7ab0885241d654",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-cli-support/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-cli-support/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-cli-support-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-cli-support-0.2.91.bazel"
@@ -9895,7 +9910,7 @@
               "sha256": "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-syntax/0.7.2/download"
+                "https://static.crates.io/crates/regex-syntax/0.7.2/download"
               ],
               "strip_prefix": "regex-syntax-0.7.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.regex-syntax-0.7.2.bazel"
@@ -9908,7 +9923,7 @@
               "sha256": "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pest_generator/2.7.0/download"
+                "https://static.crates.io/crates/pest_generator/2.7.0/download"
               ],
               "strip_prefix": "pest_generator-2.7.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_generator-2.7.0.bazel"
@@ -9921,7 +9936,7 @@
               "sha256": "e23185c0e21df6ed832a12e2bda87c7d1def6842881fb634a8511ced741b0d76",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/chrono-tz/0.8.4/download"
+                "https://static.crates.io/crates/chrono-tz/0.8.4/download"
               ],
               "strip_prefix": "chrono-tz-0.8.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.chrono-tz-0.8.4.bazel"
@@ -9958,7 +9973,7 @@
               "sha256": "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/prost-build/0.11.9/download"
+                "https://static.crates.io/crates/prost-build/0.11.9/download"
               ],
               "strip_prefix": "prost-build-0.11.9",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-build-0.11.9.bazel"
@@ -9971,7 +9986,7 @@
               "sha256": "69507643d75a0ea9a402fcf73ced517d2b95cc95385904ac09d03e0b952fde33",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-discover/0.25.0/download"
+                "https://static.crates.io/crates/gix-discover/0.25.0/download"
               ],
               "strip_prefix": "gix-discover-0.25.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-discover-0.25.0.bazel"
@@ -9984,7 +9999,7 @@
               "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/libc/0.2.139/download"
+                "https://static.crates.io/crates/libc/0.2.139/download"
               ],
               "strip_prefix": "libc-0.2.139",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.libc-0.2.139.bazel"
@@ -9997,7 +10012,7 @@
               "sha256": "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unic-common/0.9.0/download"
+                "https://static.crates.io/crates/unic-common/0.9.0/download"
               ],
               "strip_prefix": "unic-common-0.9.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-common-0.9.0.bazel"
@@ -10010,7 +10025,7 @@
               "sha256": "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tower/0.4.13/download"
+                "https://static.crates.io/crates/tower/0.4.13/download"
               ],
               "strip_prefix": "tower-0.4.13",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-0.4.13.bazel"
@@ -10023,7 +10038,7 @@
               "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bitflags/1.3.2/download"
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
               ],
               "strip_prefix": "bitflags-1.3.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
@@ -10036,7 +10051,7 @@
               "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/utf8parse/0.2.1/download"
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
               ],
               "strip_prefix": "utf8parse-0.2.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
@@ -10060,7 +10075,7 @@
               "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bumpalo/3.13.0/download"
+                "https://static.crates.io/crates/bumpalo/3.13.0/download"
               ],
               "strip_prefix": "bumpalo-3.13.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
@@ -10073,7 +10088,7 @@
               "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pin-project-lite/0.2.13/download"
+                "https://static.crates.io/crates/pin-project-lite/0.2.13/download"
               ],
               "strip_prefix": "pin-project-lite-0.2.13",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pin-project-lite-0.2.13.bazel"
@@ -10086,7 +10101,7 @@
               "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/generic-array/0.14.7/download"
+                "https://static.crates.io/crates/generic-array/0.14.7/download"
               ],
               "strip_prefix": "generic-array-0.14.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.generic-array-0.14.7.bazel"
@@ -10110,7 +10125,7 @@
               "sha256": "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-codec/0.1.2/download"
+                "https://static.crates.io/crates/tokio-codec/0.1.2/download"
               ],
               "strip_prefix": "tokio-codec-0.1.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-codec-0.1.2.bazel"
@@ -10123,7 +10138,7 @@
               "sha256": "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ureq/2.8.0/download"
+                "https://static.crates.io/crates/ureq/2.8.0/download"
               ],
               "strip_prefix": "ureq-2.8.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.ureq-2.8.0.bazel"
@@ -10136,7 +10151,7 @@
               "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/parking_lot_core/0.9.9/download"
+                "https://static.crates.io/crates/parking_lot_core/0.9.9/download"
               ],
               "strip_prefix": "parking_lot_core-0.9.9",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.parking_lot_core-0.9.9.bazel"
@@ -10149,7 +10164,7 @@
               "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/core-foundation-sys/0.8.4/download"
+                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
               ],
               "strip_prefix": "core-foundation-sys-0.8.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
@@ -10162,7 +10177,7 @@
               "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/quote/1.0.29/download"
+                "https://static.crates.io/crates/quote/1.0.29/download"
               ],
               "strip_prefix": "quote-1.0.29",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.quote-1.0.29.bazel"
@@ -10181,7 +10196,7 @@
               "sha256": "70731852eec72c56d11226c8a5f96ad5058a3dab73647ca5f7ee351e464f2571",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/protobuf/2.8.2/download"
+                "https://static.crates.io/crates/protobuf/2.8.2/download"
               ],
               "strip_prefix": "protobuf-2.8.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.protobuf-2.8.2.bazel"
@@ -10194,7 +10209,7 @@
               "sha256": "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-shared-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.91.bazel"
@@ -10207,7 +10222,7 @@
               "sha256": "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/httpdate/1.0.2/download"
+                "https://static.crates.io/crates/httpdate/1.0.2/download"
               ],
               "strip_prefix": "httpdate-1.0.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.httpdate-1.0.2.bazel"
@@ -10220,7 +10235,7 @@
               "sha256": "1e7e19616c67967374137bae83e950e9b518a9ea8a605069bd6716ada357fd6f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-object/0.37.0/download"
+                "https://static.crates.io/crates/gix-object/0.37.0/download"
               ],
               "strip_prefix": "gix-object-0.37.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-object-0.37.0.bazel"
@@ -10233,7 +10248,7 @@
               "sha256": "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-queue/0.3.8/download"
+                "https://static.crates.io/crates/crossbeam-queue/0.3.8/download"
               ],
               "strip_prefix": "crossbeam-queue-0.3.8",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-queue-0.3.8.bazel"
@@ -10246,7 +10261,7 @@
               "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/iana-time-zone/0.1.57/download"
+                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
               ],
               "strip_prefix": "iana-time-zone-0.1.57",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
@@ -10259,7 +10274,7 @@
               "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
@@ -10272,7 +10287,7 @@
               "sha256": "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/deunicode/0.4.3/download"
+                "https://static.crates.io/crates/deunicode/0.4.3/download"
               ],
               "strip_prefix": "deunicode-0.4.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.deunicode-0.4.3.bazel"
@@ -10285,7 +10300,7 @@
               "sha256": "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.87/download"
+                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.87/download"
               ],
               "strip_prefix": "wasm-bindgen-macro-0.2.87",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.87.bazel"
@@ -10298,7 +10313,7 @@
               "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pin-utils/0.1.0/download"
+                "https://static.crates.io/crates/pin-utils/0.1.0/download"
               ],
               "strip_prefix": "pin-utils-0.1.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-utils-0.1.0.bazel"
@@ -10311,7 +10326,7 @@
               "sha256": "409268480841ad008e81c17ca5a293393fbf9f2b6c2f85b8ab9de1f0c5176a16",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-hashtable/0.4.0/download"
+                "https://static.crates.io/crates/gix-hashtable/0.4.0/download"
               ],
               "strip_prefix": "gix-hashtable-0.4.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-hashtable-0.4.0.bazel"
@@ -10324,7 +10339,7 @@
               "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno/0.3.1/download"
+                "https://static.crates.io/crates/errno/0.3.1/download"
               ],
               "strip_prefix": "errno-0.3.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.errno-0.3.1.bazel"
@@ -10337,7 +10352,7 @@
               "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fnv/1.0.7/download"
+                "https://static.crates.io/crates/fnv/1.0.7/download"
               ],
               "strip_prefix": "fnv-1.0.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
@@ -10350,7 +10365,7 @@
               "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/js-sys/0.3.64/download"
+                "https://static.crates.io/crates/js-sys/0.3.64/download"
               ],
               "strip_prefix": "js-sys-0.3.64",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.js-sys-0.3.64.bazel"
@@ -10370,7 +10385,7 @@
               "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/once_cell/1.18.0/download"
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
               ],
               "strip_prefix": "once_cell-1.18.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
@@ -10383,7 +10398,7 @@
               "sha256": "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/prost/0.11.9/download"
+                "https://static.crates.io/crates/prost/0.11.9/download"
               ],
               "strip_prefix": "prost-0.11.9",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-0.11.9.bazel"
@@ -10396,7 +10411,7 @@
               "sha256": "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/slab/0.3.0/download"
+                "https://static.crates.io/crates/slab/0.3.0/download"
               ],
               "strip_prefix": "slab-0.3.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.slab-0.3.0.bazel"
@@ -10409,7 +10424,7 @@
               "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand_core/0.6.4/download"
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
               ],
               "strip_prefix": "rand_core-0.6.4",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
@@ -10422,7 +10437,7 @@
               "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bitflags/1.3.2/download"
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
               ],
               "strip_prefix": "bitflags-1.3.2",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
@@ -10435,7 +10450,7 @@
               "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
               ],
               "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
@@ -10448,7 +10463,7 @@
               "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_gnu-0.48.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
@@ -10461,7 +10476,7 @@
               "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/alloc-no-stdlib/2.0.4/download"
+                "https://static.crates.io/crates/alloc-no-stdlib/2.0.4/download"
               ],
               "strip_prefix": "alloc-no-stdlib-2.0.4",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.alloc-no-stdlib-2.0.4.bazel"
@@ -10474,7 +10489,7 @@
               "sha256": "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/env_logger/0.8.4/download"
+                "https://static.crates.io/crates/env_logger/0.8.4/download"
               ],
               "strip_prefix": "env_logger-0.8.4",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.env_logger-0.8.4.bazel"
@@ -10487,7 +10502,7 @@
               "sha256": "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/smol_str/0.2.0/download"
+                "https://static.crates.io/crates/smol_str/0.2.0/download"
               ],
               "strip_prefix": "smol_str-0.2.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smol_str-0.2.0.bazel"
@@ -10500,7 +10515,7 @@
               "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/memoffset/0.9.0/download"
+                "https://static.crates.io/crates/memoffset/0.9.0/download"
               ],
               "strip_prefix": "memoffset-0.9.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
@@ -10513,7 +10528,7 @@
               "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/log/0.4.19/download"
+                "https://static.crates.io/crates/log/0.4.19/download"
               ],
               "strip_prefix": "log-0.4.19",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.log-0.4.19.bazel"
@@ -10526,7 +10541,7 @@
               "sha256": "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.87/download"
+                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.87/download"
               ],
               "strip_prefix": "wasm-bindgen-backend-0.2.87",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.87.bazel"
@@ -10539,7 +10554,7 @@
               "sha256": "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pest/2.7.0/download"
+                "https://static.crates.io/crates/pest/2.7.0/download"
               ],
               "strip_prefix": "pest-2.7.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest-2.7.0.bazel"
@@ -10552,7 +10567,7 @@
               "sha256": "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/docopt/1.1.1/download"
+                "https://static.crates.io/crates/docopt/1.1.1/download"
               ],
               "strip_prefix": "docopt-1.1.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.docopt-1.1.1.bazel"
@@ -10565,7 +10580,7 @@
               "sha256": "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustc-demangle/0.1.23/download"
+                "https://static.crates.io/crates/rustc-demangle/0.1.23/download"
               ],
               "strip_prefix": "rustc-demangle-0.1.23",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustc-demangle-0.1.23.bazel"
@@ -10578,7 +10593,7 @@
               "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand_chacha/0.3.1/download"
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
               ],
               "strip_prefix": "rand_chacha-0.3.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
@@ -10591,7 +10606,7 @@
               "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/syn/1.0.109/download"
+                "https://static.crates.io/crates/syn/1.0.109/download"
               ],
               "strip_prefix": "syn-1.0.109",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.syn-1.0.109.bazel"
@@ -10604,7 +10619,7 @@
               "sha256": "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pathdiff/0.2.1/download"
+                "https://static.crates.io/crates/pathdiff/0.2.1/download"
               ],
               "strip_prefix": "pathdiff-0.2.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pathdiff-0.2.1.bazel"
@@ -10629,7 +10644,7 @@
               "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/either/1.8.1/download"
+                "https://static.crates.io/crates/either/1.8.1/download"
               ],
               "strip_prefix": "either-1.8.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.either-1.8.1.bazel"
@@ -10642,7 +10657,7 @@
               "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_msvc-0.48.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
@@ -10655,7 +10670,7 @@
               "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crc32fast/1.3.2/download"
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
               ],
               "strip_prefix": "crc32fast-1.3.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
@@ -10668,7 +10683,7 @@
               "sha256": "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-backend/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-backend-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.91.bazel"
@@ -10681,7 +10696,7 @@
               "sha256": "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/encoding_rs/0.8.33/download"
+                "https://static.crates.io/crates/encoding_rs/0.8.33/download"
               ],
               "strip_prefix": "encoding_rs-0.8.33",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.encoding_rs-0.8.33.bazel"
@@ -10694,7 +10709,7 @@
               "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_msvc-0.48.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
@@ -10707,7 +10722,7 @@
               "sha256": "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hermit-abi/0.2.6/download"
+                "https://static.crates.io/crates/hermit-abi/0.2.6/download"
               ],
               "strip_prefix": "hermit-abi-0.2.6",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.hermit-abi-0.2.6.bazel"
@@ -10720,7 +10735,7 @@
               "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/want/0.3.1/download"
+                "https://static.crates.io/crates/want/0.3.1/download"
               ],
               "strip_prefix": "want-0.3.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.want-0.3.1.bazel"
@@ -10733,7 +10748,7 @@
               "sha256": "a9d76e85f11251dcf751d2c5e918a14f562db5be6f727fd24775245653e9b19d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-glob/0.13.0/download"
+                "https://static.crates.io/crates/gix-glob/0.13.0/download"
               ],
               "strip_prefix": "gix-glob-0.13.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-glob-0.13.0.bazel"
@@ -10746,7 +10761,7 @@
               "sha256": "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-timer/0.2.13/download"
+                "https://static.crates.io/crates/tokio-timer/0.2.13/download"
               ],
               "strip_prefix": "tokio-timer-0.2.13",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.2.13.bazel"
@@ -10759,7 +10774,7 @@
               "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/itoa/1.0.8/download"
+                "https://static.crates.io/crates/itoa/1.0.8/download"
               ],
               "strip_prefix": "itoa-1.0.8",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
@@ -10772,7 +10787,7 @@
               "sha256": "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cloudabi/0.0.3/download"
+                "https://static.crates.io/crates/cloudabi/0.0.3/download"
               ],
               "strip_prefix": "cloudabi-0.0.3",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cloudabi-0.0.3.bazel"
@@ -10785,7 +10800,7 @@
               "sha256": "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde_json/1.0.108/download"
+                "https://static.crates.io/crates/serde_json/1.0.108/download"
               ],
               "strip_prefix": "serde_json-1.0.108",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_json-1.0.108.bazel"
@@ -10798,7 +10813,7 @@
               "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/log/0.4.19/download"
+                "https://static.crates.io/crates/log/0.4.19/download"
               ],
               "strip_prefix": "log-0.4.19",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.log-0.4.19.bazel"
@@ -10811,7 +10826,7 @@
               "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/termcolor/1.2.0/download"
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
               ],
               "strip_prefix": "termcolor-1.2.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
@@ -10824,7 +10839,7 @@
               "sha256": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hermit-abi/0.1.19/download"
+                "https://static.crates.io/crates/hermit-abi/0.1.19/download"
               ],
               "strip_prefix": "hermit-abi-0.1.19",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.1.19.bazel"
@@ -10837,7 +10852,7 @@
               "sha256": "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/bstr/1.6.0/download"
+                "https://static.crates.io/crates/bstr/1.6.0/download"
               ],
               "strip_prefix": "bstr-1.6.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.bstr-1.6.0.bazel"
@@ -10850,7 +10865,7 @@
               "sha256": "788ddb152c388206e81f36bcbb574e7ed7827c27d8fa62227b34edc333d8928c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-diff/0.36.0/download"
+                "https://static.crates.io/crates/gix-diff/0.36.0/download"
               ],
               "strip_prefix": "gix-diff-0.36.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-diff-0.36.0.bazel"
@@ -10863,7 +10878,7 @@
               "sha256": "f54d63a9d13c13088f41f5a3accbec284e492ac8f4f707fcc307c139622e17b7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-index/0.25.0/download"
+                "https://static.crates.io/crates/gix-index/0.25.0/download"
               ],
               "strip_prefix": "gix-index-0.25.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-index-0.25.0.bazel"
@@ -10876,7 +10891,7 @@
               "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_gnu-0.48.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
@@ -10889,7 +10904,7 @@
               "sha256": "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/lock_api/0.3.4/download"
+                "https://static.crates.io/crates/lock_api/0.3.4/download"
               ],
               "strip_prefix": "lock_api-0.3.4",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.lock_api-0.3.4.bazel"
@@ -10902,7 +10917,7 @@
               "sha256": "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/filetime/0.2.22/download"
+                "https://static.crates.io/crates/filetime/0.2.22/download"
               ],
               "strip_prefix": "filetime-0.2.22",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.filetime-0.2.22.bazel"
@@ -10915,7 +10930,7 @@
               "sha256": "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tracing-log/0.1.4/download"
+                "https://static.crates.io/crates/tracing-log/0.1.4/download"
               ],
               "strip_prefix": "tracing-log-0.1.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-log-0.1.4.bazel"
@@ -10928,7 +10943,7 @@
               "sha256": "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustix/0.38.21/download"
+                "https://static.crates.io/crates/rustix/0.38.21/download"
               ],
               "strip_prefix": "rustix-0.38.21",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustix-0.38.21.bazel"
@@ -10941,7 +10956,7 @@
               "sha256": "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/indoc/2.0.4/download"
+                "https://static.crates.io/crates/indoc/2.0.4/download"
               ],
               "strip_prefix": "indoc-2.0.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.indoc-2.0.4.bazel"
@@ -10954,7 +10969,7 @@
               "sha256": "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-bom/2.0.2/download"
+                "https://static.crates.io/crates/unicode-bom/2.0.2/download"
               ],
               "strip_prefix": "unicode-bom-2.0.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-bom-2.0.2.bazel"
@@ -10967,7 +10982,7 @@
               "sha256": "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/smallvec/1.11.0/download"
+                "https://static.crates.io/crates/smallvec/1.11.0/download"
               ],
               "strip_prefix": "smallvec-1.11.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.smallvec-1.11.0.bazel"
@@ -10980,7 +10995,7 @@
               "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/redox_syscall/0.3.5/download"
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
               ],
               "strip_prefix": "redox_syscall-0.3.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
@@ -10993,7 +11008,7 @@
               "sha256": "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ignore/0.4.18/download"
+                "https://static.crates.io/crates/ignore/0.4.18/download"
               ],
               "strip_prefix": "ignore-0.4.18",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ignore-0.4.18.bazel"
@@ -11006,7 +11021,7 @@
               "sha256": "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/textwrap/0.16.0/download"
+                "https://static.crates.io/crates/textwrap/0.16.0/download"
               ],
               "strip_prefix": "textwrap-0.16.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.textwrap-0.16.0.bazel"
@@ -11019,7 +11034,7 @@
               "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
@@ -11032,7 +11047,7 @@
               "sha256": "4e6b653f6820409609bda0f176e6949302307af7a7b9479cd4d4b1bdc31eb9cd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-wasm-conventions/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-wasm-conventions/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-wasm-conventions-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-conventions-0.2.91.bazel"
@@ -11045,7 +11060,7 @@
               "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/valuable/0.1.0/download"
+                "https://static.crates.io/crates/valuable/0.1.0/download"
               ],
               "strip_prefix": "valuable-0.1.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.valuable-0.1.0.bazel"
@@ -11058,7 +11073,7 @@
               "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/form_urlencoded/1.2.0/download"
+                "https://static.crates.io/crates/form_urlencoded/1.2.0/download"
               ],
               "strip_prefix": "form_urlencoded-1.2.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.form_urlencoded-1.2.0.bazel"
@@ -11071,7 +11086,7 @@
               "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cfg-if/1.0.0/download"
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
               ],
               "strip_prefix": "cfg-if-1.0.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
@@ -11084,7 +11099,7 @@
               "sha256": "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-core/0.1.18/download"
+                "https://static.crates.io/crates/tokio-core/0.1.18/download"
               ],
               "strip_prefix": "tokio-core-0.1.18",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-core-0.1.18.bazel"
@@ -11097,7 +11112,7 @@
               "sha256": "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/prost-derive/0.11.9/download"
+                "https://static.crates.io/crates/prost-derive/0.11.9/download"
               ],
               "strip_prefix": "prost-derive-0.11.9",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.prost-derive-0.11.9.bazel"
@@ -11110,7 +11125,7 @@
               "sha256": "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-shared/0.2.87/download"
+                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.87/download"
               ],
               "strip_prefix": "wasm-bindgen-shared-0.2.87",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.87.bazel"
@@ -11123,7 +11138,7 @@
               "sha256": "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-utils/0.7.2/download"
+                "https://static.crates.io/crates/crossbeam-utils/0.7.2/download"
               ],
               "strip_prefix": "crossbeam-utils-0.7.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-utils-0.7.2.bazel"
@@ -11136,7 +11151,7 @@
               "sha256": "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/spectral/0.6.0/download"
+                "https://static.crates.io/crates/spectral/0.6.0/download"
               ],
               "strip_prefix": "spectral-0.6.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.spectral-0.6.0.bazel"
@@ -11149,7 +11164,7 @@
               "sha256": "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/float-cmp/0.8.0/download"
+                "https://static.crates.io/crates/float-cmp/0.8.0/download"
               ],
               "strip_prefix": "float-cmp-0.8.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.float-cmp-0.8.0.bazel"
@@ -11162,7 +11177,7 @@
               "sha256": "5ae0978f3e11dc57290ee75ac2477c815bca1ce2fa7ed5dc5f16db067410ac4d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-tempfile/10.0.0/download"
+                "https://static.crates.io/crates/gix-tempfile/10.0.0/download"
               ],
               "strip_prefix": "gix-tempfile-10.0.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-tempfile-10.0.0.bazel"
@@ -11175,7 +11190,7 @@
               "sha256": "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tower-layer/0.3.2/download"
+                "https://static.crates.io/crates/tower-layer/0.3.2/download"
               ],
               "strip_prefix": "tower-layer-0.3.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-layer-0.3.2.bazel"
@@ -11188,7 +11203,7 @@
               "sha256": "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cfg-expr/0.15.5/download"
+                "https://static.crates.io/crates/cfg-expr/0.15.5/download"
               ],
               "strip_prefix": "cfg-expr-0.15.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cfg-expr-0.15.5.bazel"
@@ -11201,7 +11216,7 @@
               "sha256": "794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/prodash/26.2.2/download"
+                "https://static.crates.io/crates/prodash/26.2.2/download"
               ],
               "strip_prefix": "prodash-26.2.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.prodash-26.2.2.bazel"
@@ -11214,7 +11229,7 @@
               "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
@@ -11227,7 +11242,7 @@
               "sha256": "ad6d32e74454459690d57d18ea4ebec1629936e6b130b51d12cb4a81630ac953",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix/0.54.1/download"
+                "https://static.crates.io/crates/gix/0.54.1/download"
               ],
               "strip_prefix": "gix-0.54.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-0.54.1.bazel"
@@ -11240,7 +11255,7 @@
               "sha256": "3c576cfbf577f72c097b5f88aedea502cd62952bdc1fb3adcab4531d5525a4c7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-command/0.2.10/download"
+                "https://static.crates.io/crates/gix-command/0.2.10/download"
               ],
               "strip_prefix": "gix-command-0.2.10",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-command-0.2.10.bazel"
@@ -11253,7 +11268,7 @@
               "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tinyvec_macros/0.1.1/download"
+                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
               ],
               "strip_prefix": "tinyvec_macros-0.1.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
@@ -11266,7 +11281,7 @@
               "sha256": "8d6a392c6ba3a2f133cdc63120e9bc7aec81eef763db372c817de31febfe64bf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-odb/0.53.0/download"
+                "https://static.crates.io/crates/gix-odb/0.53.0/download"
               ],
               "strip_prefix": "gix-odb-0.53.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-odb-0.53.0.bazel"
@@ -11279,7 +11294,7 @@
               "sha256": "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustix/0.37.20/download"
+                "https://static.crates.io/crates/rustix/0.37.20/download"
               ],
               "strip_prefix": "rustix-0.37.20",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.rustix-0.37.20.bazel"
@@ -11292,7 +11307,7 @@
               "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_msvc-0.48.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
@@ -11305,7 +11320,7 @@
               "sha256": "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_builder/4.3.3/download"
+                "https://static.crates.io/crates/clap_builder/4.3.3/download"
               ],
               "strip_prefix": "clap_builder-4.3.3",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap_builder-4.3.3.bazel"
@@ -11337,7 +11352,7 @@
               "sha256": "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-threadpool/0.1.18/download"
+                "https://static.crates.io/crates/tokio-threadpool/0.1.18/download"
               ],
               "strip_prefix": "tokio-threadpool-0.1.18",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-threadpool-0.1.18.bazel"
@@ -11350,7 +11365,7 @@
               "sha256": "c3b9d411ecbaf79885c6df4d75fff75858d5995ff25385657a28af47e82f9c36",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/annotate-snippets/0.9.1/download"
+                "https://static.crates.io/crates/annotate-snippets/0.9.1/download"
               ],
               "strip_prefix": "annotate-snippets-0.9.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.annotate-snippets-0.9.1.bazel"
@@ -11363,7 +11378,7 @@
               "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/httparse/1.8.0/download"
+                "https://static.crates.io/crates/httparse/1.8.0/download"
               ],
               "strip_prefix": "httparse-1.8.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.httparse-1.8.0.bazel"
@@ -11376,7 +11391,7 @@
               "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/powerfmt/0.2.0/download"
+                "https://static.crates.io/crates/powerfmt/0.2.0/download"
               ],
               "strip_prefix": "powerfmt-0.2.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.powerfmt-0.2.0.bazel"
@@ -11389,7 +11404,7 @@
               "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/strsim/0.10.0/download"
+                "https://static.crates.io/crates/strsim/0.10.0/download"
               ],
               "strip_prefix": "strsim-0.10.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
@@ -11402,7 +11417,7 @@
               "sha256": "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tonic/0.9.2/download"
+                "https://static.crates.io/crates/tonic/0.9.2/download"
               ],
               "strip_prefix": "tonic-0.9.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tonic-0.9.2.bazel"
@@ -11415,7 +11430,7 @@
               "sha256": "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/async-trait/0.1.68/download"
+                "https://static.crates.io/crates/async-trait/0.1.68/download"
               ],
               "strip_prefix": "async-trait-0.1.68",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.async-trait-0.1.68.bazel"
@@ -11428,7 +11443,7 @@
               "sha256": "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/brotli-decompressor/2.5.1/download"
+                "https://static.crates.io/crates/brotli-decompressor/2.5.1/download"
               ],
               "strip_prefix": "brotli-decompressor-2.5.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.brotli-decompressor-2.5.1.bazel"
@@ -11441,7 +11456,7 @@
               "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_msvc-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
@@ -11454,7 +11469,7 @@
               "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-normalization/0.1.22/download"
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
               ],
               "strip_prefix": "unicode-normalization-0.1.22",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
@@ -11467,7 +11482,7 @@
               "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_msvc-0.48.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
@@ -11480,7 +11495,7 @@
               "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/idna/0.4.0/download"
+                "https://static.crates.io/crates/idna/0.4.0/download"
               ],
               "strip_prefix": "idna-0.4.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.idna-0.4.0.bazel"
@@ -11493,7 +11508,7 @@
               "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex/1.9.1/download"
+                "https://static.crates.io/crates/regex/1.9.1/download"
               ],
               "strip_prefix": "regex-1.9.1",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-1.9.1.bazel"
@@ -11506,7 +11521,7 @@
               "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle-parse/0.2.1/download"
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
               ],
               "strip_prefix": "anstyle-parse-0.2.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
@@ -11519,7 +11534,7 @@
               "sha256": "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wait-timeout/0.2.0/download"
+                "https://static.crates.io/crates/wait-timeout/0.2.0/download"
               ],
               "strip_prefix": "wait-timeout-0.2.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wait-timeout-0.2.0.bazel"
@@ -11532,7 +11547,7 @@
               "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
@@ -11545,7 +11560,7 @@
               "sha256": "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/quick-error/1.2.3/download"
+                "https://static.crates.io/crates/quick-error/1.2.3/download"
               ],
               "strip_prefix": "quick-error-1.2.3",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.quick-error-1.2.3.bazel"
@@ -11558,7 +11573,7 @@
               "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi/0.3.9/download"
+                "https://static.crates.io/crates/winapi/0.3.9/download"
               ],
               "strip_prefix": "winapi-0.3.9",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
@@ -11571,7 +11586,7 @@
               "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/core-foundation-sys/0.8.4/download"
+                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
               ],
               "strip_prefix": "core-foundation-sys-0.8.4",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
@@ -11584,7 +11599,7 @@
               "sha256": "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/futures-core/0.3.28/download"
+                "https://static.crates.io/crates/futures-core/0.3.28/download"
               ],
               "strip_prefix": "futures-core-0.3.28",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-core-0.3.28.bazel"
@@ -11597,7 +11612,7 @@
               "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
@@ -11610,7 +11625,7 @@
               "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle/1.0.1/download"
+                "https://static.crates.io/crates/anstyle/1.0.1/download"
               ],
               "strip_prefix": "anstyle-1.0.1",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
@@ -11623,7 +11638,7 @@
               "sha256": "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/dunce/1.0.4/download"
+                "https://static.crates.io/crates/dunce/1.0.4/download"
               ],
               "strip_prefix": "dunce-1.0.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.dunce-1.0.4.bazel"
@@ -11636,7 +11651,7 @@
               "sha256": "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/phf_generator/0.11.2/download"
+                "https://static.crates.io/crates/phf_generator/0.11.2/download"
               ],
               "strip_prefix": "phf_generator-0.11.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf_generator-0.11.2.bazel"
@@ -11649,7 +11664,7 @@
               "sha256": "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/fastrand/1.9.0/download"
+                "https://static.crates.io/crates/fastrand/1.9.0/download"
               ],
               "strip_prefix": "fastrand-1.9.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.fastrand-1.9.0.bazel"
@@ -11662,7 +11677,7 @@
               "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnu-0.48.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
@@ -11675,7 +11690,7 @@
               "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/memoffset/0.9.0/download"
+                "https://static.crates.io/crates/memoffset/0.9.0/download"
               ],
               "strip_prefix": "memoffset-0.9.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
@@ -11688,7 +11703,7 @@
               "sha256": "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-targets/0.48.0/download"
+                "https://static.crates.io/crates/windows-targets/0.48.0/download"
               ],
               "strip_prefix": "windows-targets-0.48.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows-targets-0.48.0.bazel"
@@ -11701,7 +11716,7 @@
               "sha256": "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/twoway/0.1.8/download"
+                "https://static.crates.io/crates/twoway/0.1.8/download"
               ],
               "strip_prefix": "twoway-0.1.8",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.twoway-0.1.8.bazel"
@@ -11714,7 +11729,7 @@
               "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/linux-raw-sys/0.3.8/download"
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
               ],
               "strip_prefix": "linux-raw-sys-0.3.8",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
@@ -11727,7 +11742,7 @@
               "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/quote/1.0.29/download"
+                "https://static.crates.io/crates/quote/1.0.29/download"
               ],
               "strip_prefix": "quote-1.0.29",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.quote-1.0.29.bazel"
@@ -11740,7 +11755,7 @@
               "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/safemem/0.3.3/download"
+                "https://static.crates.io/crates/safemem/0.3.3/download"
               ],
               "strip_prefix": "safemem-0.3.3",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
@@ -11753,7 +11768,7 @@
               "sha256": "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/assert_cmd/1.0.8/download"
+                "https://static.crates.io/crates/assert_cmd/1.0.8/download"
               ],
               "strip_prefix": "assert_cmd-1.0.8",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.assert_cmd-1.0.8.bazel"
@@ -11766,7 +11781,7 @@
               "sha256": "29675b116dd4c7ab4012e00e71f6dee9ed8c731108468b4434779c6b9eec7957",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde_starlark/0.1.14/download"
+                "https://static.crates.io/crates/serde_starlark/0.1.14/download"
               ],
               "strip_prefix": "serde_starlark-0.1.14",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_starlark-0.1.14.bazel"
@@ -11779,7 +11794,7 @@
               "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ppv-lite86/0.2.17/download"
+                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
               ],
               "strip_prefix": "ppv-lite86-0.2.17",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
@@ -11792,7 +11807,7 @@
               "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand_core/0.6.4/download"
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
               ],
               "strip_prefix": "rand_core-0.6.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
@@ -11805,7 +11820,7 @@
               "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
               ],
               "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
@@ -11818,7 +11833,7 @@
               "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustix/0.37.23/download"
+                "https://static.crates.io/crates/rustix/0.37.23/download"
               ],
               "strip_prefix": "rustix-0.37.23",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
@@ -11831,7 +11846,7 @@
               "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_lex/0.5.0/download"
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
               ],
               "strip_prefix": "clap_lex-0.5.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
@@ -11844,7 +11859,7 @@
               "sha256": "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/base64/0.21.2/download"
+                "https://static.crates.io/crates/base64/0.21.2/download"
               ],
               "strip_prefix": "base64-0.21.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.base64-0.21.2.bazel"
@@ -11857,7 +11872,7 @@
               "sha256": "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/log/0.3.9/download"
+                "https://static.crates.io/crates/log/0.3.9/download"
               ],
               "strip_prefix": "log-0.3.9",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.log-0.3.9.bazel"
@@ -11870,7 +11885,7 @@
               "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_msvc-0.48.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
@@ -11883,7 +11898,7 @@
               "sha256": "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/home/0.5.5/download"
+                "https://static.crates.io/crates/home/0.5.5/download"
               ],
               "strip_prefix": "home-0.5.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.home-0.5.5.bazel"
@@ -11896,7 +11911,7 @@
               "sha256": "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/memoffset/0.5.6/download"
+                "https://static.crates.io/crates/memoffset/0.5.6/download"
               ],
               "strip_prefix": "memoffset-0.5.6",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.memoffset-0.5.6.bazel"
@@ -11909,7 +11924,7 @@
               "sha256": "2451665e70709ba4753b623ef97511ee98c4a73816b2c5b5df25678d607ed820",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-attributes/0.19.0/download"
+                "https://static.crates.io/crates/gix-attributes/0.19.0/download"
               ],
               "strip_prefix": "gix-attributes-0.19.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-attributes-0.19.0.bazel"
@@ -11922,7 +11937,7 @@
               "sha256": "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap/4.3.3/download"
+                "https://static.crates.io/crates/clap/4.3.3/download"
               ],
               "strip_prefix": "clap-4.3.3",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clap-4.3.3.bazel"
@@ -11935,7 +11950,7 @@
               "sha256": "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hyper/0.14.26/download"
+                "https://static.crates.io/crates/hyper/0.14.26/download"
               ],
               "strip_prefix": "hyper-0.14.26",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hyper-0.14.26.bazel"
@@ -11948,7 +11963,7 @@
               "sha256": "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/predicates/2.1.5/download"
+                "https://static.crates.io/crates/predicates/2.1.5/download"
               ],
               "strip_prefix": "predicates-2.1.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.predicates-2.1.5.bazel"
@@ -11961,7 +11976,7 @@
               "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_msvc-0.48.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
@@ -11974,7 +11989,7 @@
               "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/redox_syscall/0.3.5/download"
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
               ],
               "strip_prefix": "redox_syscall-0.3.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
@@ -11987,7 +12002,7 @@
               "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/indexmap/1.9.3/download"
+                "https://static.crates.io/crates/indexmap/1.9.3/download"
               ],
               "strip_prefix": "indexmap-1.9.3",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
@@ -12000,7 +12015,7 @@
               "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/once_cell/1.18.0/download"
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
               ],
               "strip_prefix": "once_cell-1.18.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
@@ -12013,7 +12028,7 @@
               "sha256": "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/termtree/0.4.1/download"
+                "https://static.crates.io/crates/termtree/0.4.1/download"
               ],
               "strip_prefix": "termtree-0.4.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.termtree-0.4.1.bazel"
@@ -12026,7 +12041,7 @@
               "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstream/0.3.2/download"
+                "https://static.crates.io/crates/anstream/0.3.2/download"
               ],
               "strip_prefix": "anstream-0.3.2",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
@@ -12039,7 +12054,7 @@
               "sha256": "cc7b700dc20cc9be8a5130a1fd7e10c34117ffa7068431c8c24d963f0a2e0c9b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-protocol/0.40.0/download"
+                "https://static.crates.io/crates/gix-protocol/0.40.0/download"
               ],
               "strip_prefix": "gix-protocol-0.40.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-protocol-0.40.0.bazel"
@@ -12061,7 +12076,7 @@
               "sha256": "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/doc-comment/0.3.3/download"
+                "https://static.crates.io/crates/doc-comment/0.3.3/download"
               ],
               "strip_prefix": "doc-comment-0.3.3",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.doc-comment-0.3.3.bazel"
@@ -12074,7 +12089,7 @@
               "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crc32fast/1.3.2/download"
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
               ],
               "strip_prefix": "crc32fast-1.3.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
@@ -12087,7 +12102,7 @@
               "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/aho-corasick/1.0.2/download"
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
               ],
               "strip_prefix": "aho-corasick-1.0.2",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
@@ -12100,7 +12115,7 @@
               "sha256": "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/walrus-macro/0.19.0/download"
+                "https://static.crates.io/crates/walrus-macro/0.19.0/download"
               ],
               "strip_prefix": "walrus-macro-0.19.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.walrus-macro-0.19.0.bazel"
@@ -12113,7 +12128,7 @@
               "sha256": "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rdrand/0.4.0/download"
+                "https://static.crates.io/crates/rdrand/0.4.0/download"
               ],
               "strip_prefix": "rdrand-0.4.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rdrand-0.4.0.bazel"
@@ -12126,7 +12141,7 @@
               "sha256": "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cpufeatures/0.2.9/download"
+                "https://static.crates.io/crates/cpufeatures/0.2.9/download"
               ],
               "strip_prefix": "cpufeatures-0.2.9",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cpufeatures-0.2.9.bazel"
@@ -12139,7 +12154,7 @@
               "sha256": "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/mio/0.8.8/download"
+                "https://static.crates.io/crates/mio/0.8.8/download"
               ],
               "strip_prefix": "mio-0.8.8",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.mio-0.8.8.bazel"
@@ -12152,7 +12167,7 @@
               "sha256": "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/base64/0.9.3/download"
+                "https://static.crates.io/crates/base64/0.9.3/download"
               ],
               "strip_prefix": "base64-0.9.3",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.base64-0.9.3.bazel"
@@ -12165,7 +12180,7 @@
               "sha256": "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustc-serialize/0.3.25/download"
+                "https://static.crates.io/crates/rustc-serialize/0.3.25/download"
               ],
               "strip_prefix": "rustc-serialize-0.3.25",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustc-serialize-0.3.25.bazel"
@@ -12178,7 +12193,7 @@
               "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anyhow/1.0.71/download"
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
               ],
               "strip_prefix": "anyhow-1.0.71",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
@@ -12191,7 +12206,7 @@
               "sha256": "6a1d370115171e3ae03c5c6d4f7d096f2981a40ddccb98dfd704c773530ba73b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-path/0.10.0/download"
+                "https://static.crates.io/crates/gix-path/0.10.0/download"
               ],
               "strip_prefix": "gix-path-0.10.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-path-0.10.0.bazel"
@@ -12204,7 +12219,7 @@
               "sha256": "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hermit-abi/0.3.1/download"
+                "https://static.crates.io/crates/hermit-abi/0.3.1/download"
               ],
               "strip_prefix": "hermit-abi-0.3.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.hermit-abi-0.3.1.bazel"
@@ -12217,7 +12232,7 @@
               "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cc/1.0.83/download"
+                "https://static.crates.io/crates/cc/1.0.83/download"
               ],
               "strip_prefix": "cc-1.0.83",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.cc-1.0.83.bazel"
@@ -12230,7 +12245,7 @@
               "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/utf8parse/0.2.1/download"
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
               ],
               "strip_prefix": "utf8parse-0.2.1",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
@@ -12243,7 +12258,7 @@
               "sha256": "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/futures-cpupool/0.1.8/download"
+                "https://static.crates.io/crates/futures-cpupool/0.1.8/download"
               ],
               "strip_prefix": "futures-cpupool-0.1.8",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.futures-cpupool-0.1.8.bazel"
@@ -12268,7 +12283,7 @@
               "sha256": "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex/1.10.2/download"
+                "https://static.crates.io/crates/regex/1.10.2/download"
               ],
               "strip_prefix": "regex-1.10.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-1.10.2.bazel"
@@ -12281,7 +12296,7 @@
               "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/log/0.4.19/download"
+                "https://static.crates.io/crates/log/0.4.19/download"
               ],
               "strip_prefix": "log-0.4.19",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.log-0.4.19.bazel"
@@ -12294,7 +12309,7 @@
               "sha256": "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cargo_metadata/0.18.1/download"
+                "https://static.crates.io/crates/cargo_metadata/0.18.1/download"
               ],
               "strip_prefix": "cargo_metadata-0.18.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo_metadata-0.18.1.bazel"
@@ -12307,7 +12322,7 @@
               "sha256": "09815faba62fe9b32d918b75a554686c98e43f7d48c43a80df58eb718e5c6635",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-fs/0.7.0/download"
+                "https://static.crates.io/crates/gix-fs/0.7.0/download"
               ],
               "strip_prefix": "gix-fs-0.7.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-fs-0.7.0.bazel"
@@ -12320,7 +12335,7 @@
               "sha256": "92b9542ac025a8c02ed5d17b3fc031a111a384e859d0be3532ec4d58c40a0f28",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-sec/0.10.0/download"
+                "https://static.crates.io/crates/gix-sec/0.10.0/download"
               ],
               "strip_prefix": "gix-sec-0.10.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-sec-0.10.0.bazel"
@@ -12333,7 +12348,7 @@
               "sha256": "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-trace/0.1.3/download"
+                "https://static.crates.io/crates/gix-trace/0.1.3/download"
               ],
               "strip_prefix": "gix-trace-0.1.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-trace-0.1.3.bazel"
@@ -12346,7 +12361,7 @@
               "sha256": "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/humansize/2.1.3/download"
+                "https://static.crates.io/crates/humansize/2.1.3/download"
               ],
               "strip_prefix": "humansize-2.1.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.humansize-2.1.3.bazel"
@@ -12359,7 +12374,7 @@
               "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
@@ -12372,7 +12387,7 @@
               "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/io-lifetimes/1.0.11/download"
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
               ],
               "strip_prefix": "io-lifetimes-1.0.11",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
@@ -12385,7 +12400,7 @@
               "sha256": "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tower-service/0.3.2/download"
+                "https://static.crates.io/crates/tower-service/0.3.2/download"
               ],
               "strip_prefix": "tower-service-0.3.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tower-service-0.3.2.bazel"
@@ -12398,7 +12413,7 @@
               "sha256": "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/diff/0.1.13/download"
+                "https://static.crates.io/crates/diff/0.1.13/download"
               ],
               "strip_prefix": "diff-0.1.13",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.diff-0.1.13.bazel"
@@ -12411,7 +12426,7 @@
               "sha256": "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand_core/0.4.2/download"
+                "https://static.crates.io/crates/rand_core/0.4.2/download"
               ],
               "strip_prefix": "rand_core-0.4.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_core-0.4.2.bazel"
@@ -12424,7 +12439,7 @@
               "sha256": "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/phf/0.11.2/download"
+                "https://static.crates.io/crates/phf/0.11.2/download"
               ],
               "strip_prefix": "phf-0.11.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf-0.11.2.bazel"
@@ -12437,7 +12452,7 @@
               "sha256": "90a2e577034352f9aa9352730fcf2562c68957f2e9b9ee70ab6379510e49e2fe",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-threads-xform/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-threads-xform/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-threads-xform-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-threads-xform-0.2.91.bazel"
@@ -12450,7 +12465,7 @@
               "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi/0.3.9/download"
+                "https://static.crates.io/crates/winapi/0.3.9/download"
               ],
               "strip_prefix": "winapi-0.3.9",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
@@ -12463,7 +12478,7 @@
               "sha256": "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen/0.2.87/download"
+                "https://static.crates.io/crates/wasm-bindgen/0.2.87/download"
               ],
               "strip_prefix": "wasm-bindgen-0.2.87",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.wasm-bindgen-0.2.87.bazel"
@@ -12476,7 +12491,7 @@
               "sha256": "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasmparser/0.102.0/download"
+                "https://static.crates.io/crates/wasmparser/0.102.0/download"
               ],
               "strip_prefix": "wasmparser-0.102.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.102.0.bazel"
@@ -12489,7 +12504,7 @@
               "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
@@ -12502,7 +12517,7 @@
               "sha256": "907274ce8ee7b40a0d0b0db09022ea22846a47cfb1fc8ad2c983c70001b4ffb1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/grpc-compiler/0.6.2/download"
+                "https://static.crates.io/crates/grpc-compiler/0.6.2/download"
               ],
               "strip_prefix": "grpc-compiler-0.6.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.grpc-compiler-0.6.2.bazel"
@@ -12515,7 +12530,7 @@
               "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/heck/0.4.1/download"
+                "https://static.crates.io/crates/heck/0.4.1/download"
               ],
               "strip_prefix": "heck-0.4.1",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.heck-0.4.1.bazel"
@@ -12528,7 +12543,7 @@
               "sha256": "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hermit-abi/0.2.6/download"
+                "https://static.crates.io/crates/hermit-abi/0.2.6/download"
               ],
               "strip_prefix": "hermit-abi-0.2.6",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hermit-abi-0.2.6.bazel"
@@ -12541,7 +12556,7 @@
               "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/autocfg/1.1.0/download"
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
               ],
               "strip_prefix": "autocfg-1.1.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
@@ -12554,7 +12569,7 @@
               "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/version_check/0.9.4/download"
+                "https://static.crates.io/crates/version_check/0.9.4/download"
               ],
               "strip_prefix": "version_check-0.9.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
@@ -12567,7 +12582,7 @@
               "sha256": "fc7df669639582dc7c02737642f76890b03b5544e141caba68a7d6b4eb551e0d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-date/0.8.0/download"
+                "https://static.crates.io/crates/gix-date/0.8.0/download"
               ],
               "strip_prefix": "gix-date-0.8.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-date-0.8.0.bazel"
@@ -12580,7 +12595,7 @@
               "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/scopeguard/1.2.0/download"
+                "https://static.crates.io/crates/scopeguard/1.2.0/download"
               ],
               "strip_prefix": "scopeguard-1.2.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
@@ -12593,7 +12608,7 @@
               "sha256": "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clang-sys/1.6.1/download"
+                "https://static.crates.io/crates/clang-sys/1.6.1/download"
               ],
               "strip_prefix": "clang-sys-1.6.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.clang-sys-1.6.1.bazel"
@@ -12606,7 +12621,7 @@
               "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle-parse/0.2.1/download"
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
               ],
               "strip_prefix": "anstyle-parse-0.2.1",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
@@ -12619,7 +12634,7 @@
               "sha256": "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num_cpus/1.16.0/download"
+                "https://static.crates.io/crates/num_cpus/1.16.0/download"
               ],
               "strip_prefix": "num_cpus-1.16.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num_cpus-1.16.0.bazel"
@@ -12651,7 +12666,7 @@
               "sha256": "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/phf_codegen/0.11.2/download"
+                "https://static.crates.io/crates/phf_codegen/0.11.2/download"
               ],
               "strip_prefix": "phf_codegen-0.11.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.phf_codegen-0.11.2.bazel"
@@ -12664,7 +12679,7 @@
               "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-util/0.1.5/download"
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
               ],
               "strip_prefix": "winapi-util-0.1.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
@@ -12677,7 +12692,7 @@
               "sha256": "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-current-thread/0.1.7/download"
+                "https://static.crates.io/crates/tokio-current-thread/0.1.7/download"
               ],
               "strip_prefix": "tokio-current-thread-0.1.7",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-current-thread-0.1.7.bazel"
@@ -12690,7 +12705,7 @@
               "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-deque/0.8.3/download"
+                "https://static.crates.io/crates/crossbeam-deque/0.8.3/download"
               ],
               "strip_prefix": "crossbeam-deque-0.8.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-deque-0.8.3.bazel"
@@ -12703,7 +12718,7 @@
               "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/android_system_properties/0.1.5/download"
+                "https://static.crates.io/crates/android_system_properties/0.1.5/download"
               ],
               "strip_prefix": "android_system_properties-0.1.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.android_system_properties-0.1.5.bazel"
@@ -12716,7 +12731,7 @@
               "sha256": "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pest_meta/2.7.0/download"
+                "https://static.crates.io/crates/pest_meta/2.7.0/download"
               ],
               "strip_prefix": "pest_meta-2.7.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.pest_meta-2.7.0.bazel"
@@ -12729,7 +12744,7 @@
               "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle-wincon/1.0.1/download"
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
               ],
               "strip_prefix": "anstyle-wincon-1.0.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
@@ -12742,7 +12757,7 @@
               "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle-query/1.0.0/download"
+                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
               ],
               "strip_prefix": "anstyle-query-1.0.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
@@ -12755,7 +12770,7 @@
               "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap_derive/4.3.2/download"
+                "https://static.crates.io/crates/clap_derive/4.3.2/download"
               ],
               "strip_prefix": "clap_derive-4.3.2",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
@@ -12768,7 +12783,7 @@
               "sha256": "1884c7b41ea0875217c1be9ce91322f90bde433e91d374d0e1276073a51ccc60",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-hash/0.13.1/download"
+                "https://static.crates.io/crates/gix-hash/0.13.1/download"
               ],
               "strip_prefix": "gix-hash-0.13.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-hash-0.13.1.bazel"
@@ -12781,7 +12796,7 @@
               "sha256": "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/maybe-async/0.2.7/download"
+                "https://static.crates.io/crates/maybe-async/0.2.7/download"
               ],
               "strip_prefix": "maybe-async-0.2.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.maybe-async-0.2.7.bazel"
@@ -12794,7 +12809,7 @@
               "sha256": "1be40d28cd41445bb6cd52c4d847d915900e5466f7433eaee6a9e0a3d1d88b08",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-filter/0.5.0/download"
+                "https://static.crates.io/crates/gix-filter/0.5.0/download"
               ],
               "strip_prefix": "gix-filter-0.5.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-filter-0.5.0.bazel"
@@ -12807,7 +12822,7 @@
               "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/mime/0.3.17/download"
+                "https://static.crates.io/crates/mime/0.3.17/download"
               ],
               "strip_prefix": "mime-0.3.17",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.mime-0.3.17.bazel"
@@ -12820,7 +12835,7 @@
               "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustix/0.37.23/download"
+                "https://static.crates.io/crates/rustix/0.37.23/download"
               ],
               "strip_prefix": "rustix-0.37.23",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
@@ -12833,7 +12848,7 @@
               "sha256": "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hermit-abi/0.3.1/download"
+                "https://static.crates.io/crates/hermit-abi/0.3.1/download"
               ],
               "strip_prefix": "hermit-abi-0.3.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hermit-abi-0.3.1.bazel"
@@ -12846,7 +12861,7 @@
               "sha256": "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/maplit/1.0.2/download"
+                "https://static.crates.io/crates/maplit/1.0.2/download"
               ],
               "strip_prefix": "maplit-1.0.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.maplit-1.0.2.bazel"
@@ -12859,7 +12874,7 @@
               "sha256": "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/syn/2.0.25/download"
+                "https://static.crates.io/crates/syn/2.0.25/download"
               ],
               "strip_prefix": "syn-2.0.25",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.syn-2.0.25.bazel"
@@ -12872,7 +12887,7 @@
               "sha256": "9f5e32972801bd82d56609e6fc84efc358fa1f11f25c5e83b7807ee2280f14fe",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-worktree/0.26.0/download"
+                "https://static.crates.io/crates/gix-worktree/0.26.0/download"
               ],
               "strip_prefix": "gix-worktree-0.26.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-worktree-0.26.0.bazel"
@@ -12885,7 +12900,7 @@
               "sha256": "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/semver/1.0.17/download"
+                "https://static.crates.io/crates/semver/1.0.17/download"
               ],
               "strip_prefix": "semver-1.0.17",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.semver-1.0.17.bazel"
@@ -12898,7 +12913,7 @@
               "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/once_cell/1.18.0/download"
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
               ],
               "strip_prefix": "once_cell-1.18.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
@@ -12911,7 +12926,7 @@
               "sha256": "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasmparser/0.80.2/download"
+                "https://static.crates.io/crates/wasmparser/0.80.2/download"
               ],
               "strip_prefix": "wasmparser-0.80.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.80.2.bazel"
@@ -12924,7 +12939,7 @@
               "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/heck/0.4.1/download"
+                "https://static.crates.io/crates/heck/0.4.1/download"
               ],
               "strip_prefix": "heck-0.4.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.heck-0.4.1.bazel"
@@ -12937,7 +12952,7 @@
               "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
@@ -12963,7 +12978,7 @@
               "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/either/1.8.1/download"
+                "https://static.crates.io/crates/either/1.8.1/download"
               ],
               "strip_prefix": "either-1.8.1",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.either-1.8.1.bazel"
@@ -12976,7 +12991,7 @@
               "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/minimal-lexical/0.2.1/download"
+                "https://static.crates.io/crates/minimal-lexical/0.2.1/download"
               ],
               "strip_prefix": "minimal-lexical-0.2.1",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.minimal-lexical-0.2.1.bazel"
@@ -12989,7 +13004,7 @@
               "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-automata/0.3.3/download"
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
               ],
               "strip_prefix": "regex-automata-0.3.3",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
@@ -13002,7 +13017,7 @@
               "sha256": "62bde1398b09b9f93fc2fc9b9da86e362693e999d3a54a8ac47a99a5a73f638b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/spdx/0.10.3/download"
+                "https://static.crates.io/crates/spdx/0.10.3/download"
               ],
               "strip_prefix": "spdx-0.10.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.spdx-0.10.3.bazel"
@@ -13015,7 +13030,7 @@
               "sha256": "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/normalize-line-endings/0.3.0/download"
+                "https://static.crates.io/crates/normalize-line-endings/0.3.0/download"
               ],
               "strip_prefix": "normalize-line-endings-0.3.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.normalize-line-endings-0.3.0.bazel"
@@ -13028,7 +13043,7 @@
               "sha256": "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/h2/0.3.19/download"
+                "https://static.crates.io/crates/h2/0.3.19/download"
               ],
               "strip_prefix": "h2-0.3.19",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.h2-0.3.19.bazel"
@@ -13041,7 +13056,7 @@
               "sha256": "76c956109dcb41436a39391139d9b6e2d0a5e0b158e1293ef352ec977e5e36c5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasmparser/0.108.0/download"
+                "https://static.crates.io/crates/wasmparser/0.108.0/download"
               ],
               "strip_prefix": "wasmparser-0.108.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.108.0.bazel"
@@ -13054,7 +13069,7 @@
               "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/colorchoice/1.0.0/download"
+                "https://static.crates.io/crates/colorchoice/1.0.0/download"
               ],
               "strip_prefix": "colorchoice-1.0.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
@@ -13067,7 +13082,7 @@
               "sha256": "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-sync/0.1.8/download"
+                "https://static.crates.io/crates/tokio-sync/0.1.8/download"
               ],
               "strip_prefix": "tokio-sync-0.1.8",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-sync-0.1.8.bazel"
@@ -13080,7 +13095,7 @@
               "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/nom/7.1.3/download"
+                "https://static.crates.io/crates/nom/7.1.3/download"
               ],
               "strip_prefix": "nom-7.1.3",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.nom-7.1.3.bazel"
@@ -13093,7 +13108,7 @@
               "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hashbrown/0.12.3/download"
+                "https://static.crates.io/crates/hashbrown/0.12.3/download"
               ],
               "strip_prefix": "hashbrown-0.12.3",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hashbrown-0.12.3.bazel"
@@ -13106,7 +13121,7 @@
               "sha256": "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/clap/4.3.11/download"
+                "https://static.crates.io/crates/clap/4.3.11/download"
               ],
               "strip_prefix": "clap-4.3.11",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.clap-4.3.11.bazel"
@@ -13119,7 +13134,7 @@
               "sha256": "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cexpr/0.6.0/download"
+                "https://static.crates.io/crates/cexpr/0.6.0/download"
               ],
               "strip_prefix": "cexpr-0.6.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.cexpr-0.6.0.bazel"
@@ -13132,7 +13147,7 @@
               "sha256": "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num-bigint/0.1.44/download"
+                "https://static.crates.io/crates/num-bigint/0.1.44/download"
               ],
               "strip_prefix": "num-bigint-0.1.44",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-bigint-0.1.44.bazel"
@@ -13145,7 +13160,7 @@
               "sha256": "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/nu-ansi-term/0.46.0/download"
+                "https://static.crates.io/crates/nu-ansi-term/0.46.0/download"
               ],
               "strip_prefix": "nu-ansi-term-0.46.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.nu-ansi-term-0.46.0.bazel"
@@ -13158,7 +13173,7 @@
               "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
               ],
               "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
@@ -13171,7 +13186,7 @@
               "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/lazy_static/1.4.0/download"
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
               ],
               "strip_prefix": "lazy_static-1.4.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
@@ -13184,7 +13199,7 @@
               "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde_derive/1.0.171/download"
+                "https://static.crates.io/crates/serde_derive/1.0.171/download"
               ],
               "strip_prefix": "serde_derive-1.0.171",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
@@ -13197,7 +13212,7 @@
               "sha256": "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstyle/1.0.0/download"
+                "https://static.crates.io/crates/anstyle/1.0.0/download"
               ],
               "strip_prefix": "anstyle-1.0.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.anstyle-1.0.0.bazel"
@@ -13210,7 +13225,7 @@
               "sha256": "8a8384b1e964151aff0d5632dd9b191059d07dff358b96bd940f1b452600d7ab",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-packetline/0.16.7/download"
+                "https://static.crates.io/crates/gix-packetline/0.16.7/download"
               ],
               "strip_prefix": "gix-packetline-0.16.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-packetline-0.16.7.bazel"
@@ -13223,7 +13238,7 @@
               "sha256": "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/time-core/0.1.2/download"
+                "https://static.crates.io/crates/time-core/0.1.2/download"
               ],
               "strip_prefix": "time-core-0.1.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-core-0.1.2.bazel"
@@ -13236,7 +13251,7 @@
               "sha256": "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/itertools/0.12.0/download"
+                "https://static.crates.io/crates/itertools/0.12.0/download"
               ],
               "strip_prefix": "itertools-0.12.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.itertools-0.12.0.bazel"
@@ -13249,7 +13264,7 @@
               "sha256": "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/time-macros/0.2.15/download"
+                "https://static.crates.io/crates/time-macros/0.2.15/download"
               ],
               "strip_prefix": "time-macros-0.2.15",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.time-macros-0.2.15.bazel"
@@ -13262,7 +13277,7 @@
               "sha256": "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/try-lock/0.2.4/download"
+                "https://static.crates.io/crates/try-lock/0.2.4/download"
               ],
               "strip_prefix": "try-lock-0.2.4",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.try-lock-0.2.4.bazel"
@@ -13275,7 +13290,7 @@
               "sha256": "970dff17c11e884a4a09bc76e3a17ef71e01bb13447a11e85226e254fe6d10b8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tera/1.19.1/download"
+                "https://static.crates.io/crates/tera/1.19.1/download"
               ],
               "strip_prefix": "tera-1.19.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tera-1.19.1.bazel"
@@ -13288,7 +13303,7 @@
               "sha256": "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tempfile/3.6.0/download"
+                "https://static.crates.io/crates/tempfile/3.6.0/download"
               ],
               "strip_prefix": "tempfile-3.6.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.tempfile-3.6.0.bazel"
@@ -13301,7 +13316,7 @@
               "sha256": "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/axum-core/0.3.4/download"
+                "https://static.crates.io/crates/axum-core/0.3.4/download"
               ],
               "strip_prefix": "axum-core-0.3.4",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.axum-core-0.3.4.bazel"
@@ -13314,7 +13329,7 @@
               "sha256": "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/globset/0.4.11/download"
+                "https://static.crates.io/crates/globset/0.4.11/download"
               ],
               "strip_prefix": "globset-0.4.11",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.globset-0.4.11.bazel"
@@ -13327,7 +13342,7 @@
               "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/colorchoice/1.0.0/download"
+                "https://static.crates.io/crates/colorchoice/1.0.0/download"
               ],
               "strip_prefix": "colorchoice-1.0.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
@@ -13340,7 +13355,7 @@
               "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-sys/0.48.0/download"
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
               ],
               "strip_prefix": "windows-sys-0.48.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
@@ -13353,7 +13368,7 @@
               "sha256": "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/libc/0.2.146/download"
+                "https://static.crates.io/crates/libc/0.2.146/download"
               ],
               "strip_prefix": "libc-0.2.146",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.libc-0.2.146.bazel"
@@ -13366,7 +13381,7 @@
               "sha256": "d1e019acde479e2f090fb7f14a51fa0077ec3a7bb12a56e0e888a82be7b5bd3f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-multi-value-xform/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-multi-value-xform/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-multi-value-xform-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-multi-value-xform-0.2.91.bazel"
@@ -13379,7 +13394,7 @@
               "sha256": "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/itertools/0.10.5/download"
+                "https://static.crates.io/crates/itertools/0.10.5/download"
               ],
               "strip_prefix": "itertools-0.10.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.itertools-0.10.5.bazel"
@@ -13392,7 +13407,7 @@
               "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-sys/0.48.0/download"
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
               ],
               "strip_prefix": "windows-sys-0.48.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
@@ -13405,7 +13420,7 @@
               "sha256": "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/futures/0.1.31/download"
+                "https://static.crates.io/crates/futures/0.1.31/download"
               ],
               "strip_prefix": "futures-0.1.31",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.futures-0.1.31.bazel"
@@ -13418,7 +13433,7 @@
               "sha256": "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-deque/0.7.4/download"
+                "https://static.crates.io/crates/crossbeam-deque/0.7.4/download"
               ],
               "strip_prefix": "crossbeam-deque-0.7.4",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.crossbeam-deque-0.7.4.bazel"
@@ -13431,7 +13446,7 @@
               "sha256": "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rayon/1.7.0/download"
+                "https://static.crates.io/crates/rayon/1.7.0/download"
               ],
               "strip_prefix": "rayon-1.7.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rayon-1.7.0.bazel"
@@ -13444,7 +13459,7 @@
               "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/spin/0.9.8/download"
+                "https://static.crates.io/crates/spin/0.9.8/download"
               ],
               "strip_prefix": "spin-0.9.8",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.spin-0.9.8.bazel"
@@ -13457,7 +13472,7 @@
               "sha256": "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi/0.2.8/download"
+                "https://static.crates.io/crates/winapi/0.2.8/download"
               ],
               "strip_prefix": "winapi-0.2.8",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.winapi-0.2.8.bazel"
@@ -13470,7 +13485,7 @@
               "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/num-traits/0.2.15/download"
+                "https://static.crates.io/crates/num-traits/0.2.15/download"
               ],
               "strip_prefix": "num-traits-0.2.15",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.num-traits-0.2.15.bazel"
@@ -13483,7 +13498,7 @@
               "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/heck/0.4.1/download"
+                "https://static.crates.io/crates/heck/0.4.1/download"
               ],
               "strip_prefix": "heck-0.4.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.heck-0.4.1.bazel"
@@ -13496,7 +13511,7 @@
               "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rand_chacha/0.3.1/download"
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
               ],
               "strip_prefix": "rand_chacha-0.3.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
@@ -13509,7 +13524,7 @@
               "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anstream/0.3.2/download"
+                "https://static.crates.io/crates/anstream/0.3.2/download"
               ],
               "strip_prefix": "anstream-0.3.2",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
@@ -13522,7 +13537,7 @@
               "sha256": "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cargo-lock/9.0.0/download"
+                "https://static.crates.io/crates/cargo-lock/9.0.0/download"
               ],
               "strip_prefix": "cargo-lock-9.0.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.cargo-lock-9.0.0.bazel"
@@ -13535,7 +13550,7 @@
               "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-util/0.1.5/download"
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
               ],
               "strip_prefix": "winapi-util-0.1.5",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
@@ -13548,7 +13563,7 @@
               "sha256": "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/buf_redux/0.8.4/download"
+                "https://static.crates.io/crates/buf_redux/0.8.4/download"
               ],
               "strip_prefix": "buf_redux-0.8.4",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.buf_redux-0.8.4.bazel"
@@ -13561,7 +13576,7 @@
               "sha256": "049c03787a0595182357fbd487577947f4351b78ce20c3668f6d49f17feb13d1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tls-api/0.1.22/download"
+                "https://static.crates.io/crates/tls-api/0.1.22/download"
               ],
               "strip_prefix": "tls-api-0.1.22",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tls-api-0.1.22.bazel"
@@ -13574,7 +13589,7 @@
               "sha256": "239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/faster-hex/0.8.1/download"
+                "https://static.crates.io/crates/faster-hex/0.8.1/download"
               ],
               "strip_prefix": "faster-hex-0.8.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.faster-hex-0.8.1.bazel"
@@ -13587,7 +13602,7 @@
               "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hashbrown/0.12.3/download"
+                "https://static.crates.io/crates/hashbrown/0.12.3/download"
               ],
               "strip_prefix": "hashbrown-0.12.3",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.hashbrown-0.12.3.bazel"
@@ -13600,7 +13615,7 @@
               "sha256": "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam/0.8.2/download"
+                "https://static.crates.io/crates/crossbeam/0.8.2/download"
               ],
               "strip_prefix": "crossbeam-0.8.2",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-0.8.2.bazel"
@@ -13613,7 +13628,7 @@
               "sha256": "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/futures-channel/0.3.28/download"
+                "https://static.crates.io/crates/futures-channel/0.3.28/download"
               ],
               "strip_prefix": "futures-channel-0.3.28",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-channel-0.3.28.bazel"
@@ -13626,7 +13641,7 @@
               "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/scopeguard/1.1.0/download"
+                "https://static.crates.io/crates/scopeguard/1.1.0/download"
               ],
               "strip_prefix": "scopeguard-1.1.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
@@ -13639,7 +13654,7 @@
               "sha256": "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/futures-util/0.3.28/download"
+                "https://static.crates.io/crates/futures-util/0.3.28/download"
               ],
               "strip_prefix": "futures-util-0.3.28",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-util-0.3.28.bazel"
@@ -13652,7 +13667,7 @@
               "sha256": "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde/1.0.164/download"
+                "https://static.crates.io/crates/serde/1.0.164/download"
               ],
               "strip_prefix": "serde-1.0.164",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.serde-1.0.164.bazel"
@@ -13665,7 +13680,7 @@
               "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crossbeam-utils/0.8.16/download"
+                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
               ],
               "strip_prefix": "crossbeam-utils-0.8.16",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
@@ -13678,7 +13693,7 @@
               "sha256": "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unic-segment/0.9.0/download"
+                "https://static.crates.io/crates/unic-segment/0.9.0/download"
               ],
               "strip_prefix": "unic-segment-0.9.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-segment-0.9.0.bazel"
@@ -13691,7 +13706,7 @@
               "sha256": "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-automata/0.4.3/download"
+                "https://static.crates.io/crates/regex-automata/0.4.3/download"
               ],
               "strip_prefix": "regex-automata-0.4.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.regex-automata-0.4.3.bazel"
@@ -13704,7 +13719,7 @@
               "sha256": "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/miow/0.2.2/download"
+                "https://static.crates.io/crates/miow/0.2.2/download"
               ],
               "strip_prefix": "miow-0.2.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.miow-0.2.2.bazel"
@@ -13717,7 +13732,7 @@
               "sha256": "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/filetime/0.2.21/download"
+                "https://static.crates.io/crates/filetime/0.2.21/download"
               ],
               "strip_prefix": "filetime-0.2.21",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.filetime-0.2.21.bazel"
@@ -13730,7 +13745,7 @@
               "sha256": "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-targets/0.48.0/download"
+                "https://static.crates.io/crates/windows-targets/0.48.0/download"
               ],
               "strip_prefix": "windows-targets-0.48.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows-targets-0.48.0.bazel"
@@ -13743,7 +13758,7 @@
               "sha256": "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/petgraph/0.6.3/download"
+                "https://static.crates.io/crates/petgraph/0.6.3/download"
               ],
               "strip_prefix": "petgraph-0.6.3",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.petgraph-0.6.3.bazel"
@@ -13756,7 +13771,7 @@
               "sha256": "e9870c6b1032f2084567710c3b2106ac603377f8d25766b8a6b7c33e6e3ca279",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-revwalk/0.8.0/download"
+                "https://static.crates.io/crates/gix-revwalk/0.8.0/download"
               ],
               "strip_prefix": "gix-revwalk-0.8.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-revwalk-0.8.0.bazel"
@@ -13769,7 +13784,7 @@
               "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows-targets/0.48.1/download"
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
               ],
               "strip_prefix": "windows-targets-0.48.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
@@ -13782,7 +13797,7 @@
               "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/syn/1.0.109/download"
+                "https://static.crates.io/crates/syn/1.0.109/download"
               ],
               "strip_prefix": "syn-1.0.109",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.syn-1.0.109.bazel"
@@ -13795,7 +13810,7 @@
               "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/percent-encoding/2.3.0/download"
+                "https://static.crates.io/crates/percent-encoding/2.3.0/download"
               ],
               "strip_prefix": "percent-encoding-2.3.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.percent-encoding-2.3.0.bazel"
@@ -13808,7 +13823,7 @@
               "sha256": "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hashbrown/0.14.0/download"
+                "https://static.crates.io/crates/hashbrown/0.14.0/download"
               ],
               "strip_prefix": "hashbrown-0.14.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.hashbrown-0.14.0.bazel"
@@ -13821,7 +13836,7 @@
               "sha256": "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/toml_datetime/0.6.5/download"
+                "https://static.crates.io/crates/toml_datetime/0.6.5/download"
               ],
               "strip_prefix": "toml_datetime-0.6.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_datetime-0.6.5.bazel"
@@ -13834,7 +13849,7 @@
               "sha256": "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/log/0.4.17/download"
+                "https://static.crates.io/crates/log/0.4.17/download"
               ],
               "strip_prefix": "log-0.4.17",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.log-0.4.17.bazel"
@@ -13847,7 +13862,7 @@
               "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tinyvec/1.6.0/download"
+                "https://static.crates.io/crates/tinyvec/1.6.0/download"
               ],
               "strip_prefix": "tinyvec-1.6.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
@@ -13860,7 +13875,7 @@
               "sha256": "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/btoi/0.4.3/download"
+                "https://static.crates.io/crates/btoi/0.4.3/download"
               ],
               "strip_prefix": "btoi-0.4.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.btoi-0.4.3.bazel"
@@ -13873,7 +13888,7 @@
               "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/ppv-lite86/0.2.17/download"
+                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
               ],
               "strip_prefix": "ppv-lite86-0.2.17",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
@@ -13886,7 +13901,7 @@
               "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi/0.3.9/download"
+                "https://static.crates.io/crates/winapi/0.3.9/download"
               ],
               "strip_prefix": "winapi-0.3.9",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
@@ -13899,7 +13914,7 @@
               "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/winapi-util/0.1.5/download"
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
               ],
               "strip_prefix": "winapi-util-0.1.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
@@ -13912,7 +13927,7 @@
               "sha256": "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/maybe-uninit/2.0.0/download"
+                "https://static.crates.io/crates/maybe-uninit/2.0.0/download"
               ],
               "strip_prefix": "maybe-uninit-2.0.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.maybe-uninit-2.0.0.bazel"
@@ -13925,7 +13940,7 @@
               "sha256": "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-tcp/0.1.4/download"
+                "https://static.crates.io/crates/tokio-tcp/0.1.4/download"
               ],
               "strip_prefix": "tokio-tcp-0.1.4",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-tcp-0.1.4.bazel"
@@ -13938,7 +13953,7 @@
               "sha256": "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/yansi-term/0.1.2/download"
+                "https://static.crates.io/crates/yansi-term/0.1.2/download"
               ],
               "strip_prefix": "yansi-term-0.1.2",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.yansi-term-0.1.2.bazel"
@@ -13951,7 +13966,7 @@
               "sha256": "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/toml_edit/0.22.4/download"
+                "https://static.crates.io/crates/toml_edit/0.22.4/download"
               ],
               "strip_prefix": "toml_edit-0.22.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.toml_edit-0.22.4.bazel"
@@ -13964,7 +13979,7 @@
               "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_msvc/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_msvc-0.48.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
@@ -13977,7 +13992,7 @@
               "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/block-buffer/0.10.4/download"
+                "https://static.crates.io/crates/block-buffer/0.10.4/download"
               ],
               "strip_prefix": "block-buffer-0.10.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.block-buffer-0.10.4.bazel"
@@ -13990,7 +14005,7 @@
               "sha256": "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/chrono-tz-build/0.2.1/download"
+                "https://static.crates.io/crates/chrono-tz-build/0.2.1/download"
               ],
               "strip_prefix": "chrono-tz-build-0.2.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.chrono-tz-build-0.2.1.bazel"
@@ -14003,7 +14018,7 @@
               "sha256": "0ccab4bc576844ddb51b78d81b4a42d73e6229660fa614dfc3d3999c874d1959",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-bitmap/0.2.7/download"
+                "https://static.crates.io/crates/gix-bitmap/0.2.7/download"
               ],
               "strip_prefix": "gix-bitmap-0.2.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-bitmap-0.2.7.bazel"
@@ -14016,7 +14031,7 @@
               "sha256": "c3e26c9b47c51be73f98d38c84494bd5fb99334c5d6fda14ef5d036d50a9e5fd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-pathspec/0.3.0/download"
+                "https://static.crates.io/crates/gix-pathspec/0.3.0/download"
               ],
               "strip_prefix": "gix-pathspec-0.3.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-pathspec-0.3.0.bazel"
@@ -14029,7 +14044,7 @@
               "sha256": "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/libc/0.2.147/download"
+                "https://static.crates.io/crates/libc/0.2.147/download"
               ],
               "strip_prefix": "libc-0.2.147",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.libc-0.2.147.bazel"
@@ -14042,7 +14057,7 @@
               "sha256": "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/base64/0.21.5/download"
+                "https://static.crates.io/crates/base64/0.21.5/download"
               ],
               "strip_prefix": "base64-0.21.5",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.base64-0.21.5.bazel"
@@ -14055,7 +14070,7 @@
               "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tracing-attributes/0.1.27/download"
+                "https://static.crates.io/crates/tracing-attributes/0.1.27/download"
               ],
               "strip_prefix": "tracing-attributes-0.1.27",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-attributes-0.1.27.bazel"
@@ -14073,7 +14088,7 @@
               "sha256": "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio/1.28.2/download"
+                "https://static.crates.io/crates/tokio/1.28.2/download"
               ],
               "strip_prefix": "tokio-1.28.2",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tokio-1.28.2.bazel"
@@ -14086,7 +14101,7 @@
               "sha256": "bda66b810a62be75176a80873726630147a5ca780cd33921e0b5709033e66b0a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/parking_lot_core/0.6.3/download"
+                "https://static.crates.io/crates/parking_lot_core/0.6.3/download"
               ],
               "strip_prefix": "parking_lot_core-0.6.3",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.parking_lot_core-0.6.3.bazel"
@@ -14099,7 +14114,7 @@
               "sha256": "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/chunked_transfer/1.4.1/download"
+                "https://static.crates.io/crates/chunked_transfer/1.4.1/download"
               ],
               "strip_prefix": "chunked_transfer-1.4.1",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.chunked_transfer-1.4.1.bazel"
@@ -14112,7 +14127,7 @@
               "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tinyvec_macros/0.1.1/download"
+                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
               ],
               "strip_prefix": "tinyvec_macros-0.1.1",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
@@ -14125,7 +14140,7 @@
               "sha256": "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/semver-parser/0.7.0/download"
+                "https://static.crates.io/crates/semver-parser/0.7.0/download"
               ],
               "strip_prefix": "semver-parser-0.7.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.semver-parser-0.7.0.bazel"
@@ -14138,7 +14153,7 @@
               "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_i686_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_i686_gnu-0.48.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
@@ -14151,7 +14166,7 @@
               "sha256": "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-udp/0.1.6/download"
+                "https://static.crates.io/crates/tokio-udp/0.1.6/download"
               ],
               "strip_prefix": "tokio-udp-0.1.6",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-udp-0.1.6.bazel"
@@ -14164,7 +14179,7 @@
               "sha256": "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unic-char-property/0.9.0/download"
+                "https://static.crates.io/crates/unic-char-property/0.9.0/download"
               ],
               "strip_prefix": "unic-char-property-0.9.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unic-char-property-0.9.0.bazel"
@@ -14177,7 +14192,7 @@
               "sha256": "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/sha1_smol/1.0.0/download"
+                "https://static.crates.io/crates/sha1_smol/1.0.0/download"
               ],
               "strip_prefix": "sha1_smol-1.0.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
@@ -14190,7 +14205,7 @@
               "sha256": "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/siphasher/0.3.10/download"
+                "https://static.crates.io/crates/siphasher/0.3.10/download"
               ],
               "strip_prefix": "siphasher-0.3.10",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.siphasher-0.3.10.bazel"
@@ -14203,7 +14218,7 @@
               "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tracing/0.1.40/download"
+                "https://static.crates.io/crates/tracing/0.1.40/download"
               ],
               "strip_prefix": "tracing-0.1.40",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.tracing-0.1.40.bazel"
@@ -14216,7 +14231,7 @@
               "sha256": "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/syn/2.0.25/download"
+                "https://static.crates.io/crates/syn/2.0.25/download"
               ],
               "strip_prefix": "syn-2.0.25",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.syn-2.0.25.bazel"
@@ -14229,7 +14244,7 @@
               "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/version_check/0.9.4/download"
+                "https://static.crates.io/crates/version_check/0.9.4/download"
               ],
               "strip_prefix": "version_check-0.9.4",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
@@ -14242,7 +14257,7 @@
               "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/is-terminal/0.4.7/download"
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
               ],
               "strip_prefix": "is-terminal-0.4.7",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
@@ -14255,7 +14270,7 @@
               "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno-dragonfly/0.1.2/download"
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
               ],
               "strip_prefix": "errno-dragonfly-0.1.2",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
@@ -14268,7 +14283,7 @@
               "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/instant/0.1.12/download"
+                "https://static.crates.io/crates/instant/0.1.12/download"
               ],
               "strip_prefix": "instant-0.1.12",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.instant-0.1.12.bazel"
@@ -14281,7 +14296,7 @@
               "sha256": "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex-automata/0.1.10/download"
+                "https://static.crates.io/crates/regex-automata/0.1.10/download"
               ],
               "strip_prefix": "regex-automata-0.1.10",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.1.10.bazel"
@@ -14294,7 +14309,7 @@
               "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hermit-abi/0.3.2/download"
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
               ],
               "strip_prefix": "hermit-abi-0.3.2",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
@@ -14307,7 +14322,7 @@
               "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/strsim/0.10.0/download"
+                "https://static.crates.io/crates/strsim/0.10.0/download"
               ],
               "strip_prefix": "strsim-0.10.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
@@ -14320,7 +14335,7 @@
               "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/arrayvec/0.7.4/download"
+                "https://static.crates.io/crates/arrayvec/0.7.4/download"
               ],
               "strip_prefix": "arrayvec-0.7.4",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.arrayvec-0.7.4.bazel"
@@ -14333,7 +14348,7 @@
               "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/errno/0.3.1/download"
+                "https://static.crates.io/crates/errno/0.3.1/download"
               ],
               "strip_prefix": "errno-0.3.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.errno-0.3.1.bazel"
@@ -14346,7 +14361,7 @@
               "sha256": "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-timer/0.1.2/download"
+                "https://static.crates.io/crates/tokio-timer/0.1.2/download"
               ],
               "strip_prefix": "tokio-timer-0.1.2",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.1.2.bazel"
@@ -14359,7 +14374,7 @@
               "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/js-sys/0.3.64/download"
+                "https://static.crates.io/crates/js-sys/0.3.64/download"
               ],
               "strip_prefix": "js-sys-0.3.64",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.js-sys-0.3.64.bazel"
@@ -14372,7 +14387,7 @@
               "sha256": "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/time/0.3.23/download"
+                "https://static.crates.io/crates/time/0.3.23/download"
               ],
               "strip_prefix": "time-0.3.23",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.time-0.3.23.bazel"
@@ -14385,7 +14400,7 @@
               "sha256": "b9ec726e6a245e68ace59a34126a1d679de60360676612985e70b0d3b102fb4e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-transport/0.37.0/download"
+                "https://static.crates.io/crates/gix-transport/0.37.0/download"
               ],
               "strip_prefix": "gix-transport-0.37.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-transport-0.37.0.bazel"
@@ -14398,7 +14413,7 @@
               "sha256": "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/net2/0.2.38/download"
+                "https://static.crates.io/crates/net2/0.2.38/download"
               ],
               "strip_prefix": "net2-0.2.38",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.net2-0.2.38.bazel"
@@ -14411,7 +14426,7 @@
               "sha256": "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/pin-project-internal/1.1.0/download"
+                "https://static.crates.io/crates/pin-project-internal/1.1.0/download"
               ],
               "strip_prefix": "pin-project-internal-1.1.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.pin-project-internal-1.1.0.bazel"
@@ -14424,7 +14439,7 @@
               "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rustc-hash/1.1.0/download"
+                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
               ],
               "strip_prefix": "rustc-hash-1.1.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
@@ -14437,7 +14452,7 @@
               "sha256": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/sharded-slab/0.1.7/download"
+                "https://static.crates.io/crates/sharded-slab/0.1.7/download"
               ],
               "strip_prefix": "sharded-slab-0.1.7",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.sharded-slab-0.1.7.bazel"
@@ -14450,7 +14465,7 @@
               "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/itoa/1.0.8/download"
+                "https://static.crates.io/crates/itoa/1.0.8/download"
               ],
               "strip_prefix": "itoa-1.0.8",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
@@ -14463,7 +14478,7 @@
               "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/form_urlencoded/1.2.0/download"
+                "https://static.crates.io/crates/form_urlencoded/1.2.0/download"
               ],
               "strip_prefix": "form_urlencoded-1.2.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.form_urlencoded-1.2.0.bazel"
@@ -14476,7 +14491,7 @@
               "sha256": "e75a975ee22cf0a002bfe9b5d5cb3d2a88e263a8a178cd7509133cff10f4df8a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-commitgraph/0.21.0/download"
+                "https://static.crates.io/crates/gix-commitgraph/0.21.0/download"
               ],
               "strip_prefix": "gix-commitgraph-0.21.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-commitgraph-0.21.0.bazel"
@@ -14489,7 +14504,7 @@
               "sha256": "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde_json/1.0.102/download"
+                "https://static.crates.io/crates/serde_json/1.0.102/download"
               ],
               "strip_prefix": "serde_json-1.0.102",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
@@ -14502,7 +14517,7 @@
               "sha256": "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tonic-build/0.8.4/download"
+                "https://static.crates.io/crates/tonic-build/0.8.4/download"
               ],
               "strip_prefix": "tonic-build-0.8.4",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.tonic-build-0.8.4.bazel"
@@ -14515,7 +14530,7 @@
               "sha256": "3716fbf57fc1084d7a706adf4e445298d123e4a44294c4e8213caf1b85fcc921",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rouille/3.6.2/download"
+                "https://static.crates.io/crates/rouille/3.6.2/download"
               ],
               "strip_prefix": "rouille-3.6.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rouille-3.6.2.bazel"
@@ -14528,7 +14543,7 @@
               "sha256": "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/anyhow/1.0.75/download"
+                "https://static.crates.io/crates/anyhow/1.0.75/download"
               ],
               "strip_prefix": "anyhow-1.0.75",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.anyhow-1.0.75.bazel"
@@ -14541,7 +14556,7 @@
               "sha256": "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/url/2.4.0/download"
+                "https://static.crates.io/crates/url/2.4.0/download"
               ],
               "strip_prefix": "url-2.4.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.url-2.4.0.bazel"
@@ -14554,7 +14569,7 @@
               "sha256": "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/uluru/3.0.0/download"
+                "https://static.crates.io/crates/uluru/3.0.0/download"
               ],
               "strip_prefix": "uluru-3.0.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.uluru-3.0.0.bazel"
@@ -14567,7 +14582,7 @@
               "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/syn/1.0.109/download"
+                "https://static.crates.io/crates/syn/1.0.109/download"
               ],
               "strip_prefix": "syn-1.0.109",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.syn-1.0.109.bazel"
@@ -14580,7 +14595,7 @@
               "sha256": "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/socket2/0.4.9/download"
+                "https://static.crates.io/crates/socket2/0.4.9/download"
               ],
               "strip_prefix": "socket2-0.4.9",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.socket2-0.4.9.bazel"
@@ -14593,7 +14608,7 @@
               "sha256": "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/futures-sink/0.3.28/download"
+                "https://static.crates.io/crates/futures-sink/0.3.28/download"
               ],
               "strip_prefix": "futures-sink-0.3.28",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.futures-sink-0.3.28.bazel"
@@ -14606,7 +14621,7 @@
               "sha256": "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-ident/1.0.9/download"
+                "https://static.crates.io/crates/unicode-ident/1.0.9/download"
               ],
               "strip_prefix": "unicode-ident-1.0.9",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.unicode-ident-1.0.9.bazel"
@@ -14619,7 +14634,7 @@
               "sha256": "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/libc/0.2.149/download"
+                "https://static.crates.io/crates/libc/0.2.149/download"
               ],
               "strip_prefix": "libc-0.2.149",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.libc-0.2.149.bazel"
@@ -14632,7 +14647,7 @@
               "sha256": "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-linebreak/0.1.5/download"
+                "https://static.crates.io/crates/unicode-linebreak/0.1.5/download"
               ],
               "strip_prefix": "unicode-linebreak-0.1.5",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-linebreak-0.1.5.bazel"
@@ -14645,7 +14660,7 @@
               "sha256": "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unix_socket/0.5.0/download"
+                "https://static.crates.io/crates/unix_socket/0.5.0/download"
               ],
               "strip_prefix": "unix_socket-0.5.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.unix_socket-0.5.0.bazel"
@@ -14658,7 +14673,7 @@
               "sha256": "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/itertools/0.11.0/download"
+                "https://static.crates.io/crates/itertools/0.11.0/download"
               ],
               "strip_prefix": "itertools-0.11.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.itertools-0.11.0.bazel"
@@ -14671,7 +14686,7 @@
               "sha256": "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/regex/1.8.4/download"
+                "https://static.crates.io/crates/regex/1.8.4/download"
               ],
               "strip_prefix": "regex-1.8.4",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.regex-1.8.4.bazel"
@@ -14684,7 +14699,7 @@
               "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/hashbrown/0.14.3/download"
+                "https://static.crates.io/crates/hashbrown/0.14.3/download"
               ],
               "strip_prefix": "hashbrown-0.14.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.hashbrown-0.14.3.bazel"
@@ -14697,7 +14712,7 @@
               "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/crypto-common/0.1.6/download"
+                "https://static.crates.io/crates/crypto-common/0.1.6/download"
               ],
               "strip_prefix": "crypto-common-0.1.6",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.crypto-common-0.1.6.bazel"
@@ -14710,7 +14725,7 @@
               "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnu/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnu-0.48.0",
               "build_file": "@@rules_rust~//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
@@ -14723,7 +14738,7 @@
               "sha256": "a7534301c0ea17abb4db06d75efc7b4b0fa360fce8e175a4330d721c71c942ff",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/byteyarn/0.2.3/download"
+                "https://static.crates.io/crates/byteyarn/0.2.3/download"
               ],
               "strip_prefix": "byteyarn-0.2.3",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.byteyarn-0.2.3.bazel"
@@ -14736,7 +14751,7 @@
               "sha256": "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-executor/0.1.10/download"
+                "https://static.crates.io/crates/tokio-executor/0.1.10/download"
               ],
               "strip_prefix": "tokio-executor-0.1.10",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-executor-0.1.10.bazel"
@@ -14749,7 +14764,7 @@
               "sha256": "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio-uds/0.1.7/download"
+                "https://static.crates.io/crates/tokio-uds/0.1.7/download"
               ],
               "strip_prefix": "tokio-uds-0.1.7",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.1.7.bazel"
@@ -14762,7 +14777,7 @@
               "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/io-lifetimes/1.0.11/download"
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
               ],
               "strip_prefix": "io-lifetimes-1.0.11",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
@@ -14775,7 +14790,7 @@
               "sha256": "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/itoa/1.0.6/download"
+                "https://static.crates.io/crates/itoa/1.0.6/download"
               ],
               "strip_prefix": "itoa-1.0.6",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.itoa-1.0.6.bazel"
@@ -14788,7 +14803,7 @@
               "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/cfg-if/1.0.0/download"
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
               ],
               "strip_prefix": "cfg-if-1.0.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
@@ -14801,7 +14816,7 @@
               "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_x86_64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
@@ -14814,7 +14829,7 @@
               "sha256": "46900b884cc5af6a6c141ee741607c0c651a4e1d33614b8d888a1ba81cc0bc8a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-credentials/0.20.0/download"
+                "https://static.crates.io/crates/gix-credentials/0.20.0/download"
               ],
               "strip_prefix": "gix-credentials-0.20.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-credentials-0.20.0.bazel"
@@ -14827,7 +14842,7 @@
               "sha256": "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tokio/0.1.22/download"
+                "https://static.crates.io/crates/tokio/0.1.22/download"
               ],
               "strip_prefix": "tokio-0.1.22",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tokio-0.1.22.bazel"
@@ -14840,7 +14855,7 @@
               "sha256": "c9a0cc8c149724db9de7d73a0e1bc80b1a74f5394f08c6f301e11f9c35fa061e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/tls-api-stub/0.1.22/download"
+                "https://static.crates.io/crates/tls-api-stub/0.1.22/download"
               ],
               "strip_prefix": "tls-api-stub-0.1.22",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.tls-api-stub-0.1.22.bazel"
@@ -14853,7 +14868,7 @@
               "sha256": "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/syn/2.0.18/download"
+                "https://static.crates.io/crates/syn/2.0.18/download"
               ],
               "strip_prefix": "syn-2.0.18",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.syn-2.0.18.bazel"
@@ -14866,7 +14881,7 @@
               "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/linux-raw-sys/0.3.8/download"
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
               ],
               "strip_prefix": "linux-raw-sys-0.3.8",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
@@ -14879,7 +14894,7 @@
               "sha256": "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde_derive/1.0.190/download"
+                "https://static.crates.io/crates/serde_derive/1.0.190/download"
               ],
               "strip_prefix": "serde_derive-1.0.190",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.serde_derive-1.0.190.bazel"
@@ -14892,7 +14907,7 @@
               "sha256": "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/serde/1.0.171/download"
+                "https://static.crates.io/crates/serde/1.0.171/download"
               ],
               "strip_prefix": "serde-1.0.171",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.serde-1.0.171.bazel"
@@ -14905,7 +14920,7 @@
               "sha256": "7689cfa896b2a71da4f16206af167542b75d242b6906313e53857972a92d5614",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/httpbis/0.7.0/download"
+                "https://static.crates.io/crates/httpbis/0.7.0/download"
               ],
               "strip_prefix": "httpbis-0.7.0",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.httpbis-0.7.0.bazel"
@@ -14918,7 +14933,7 @@
               "sha256": "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/wasm-bindgen-macro/0.2.91/download"
+                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.91/download"
               ],
               "strip_prefix": "wasm-bindgen-macro-0.2.91",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.91.bazel"
@@ -14931,7 +14946,7 @@
               "sha256": "c8c4b15cf2ab7a35f5bcb3ef146187c8d36df0177e171ca061913cbaaa890e89",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-revision/0.22.0/download"
+                "https://static.crates.io/crates/gix-revision/0.22.0/download"
               ],
               "strip_prefix": "gix-revision-0.22.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-revision-0.22.0.bazel"
@@ -14944,7 +14959,7 @@
               "sha256": "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/camino/1.1.6/download"
+                "https://static.crates.io/crates/camino/1.1.6/download"
               ],
               "strip_prefix": "camino-1.1.6",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.camino-1.1.6.bazel"
@@ -14957,7 +14972,7 @@
               "sha256": "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/signal-hook-registry/1.4.1/download"
+                "https://static.crates.io/crates/signal-hook-registry/1.4.1/download"
               ],
               "strip_prefix": "signal-hook-registry-1.4.1",
               "build_file": "@@rules_rust~//proto/prost/private/3rdparty/crates:BUILD.signal-hook-registry-1.4.1.bazel"
@@ -14970,7 +14985,7 @@
               "sha256": "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/mio/0.6.23/download"
+                "https://static.crates.io/crates/mio/0.6.23/download"
               ],
               "strip_prefix": "mio-0.6.23",
               "build_file": "@@rules_rust~//proto/protobuf/3rdparty/crates:BUILD.mio-0.6.23.bazel"
@@ -14983,7 +14998,7 @@
               "sha256": "c171514b40487d3f677ae37efc0f45ac980e3169f23c27eb30a70b47fdf88ab5",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-config/0.30.0/download"
+                "https://static.crates.io/crates/gix-config/0.30.0/download"
               ],
               "strip_prefix": "gix-config-0.30.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-config-0.30.0.bazel"
@@ -14996,7 +15011,7 @@
               "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/unicode-ident/1.0.10/download"
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
               ],
               "strip_prefix": "unicode-ident-1.0.10",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
@@ -15009,7 +15024,7 @@
               "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/itoa/1.0.8/download"
+                "https://static.crates.io/crates/itoa/1.0.8/download"
               ],
               "strip_prefix": "itoa-1.0.8",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
@@ -15022,7 +15037,7 @@
               "sha256": "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/libloading/0.7.4/download"
+                "https://static.crates.io/crates/libloading/0.7.4/download"
               ],
               "strip_prefix": "libloading-0.7.4",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.libloading-0.7.4.bazel"
@@ -15035,7 +15050,7 @@
               "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows_aarch64_gnullvm/0.48.0/download"
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
               ],
               "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
@@ -15048,7 +15063,7 @@
               "sha256": "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/alloc-stdlib/0.2.2/download"
+                "https://static.crates.io/crates/alloc-stdlib/0.2.2/download"
               ],
               "strip_prefix": "alloc-stdlib-0.2.2",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.alloc-stdlib-0.2.2.bazel"
@@ -15061,7 +15076,7 @@
               "sha256": "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/peeking_take_while/0.1.2/download"
+                "https://static.crates.io/crates/peeking_take_while/0.1.2/download"
               ],
               "strip_prefix": "peeking_take_while-0.1.2",
               "build_file": "@@rules_rust~//bindgen/3rdparty/crates:BUILD.peeking_take_while-0.1.2.bazel"
@@ -15074,7 +15089,7 @@
               "sha256": "b048f443a1f6b02da4205c34d2e287e3fd45d75e8e2f06cfb216630ea9bff5e3",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/gix-ignore/0.8.0/download"
+                "https://static.crates.io/crates/gix-ignore/0.8.0/download"
               ],
               "strip_prefix": "gix-ignore-0.8.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.gix-ignore-0.8.0.bazel"
@@ -15087,7 +15102,7 @@
               "sha256": "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/rayon-core/1.11.0/download"
+                "https://static.crates.io/crates/rayon-core/1.11.0/download"
               ],
               "strip_prefix": "rayon-core-1.11.0",
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.rayon-core-1.11.0.bazel"
@@ -15100,7 +15115,7 @@
               "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
               "type": "tar.gz",
               "urls": [
-                "https://crates.io/api/v1/crates/windows/0.48.0/download"
+                "https://static.crates.io/crates/windows/0.48.0/download"
               ],
               "strip_prefix": "windows-0.48.0",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.windows-0.48.0.bazel"

--- a/rust/extensions.bzl
+++ b/rust/extensions.bzl
@@ -1,5 +1,6 @@
 "Module extensions for using rules_rust with bzlmod"
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//rust:defs.bzl", "rust_common")
 load("//rust:repositories.bzl", "rust_register_toolchains", "rust_toolchain_tools_repository")
 load("//rust/platform:triple.bzl", "get_host_triple")
@@ -170,7 +171,10 @@ def _rust_host_tools_impl(module_ctx):
         **host_tools
     )
 
-    return module_ctx.extension_metadata(reproducible = True)
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    else:
+        return None
 
 rust_host_tools = module_extension(
     implementation = _rust_host_tools_impl,


### PR DESCRIPTION
The reproducible attribute was added in Bazel 7.1, so unconditional usage of this breaks earlier versions. This uses `@bazel_features` to detect whether we can safely use this. For more context see https://github.com/bazelbuild/rules_rust/pull/2453#issuecomment-2048115743.