### PR TITLE
Propagate `cargo_build_script.data` to `Rustc` compile actions

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -433,7 +433,7 @@ def _cargo_build_script_impl(ctx):
             flags = flags_out,
             linker_flags = link_flags,
             link_search_paths = link_search_paths,
-            compile_data = depset(),
+            compile_data = depset(transitive = script_data),
         ),
         OutputGroupInfo(
             streams = depset([streams.stdout, streams.stderr]),

--- a/test/cargo_build_script/compile_data/BUILD.bazel
+++ b/test/cargo_build_script/compile_data/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//cargo:defs.bzl", "cargo_build_script")
+load("//rust:defs.bzl", "rust_test")
+
+cargo_build_script(
+    name = "build_rs",
+    srcs = ["build.rs"],
+    data = ["data.txt"],
+    edition = "2018",
+)
+
+rust_test(
+    name = "test",
+    srcs = ["test.rs"],
+    edition = "2018",
+    deps = [":build_rs"],
+)

--- a/test/cargo_build_script/compile_data/build.rs
+++ b/test/cargo_build_script/compile_data/build.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+fn main() {
+    let path = "data.txt";
+    if !PathBuf::from(path).exists() {
+        panic!("File does not exist in path.");
+    }
+    println!("cargo:rustc-env=DATA={}", path);
+}

--- a/test/cargo_build_script/compile_data/data.txt
+++ b/test/cargo_build_script/compile_data/data.txt
@@ -1,0 +1,1 @@
+La-Li-Lu-Le-Lo

--- a/test/cargo_build_script/compile_data/test.rs
+++ b/test/cargo_build_script/compile_data/test.rs
@@ -1,0 +1,6 @@
+#[test]
+pub fn test_compile_data() {
+    let data = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", env!("DATA")));
+
+    assert_eq!("La-Li-Lu-Le-Lo\n", data);
+}


### PR DESCRIPTION
This way any outputs that the build script may refer to in flags it emits can be referenced without needing to also explicitly pass the data target to the `compile_data` attribute of it's consumer.