### PR TITLE
Delete `incompatible_no_rustc_sysroot_env`

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1068,8 +1068,6 @@ def construct_arguments(
         ))
 
     # Ensure the sysroot is set for the target platform
-    if not toolchain._incompatible_no_rustc_sysroot_env:
-        env["SYSROOT"] = toolchain.sysroot
     if toolchain._experimental_toolchain_generated_sysroot:
         rustc_flags.add(toolchain.sysroot, format = "--sysroot=%s")
 

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -98,13 +98,6 @@ bool_flag(
     build_setting_default = False,
 )
 
-# A flag to remove the SYSROOT environment variable from `Rustc` actions.
-incompatible_flag(
-    name = "incompatible_no_rustc_sysroot_env",
-    build_setting_default = True,
-    issue = "https://github.com/bazelbuild/rules_rust/issues/2429",
-)
-
 # A flag to control whether the shell path from a shell toolchain (`@bazel_tools//tools/sh:toolchain_type`)
 # is embedded into the bootstrap process wrapper for the `.sh` file.
 bool_flag(

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -698,7 +698,6 @@ def _rust_toolchain_impl(ctx):
         _experimental_use_global_allocator = experimental_use_global_allocator,
         _experimental_use_coverage_metadata_files = ctx.attr._experimental_use_coverage_metadata_files[BuildSettingInfo].value,
         _experimental_toolchain_generated_sysroot = ctx.attr._experimental_toolchain_generated_sysroot[IncompatibleFlagInfo].enabled,
-        _incompatible_no_rustc_sysroot_env = ctx.attr._incompatible_no_rustc_sysroot_env[IncompatibleFlagInfo].enabled,
         _no_std = no_std,
     )
     return [
@@ -889,9 +888,6 @@ rust_toolchain = rule(
                 "Label to a boolean build setting that informs the target build whether a global allocator is being used." +
                 "This flag is only relevant when used together with --@rules_rust//rust/settings:experimental_use_global_allocator."
             ),
-        ),
-        "_incompatible_no_rustc_sysroot_env": attr.label(
-            default = Label("//rust/settings:incompatible_no_rustc_sysroot_env"),
         ),
         "_no_std": attr.label(
             default = Label("//:no_std"),


### PR DESCRIPTION
This flag has been flipped long enough and I haven't heard any complaints.

closes https://github.com/bazelbuild/rules_rust/issues/2429