### PR TITLE
Add support for generated sources to rust-analyzer.

### DIFF
--- a/proto/prost/private/prost.bzl
+++ b/proto/prost/private/prost.bzl
@@ -275,6 +275,7 @@ def _rust_prost_aspect_impl(target, ctx):
             package_info = package_info_file,
         ),
         rust_analyzer_info,
+        OutputGroupInfo(rust_generated_srcs = [lib_rs]),
     ]
 
 rust_prost_aspect = aspect(

--- a/proto/protobuf/proto.bzl
+++ b/proto/protobuf/proto.bzl
@@ -209,7 +209,7 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
         ),
     )
 
-    return rustc_compile_action(
+    providers = rustc_compile_action(
         ctx = ctx,
         attr = ctx.attr,
         toolchain = toolchain,
@@ -233,6 +233,8 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
         ),
         output_hash = output_hash,
     )
+    providers.append(OutputGroupInfo(rust_generated_srcs = [lib_rs]))
+    return providers
 
 def _rust_protogrpc_library_impl(ctx, is_grpc):
     """Implementation of the rust_(proto|grpc)_library.

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -29,7 +29,7 @@ pub fn generate_crate_info(
             "--aspects={}//rust:defs.bzl%rust_analyzer_aspect",
             rules_rust.as_ref()
         ))
-        .arg("--output_groups=rust_analyzer_crate_spec")
+        .arg("--output_groups=rust_analyzer_crate_spec,rust_generated_srcs")
         .args(targets)
         .output()?;
 


### PR DESCRIPTION
At the moment, rust_analyzer's rust-project.json will list the root of a proto crate as, for example: `$HOME/.cache/bazel/_bazel_msta/60654fdd7bbd86377eab8595eb8577e8/execroot/_main/bazel-out/k8-dbg/bin/examples/prost/proto/example_proto.lib.rs`. However, this file does not exist, since it wasn't actually declared as the output of any rule.

With this change, tools/rust-analyzer will actually generate the generated sources.