### PR TITLE
crate-universe allows workspaces with MODULE.bazel only

### DIFF
--- a/crate_universe/src/utils/starlark/label.rs
+++ b/crate_universe/src/utils/starlark/label.rs
@@ -194,7 +194,8 @@ impl Label {
             }
             if workspace_root.is_none()
                 && (ancestor.join("WORKSPACE").exists()
-                    || ancestor.join("WORKSPACE.bazel").exists())
+                    || ancestor.join("WORKSPACE.bazel").exists()
+                    || ancestor.join("MODULE.bazel").exists())
             {
                 workspace_root = Some(ancestor);
                 break;


### PR DESCRIPTION
According to the [migration guide](https://bazel.build/external/migration), `WORKSPACE.bazel` is no longer required with Bazel 6.3 or later. This updates `crate_universe` to respect that, allowing `MODULE.bazel` to be the root marker of a workspace, without requiring a `WORKSPACE` or `WORKSPACE.bazel`.

Happy to iterate on this.