### PR TITLE
Updated rust-analyzer to use repo vs generated files as crate roots

### DIFF
--- a/test/rust_analyzer/generated_srcs_test/BUILD.bazel
+++ b/test/rust_analyzer/generated_srcs_test/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+write_file(
+    name = "generated_rs",
+    out = "generated.rs",
+    content = [
+        "pub fn forty_two() -> i32 { 42 }",
+        "",
+    ],
+)
+
+rust_library(
+    name = "generated_srcs",
+    srcs = [
+        "lib.rs",
+        ":generated.rs",
+    ],
+    edition = "2021",
+)
+
+rust_test(
+    name = "generated_srcs_test",
+    crate = ":generated_srcs",
+)
+
+rust_test(
+    name = "rust_project_json_test",
+    srcs = ["rust_project_json_test.rs"],
+    data = [":rust-project.json"],
+    edition = "2021",
+    env = {"RUST_PROJECT_JSON": "$(rootpath :rust-project.json)"},
+    # This target is tagged as manual since it's not expected to pass in
+    # contexts outside of `//test/rust_analyzer:rust_analyzer_test`. Run
+    # that target to execute this test.
+    tags = ["manual"],
+)

--- a/test/rust_analyzer/generated_srcs_test/lib.rs
+++ b/test/rust_analyzer/generated_srcs_test/lib.rs
@@ -1,0 +1,9 @@
+pub mod generated;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_fourty_two() {
+        assert_eq!(super::generated::forty_two(), 42);
+    }
+}

--- a/test/rust_analyzer/generated_srcs_test/rust_project_json_test.rs
+++ b/test/rust_analyzer/generated_srcs_test/rust_project_json_test.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_deps_of_crate_and_its_test_are_merged() {
+        let rust_project_path = PathBuf::from(env::var("RUST_PROJECT_JSON").unwrap());
+
+        let content = std::fs::read_to_string(&rust_project_path)
+            .unwrap_or_else(|_| panic!("couldn't open {:?}", &rust_project_path));
+
+        let output_base = content
+            .lines()
+            .find(|text| text.trim_start().starts_with("\"sysroot_src\":"))
+            .map(|text| {
+                let mut split = text.splitn(2, "\"sysroot_src\": ");
+                let mut with_hash = split.nth(1).unwrap().trim().splitn(2, "/external/");
+                let mut output = with_hash.next().unwrap().rsplitn(2, '/');
+                output.nth(1).unwrap()
+            })
+            .expect("Failed to find sysroot entry.");
+
+        let expected = r#"{
+      "display_name": "generated_srcs",
+      "root_module": "lib.rs",
+      "edition": "2021",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "#
+        .to_owned()
+            + output_base;
+
+        println!("{}", content);
+        assert!(
+            content.contains(&expected),
+            "expected rust-project.json to contain the following block:\n{}",
+            expected
+        );
+    }
+}

--- a/test/rust_analyzer/merging_crates_test/rust_project_json_test.rs
+++ b/test/rust_analyzer/merging_crates_test/rust_project_json_test.rs
@@ -10,8 +10,24 @@ mod tests {
         let content = std::fs::read_to_string(&rust_project_path)
             .unwrap_or_else(|_| panic!("couldn't open {:?}", &rust_project_path));
 
+        let expected = r#"{
+      "display_name": "mylib",
+      "root_module": "mylib.rs",
+      "edition": "2018",
+      "deps": [
+        {
+          "crate": 0,
+          "name": "extra_test_dep"
+        },
+        {
+          "crate": 1,
+          "name": "lib_dep"
+        }
+      ],"#;
+
+        println!("{}", content);
         assert!(
-            content.contains(r#""root_module":"mylib.rs","edition":"2018","deps":[{"crate":0,"name":"extra_test_dep"},{"crate":1,"name":"lib_dep"}]"#),
+            content.contains(expected),
             "expected rust-project.json to contain both lib_dep and extra_test_dep in deps of mylib.rs.");
     }
 }

--- a/test/rust_analyzer/static_and_shared_lib_test/rust_project_json_test.rs
+++ b/test/rust_analyzer/static_and_shared_lib_test/rust_project_json_test.rs
@@ -10,12 +10,21 @@ mod tests {
         let content = std::fs::read_to_string(&rust_project_path)
             .unwrap_or_else(|_| panic!("couldn't open {:?}", &rust_project_path));
 
+        println!("{}", content);
+
+        let expected_cdylib = r#"{
+      "display_name": "greeter_cdylib",
+      "root_module": "shared_lib.rs","#;
         assert!(
-            content.contains(r#"{"display_name":"greeter_cdylib","root_module":"shared_lib.rs"#),
+            content.contains(expected_cdylib),
             "expected rust-project.json to contain a rust_shared_library target."
         );
+
+        let expected_staticlib = r#"{
+      "display_name": "greeter_staticlib",
+      "root_module": "static_lib.rs","#;
         assert!(
-            content.contains(r#"{"display_name":"greeter_staticlib","root_module":"static_lib.rs"#),
+            content.contains(expected_staticlib),
             "expected rust-project.json to contain a rust_static_library target."
         );
     }


### PR DESCRIPTION
This change updates the `rust_analyzer_aspect` to attempt to match generated crate root sources to `srcs` inputs and use the the path of the source file in place of the generated path. The generated path is then added to `sources.include_dirs` for compatibility. The impact of this can be seen in the following diff of the `@rules_rust//:rust-project.json` file:
```diff
--- rust-project.old.json	2024-06-28 09:00:51
+++ rust-project.json	2024-06-28 09:04:43
@@ -821,10 +821,16 @@
         },
         {
             "display_name": "libgensrc_with_crate_root",
-            "root_module": "/private/var/tmp/_bazel_user/76282c66b0dfe3c5cb9a230bdc913a52/execroot/rules_rust/bazel-out/darwin_arm64-fastbuild/bin/test/generated_inputs/lib.rs",
+            "root_module": "test/generated_inputs/lib.rs",
             "edition": "2018",
             "deps": [],
             "is_workspace_member": true,
+            "source": {
+                "include_dirs": [
+                    "/private/var/tmp/_bazel_user/76282c66b0dfe3c5cb9a230bdc913a52/execroot/rules_rust/bazel-out/darwin_arm64-fastbuild/bin/test/generated_inputs"
+                ],
+                "exclude_dirs": []
+            },
             "cfg": [
                 "test",
                 "debug_assertions"
@@ -850,10 +856,16 @@
...
...
...
```

closes https://github.com/bazelbuild/rules_rust/issues/2716