### PR TITLE
Default linux abi to musl not gnu

### DIFF
--- a/rust/platform/triple.bzl
+++ b/rust/platform/triple.bzl
@@ -127,7 +127,7 @@ def get_host_triple(repository_ctx, abi = None):
         _validate_cpu_architecture(arch, supported_architectures["linux"])
         return triple("{}-unknown-linux-{}".format(
             arch,
-            abi or "gnu",
+            abi or "musl",
         ))
 
     if "mac" in repository_ctx.os.name:


### PR DESCRIPTION
The gnu-abi build cargo-bazel doesn't run in older linux distributions (e.g. centos7) because its libc implementation is too old.

This defaults to musl-linked binaries which don't link libc, so is more likely to be compatible with the execution environment.