### PR TITLE
wasm_bindgen: allow target name with directory

### DIFF
--- a/wasm_bindgen/private/wasm_bindgen.bzl
+++ b/wasm_bindgen/private/wasm_bindgen.bzl
@@ -52,10 +52,17 @@ def rust_wasm_bindgen_action(ctx, toolchain, wasm_file, target_output, bindgen_f
 
     bindgen_wasm_module = ctx.actions.declare_file(ctx.label.name + "_bg.wasm")
 
+    out_dir = ctx.label.name.split("/")
+    out_name = out_dir.pop()
+    out_dir_name = "/".join(out_dir)
+
     js_out = [ctx.actions.declare_file(ctx.label.name + ".js")]
     ts_out = []
     if not "--no-typescript" in bindgen_flags:
         ts_out.append(ctx.actions.declare_file(ctx.label.name + ".d.ts"))
+
+    if target_output == "web" or target_output == "bundler":
+        js_out.append(ctx.actions.declare_directory(out_dir_name + "/snippets"))
 
     if target_output == "bundler":
         js_out.append(ctx.actions.declare_file(ctx.label.name + "_bg.js"))
@@ -67,7 +74,7 @@ def rust_wasm_bindgen_action(ctx, toolchain, wasm_file, target_output, bindgen_f
     args = ctx.actions.args()
     args.add("--target", target_output)
     args.add("--out-dir", bindgen_wasm_module.dirname)
-    args.add("--out-name", ctx.label.name)
+    args.add("--out-name", out_name)
     args.add_all(bindgen_flags)
     args.add(input_file)
 


### PR DESCRIPTION
Looking at the current logic for setting `--out-dir` and `--out-name`, it seems that the intention is to infer those from the target name. However, if a prefix is specified for the name (`pkg/custom`), `out-dir` is set as expected (`pkg`), but that directory prefix is also set in `out-name` (`pkg/custom`). causing the build command to fail when it appends the two and ends up with `pkg/pkg/custom`).

This approach sets `out-name` to be the last path segment only.