### PR TITLE
Fix collecting cc deps in collect_deps

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -240,6 +240,7 @@ def collect_deps(
                 crate_deps.append(struct(
                     crate_info = dep_variant_info.crate_info,
                     dep_info = dep_variant_info.dep_info,
+                    cc_info = dep_variant_info.cc_info,
                 ))
 
     aliases = {k.label: v for k, v in aliases.items()}


### PR DESCRIPTION
In my repo https://github.com/mvukov/rules_ros2/pull/316 I have a use-case that I want to pass some cc-deps via dep_variant_info as in https://github.com/mvukov/rules_ros2/pull/316/files#diff-58917867447a8263989afcfff01c87ad154b41562efc3f6d789807efb26e298fR231-R253. This PR enables that.