### PR TITLE
[Bugfix] Convert metadata keys to screaming snake case instead of screaming kebab case in `cargo_build_script_runner`

### DIFF
--- a/cargo/cargo_build_script_runner/lib.rs
+++ b/cargo/cargo_build_script_runner/lib.rs
@@ -93,7 +93,7 @@ impl BuildScriptOutput {
                 // cargo:KEY=VALUE — Metadata, used by links scripts.
                 Some(BuildScriptOutput::DepEnv(format!(
                     "{}={}",
-                    key_split[1].to_uppercase(),
+                    key_split[1].to_uppercase().replace('-', "_"),
                     param
                 )))
             }


### PR DESCRIPTION
The `cargo_build_script_runner` currently converts the keys from `cargo:KEY=VALUE` metadata build script output lines into uppercase. This is not completely correct, however, because Cargo converts those keys to uppercase AND replaces dashes with underscores (effectively doing a conversion to SCREAMING_SNAKE_CASE).

To verify that Cargo is indeed doing the dash-to-underscore conversion, have a look at https://github.com/rust-lang/cargo/blob/10b7d384352f6d9a39f609de44476f815fc792a2/src/cargo/core/compiler/custom_build.rs#L46, which is the code responsible for building the `DEP_{crate-name}_{metadata-key}` env variables in Cargo. The code is
```rust
cmd.env(
    &format!("DEP_{}_{}", super::envify(&name), super::envify(key)),
    value,
);
```
where `super::envify()` is defined as
```rust
fn envify(s: &str) -> String {
    s.chars()
        .flat_map(|c| c.to_uppercase())
        .map(|c| if c == '-' { '_' } else { c })
        .collect()
}
```

This PR adds the dash-to-underscore conversion to `cargo_build_script_runner`.