### PR TITLE
Use `target_flag_value` instead of `target_triple.str`

### DIFF
--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -263,7 +263,7 @@ def _create_single_crate(ctx, attrs, info):
     crate["deps"] = [_crate_id(dep.crate) for dep in info.deps if _crate_id(dep.crate) != crate_id]
     crate["aliases"] = {_crate_id(alias_target.crate): alias_name for alias_target, alias_name in info.aliases.items()}
     crate["cfg"] = info.cfgs
-    crate["target"] = find_toolchain(ctx).target_triple.str
+    crate["target"] = find_toolchain(ctx).target_flag_value
     if info.proc_macro_dylib_path != None:
         crate["proc_macro_dylib_path"] = _EXEC_ROOT_TEMPLATE + info.proc_macro_dylib_path
     return crate


### PR DESCRIPTION
When users define a toolchain using a `.json` file the `toolchain.target_triple` is not populated, so `target_triple.str` is invalid. We use `target_flag_value` instead, which is equivalent to the `target_json.path` in cases where it's available and to `target_triple.str` otherwise. 