### PR TITLE
Doc: update outdated parameter `output_diagnostics`

### DIFF
--- a/docs/rust_analyzer.md
+++ b/docs/rust_analyzer.md
@@ -82,7 +82,7 @@ to ensure a `rust-project.json` file is created and up to date when the editor i
 
 Add the following to your bazelrc:
 ```
-build --@rules_rust//:output_diagnostics=true --output_groups=+rust_lib_rustc_output,+rust_metadata_rustc_output
+build --@rules_rust//:rustc_output_diagnostics=true --output_groups=+rust_lib_rustc_output,+rust_metadata_rustc_output
 ```
 
 Then you can use a prototype [rust-analyzer plugin](https://marketplace.visualstudio.com/items?itemName=MattStark.bazel-rust-analyzer) that automatically collects the outputs whenever you recompile.

--- a/docs/rust_analyzer.vm
+++ b/docs/rust_analyzer.vm
@@ -76,7 +76,7 @@ to ensure a `rust-project.json` file is created and up to date when the editor i
 
 Add the following to your bazelrc:
 ```
-build --@rules_rust//:output_diagnostics=true --output_groups=+rust_lib_rustc_output,+rust_metadata_rustc_output
+build --@rules_rust//:rustc_output_diagnostics=true --output_groups=+rust_lib_rustc_output,+rust_metadata_rustc_output
 ```
 
 Then you can use a prototype [rust-analyzer plugin](https://marketplace.visualstudio.com/items?itemName=MattStark.bazel-rust-analyzer) that automatically collects the outputs whenever you recompile.


### PR DESCRIPTION
## Problem
Tracking Issue: https://github.com/bazelbuild/rules_rust/issues/2814
The command in doc looks outdated and I'm getting

```
❯ bazel build --@rules_rust//:output_diagnostics=true --output_groups=+rust_lib_rustc_output,+rust_metadata_rustc_output //hellow_world
WARNING: Target pattern parsing failed.
ERROR: Skipping '@rules_rust//:output_diagnostics': no such target '@@rules_rust~//:output_diagnostics': target 'output_diagnostics' not declared in package '' defined by /private/var/tmp/_bazel_xxx/c947415ff64a19538545e009b2e6df63/external/rules_rust~/BUILD.bazel
ERROR: @rules_rust//:output_diagnostics :: Error loading option @rules_rust//:output_diagnostics: no such target '@@rules_rust~//:output_diagnostics': target 'output_diagnostics' not declared in package '' defined by /private/var/tmp/_bazel_xxx/c947415ff64a19538545e009b2e6df63/external/rules_rust~/BUILD.bazel
```
After checking the code https://github.com/bazelbuild/rules_rust/blob/dff064e21b6c82ba97a287449c6f05f373eba7d6/BUILD.bazel#L39, I feel it should be `rustc_output_diagnostics`

## Test

```
bazel build --@rules_rust//:rustc_output_diagnostics=true --output_groups=+rust_lib_rustc_output,+rust_metadata_rustc_output //hello_world
INFO: Analyzed target //hello_world:hello_world (2 packages loaded, 1443 targets configured).
ERROR: /Users/xxx/dev/bazel-rust-example/hello_world/BUILD:3:12: Compiling Rust bin hello_world (1 files) failed: (Exit 1): process_wrapper failed: error executing Rustc command (from target //hello_world:hello_world) bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/rules_rust~/util/process_wrapper/process_wrapper --subst 'pwd=${pwd}' --rustc-output-format rendered --output-file ... (remaining 27 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error[E0423]: expected function, found macro `println`
 --> hello_world/src/main.rs:2:5
  |
2 |     println("Hello, world!");
  |     ^^^^^^^ not a function
  |
help: use `!` to invoke the macro
  |
2 |     println!("Hello, world!");
  |            +

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0423`.
Target //hello_world:hello_world failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.322s, Critical Path: 0.06s
INFO: 4 processes: 4 internal.
ERROR: Build did NOT complete successfully
```
