### PR TITLE
[bug] fix coverage linker flags when using --@rules_rust//rust/settin…

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1432,6 +1432,12 @@ def rustc_compile_action(
             # Append the name of the library
             output_relative_to_package = output_relative_to_package + output_lib
 
+        coverage_link_flags = []
+        if include_coverage:
+            # coverage fails due to gcc lacking a few linker args
+            # this fixes missing symbols and links against the c lib
+            coverage_link_flags = ["-u", "__llvm_profile_runtime", "-lc"]
+
         cc_common.link(
             actions = ctx.actions,
             feature_configuration = feature_configuration,
@@ -1441,6 +1447,7 @@ def rustc_compile_action(
             name = output_relative_to_package,
             stamp = ctx.attr.stamp,
             output_type = "executable" if crate_info.type == "bin" else "dynamic_library",
+            user_link_flags = coverage_link_flags,
         )
 
         outputs = [crate_info.output]


### PR DESCRIPTION
When running bazel coverage with `--@rules_rust//rust/settings:experimental_use_cc_common_link=true`, we fail to generate coverage properly because of some missing linker flags (the c library as well as some missing symbols)

This PR fixes that