### PR TITLE
Add missing local_path_overrides in examples

### DIFF
--- a/examples/bzlmod/all_deps_vendor/MODULE.bazel
+++ b/examples/bzlmod/all_deps_vendor/MODULE.bazel
@@ -11,6 +11,10 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
 # https://github.com/bazelbuild/rules_rust/releases
 bazel_dep(name = "rules_rust", version = "0.46.0")
+local_path_override(
+    module_name = "rules_rust",
+    path = "../../..",
+)
 
 ###############################################################################
 # T O O L C H A I N S

--- a/examples/bzlmod/compile_opt/MODULE.bazel
+++ b/examples/bzlmod/compile_opt/MODULE.bazel
@@ -8,6 +8,10 @@ module(
 ###############################################################################
 # https://github.com/bazelbuild/rules_rust/releases
 bazel_dep(name = "rules_rust", version = "0.46.0")
+local_path_override(
+    module_name = "rules_rust",
+    path = "../../..",
+)
 
 ###############################################################################
 # T O O L C H A I N S

--- a/examples/bzlmod/cross_compile/MODULE.bazel
+++ b/examples/bzlmod/cross_compile/MODULE.bazel
@@ -5,6 +5,10 @@ module(
 
 # https://github.com/bazelbuild/rules_rust/releases
 bazel_dep(name = "rules_rust", version = "0.46.0")
+local_path_override(
+    module_name = "rules_rust",
+    path = "../../..",
+)
 
 # Rules for cross compilation
 bazel_dep(name = "toolchains_musl", version = "0.1.16", dev_dependency = True)

--- a/examples/bzlmod/ffi/MODULE.bazel
+++ b/examples/bzlmod/ffi/MODULE.bazel
@@ -8,6 +8,10 @@ module(
 ###############################################################################
 # https://github.com/bazelbuild/rules_rust/releases
 bazel_dep(name = "rules_rust", version = "0.46.0")
+local_path_override(
+    module_name = "rules_rust",
+    path = "../../..",
+)
 
 ###############################################################################
 # T O O L C H A I N S

--- a/examples/bzlmod/proto/MODULE.bazel
+++ b/examples/bzlmod/proto/MODULE.bazel
@@ -8,6 +8,10 @@ module(
 ###############################################################################
 # https://github.com/bazelbuild/rules_rust/releases
 bazel_dep(name = "rules_rust", version = "0.46.0")
+local_path_override(
+    module_name = "rules_rust",
+    path = "../../..",
+)
 
 #
 # Rules for protobuf / gRPC


### PR DESCRIPTION
Otherwise these test a released rules_rust not an in-repo one, and breaking changes will always fail CI.