### PR TITLE
Substitute `${SDKROOT}` and `${DEVELOPER_DIR}` by their environment variables on darwin.

### DIFF
--- a/docs/flatten.md
+++ b/docs/flatten.md
@@ -386,7 +386,7 @@ rust_bindgen_toolchain(<a href="#rust_bindgen_toolchain-name">name</a>, <a href=
 
 The tools required for the `rust_bindgen` rule.
 
-This rule depends on the [`bindgen`](https://crates.io/crates/bindgen) binary crate, and it 
+This rule depends on the [`bindgen`](https://crates.io/crates/bindgen) binary crate, and it
 in turn depends on both a clang binary and the clang library. To obtain these dependencies,
 `rust_bindgen_dependencies` imports bindgen and its dependencies.
 

--- a/docs/rust_bindgen.md
+++ b/docs/rust_bindgen.md
@@ -80,7 +80,7 @@ rust_bindgen_toolchain(<a href="#rust_bindgen_toolchain-name">name</a>, <a href=
 
 The tools required for the `rust_bindgen` rule.
 
-This rule depends on the [`bindgen`](https://crates.io/crates/bindgen) binary crate, and it 
+This rule depends on the [`bindgen`](https://crates.io/crates/bindgen) binary crate, and it
 in turn depends on both a clang binary and the clang library. To obtain these dependencies,
 `rust_bindgen_dependencies` imports bindgen and its dependencies.
 

--- a/util/process_wrapper/options.rs
+++ b/util/process_wrapper/options.rs
@@ -138,11 +138,14 @@ pub(crate) fn options() -> Result<Options, OptionError> {
                 OptionError::Generic(format!("empty key for substitution '{arg}'"))
             })?;
             let v = if val == "${pwd}" {
-                current_dir.as_str()
+                current_dir.as_str().to_owned()
+            } else if val == "${SDKROOT}" {
+                std::env::var("SDKROOT").unwrap_or(val.to_owned())
+            } else if val == "${DEVELOPER_DIR}" {
+                std::env::var("DEVELOPER_DIR").unwrap_or(val.to_owned())
             } else {
-                val
-            }
-            .to_owned();
+                val.to_owned()
+            };
             Ok((key.to_owned(), v))
         })
         .collect::<Result<Vec<(String, String)>, OptionError>>()?;


### PR DESCRIPTION
Substitute `${SDKROOT}` and `${DEVELOPER_DIR}` by their environment variables on darwin.

This PR attempts to fix an issue with bindgen when used on darwin with clang
compiled from source (i.e. from `@llvm-project`).

When using clang compiled from source on darwin, libclang (used through `clang-sys`) failed
to find system header files (such as `stdarg.h` or `stdbool.h`) because these
files are actually living under the SDK path (under `<SDK_PATH>/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/` and `<SDK_PATH>/usr/include`).

Similar to what Bazel did in their [`xcrunwrapper.sh`](https://github.com/bazelbuild/bazel/blob/d8c27bfcd37a74dfbf1bdb9a1e3df13af8360a01/tools/objc/xcrunwrapper.sh#L17), we must have a way to tell bindgen's libclang
where to find these system headers.

In this commit, I add the following two substitutes variables:
  - `${SDKROOT}`: replaced by `std::env::var("SDKROOT")` if found.
  - `${DEVELOPER_DIR}`: replaced by `std::env::var("DEVELOPER")` if found.

This is similar to what it is currently done for `${pwd}`.

The following rule should now work on darwin:

```c
// mylib.h
#include <stdarg.h>
```

```starlark
# BUILD
cc_library(
    name = "mylib",
    srcs = ["mylib.c"],
    hdrs = ["mylib.h"],
)

rust_bindgen_library(
    name = "mylib_bindgen",
    cc_lib = ":mylib",
    clang_flags = select({
        "@platforms//os:macos": [
            "--sysroot=${SDKROOT}",
            "-isystem${SDKROOT}/usr/include",
            "-isystem${SDKROOT}/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/",
        ],
        "//conditions:default": [],
    }),
    crate_name = "mylib",
    header = "mylib.h",
)
```

It may also fix #1834.
