### PR TITLE
Add version to bindgen dep

### DIFF
--- a/bindgen/3rdparty/BUILD.bazel
+++ b/bindgen/3rdparty/BUILD.bazel
@@ -50,6 +50,7 @@ crates_vendor(
         "clang-sys": crate.spec(
             # Should match the version of llvm-project being used.
             features = ["clang_14_0"],
+            version = "1.6.1",
         ),
     }.items() + _BINDGEN_CLI_PACKAGES.items()),
     repository_name = "rules_rust_bindgen",


### PR DESCRIPTION
I don't know how this ever worked before. I've picked the version that happens to be in the lockfile at the moment.

Fixes #2752