### PR TITLE
Add Apple visionOS support

### DIFF
--- a/rust/platform/platform.bzl
+++ b/rust/platform/platform.bzl
@@ -26,6 +26,7 @@ _SUPPORTED_SYSTEMS = [
     "darwin",
     "freebsd",
     "ios",
+    "visionos",
     "linux",
     "windows",
     "nto",

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -51,6 +51,8 @@ SUPPORTED_T2_PLATFORM_TRIPLES = [
 
 SUPPORTED_T3_PLATFORM_TRIPLES = [
     "aarch64-unknown-nto-qnx710",
+    "aarch64-apple-visionos-sim",
+    "aarch64-apple-visionos",
 ]
 
 SUPPORTED_PLATFORM_TRIPLES = SUPPORTED_T1_PLATFORM_TRIPLES + SUPPORTED_T2_PLATFORM_TRIPLES + SUPPORTED_T3_PLATFORM_TRIPLES
@@ -97,6 +99,7 @@ _SYSTEM_TO_BUILTIN_SYS_SUFFIX = {
     "freebsd": "freebsd",
     "fuchsia": "fuchsia",
     "ios": "ios",
+    "visionos": "visionos",
     "linux": "linux",
     "nacl": None,
     "netbsd": None,
@@ -119,6 +122,7 @@ _SYSTEM_TO_BINARY_EXT = {
     "freebsd": "",
     "fuchsia": "",
     "ios": "",
+    "visionos": "",
     "linux": "",
     "nixos": "",
     "none": "",
@@ -140,6 +144,7 @@ _SYSTEM_TO_STATICLIB_EXT = {
     "freebsd": ".a",
     "fuchsia": ".a",
     "ios": ".a",
+    "visionos": ".a",
     "linux": ".a",
     "nixos": ".a",
     "none": ".a",
@@ -158,6 +163,7 @@ _SYSTEM_TO_DYLIB_EXT = {
     "freebsd": ".so",
     "fuchsia": ".so",
     "ios": ".dylib",
+    "visionos": ".dylib",
     "linux": ".so",
     "nixos": ".so",
     "none": ".so",
@@ -198,6 +204,7 @@ _SYSTEM_TO_STDLIB_LINKFLAGS = {
     "fuchsia": ["-lzircon", "-lfdio"],
     "illumos": ["-lsocket", "-lposix4", "-lpthread", "-lresolv", "-lnsl", "-lumem"],
     "ios": ["-lSystem", "-lobjc", "-Wl,-framework,Security", "-Wl,-framework,Foundation", "-lresolv"],
+    "visionos": ["-lSystem", "-lobjc", "-Wl,-framework,Security", "-Wl,-framework,Foundation", "-lresolv"],
     # TODO: This ignores musl. Longer term what does Bazel think about musl?
     "linux": ["-ldl", "-lpthread"],
     "nacl": [],
@@ -263,8 +270,8 @@ def abi_to_constraints(abi, *, arch = None, system = None):
         List: A list of labels to constraint values
     """
 
-    # add constraints for iOS + watchOS simulator and device triples
-    if system in ["ios", "watchos"]:
+    # add constraints for iOS + watchOS + visionOS simulator and device triples
+    if system in ["ios", "watchos", "visionos"]:
         if arch == "x86_64" or abi == "sim":
             return ["@build_bazel_apple_support//constraints:simulator"]
         else:

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2007,7 +2007,7 @@ def _add_native_link_flags(args, dep_info, linkstamp_outs, ambiguous_libs, crate
     if toolchain.target_os == "windows":
         make_link_flags = _make_link_flags_windows_msvc if toolchain.target_triple.abi == "msvc" else _make_link_flags_windows_gnu
         get_lib_name = get_lib_name_for_windows
-    elif toolchain.target_os.startswith(("mac", "darwin", "ios")):
+    elif toolchain.target_os.startswith(("mac", "darwin", "ios", "visionos")):
         make_link_flags = _make_link_flags_darwin
         get_lib_name = get_lib_name_default
     else:


### PR DESCRIPTION
👋 

A small PR to support VisionOS. As it's a tier 3 toolchain, you'll need to build and host the standard library. Below is an example demonstrating the use of the `rust_repository_set` rule to configure the toolchain.

```
rust_repository_set(
    name = "aarch64_apple_visionos_on_aarch64_apple_darwin",
    edition = "2024",
    exec_triple = "aarch64-apple-darwin",
    extra_target_triples = {
        "aarch64-apple-visionos": [
            "@platforms//os:visionos",
            "@platforms//cpu:arm64",
            "@build_bazel_apple_support//constraints:apple",
            "@build_bazel_apple_support//constraints:device",
        ],
        "aarch64-apple-visionos-sim": [
            "@platforms//os:visionos",
            "@platforms//cpu:arm64",
            "@build_bazel_apple_support//constraints:apple",
            "@build_bazel_apple_support//constraints:simulator",
        ],
    },
    urls = ["URLS_TO_YOUR_RUST_STD"],
)
```