### PR TITLE
use bazel_ci_rules bazel_dep instead of http_archive

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -63,7 +63,7 @@ tasks:
       - //test:query_test_binary
   rbe_ubuntu2004:
     shell_commands:
-      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
+      - sed -i 's/^# load("@bazel_ci_rules/load("@bazel_ci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets: *default_linux_targets
     test_targets: *default_linux_targets
@@ -126,7 +126,7 @@ tasks:
     name: With Aspects
     platform: rbe_ubuntu2004
     shell_commands:
-      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
+      - sed -i 's/^# load("@bazel_ci_rules/load("@bazel_ci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_flags: *aspects_flags
     build_targets: *default_linux_targets
@@ -135,7 +135,7 @@ tasks:
     name: RBE Rolling Bazel Version With Aspects
     platform: rbe_ubuntu2004
     shell_commands:
-      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
+      - sed -i 's/^# load("@bazel_ci_rules/load("@bazel_ci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets: *default_linux_targets
     test_targets: *default_linux_targets
@@ -406,7 +406,7 @@ tasks:
       # See https://github.com/bazelbuild/bazel/issues/9987
       - "-//ffi/rust_calling_c:matrix_dylib_test"
     shell_commands:
-      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
+      - sed -i 's/^# load("@bazel_ci_rules/load("@bazel_ci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     build_targets: *rbe_examples_targets
     test_targets: *rbe_examples_targets
@@ -463,7 +463,7 @@ tasks:
     platform: rbe_ubuntu2004
     working_directory: examples/crate_universe
     shell_commands:
-      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
+      - sed -i 's/^# load("@bazel_ci_rules/load("@bazel_ci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     run_targets: *crate_universe_vendor_example_targets
     build_targets:
@@ -476,7 +476,7 @@ tasks:
     platform: rbe_ubuntu2004
     working_directory: examples/crate_universe_unnamed
     shell_commands:
-      - sed -i 's/^# load("@bazelci_rules/load("@bazelci_rules/' WORKSPACE.bazel
+      - sed -i 's/^# load("@bazel_ci_rules/load("@bazel_ci_rules/' WORKSPACE.bazel
       - sed -i 's/^# rbe_preconfig/rbe_preconfig/' WORKSPACE.bazel
     run_targets: *crate_universe_unnamed_vendor_example_targets
     build_targets:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,6 +45,11 @@ bazel_dep(
 )
 
 bazel_dep(
+    name = "bazel_ci_rules",
+    version = "1.0.0",
+    dev_dependency = True,
+)
+bazel_dep(
     name = "rules_python",
     version = "0.31.0",
     dev_dependency = True,
@@ -58,7 +63,6 @@ bazel_dep(
 internal_deps = use_extension("//rust/private:extensions.bzl", "i")
 use_repo(
     internal_deps,
-    "bazelci_rules",
     "cargo_bazel.buildifier-darwin-amd64",
     "cargo_bazel.buildifier-darwin-arm64",
     "cargo_bazel.buildifier-linux-amd64",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -70,7 +70,7 @@ rules_rust_test_deps_transitive()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "bazelci_rules",
+    name = "bazel_ci_rules",
     sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
     strip_prefix = "bazelci_rules-1.0.0",
     url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
@@ -78,7 +78,7 @@ http_archive(
 
 # To run with RBE on Bazel CI, uncomment the following lines.
 #
-# load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
+# load("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")
 # rbe_preconfig(name = "buildkite_config", toolchain = "ubuntu2004-bazel-java11")
 
 http_archive(

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -164,13 +164,13 @@ http_archive(
 ###############################################################################
 
 http_archive(
-    name = "bazelci_rules",
+    name = "bazel_ci_rules",
     sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
     strip_prefix = "bazelci_rules-1.0.0",
     url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
 )
 
-load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
+load("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
 # Creates a default toolchain config for RBE.
 # Use this as is if you are using the rbe_ubuntu16_04 container,

--- a/rust/private/extensions.bzl
+++ b/rust/private/extensions.bzl
@@ -27,14 +27,6 @@ def _internal_deps_impl(module_ctx):
     direct_deps.extend(rust_wasm_bindgen_dependencies())
     direct_deps.extend(rules_rust_test_deps())
 
-    http_archive(
-        name = "bazelci_rules",
-        sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
-        strip_prefix = "bazelci_rules-1.0.0",
-        url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
-    )
-    direct_deps.append(struct(repo = "bazelci_rules", is_dev_dep = True))
-
     # is_dev_dep is ignored here. It's not relevant for internal_deps, as dev
     # dependencies are only relevant for module extensions that can be used
     # by other MODULES.


### PR DESCRIPTION
bazel_ci_rules@1.0.0 module has been published to the BCR, see https://github.com/bazelbuild/bazel-central-registry/pull/2058

This use it has a bazel_dep instead of a http_archive