### PR TITLE
Update crate universe to generate build script targets with compile data

### DIFF
--- a/bindgen/3rdparty/crates/BUILD.bindgen-0.69.1.bazel
+++ b/bindgen/3rdparty/crates/BUILD.bindgen-0.69.1.bazel
@@ -108,6 +108,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "__cli",
         "experimental",

--- a/bindgen/3rdparty/crates/BUILD.clang-sys-1.6.1.bazel
+++ b/bindgen/3rdparty/crates/BUILD.clang-sys-1.6.1.bazel
@@ -113,6 +113,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "clang_10_0",
         "clang_11_0",

--- a/bindgen/3rdparty/crates/BUILD.libc-0.2.146.bazel
+++ b/bindgen/3rdparty/crates/BUILD.libc-0.2.146.bazel
@@ -247,6 +247,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
             "default",  # aarch64-apple-darwin

--- a/bindgen/3rdparty/crates/BUILD.rustix-0.37.20.bazel
+++ b/bindgen/3rdparty/crates/BUILD.rustix-0.37.20.bazel
@@ -298,6 +298,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "io-lifetimes",

--- a/bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -104,6 +104,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "consoleapi",
         "errhandlingapi",

--- a/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.75.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.75.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.camino-1.1.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.camino-1.1.6.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "serde",
         "serde1",

--- a/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.8.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.8.4.bazel
@@ -96,6 +96,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
@@ -98,6 +98,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "alloc",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-queue-0.3.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-queue-0.3.8.bazel
@@ -96,6 +96,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "alloc",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -91,6 +91,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.7.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "more_lengths",
     ],

--- a/crate_universe/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -201,6 +201,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "close",
         "default",

--- a/crate_universe/3rdparty/crates/BUILD.libc-0.2.149.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libc-0.2.149.bazel
@@ -186,6 +186,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.libm-0.2.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libm-0.2.7.bazel
@@ -93,6 +93,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
     ],

--- a/crate_universe/3rdparty/crates/BUILD.lock_api-0.4.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.lock_api-0.4.11.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "atomic_usize",
         "default",

--- a/crate_universe/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
@@ -93,6 +93,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
     ],

--- a/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
@@ -96,6 +96,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.parking_lot_core-0.9.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.parking_lot_core-0.9.9.bazel
@@ -175,6 +175,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/crate_universe/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/crate_universe/3rdparty/crates/BUILD.rayon-core-1.12.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rayon-core-1.12.0.bazel
@@ -92,6 +92,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -298,6 +298,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "io-lifetimes",

--- a/crate_universe/3rdparty/crates/BUILD.rustix-0.38.21.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustix-0.38.21.bazel
@@ -393,6 +393,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "alloc",
         "default",

--- a/crate_universe/3rdparty/crates/BUILD.semver-1.0.20.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.semver-1.0.20.bazel
@@ -96,6 +96,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "serde",

--- a/crate_universe/3rdparty/crates/BUILD.serde-1.0.190.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde-1.0.190.bazel
@@ -100,6 +100,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "derive",

--- a/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.108.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.108.bazel
@@ -98,6 +98,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/crate_universe/3rdparty/crates/BUILD.syn-1.0.109.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.syn-1.0.109.bazel
@@ -104,6 +104,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "clone-impls",
         "default",

--- a/crate_universe/3rdparty/crates/BUILD.thiserror-1.0.50.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.thiserror-1.0.50.bazel
@@ -93,6 +93,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.typenum-1.16.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.typenum-1.16.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_main",
     crate_root = "build/main.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.valuable-0.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.valuable-0.1.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-0.2.87.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.87.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -108,6 +108,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "consoleapi",
         "errhandlingapi",

