### PR TITLE
Allow runfiles object to be an arbitrary expression.

### DIFF
--- a/tools/runfiles/runfiles.rs
+++ b/tools/runfiles/runfiles.rs
@@ -44,7 +44,7 @@ const TEST_SRCDIR_ENV_VAR: &str = "TEST_SRCDIR";
 
 #[macro_export]
 macro_rules! rlocation {
-    ($r:ident, $path:expr) => {
+    ($r:expr, $path:expr) => {
         $r.rlocation_from($path, env!("REPOSITORY_NAME"))
     };
 }


### PR DESCRIPTION
Our use case is `runfiles::rlocation!(cache.runfiles, "foo")` but this would also allow `runfiles::rlocation!(Runfiles::create()?, "foo")`