### PR TITLE
Added debug logging for spliced manifests to crate_universe

### DIFF
--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -141,6 +141,8 @@ impl Digest {
             .with_context(|| format!("Failed to run {} to get its version", binary.display()))?;
 
         if !output.status.success() {
+            eprintln!("{}", String::from_utf8_lossy(&output.stdout));
+            eprintln!("{}", String::from_utf8_lossy(&output.stderr));
             bail!("Failed to query cargo version")
         }
 

--- a/crate_universe/src/splicing.rs
+++ b/crate_universe/src/splicing.rs
@@ -251,6 +251,9 @@ impl WorkspaceMetadata {
         })
     }
 
+    /// Update an existing Cargo manifest with metadata about registry urls and target
+    /// features that are needed in generator steps beyond splicing.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn write_registry_urls_and_feature_map(
         cargo: &Cargo,
         lockfile: &cargo_lock::Lockfile,


### PR DESCRIPTION
This adds the following new logging when `CARGO_BAZEL_DEBUG=1` is enabled in the environment when the repository rule runs.
```
cd test/no_std && CARGO_BAZEL_REPIN=1 CARGO_BAZEL_DEBUG=1 bazel sync --only=no_std_crate_index
```
````
...
...
Splice 2024-04-27T16:31:48.249675Z DEBUG write_registry_urls_and_feature_map: cargo_bazel::splicing::splicer: Writing Cargo manifest '/private/var/tmp/_bazel_user/427c86c43c8db37f50959419e7306f4e/external/no_std_crate_index/splicing-workspace/Cargo.toml':
```toml
[dependencies.libc_alloc]
version = "1.0.3"

[lib]
name = "direct_cargo_bazel_deps"
path = ".direct_cargo_bazel_deps.rs"
required-features = []

[package]
edition = "2018"
name = "direct-cargo-bazel-deps"
version = "0.0.1"

[workspace]
members = []
resolver = "2"

[workspace.metadata.cargo-bazel.features."direct-cargo-bazel-deps 0.0.1"]
common = []

[workspace.metadata.cargo-bazel.features."direct-cargo-bazel-deps 0.0.1".selects]

[workspace.metadata.cargo-bazel.features."libc_alloc 1.0.4"]
common = []

[workspace.metadata.cargo-bazel.features."libc_alloc 1.0.4".selects]

[workspace.metadata.cargo-bazel.package_prefixes]

[workspace.metadata.cargo-bazel.sources."libc_alloc 1.0.4"]
sha256 = "6a090348b66d90d8507e30f0d2bd88e5a5c454bd1733fc6d617cbc3471bf69ea"
url = "https://static.crates.io/crates/libc_alloc/1.0.4/download"
```
...
...
````