### PR TITLE
Depend on a copy of rustfmt for the target

### DIFF
--- a/rust/toolchain/BUILD.bazel
+++ b/rust/toolchain/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//rust/private:rustfmt.bzl", "current_rustfmt_toolchain")
-load("//rust/private:toolchain_utils.bzl", "current_rust_toolchain", "toolchain_files")
+load("//rust/private:toolchain_utils.bzl", "current_rust_toolchain", "toolchain_files", "toolchain_files_for_target")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -39,6 +39,12 @@ current_rust_toolchain(
 
 current_rustfmt_toolchain(
     name = "current_rustfmt_toolchain",
+)
+
+toolchain_files_for_target(
+    name = "current_rustfmt_toolchain_for_target",
+    toolchain_files = ":current_rustfmt_toolchain",
+    visibility = ["//:__subpackages__"],
 )
 
 alias(

--- a/tools/rustfmt/BUILD.bazel
+++ b/tools/rustfmt/BUILD.bazel
@@ -55,10 +55,7 @@ rust_binary(
         "ASPECT_REPOSITORY": aspect_repository(),
         "RUST_DEFAULT_EDITION": "$(RUST_DEFAULT_EDITION)",
     },
-    toolchains = [
-        "@rules_rust//rust/toolchain:current_rust_toolchain",
-        "@rules_rust//rust/toolchain:current_rustfmt_toolchain",
-    ],
+    toolchains = ["@rules_rust//rust/toolchain:current_rust_toolchain"],
     visibility = ["//visibility:public"],
     deps = [
         ":rustfmt_lib",
@@ -99,10 +96,7 @@ rust_binary(
     rustc_env = {
         "RUSTFMT": "$(rlocationpath //rust/toolchain:current_rustfmt_toolchain)",
     },
-    toolchains = [
-        "@rules_rust//rust/toolchain:current_rust_toolchain",
-        "@rules_rust//rust/toolchain:current_rustfmt_toolchain",
-    ],
+    toolchains = ["@rules_rust//rust/toolchain:current_rust_toolchain"],
     visibility = ["//visibility:public"],
     deps = [
         "//tools/runfiles",

--- a/tools/rustfmt/BUILD.bazel
+++ b/tools/rustfmt/BUILD.bazel
@@ -20,11 +20,11 @@ rust_library(
     ),
     data = [
         "//:rustfmt.toml",
-        "//rust/toolchain:current_rustfmt_toolchain",
+        "//rust/toolchain:current_rustfmt_toolchain_for_target",
     ],
     edition = "2018",
     rustc_env = {
-        "RUSTFMT": "$(rlocationpath //rust/toolchain:current_rustfmt_toolchain)",
+        "RUSTFMT": "$(rlocationpath //rust/toolchain:current_rustfmt_toolchain_for_target)",
         "RUSTFMT_CONFIG": "$(rlocationpath //:rustfmt.toml)",
     },
     deps = [
@@ -91,10 +91,10 @@ rust_binary(
     srcs = [
         "src/upstream_rustfmt_wrapper.rs",
     ],
-    data = ["//rust/toolchain:current_rustfmt_toolchain"],
+    data = ["//rust/toolchain:current_rustfmt_toolchain_for_target"],
     edition = "2018",
     rustc_env = {
-        "RUSTFMT": "$(rlocationpath //rust/toolchain:current_rustfmt_toolchain)",
+        "RUSTFMT": "$(rlocationpath //rust/toolchain:current_rustfmt_toolchain_for_target)",
     },
     toolchains = ["@rules_rust//rust/toolchain:current_rust_toolchain"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
The toolchain_files() and current_rust_toolchain() rules return files for the current 'exec' platform. This is perfecly reasonable if you want to use these tools as part of ctx.actions.run(). But if you want to use these as part of 'data = []' (runfiles), they must be built for the target.

Fixes: https://github.com/bazelbuild/rules_rust/issues/2684