--- a/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -87,6 +87,7 @@ def _annotation(
         additive_build_file = None,
         additive_build_file_content = None,
         alias_rule = None,
+        build_script_compile_data = None,
         build_script_data = None,
         build_script_tools = None,
         build_script_data_glob = None,
@@ -125,6 +126,7 @@ def _annotation(
             generated BUILD files.
         alias_rule (str, optional): Alias rule to use instead of `native.alias()`.  Overrides [render_config](#render_config)'s
             'default_alias_rule'.
+        build_script_compile_data (list, optional): A list of labels to add to a crate's `cargo_build_script::compile_data` attribute.
         build_script_data (list, optional): A list of labels to add to a crate's `cargo_build_script::data` attribute.
         build_script_tools (list, optional): A list of labels to add to a crate's `cargo_build_script::tools` attribute.
         build_script_data_glob (list, optional): A list of glob patterns to add to a crate's `cargo_build_script::data`
@@ -185,6 +187,7 @@ def _annotation(
             additive_build_file = _stringify_label(additive_build_file),
             additive_build_file_content = additive_build_file_content,
             alias_rule = parse_alias_rule(alias_rule),
+            build_script_compile_data = _stringify_list(build_script_compile_data),
             build_script_data = _stringify_list(build_script_data),
             build_script_tools = _stringify_list(build_script_tools),
             build_script_data_glob = build_script_data_glob,

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -275,6 +275,10 @@ pub(crate) struct CrateAnnotations {
     /// [proc_macro_deps](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-proc_macro_deps) attribute.
     pub(crate) build_script_proc_macro_deps: Option<Select<BTreeSet<Label>>>,
 
+    /// Additional compile-only data to pass to a build script's
+    /// [compile_data](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-compile_data) attribute.
+    pub(crate) build_script_compile_data: Option<Select<BTreeSet<Label>>>,
+
     /// Additional data to pass to a build script's
     /// [build_script_data](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-data) attribute.
     pub(crate) build_script_data: Option<Select<BTreeSet<Label>>>,
@@ -387,6 +391,7 @@ impl Add for CrateAnnotations {
             rustc_flags: select_merge(self.rustc_flags, rhs.rustc_flags),
             build_script_deps: select_merge(self.build_script_deps, rhs.build_script_deps),
             build_script_proc_macro_deps: select_merge(self.build_script_proc_macro_deps, rhs.build_script_proc_macro_deps),
+            build_script_compile_data: select_merge(self.build_script_compile_data, rhs.build_script_compile_data),
             build_script_data: select_merge(self.build_script_data, rhs.build_script_data),
             build_script_tools: select_merge(self.build_script_tools, rhs.build_script_tools),
             build_script_data_glob: joined_extra_member!(self.build_script_data_glob, rhs.build_script_data_glob, BTreeSet::new, BTreeSet::extend),

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -175,6 +175,9 @@ pub(crate) struct BuildScriptAttributes {
     #[serde(skip_serializing_if = "Select::is_empty")]
     pub(crate) compile_data: Select<BTreeSet<Label>>,
 
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    pub(crate) compile_data_glob: BTreeSet<String>,
+
     #[serde(skip_serializing_if = "Select::is_empty")]
     pub(crate) data: Select<BTreeSet<Label>>,
 
@@ -245,6 +248,9 @@ impl Default for BuildScriptAttributes {
     fn default() -> Self {
         Self {
             compile_data: Default::default(),
+            // The build script itself also has access to all
+            // source files by default.
+            compile_data_glob: BTreeSet::from(["**".to_owned()]),
             data: Default::default(),
             // Build scripts include all sources by default
             data_glob: BTreeSet::from(["**".to_owned()]),
@@ -617,6 +623,11 @@ impl CrateContext {
                 // Data
                 if let Some(extra) = &crate_extra.build_script_data {
                     attrs.data = Select::merge(attrs.data.clone(), extra.clone());
+                }
+
+                // Compile Data
+                if let Some(extra) = &crate_extra.build_script_compile_data {
+                    attrs.compile_data = Select::merge(attrs.compile_data.clone(), extra.clone());
                 }
 
                 // Tools

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -286,7 +286,7 @@ mod test {
         );
 
         assert_eq!(
-            Digest("610cbb406b7452d32ae31c45ec82cd3b3b1fb184c3411ef613c948d88492441b".to_owned()),
+            Digest("5e0fd9106767c43deb77bb1024ca24e99685110a1085c03abc028c75e180831f".to_owned()),
             digest,
         );
     }

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -456,7 +456,9 @@ impl Renderer {
             ),
             compile_data: make_data(
                 platforms,
-                Default::default(),
+                attrs
+                    .map(|attrs| attrs.compile_data_glob.clone())
+                    .unwrap_or_default(),
                 attrs
                     .map(|attrs| attrs.compile_data.clone())
                     .unwrap_or_default(),
@@ -1070,6 +1072,7 @@ mod test {
         assert!(build_file_content.contains("cargo_build_script("));
         assert!(build_file_content.contains("name = \"build_script_build\""));
         assert!(build_file_content.contains("\"crate-name=mock_crate\""));
+        assert!(build_file_content.contains("compile_data = glob("));
 
         // Ensure `cargo_build_script` requirements are met
         assert!(build_file_content.contains("name = \"_bs\""));

--- a/crate_universe/src/utils/starlark.rs
+++ b/crate_universe/src/utils/starlark.rs
@@ -88,7 +88,7 @@ pub(crate) struct Alias {
     pub(crate) tags: Set<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename = "cargo_build_script")]
 pub(crate) struct CargoBuildScript {
     pub(crate) name: String,
@@ -205,6 +205,7 @@ pub(crate) struct CommonAttrs {
     pub(crate) version: String,
 }
 
+#[derive(Debug)]
 pub(crate) struct Data {
     pub(crate) glob: Glob,
     pub(crate) select: SelectSet<Label>,

--- a/docs/src/crate_universe.md
+++ b/docs/src/crate_universe.md
@@ -471,13 +471,13 @@ list: A list of labels to generated rust targets (str)
 
 <pre>
 crate.annotation(<a href="#crate.annotation-version">version</a>, <a href="#crate.annotation-additive_build_file">additive_build_file</a>, <a href="#crate.annotation-additive_build_file_content">additive_build_file_content</a>, <a href="#crate.annotation-alias_rule">alias_rule</a>,
-                 <a href="#crate.annotation-build_script_data">build_script_data</a>, <a href="#crate.annotation-build_script_tools">build_script_tools</a>, <a href="#crate.annotation-build_script_data_glob">build_script_data_glob</a>, <a href="#crate.annotation-build_script_deps">build_script_deps</a>,
-                 <a href="#crate.annotation-build_script_env">build_script_env</a>, <a href="#crate.annotation-build_script_proc_macro_deps">build_script_proc_macro_deps</a>, <a href="#crate.annotation-build_script_rundir">build_script_rundir</a>,
-                 <a href="#crate.annotation-build_script_rustc_env">build_script_rustc_env</a>, <a href="#crate.annotation-build_script_toolchains">build_script_toolchains</a>, <a href="#crate.annotation-compile_data">compile_data</a>, <a href="#crate.annotation-compile_data_glob">compile_data_glob</a>,
-                 <a href="#crate.annotation-crate_features">crate_features</a>, <a href="#crate.annotation-data">data</a>, <a href="#crate.annotation-data_glob">data_glob</a>, <a href="#crate.annotation-deps">deps</a>, <a href="#crate.annotation-extra_aliased_targets">extra_aliased_targets</a>, <a href="#crate.annotation-gen_binaries">gen_binaries</a>,
-                 <a href="#crate.annotation-disable_pipelining">disable_pipelining</a>, <a href="#crate.annotation-gen_build_script">gen_build_script</a>, <a href="#crate.annotation-patch_args">patch_args</a>, <a href="#crate.annotation-patch_tool">patch_tool</a>, <a href="#crate.annotation-patches">patches</a>,
-                 <a href="#crate.annotation-proc_macro_deps">proc_macro_deps</a>, <a href="#crate.annotation-rustc_env">rustc_env</a>, <a href="#crate.annotation-rustc_env_files">rustc_env_files</a>, <a href="#crate.annotation-rustc_flags">rustc_flags</a>, <a href="#crate.annotation-shallow_since">shallow_since</a>,
-                 <a href="#crate.annotation-override_targets">override_targets</a>)
+                 <a href="#crate.annotation-build_script_compile_data">build_script_compile_data</a>, <a href="#crate.annotation-build_script_data">build_script_data</a>, <a href="#crate.annotation-build_script_tools">build_script_tools</a>,
+                 <a href="#crate.annotation-build_script_data_glob">build_script_data_glob</a>, <a href="#crate.annotation-build_script_deps">build_script_deps</a>, <a href="#crate.annotation-build_script_env">build_script_env</a>,
+                 <a href="#crate.annotation-build_script_proc_macro_deps">build_script_proc_macro_deps</a>, <a href="#crate.annotation-build_script_rundir">build_script_rundir</a>, <a href="#crate.annotation-build_script_rustc_env">build_script_rustc_env</a>,
+                 <a href="#crate.annotation-build_script_toolchains">build_script_toolchains</a>, <a href="#crate.annotation-compile_data">compile_data</a>, <a href="#crate.annotation-compile_data_glob">compile_data_glob</a>, <a href="#crate.annotation-crate_features">crate_features</a>, <a href="#crate.annotation-data">data</a>,
+                 <a href="#crate.annotation-data_glob">data_glob</a>, <a href="#crate.annotation-deps">deps</a>, <a href="#crate.annotation-extra_aliased_targets">extra_aliased_targets</a>, <a href="#crate.annotation-gen_binaries">gen_binaries</a>, <a href="#crate.annotation-disable_pipelining">disable_pipelining</a>,
+                 <a href="#crate.annotation-gen_build_script">gen_build_script</a>, <a href="#crate.annotation-patch_args">patch_args</a>, <a href="#crate.annotation-patch_tool">patch_tool</a>, <a href="#crate.annotation-patches">patches</a>, <a href="#crate.annotation-proc_macro_deps">proc_macro_deps</a>, <a href="#crate.annotation-rustc_env">rustc_env</a>,
+                 <a href="#crate.annotation-rustc_env_files">rustc_env_files</a>, <a href="#crate.annotation-rustc_flags">rustc_flags</a>, <a href="#crate.annotation-shallow_since">shallow_since</a>, <a href="#crate.annotation-override_targets">override_targets</a>)
 </pre>
 
 A collection of extra attributes and settings for a particular crate
@@ -491,6 +491,7 @@ A collection of extra attributes and settings for a particular crate
 | <a id="crate.annotation-additive_build_file"></a>additive_build_file |  A file containing extra contents to write to the bottom of generated BUILD files.   |  `None` |
 | <a id="crate.annotation-additive_build_file_content"></a>additive_build_file_content |  Extra contents to write to the bottom of generated BUILD files.   |  `None` |
 | <a id="crate.annotation-alias_rule"></a>alias_rule |  Alias rule to use instead of `native.alias()`.  Overrides [render_config](#render_config)'s 'default_alias_rule'.   |  `None` |
+| <a id="crate.annotation-build_script_compile_data"></a>build_script_compile_data |  A list of labels to add to a crate's `cargo_build_script::compile_data` attribute.   |  `None` |
 | <a id="crate.annotation-build_script_data"></a>build_script_data |  A list of labels to add to a crate's `cargo_build_script::data` attribute.   |  `None` |
 | <a id="crate.annotation-build_script_tools"></a>build_script_tools |  A list of labels to add to a crate's `cargo_build_script::tools` attribute.   |  `None` |
 | <a id="crate.annotation-build_script_data_glob"></a>build_script_data_glob |  A list of glob patterns to add to a crate's `cargo_build_script::data` attribute.   |  `None` |

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5a1ea5923b61d2ea2c67ed4eefa9e24d282fdb2b3a7e78789d6668d0ab25ffa6",
+  "checksum": "31f8e7eca10f28e797d701c43ea9879748d4ea682232a61f66bcc8304634c328",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -95,6 +95,9 @@
         "version": "0.1.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f89ff66879b7332a7811b1d818de9d8cf6706f2a53c9b2da5be79c347eab49fd",
+  "checksum": "11357d1f08e103e047135755074b4e5bd339a42fb4832df8bd1c76023d6d310e",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -95,6 +95,9 @@
         "version": "0.1.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4321d7309350d07645bc427c9874b376060335c9ee9a4aad888a58a59dcac079",
+  "checksum": "9c13eed5ca3e946f45810e96a2e02fd54daf5622e2a491beefb41efc616d57af",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -95,6 +95,9 @@
         "version": "0.1.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "8193cbb833300984ea49fd10a0459f356c24158707a28679b2f5392b48d11bc6",
+  "checksum": "00285d00a58629c73575c530fc851bff0875c2c6f9407917f51ec41092239183",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -95,6 +95,9 @@
         "version": "0.1.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5d58921fc8618d0f26866720796b757c3f46ee12ba0cfd1cf4096652df6d34b8",
+  "checksum": "40b6b7bb526787ef1e2fa886cf6716090845a2fa150c43d214f9a3d67cfc3db6",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -95,6 +95,9 @@
         "version": "0.1.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "72d9a540e32b0329a0e70174c946a7077ec0922d2dd33fca21f3aaa510718dd2",
+  "checksum": "f63d6ac8c61f3a3fb565767e7f5d86de8f9449c44837fb698e5cad9033bc7d31",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -95,6 +95,9 @@
         "version": "0.1.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "62d0c7df4d6588182fd3771b50f00f7a24020270243bf7427ee3a32b38cbb2b2",
+  "checksum": "fda8eab09cfc1e21853fec639c221fb60cd33499e38a438218bf3cf9d612a8f9",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",
@@ -95,6 +95,9 @@
         "version": "0.1.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "da8c3fc9e9e97df010348453c34e0d41c430d5097db90b0f365776cb18271861",
+  "checksum": "b777ed65566b37e564322fb1f14ad2e9fde4782b854c01ea01c4c7748d6fbf3b",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",
@@ -959,6 +959,9 @@
         "version": "1.9.2"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -1033,6 +1036,9 @@
         "version": "0.2.139"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1163,6 +1169,9 @@
         "version": "0.4.14"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1235,6 +1244,9 @@
         "version": "2.5.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1319,6 +1331,9 @@
         "version": "0.12.1-dev"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1399,6 +1414,9 @@
         "version": "0.13.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1631,6 +1649,9 @@
         "version": "1.0.4"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -1713,6 +1734,9 @@
         "version": "1.0.4"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -1798,6 +1822,9 @@
         "version": "1.0.51"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1874,6 +1901,9 @@
         "version": "1.0.23"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2433,6 +2463,9 @@
         "version": "1.0.109"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2635,6 +2668,9 @@
         "version": "1.0.0-alpha.7"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -2824,6 +2860,9 @@
         "version": "0.3.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2889,6 +2928,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -3004,6 +3046,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/cargo_conditional_deps/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_conditional_deps/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "45098cc49211a4b6ba1277079a41b00fd909f61c619defcba97a684527fc29bd",
+  "checksum": "bd3f30eb076faf6d1ea116e0a47b8d83d8b1c933970450c3f5fb5cb1bf7b608e",
   "crates": {
     "autocfg 1.1.0": {
       "name": "autocfg",
@@ -215,6 +215,9 @@
         "version": "0.2.146"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -286,6 +289,9 @@
         "version": "0.7.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],

--- a/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b34c33f580fc1191aa589a8df52e192f544b21d0a59ee90650e2989515d2cf70",
+  "checksum": "419f7feb77c4b926af5928c42efa1fa0208d1091a7853242d5fced52b408ede9",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -594,6 +594,9 @@
         "version": "0.1.16"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -707,6 +710,9 @@
         "version": "0.2.139"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1691,6 +1697,9 @@
         "version": "0.3.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1756,6 +1765,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1821,6 +1833,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/complicated_dependencies/cargo-bazel-lock.json
+++ b/examples/crate_universe/complicated_dependencies/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "69deaaf1c5a71d44f55a2f85e3a5c64265fa2edd26c1dbe3a635f9d5516894af",
+  "checksum": "00a3a71b3bac0df6fd4b94a93bd822e981273474ee64cf1dd23c6a8e7c40bafa",
   "crates": {
     "aho-corasick 1.1.3": {
       "name": "aho-corasick",
@@ -148,6 +148,9 @@
         "version": "0.66.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -330,6 +333,9 @@
         "version": "3.1.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data": {
           "common": [
             "@//complicated_dependencies:boringssl_gen_dir",
@@ -583,6 +589,9 @@
         "version": "1.7.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -1138,6 +1147,9 @@
         "version": "0.2.154"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1262,6 +1274,9 @@
         "version": "1.1.15"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data": {
           "common": [
             "@rules_foreign_cc//toolchains:current_cmake_toolchain"
@@ -1599,6 +1614,9 @@
         "version": "1.0.81"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2121,6 +2139,9 @@
         "version": "0.3.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2186,6 +2207,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2251,6 +2275,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2408,6 +2435,9 @@
         "version": "0.52.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2473,6 +2503,9 @@
         "version": "0.52.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2538,6 +2571,9 @@
         "version": "0.52.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2603,6 +2639,9 @@
         "version": "0.52.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2668,6 +2707,9 @@
         "version": "0.52.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2733,6 +2775,9 @@
         "version": "0.52.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2798,6 +2843,9 @@
         "version": "0.52.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2863,6 +2911,9 @@
         "version": "0.52.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/multi_package/cargo-bazel-lock.json
+++ b/examples/crate_universe/multi_package/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d7bbfb497e7e5a759d63310573e208e6be5edac715e04cc3b69163a51affa7ae",
+  "checksum": "4ac3327ed0666dc99d18c84f3c69533a329fee5f6ca5747925073d4fc83eaf48",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",
@@ -117,6 +117,9 @@
         "version": "1.0.69"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -485,6 +488,9 @@
         "version": "1.12.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -695,6 +701,9 @@
         "version": "1.6.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -1568,6 +1577,9 @@
         "version": "0.1.64"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2207,6 +2219,9 @@
         "version": "0.8.15"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2355,6 +2370,9 @@
         "version": "0.4.44"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -2816,6 +2834,9 @@
         "version": "0.3.26"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2889,6 +2910,9 @@
         "version": "0.3.26"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -4224,6 +4248,9 @@
         "version": "0.3.26"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -4341,6 +4368,9 @@
         "version": "0.3.26"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -4410,6 +4440,9 @@
         "version": "0.14.6"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -4889,6 +4922,9 @@
         "version": "1.8.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -5847,6 +5883,9 @@
         "version": "1.9.2"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -6114,6 +6153,9 @@
         "version": "1.7.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -6406,6 +6448,9 @@
         "version": "0.2.139"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -6478,6 +6523,9 @@
         "version": "0.1.7+1.45.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**",
           "nghttp2/**"
@@ -6564,6 +6612,9 @@
         "version": "1.1.8"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -6665,6 +6716,9 @@
         "version": "0.4.17"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -6800,6 +6854,9 @@
         "version": "2.5.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -7734,6 +7791,9 @@
         "version": "2.5.2"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -7871,6 +7931,9 @@
         "version": "1.0.51"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -7947,6 +8010,9 @@
         "version": "1.0.23"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9153,6 +9219,9 @@
         "version": "0.16.20"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -9251,6 +9320,9 @@
         "version": "0.20.8"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -9360,6 +9432,9 @@
         "version": "0.8.2"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -9525,6 +9600,9 @@
         "version": "1.0.11"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9747,6 +9825,9 @@
         "version": "1.0.152"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9830,6 +9911,9 @@
         "version": "1.0.152"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9914,6 +9998,9 @@
         "version": "1.0.93"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -10106,6 +10193,9 @@
         "version": "0.3.15"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -10271,6 +10361,9 @@
         "version": "0.4.8"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -10527,6 +10620,9 @@
         "version": "1.0.109"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -11552,6 +11648,9 @@
         "version": "1.26.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -12242,6 +12341,9 @@
         "version": "1.16.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -12558,6 +12660,9 @@
         "version": "1.0.0-alpha.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -12868,6 +12973,9 @@
         "version": "0.2.84"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -13217,6 +13325,9 @@
         "version": "0.2.84"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -13468,6 +13579,9 @@
         "version": "0.1.2"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**",
           "vendor/**"
@@ -13579,6 +13693,9 @@
         "version": "0.3.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -13644,6 +13761,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -13709,6 +13829,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -14095,6 +14218,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -14160,6 +14286,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -14225,6 +14354,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -14290,6 +14422,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -14355,6 +14490,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -14420,6 +14558,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -14485,6 +14626,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -14600,6 +14744,9 @@
         "version": "0.10.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/no_cargo_manifests/cargo-bazel-lock.json
+++ b/examples/crate_universe/no_cargo_manifests/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "69cf1ceb0d21e31b7cfff160101f29361a3cb8b036a2c894b09f5701df42314a",
+  "checksum": "bcafafdecceb3d85d48d25cc939df18070288b557c30332396a4eb3b54a46a03",
   "crates": {
     "async-trait 0.1.64": {
       "name": "async-trait",
@@ -67,6 +67,9 @@
         "version": "0.1.64"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -701,6 +704,9 @@
         "version": "0.3.26"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -774,6 +780,9 @@
         "version": "0.3.26"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -892,6 +901,9 @@
         "version": "0.3.26"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -979,6 +991,9 @@
         "version": "0.3.26"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1380,6 +1395,9 @@
         "version": "1.8.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1617,6 +1635,9 @@
         "version": "1.9.2"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -1776,6 +1797,9 @@
         "version": "0.2.139"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -1845,6 +1869,9 @@
         "version": "0.4.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -1929,6 +1956,9 @@
         "version": "0.4.17"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2045,6 +2075,9 @@
         "version": "2.5.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2509,6 +2542,9 @@
         "version": "0.9.7"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2813,6 +2849,9 @@
         "version": "1.0.51"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -2889,6 +2928,9 @@
         "version": "1.0.23"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -3086,6 +3128,9 @@
         "version": "1.0.152"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -3171,6 +3216,9 @@
         "version": "1.0.93"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -3398,6 +3446,9 @@
         "version": "0.4.8"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -3600,6 +3651,9 @@
         "version": "1.0.109"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -4228,6 +4282,9 @@
         "version": "1.26.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -5117,6 +5174,9 @@
         "version": "0.1.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -5303,6 +5363,9 @@
         "version": "0.3.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -5368,6 +5431,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -5433,6 +5499,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -5685,6 +5754,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -5750,6 +5822,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -5815,6 +5890,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -5880,6 +5958,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -5945,6 +6026,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -6010,6 +6094,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -6075,6 +6162,9 @@
         "version": "0.42.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/override_target/cargo-bazel-lock.json
+++ b/examples/crate_universe/override_target/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6f04f2cfab8953635badddb89ab02911726da2d49732f6b3fe93feb29d97757b",
+  "checksum": "c0a366a9eae4382746f463c52c27d9d2202a63132d2d2811fb314db2a841a969",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/crate_universe/using_cxx/cargo-bazel-lock.json
+++ b/examples/crate_universe/using_cxx/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2a6dfa4abc9b0f5192082e12499e50cbf65e3e0a106a67dac6788365db151598",
+  "checksum": "afcffe3c0b6f201d5112033ad16d66ff187bbca1e0209f2cc6fa07c042858678",
   "crates": {
     "cc 1.0.82": {
       "name": "cc",
@@ -328,6 +328,9 @@
         "version": "0.2.147"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -399,6 +402,9 @@
         "version": "1.0.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -485,6 +491,9 @@
         "version": "1.0.66"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.Bazel.lock
+++ b/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "43e468e08c6dea833561ad5812d3fbf20b0cb777cbcb2c1f7041500a74c5a93d",
+  "checksum": "5c09b8b6ffb7a7587e8fc46c8c8618250ad637084459e063ccbda22d6ea884b6",
   "crates": {
     "anstyle 1.0.1": {
       "name": "anstyle",
@@ -371,6 +371,9 @@
         "version": "1.0.66"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -751,6 +754,9 @@
         "version": "0.3.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -816,6 +822,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -931,6 +940,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/crate_universe/vendor_external/crates/BUILD.indexmap-1.8.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.indexmap-1.8.0.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "std",
     ],

--- a/examples/crate_universe/vendor_external/crates/BUILD.libc-0.2.119.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.libc-0.2.119.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_external/crates/BUILD.memchr-2.4.1.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.memchr-2.4.1.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-1.0.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-1.0.4.bazel
@@ -101,6 +101,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "syn",

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -92,6 +92,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro2-1.0.36.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro2-1.0.36.bazel
@@ -96,6 +96,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/examples/crate_universe/vendor_external/crates/BUILD.pulldown-cmark-0.8.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.pulldown-cmark-0.8.0.bazel
@@ -93,6 +93,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_external/crates/BUILD.semver-1.0.6.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.semver-1.0.6.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_external/crates/BUILD.serde-1.0.136.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.serde-1.0.136.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_external/crates/BUILD.syn-1.0.86.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.syn-1.0.86.bazel
@@ -103,6 +103,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "clone-impls",
         "default",

--- a/examples/crate_universe/vendor_external/crates/BUILD.unicase-2.6.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.unicase-2.6.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-0.3.9.bazel
@@ -103,6 +103,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "consoleapi",
         "errhandlingapi",

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_manifests/crates/libc-0.2.158/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/libc-0.2.158/BUILD.bazel
@@ -150,6 +150,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_local_manifests/crates/lock_api-0.4.12/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/lock_api-0.4.12/BUILD.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "atomic_usize",
         "default",

--- a/examples/crate_universe/vendor_local_manifests/crates/parking_lot_core-0.9.10/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/parking_lot_core-0.9.10/BUILD.bazel
@@ -175,6 +175,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_manifests/crates/proc-macro2-1.0.86/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/proc-macro2-1.0.86/BUILD.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/examples/crate_universe/vendor_local_manifests/crates/rustix-0.38.36/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/rustix-0.38.36/BUILD.bazel
@@ -320,6 +320,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "alloc",
         "default",

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_gnullvm-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_msvc-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnu-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnu-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnullvm-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_msvc-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnu-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnu-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnullvm-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_msvc-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/httparse-1.9.4/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/httparse-1.9.4/BUILD.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_local_pkgs/crates/libc-0.2.158/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/libc-0.2.158/BUILD.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_local_pkgs/crates/lock_api-0.4.12/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/lock_api-0.4.12/BUILD.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "atomic_usize",
         "default",

--- a/examples/crate_universe/vendor_local_pkgs/crates/parking_lot_core-0.9.10/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/parking_lot_core-0.9.10/BUILD.bazel
@@ -175,6 +175,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/proc-macro2-1.0.86/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/proc-macro2-1.0.86/BUILD.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/examples/crate_universe/vendor_local_pkgs/crates/serde-1.0.210/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/serde-1.0.210/BUILD.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_local_pkgs/crates/serde_json-1.0.128/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/serde_json-1.0.128/BUILD.bazel
@@ -99,6 +99,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "raw_value",

--- a/examples/crate_universe/vendor_local_pkgs/crates/slab-0.4.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/slab-0.4.9/BUILD.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_local_pkgs/crates/valuable-0.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/valuable-0.1.0/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-0.3.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-0.3.9/BUILD.bazel
@@ -99,6 +99,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "consoleapi",
         "errhandlingapi",

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_gnullvm-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_msvc-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnu-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnu-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnullvm-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_msvc-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnu-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnu-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnullvm-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_msvc-0.52.6/BUILD.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = False,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.libc-0.2.158.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.libc-0.2.158.bazel
@@ -150,6 +150,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.lock_api-0.4.12.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.lock_api-0.4.12.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "atomic_usize",
         "default",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.10.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.10.bazel
@@ -175,6 +175,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.86.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.86.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.rustix-0.38.36.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.rustix-0.38.36.bazel
@@ -320,6 +320,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "alloc",
         "default",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httparse-1.9.4.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httparse-1.9.4.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.libc-0.2.158.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.libc-0.2.158.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.12.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.12.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "atomic_usize",
         "default",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.9.10.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.9.10.bazel
@@ -175,6 +175,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.86.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.86.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde-1.0.210.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde-1.0.210.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.128.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.128.bazel
@@ -99,6 +99,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "raw_value",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.slab-0.4.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.slab-0.4.9.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
@@ -99,6 +99,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "consoleapi",
         "errhandlingapi",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnu-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnu-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_msvc-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/examples/musl_cross_compiling/Cargo.Bazel.lock.json
+++ b/examples/musl_cross_compiling/Cargo.Bazel.lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "dea1e8796c8b3c84ed71c17b9449fadcf6c9e77aa448f294a165df1c0881fea5",
+  "checksum": "7a3e15ae6c6ff1b94459b9ca9a6cdb80d505b162bd011987c891898706874c30",
   "crates": {
     "aes 0.8.4": {
       "name": "aes",
@@ -364,6 +364,9 @@
         "version": "1.6.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -482,6 +485,9 @@
         "version": "1.13.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -1865,6 +1871,9 @@
         "version": "0.8.20"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -3138,6 +3147,9 @@
         "version": "0.14.7"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -3721,6 +3733,9 @@
         "version": "1.0.11"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -4136,6 +4151,9 @@
         "version": "0.2.155"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -4524,6 +4542,9 @@
         "version": "0.7.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -4597,6 +4618,9 @@
         "version": "0.9.1"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -5156,6 +5180,9 @@
         "version": "0.2.19"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -5551,6 +5578,9 @@
         "version": "2.8.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -5813,6 +5843,9 @@
         "version": "1.0.86"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -6385,6 +6418,9 @@
         "version": "0.37.27"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -6489,6 +6525,9 @@
         "version": "0.38.34"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -6802,6 +6841,9 @@
         "version": "1.0.204"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -7204,6 +7246,9 @@
         "version": "0.4.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ],
@@ -7444,6 +7489,9 @@
         "version": "1.0.109"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -7923,6 +7971,9 @@
         "version": "1.17.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -8216,6 +8267,9 @@
         "version": "0.3.9"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -8281,6 +8335,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -8346,6 +8403,9 @@
         "version": "0.4.0"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -8695,6 +8755,9 @@
         "version": "0.48.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -8760,6 +8823,9 @@
         "version": "0.52.6"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -8825,6 +8891,9 @@
         "version": "0.48.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -8890,6 +8959,9 @@
         "version": "0.52.6"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -8955,6 +9027,9 @@
         "version": "0.48.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9020,6 +9095,9 @@
         "version": "0.52.6"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9085,6 +9163,9 @@
         "version": "0.52.6"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9150,6 +9231,9 @@
         "version": "0.48.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9215,6 +9299,9 @@
         "version": "0.52.6"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9280,6 +9367,9 @@
         "version": "0.48.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9345,6 +9435,9 @@
         "version": "0.52.6"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9410,6 +9503,9 @@
         "version": "0.48.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9475,6 +9571,9 @@
         "version": "0.52.6"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9540,6 +9639,9 @@
         "version": "0.48.5"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]
@@ -9605,6 +9707,9 @@
         "version": "0.52.6"
       },
       "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "**"
         ]

--- a/examples/nix_cross_compiling/bazel/cargo/cargo-bazel-lock.json
+++ b/examples/nix_cross_compiling/bazel/cargo/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "354bc0813bcbc0a52365b289a2fe1c6fa6bfb2523ecc77ea1894d04d43e2a8bd",
+  "checksum": "c22a9f549cef5a17cf62ae10f1b9ec71f542c674702c9939b903fb3a92deaf0b",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",

--- a/proto/prost/private/3rdparty/crates/BUILD.anyhow-1.0.86.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.anyhow-1.0.86.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/proto/prost/private/3rdparty/crates/BUILD.axum-0.7.5.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.axum-0.7.5.bazel
@@ -110,6 +110,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.axum-core-0.4.3.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.axum-core-0.4.3.bazel
@@ -103,6 +103,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.backtrace-0.3.73.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.backtrace-0.3.73.bazel
@@ -280,6 +280,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.httparse-1.9.4.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.httparse-1.9.4.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/proto/prost/private/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
@@ -91,6 +91,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.libc-0.2.158.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.libc-0.2.158.bazel
@@ -150,6 +150,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/proto/prost/private/3rdparty/crates/BUILD.lock_api-0.4.12.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.lock_api-0.4.12.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "atomic_usize",
         "default",

--- a/proto/prost/private/3rdparty/crates/BUILD.parking_lot_core-0.9.10.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.parking_lot_core-0.9.10.bazel
@@ -175,6 +175,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.prettyplease-0.2.22.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.prettyplease-0.2.22.bazel
@@ -92,6 +92,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.proc-macro2-1.0.86.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.proc-macro2-1.0.86.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/proto/prost/private/3rdparty/crates/BUILD.rustix-0.38.34.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.rustix-0.38.34.bazel
@@ -320,6 +320,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "alloc",
         "default",

--- a/proto/prost/private/3rdparty/crates/BUILD.rustversion-1.0.17.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.rustversion-1.0.17.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build/build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.serde-1.0.209.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.serde-1.0.209.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/proto/prost/private/3rdparty/crates/BUILD.slab-0.4.9.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.slab-0.4.9.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnu-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnu-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_i686_msvc-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_i686_msvc-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/protobuf/3rdparty/crates/BUILD.crossbeam-epoch-0.8.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.crossbeam-epoch-0.8.2.bazel
@@ -101,6 +101,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "lazy_static",

--- a/proto/protobuf/3rdparty/crates/BUILD.crossbeam-utils-0.7.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.crossbeam-utils-0.7.2.bazel
@@ -97,6 +97,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "lazy_static",

--- a/proto/protobuf/3rdparty/crates/BUILD.httpbis-0.7.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.httpbis-0.7.0.bazel
@@ -200,6 +200,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/protobuf/3rdparty/crates/BUILD.kernel32-sys-0.2.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.kernel32-sys-0.2.2.bazel
@@ -91,6 +91,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/protobuf/3rdparty/crates/BUILD.libc-0.2.139.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.libc-0.2.139.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/proto/protobuf/3rdparty/crates/BUILD.log-0.4.17.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.log-0.4.17.bazel
@@ -166,6 +166,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
             "std",  # aarch64-apple-darwin

--- a/proto/protobuf/3rdparty/crates/BUILD.maybe-uninit-2.0.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.maybe-uninit-2.0.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/protobuf/3rdparty/crates/BUILD.memoffset-0.5.6.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.memoffset-0.5.6.bazel
@@ -93,6 +93,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
     ],

--- a/proto/protobuf/3rdparty/crates/BUILD.parking_lot-0.9.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.parking_lot-0.9.0.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
     ],

--- a/proto/protobuf/3rdparty/crates/BUILD.parking_lot_core-0.6.3.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.parking_lot_core-0.6.3.bazel
@@ -175,6 +175,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/protobuf/3rdparty/crates/BUILD.protobuf-2.8.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.protobuf-2.8.2.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "bytes",
         "with-bytes",

--- a/proto/protobuf/3rdparty/crates/BUILD.slab-0.4.7.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.slab-0.4.7.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/proto/protobuf/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -103,6 +103,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "errhandlingapi",
         "handleapi",

--- a/proto/protobuf/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/protobuf/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/proto/protobuf/3rdparty/crates/BUILD.ws2_32-sys-0.2.1.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.ws2_32-sys-0.2.1.bazel
@@ -91,6 +91,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/test/3rdparty/crates/BUILD.proc-macro2-1.0.86.bazel
+++ b/test/3rdparty/crates/BUILD.proc-macro2-1.0.86.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "proc-macro",
     ],

--- a/test/3rdparty/crates/BUILD.serde-1.0.210.bazel
+++ b/test/3rdparty/crates/BUILD.serde-1.0.210.bazel
@@ -99,6 +99,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "derive",

--- a/test/3rdparty/crates/BUILD.serde_json-1.0.128.bazel
+++ b/test/3rdparty/crates/BUILD.serde_json-1.0.128.bazel
@@ -98,6 +98,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
@@ -78,6 +78,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -75,6 +75,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -137,6 +137,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "close",
         "default",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.libc-0.2.147.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.libc-0.2.147.bazel
@@ -79,6 +79,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "extra_traits",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.memchr-2.5.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.memchr-2.5.0.bazel
@@ -78,6 +78,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -79,6 +79,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -79,6 +79,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -183,6 +183,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "io-lifetimes",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.serde-1.0.171.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.serde-1.0.171.bazel
@@ -83,6 +83,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "derive",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
@@ -81,6 +81,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -86,6 +86,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "consoleapi",
         "errhandlingapi",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -74,6 +74,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -74,6 +74,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -74,6 +74,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -74,6 +74,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -74,6 +74,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -74,6 +74,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -74,6 +74,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -74,6 +74,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -74,6 +74,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/wasm_bindgen/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
@@ -98,6 +98,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "alloc",
         "std",

--- a/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/wasm_bindgen/3rdparty/crates/BUILD.doc-comment-0.3.3.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.doc-comment-0.3.3.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -91,6 +91,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.httparse-1.8.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.httparse-1.8.0.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/wasm_bindgen/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
@@ -91,6 +91,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -97,6 +97,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "close",
         "hermit-abi",

--- a/wasm_bindgen/3rdparty/crates/BUILD.libc-0.2.150.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.libc-0.2.150.bazel
@@ -242,6 +242,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
             "default",  # aarch64-apple-darwin

--- a/wasm_bindgen/3rdparty/crates/BUILD.memchr-2.5.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.memchr-2.5.0.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/wasm_bindgen/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
@@ -93,6 +93,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
     ],

--- a/wasm_bindgen/3rdparty/crates/BUILD.mime_guess-2.0.4.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.mime_guess-2.0.4.bazel
@@ -96,6 +96,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "rev-mappings",

--- a/wasm_bindgen/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -96,6 +96,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/wasm_bindgen/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -95,6 +95,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "proc-macro",

--- a/wasm_bindgen/3rdparty/crates/BUILD.rayon-core-1.11.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.rayon-core-1.11.0.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.ring-0.17.5.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.ring-0.17.5.bazel
@@ -183,6 +183,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "alloc",
         "default",

--- a/wasm_bindgen/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -298,6 +298,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "fs",

--- a/wasm_bindgen/3rdparty/crates/BUILD.rustls-0.21.8.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.rustls-0.21.8.bazel
@@ -100,6 +100,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "log",

--- a/wasm_bindgen/3rdparty/crates/BUILD.semver-1.0.17.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.semver-1.0.17.bazel
@@ -94,6 +94,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/wasm_bindgen/3rdparty/crates/BUILD.serde-1.0.171.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.serde-1.0.171.bazel
@@ -99,6 +99,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "derive",

--- a/wasm_bindgen/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
@@ -97,6 +97,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "std",

--- a/wasm_bindgen/3rdparty/crates/BUILD.syn-1.0.109.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.syn-1.0.109.bazel
@@ -103,6 +103,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "clone-impls",
         "default",

--- a/wasm_bindgen/3rdparty/crates/BUILD.tempfile-3.6.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.tempfile-3.6.0.bazel
@@ -178,6 +178,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.unicase-2.6.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.unicase-2.6.0.bazel
@@ -92,6 +92,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-0.2.92.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-0.2.92.bazel
@@ -99,6 +99,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "default",
         "spans",

--- a/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.92.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.92.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -105,6 +105,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_features = [
         "consoleapi",
         "errhandlingapi",

--- a/wasm_bindgen/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -90,6 +90,18 @@ cargo_build_script(
         include = ["**/*.rs"],
         allow_empty = True,
     ),
+    compile_data = glob(
+        include = ["**"],
+        allow_empty = True,
+        exclude = [
+            "**/* *",
+            ".tmp_git_root/**/*",
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+    ),
     crate_name = "build_script_build",
     crate_root = "build.rs",
     data = glob(


### PR DESCRIPTION
https://github.com/bazelbuild/rules_rust/pull/2826 ended up introducing a regression for crates with build scripts that require extra data at compile time. This change adds a default glob for all `cargo_build_script` targets generated by `crate_universe` and also introduces an `annotation.build_script_compile_data` attribute to add custom targets to generated outputs.