### PR TITLE
[bug] only generate rust libraries with coverage instrumentation only when coverage is enabled

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -206,6 +206,7 @@ def _rust_library_common(ctx, crate_type):
             compile_data_targets = depset(ctx.attr.compile_data),
             owner = ctx.label,
         ),
+        include_coverage = ctx.configuration.coverage_enabled,
     )
 
 def _rust_binary_impl(ctx):
@@ -254,6 +255,7 @@ def _rust_binary_impl(ctx):
             compile_data_targets = depset(ctx.attr.compile_data),
             owner = ctx.label,
         ),
+        include_coverage = ctx.configuration.coverage_enabled,
     )
 
     providers.append(RunEnvironmentInfo(
@@ -411,6 +413,7 @@ def _rust_test_impl(ctx):
         crate_info_dict = crate_info_dict,
         rust_flags = get_rust_test_flags(ctx.attr),
         skip_expanding_rustc_env = True,
+        include_coverage = ctx.configuration.coverage_enabled,
     )
     data = getattr(ctx.attr, "data", [])
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1125,7 +1125,7 @@ def rustc_compile_action(
         force_all_deps_direct = False,
         crate_info_dict = None,
         skip_expanding_rustc_env = False,
-        include_coverage = True):
+        include_coverage = False):
     """Create and run a rustc compile action based on the current rule's attributes
 
     Args:


### PR DESCRIPTION
Currently, binaries produced by rust_binary generate profraw files which means the binary is built with code coverage instrumentation with bazel build. We should only generate coverage with bazel coverage. This PR fixes this bug