### PR TITLE
Support emitting debug logs in rules_rust process wrapper.

### DIFF
--- a/util/process_wrapper/main.rs
+++ b/util/process_wrapper/main.rs
@@ -63,7 +63,7 @@ impl std::error::Error for ProcessWrapperError {}
 
 macro_rules! log {
     ($($arg:tt)*) => {
-        if std::env::var("RULES_RUST_PROCESS_WRAPPER_DEBUG").is_ok() {
+        if std::env::var_os("RULES_RUST_PROCESS_WRAPPER_DEBUG").is_some() {
             eprintln!($($arg)*);
         }
     };

--- a/util/process_wrapper/main.rs
+++ b/util/process_wrapper/main.rs
@@ -61,10 +61,19 @@ impl fmt::Display for ProcessWrapperError {
 
 impl std::error::Error for ProcessWrapperError {}
 
+macro_rules! log {
+    ($($arg:tt)*) => {
+        if std::env::var("RULES_RUST_PROCESS_WRAPPER_DEBUG").is_ok() {
+            eprintln!($($arg)*);
+        }
+    };
+}
+
 fn main() -> Result<(), ProcessWrapperError> {
     let opts = options().map_err(|e| ProcessWrapperError(e.to_string()))?;
 
-    let mut child = Command::new(opts.executable)
+    let mut command = Command::new(opts.executable);
+    command
         .args(opts.child_arguments)
         .env_clear()
         .envs(opts.child_environment)
@@ -79,7 +88,9 @@ fn main() -> Result<(), ProcessWrapperError> {
         } else {
             Stdio::inherit()
         })
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    log!("{:#?}", command);
+    let mut child = command
         .spawn()
         .map_err(|e| ProcessWrapperError(format!("failed to spawn child process: {}", e)))?;
 


### PR DESCRIPTION
When debugging an action it can be incredibly helpful to have the exact command used to invoke `rustc`. This PR updates the rustc process wrapper to emit debug logs when the `RULES_RUST_PROCESS_WRAPPER_DEBUG` environment variable is enabled.

Example:
```bash
bazel build //test/... --action_env=RULES_RUST_PROCESS_WRAPPER_DEBUG=1
```
```
INFO: From Generating Rustdoc for @//test/unit/rustdoc:lib_with_proc_macro:
Command: Command {
    program: "bazel-out/darwin_arm64-fastbuild/bin/external/rust_darwin_aarch64__aarch64-apple-darwin__stable_tools/rust_toolchain/bin/rustdoc",
    args: [
        "bazel-out/darwin_arm64-fastbuild/bin/external/rust_darwin_aarch64__aarch64-apple-darwin__stable_tools/rust_toolchain/bin/rustdoc",
        "test/unit/rustdoc/rustdoc_lib.rs",
        "--crate-name=lib_with_proc_macro",
        "--crate-type=rlib",
        "--error-format=human",
        "--codegen=opt-level=0",
        "--codegen=debuginfo=0",
        "--codegen=strip=none",
        "--color=always",
        "--target=aarch64-apple-darwin",
        "-L",
        "bazel-out/darwin_arm64-fastbuild/bin/external/rust_darwin_aarch64__aarch64-apple-darwin__stable_tools/rust_toolchain/lib/rustlib/aarch64-apple-darwin/lib",
        "--output",
        "bazel-out/darwin_arm64-fastbuild/bin/test/unit/rustdoc/lib_with_proc_macro_doc.rustdoc",
        "--extern",
        "lib_with_proc_macro=bazel-out/darwin_arm64-fastbuild/bin/test/unit/rustdoc/liblib_with_proc_macro-78138021.rlib",
        "--edition=2018",
        "--codegen=linker=external/local_config_cc/cc_wrapper.sh",
        "--codegen=link-arg=-mmacosx-version-min=14.5",
        "--codegen=link-arg=-no-canonical-prefixes",
        "--codegen=link-arg=-fobjc-link-runtime",
        "--codegen=link-arg=-headerpad_max_install_names",
        "--codegen=link-arg=-lc++",
        "--codegen=link-arg=-lm",
        "--extern=rustdoc_proc_macro=bazel-out/darwin_arm64-opt-exec-ST-a828a81199fe/bin/test/unit/rustdoc/librustdoc_proc_macro-2600278351.dylib",
        "-Ldependency=bazel-out/darwin_arm64-opt-exec-ST-a828a81199fe/bin/test/unit/rustdoc",
        "--sysroot=bazel-out/darwin_arm64-fastbuild/bin/external/rust_darwin_aarch64__aarch64-apple-darwin__stable_tools/rust_toolchain",
    ],
    env: CommandEnv {
        clear: true,
        vars: {
            "CARGO_CFG_TARGET_ARCH": Some(
                "aarch64",
            ),
            "CARGO_CFG_TARGET_OS": Some(
                "darwin",
            ),
            "CARGO_CRATE_NAME": Some(
                "lib_with_proc_macro",
            ),
            "CARGO_MANIFEST_DIR": Some(
                "/private/var/tmp/_bazel_user/76282c66b0dfe3c5cb9a230bdc913a52/sandbox/darwin-sandbox/1151/execroot/rules_rust/test/unit/rustdoc",
            ),
            "CARGO_PKG_AUTHORS": Some(
                "",
            ),
            "CARGO_PKG_DESCRIPTION": Some(
                "",
            ),
            "CARGO_PKG_HOMEPAGE": Some(
                "",
            ),
            "CARGO_PKG_NAME": Some(
                "lib_with_proc_macro",
            ),
            "CARGO_PKG_VERSION": Some(
                "0.0.0",
            ),
            "CARGO_PKG_VERSION_MAJOR": Some(
                "0",
            ),
            "CARGO_PKG_VERSION_MINOR": Some(
                "0",
            ),
            "CARGO_PKG_VERSION_PATCH": Some(
                "0",
            ),
            "CARGO_PKG_VERSION_PRE": Some(
                "",
            ),
            "REPOSITORY_NAME": Some(
                "",
            ),
            "RULES_RUST_PROCESS_WRAPPER_DEBUG": Some(
                "1",
            ),
            "TMPDIR": Some(
                "/var/folders/hf/phjl9q7501gb5wt_qr4ltn3m0000gn/T/",
            ),
            "ZERO_AR_DATE": Some(
                "1",
            ),
            "__CF_USER_TEXT_ENCODING": Some(
                "0x1F5:0x0:0x0",
            ),
        },
    },
    stdout: Some(
        Inherit,
    ),
    stderr: Some(
        MakePipe,
    ),
}
```