### PR TITLE
Allow external crates to be aliased to local targets

### DIFF
--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -113,7 +113,8 @@ def _annotation(
         rustc_env = None,
         rustc_env_files = None,
         rustc_flags = None,
-        shallow_since = None):
+        shallow_since = None,
+        override_targets = None):
     """A collection of extra attributes and settings for a particular crate
 
     Args:
@@ -166,6 +167,8 @@ def _annotation(
         rustc_flags (list, optional): A list of strings to set on a crate's `rust_library::rustc_flags` attribute.
         shallow_since (str, optional): An optional timestamp used for crates originating from a git repository
             instead of a crate registry. This flag optimizes fetching the source code.
+        override_targets (dict, optional): A dictionary of alternate tagets to use when something depends on this crate to allow
+            the parent repo to provide its own version of this dependency. Keys can be `proc_marco`, `build_script`, `lib`, `bin`.
 
     Returns:
         string: A json encoded string containing the specified version and separately all other inputs.
@@ -209,6 +212,7 @@ def _annotation(
             rustc_env_files = _stringify_list(rustc_env_files),
             rustc_flags = rustc_flags,
             shallow_since = shallow_since,
+            override_targets = override_targets,
         ),
     ))
 

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -338,6 +338,9 @@ pub(crate) struct CrateAnnotations {
 
     /// Transition rule to use instead of `native.alias()`.
     pub(crate) alias_rule: Option<AliasRule>,
+
+    /// The crates to use instead of the generated one.
+    pub(crate) override_targets: Option<BTreeMap<String, Label>>,
 }
 
 macro_rules! joined_extra_member {
@@ -410,6 +413,7 @@ impl Add for CrateAnnotations {
             patches: joined_extra_member!(self.patches, rhs.patches, BTreeSet::new, BTreeSet::extend),
             extra_aliased_targets: joined_extra_member!(self.extra_aliased_targets, rhs.extra_aliased_targets, BTreeMap::new, BTreeMap::extend),
             alias_rule: self.alias_rule.or(rhs.alias_rule),
+            override_targets: self.override_targets.or(rhs.override_targets),
         };
 
         output

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -312,6 +312,12 @@ pub(crate) struct CrateContext {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub(crate) alias_rule: Option<AliasRule>,
+
+    /// Targets to use instead of the default target for the crate.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(default)]
+    pub(crate) override_targets: BTreeMap<String, Label>,
+
 }
 
 impl CrateContext {
@@ -497,6 +503,7 @@ impl CrateContext {
             disable_pipelining: false,
             extra_aliased_targets: BTreeMap::new(),
             alias_rule: None,
+            override_targets: BTreeMap::new(),
         }
         .with_overrides(extras)
     }
@@ -668,7 +675,12 @@ impl CrateContext {
                     }
                 }
             }
+
+            if let Some(override_targets) = &crate_extra.override_targets {
+                self.override_targets.extend(override_targets.clone());
+            }
         }
+
 
         self
     }

--- a/crate_universe/src/context/platforms.rs
+++ b/crate_universe/src/context/platforms.rs
@@ -158,6 +158,7 @@ mod test {
             disable_pipelining: false,
             extra_aliased_targets: BTreeMap::default(),
             alias_rule: None,
+            override_targets: BTreeMap::default(),
         };
 
         let configurations =
@@ -215,6 +216,7 @@ mod test {
             disable_pipelining: false,
             extra_aliased_targets: BTreeMap::default(),
             alias_rule: None,
+            override_targets: BTreeMap::default(),
         }
     }
 
@@ -300,6 +302,7 @@ mod test {
             disable_pipelining: false,
             extra_aliased_targets: BTreeMap::default(),
             alias_rule: None,
+            override_targets: BTreeMap::default(),
         };
 
         let configurations =
@@ -365,6 +368,7 @@ mod test {
             disable_pipelining: false,
             extra_aliased_targets: BTreeMap::default(),
             alias_rule: None,
+            override_targets: BTreeMap::default(),
         };
 
         let configurations =

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -286,7 +286,7 @@ mod test {
         );
 
         assert_eq!(
-            Digest("4148d6b336e574a67417f77fb4727e9c1b014a0b5ab90771f57285f96bca0fee".to_owned()),
+            Digest("610cbb406b7452d32ae31c45ec82cd3b3b1fb184c3411ef613c948d88492441b".to_owned()),
             digest,
         );
     }


### PR DESCRIPTION
In some cases it may be desirable to alias a public crate to a locally define rust_library target, even for dependencies of crates that are not being overriden.

Support this use case by swapping out `alias` for `rust_library` when a user overrides the target using an annotation.