### PR TITLE
Update `cargo_build_script` to work without runfiles support.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -36,6 +36,21 @@ default_windows_targets: &default_windows_targets
   - "//..."
   - "-//test/proto/..."
   - "-//test/unit/pipelined_compilation/..."
+default_windows_no_runfiles_targets: &default_windows_no_runfiles_targets
+  - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
+  - "//..."
+  # TODO: https://github.com/bazelbuild/rules_rust/issues/1156
+  - "-//crate_universe/..."
+  - "-//test/chained_direct_deps:mod3_doc_test"
+  - "-//test/out_dir_in_tests:demo_lib_doc_test"
+  - "-//test/proto/..."
+  - "-//test/rustc_env_files:output_test"
+  - "-//test/test_env_launcher:test"
+  - "-//test/test_env:test_manifest_dir"
+  - "-//test/test_env:test_run"
+  - "-//test/unit/pipelined_compilation/..."
+  - "-//test/unit/rustdoc/..."
+  - "-//tools/runfiles/..."
 crate_universe_vendor_example_targets: &crate_universe_vendor_example_targets
   - "//vendor_external:crates_vendor"
   - "//vendor_local_manifests:crates_vendor"
@@ -78,6 +93,15 @@ tasks:
   windows:
     build_targets: *default_windows_targets
     test_targets: *default_windows_targets
+  windows_no_runfiles:
+    name: No Runfiles
+    platform: windows
+    build_flags:
+      - "--noenable_runfiles"
+    test_flags:
+      - "--noenable_runfiles"
+    build_targets: *default_windows_no_runfiles_targets
+    test_targets: *default_windows_no_runfiles_targets
   ubuntu2004_split_coverage_postprocessing:
     name: Split Coverage Postprocessing
     platform: ubuntu2004
@@ -171,6 +195,19 @@ tasks:
       - "--config=clippy"
     build_targets: *default_windows_targets
     test_targets: *default_windows_targets
+  windows_no_runfiles_with_aspects:
+    name: No Runfiles With Aspects
+    platform: windows
+    build_flags:
+      - "--noenable_runfiles"
+      - "--config=rustfmt"
+      - "--config=clippy"
+    test_flags:
+      - "--noenable_runfiles"
+      - "--config=rustfmt"
+      - "--config=clippy"
+    build_targets: *default_windows_no_runfiles_targets
+    test_targets: *default_windows_no_runfiles_targets
   windows_rolling_with_aspects:
     name: "Windows Rolling Bazel Version With Aspects"
     platform: windows

--- a/bindgen/3rdparty/crates/BUILD.bindgen-0.70.1.bazel
+++ b/bindgen/3rdparty/crates/BUILD.bindgen-0.70.1.bazel
@@ -113,6 +113,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/bindgen/3rdparty/crates/BUILD.clang-sys-1.8.1.bazel
+++ b/bindgen/3rdparty/crates/BUILD.clang-sys-1.8.1.bazel
@@ -118,6 +118,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/bindgen/3rdparty/crates/BUILD.libc-0.2.158.bazel
+++ b/bindgen/3rdparty/crates/BUILD.libc-0.2.158.bazel
@@ -198,6 +198,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -102,6 +102,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/cargo/private/BUILD.bazel
+++ b/cargo/private/BUILD.bazel
@@ -1,7 +1,13 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":runfiles_enabled.bzl", "runfiles_enabled_build_setting")
 
 bzl_library(
     name = "bzl_lib",
     srcs = glob(["**/*.bzl"]),
     visibility = ["//:__subpackages__"],
+)
+
+runfiles_enabled_build_setting(
+    name = "runfiles_enabled",
+    visibility = ["//visibility:public"],
 )

--- a/cargo/private/runfiles_enabled.bzl
+++ b/cargo/private/runfiles_enabled.bzl
@@ -1,0 +1,167 @@
+"""A small utility module dedicated to detecting whether or not the `--enable_runfiles` and `--windows_enable_symlinks` flag are enabled
+"""
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
+
+RunfilesEnabledInfo = provider(
+    doc = "A singleton provider that contains the raw value of a build setting",
+    fields = {
+        "value": "The value of the build setting in the current configuration. " +
+                 "This value may come from the command line or an upstream transition, " +
+                 "or else it will be the build setting's default.",
+    },
+)
+
+def _runfiles_enabled_setting_impl(ctx):
+    return RunfilesEnabledInfo(value = ctx.attr.value)
+
+runfiles_enabled_setting = rule(
+    implementation = _runfiles_enabled_setting_impl,
+    doc = "A bool-typed build setting that cannot be set on the command line",
+    attrs = {
+        "value": attr.bool(
+            doc = "A boolean value",
+            mandatory = True,
+        ),
+    },
+)
+
+_RUNFILES_ENABLED_ATTR_NAME = "_runfiles_enabled"
+
+def runfiles_enabled_attr(default):
+    return {
+        _RUNFILES_ENABLED_ATTR_NAME: attr.label(
+            doc = "A flag representing whether or not runfiles are enabled.",
+            providers = [RunfilesEnabledInfo],
+            default = default,
+            cfg = "exec",
+        ),
+    }
+
+def runfiles_enabled_build_setting(name, **kwargs):
+    """Define a build setting identifying if runfiles are enabled.
+
+    Args:
+        name (str): The name of the build setting
+        **kwargs: Additional keyword arguments for the target.
+    """
+    native.config_setting(
+        name = "{}__enable_runfiles".format(name),
+        values = {"enable_runfiles": "true"},
+    )
+
+    native.config_setting(
+        name = "{}__disable_runfiles".format(name),
+        values = {"enable_runfiles": "false"},
+    )
+
+    bool_setting(
+        name = "{}__always_true".format(name),
+        build_setting_default = True,
+    )
+
+    native.config_setting(
+        name = "{}__always_true_setting".format(name),
+        flag_values = {":{}__always_true".format(name): "True"},
+    )
+
+    native.config_setting(
+        name = "{}__always_false_setting".format(name),
+        flag_values = {":{}__always_true".format(name): "False"},
+    )
+
+    # There is no way to query a setting that is unset. By utilizing constant
+    # settings, we can filter to a fallback setting where no known value is
+    # defined.
+    native.alias(
+        name = "{}__unset_runfiles".format(name),
+        actual = select({
+            ":{}__disable_runfiles".format(name): ":{}__always_false_setting".format(name),
+            ":{}__enable_runfiles".format(name): ":{}__always_false_setting".format(name),
+            "//conditions:default": ":{}__always_true_setting".format(name),
+        }),
+    )
+
+    selects.config_setting_group(
+        name = "{}__windows_enable_runfiles".format(name),
+        match_all = [
+            ":{}__enable_runfiles".format(name),
+            "@platforms//os:windows",
+        ],
+    )
+
+    selects.config_setting_group(
+        name = "{}__windows_disable_runfiles".format(name),
+        match_all = [
+            ":{}__disable_runfiles".format(name),
+            "@platforms//os:windows",
+        ],
+    )
+
+    selects.config_setting_group(
+        name = "{}__windows_unset_runfiles".format(name),
+        match_all = [
+            ":{}__unset_runfiles".format(name),
+            "@platforms//os:windows",
+        ],
+    )
+
+    native.alias(
+        name = "{}__unix".format(name),
+        actual = select({
+            "@platforms//os:windows": ":{}__always_false_setting".format(name),
+            "//conditions:default": ":{}__always_true_setting".format(name),
+        }),
+    )
+
+    selects.config_setting_group(
+        name = "{}__unix_enable_runfiles".format(name),
+        match_all = [
+            ":{}__enable_runfiles".format(name),
+            ":{}__unix".format(name),
+        ],
+    )
+
+    selects.config_setting_group(
+        name = "{}__unix_disable_runfiles".format(name),
+        match_all = [
+            ":{}__disable_runfiles".format(name),
+            ":{}__unix".format(name),
+        ],
+    )
+
+    selects.config_setting_group(
+        name = "{}__unix_unset_runfiles".format(name),
+        match_all = [
+            ":{}__unset_runfiles".format(name),
+            ":{}__unix".format(name),
+        ],
+    )
+
+    runfiles_enabled_setting(
+        name = name,
+        value = select({
+            ":{}__windows_enable_runfiles".format(name): True,
+            ":{}__windows_disable_runfiles".format(name): False,
+            ":{}__windows_unset_runfiles".format(name): False,
+            ":{}__unix_enable_runfiles".format(name): True,
+            ":{}__unix_disable_runfiles".format(name): False,
+            ":{}__unix_unset_runfiles".format(name): True,
+            "//conditions:default": True,
+        }),
+        **kwargs
+    )
+
+def is_runfiles_enabled(attr):
+    """Determine whether or not runfiles are enabled.
+
+    Args:
+        attr (struct): A rule's struct of attributes (`ctx.attr`)
+    Returns:
+        bool: The enable_runfiles value.
+    """
+
+    runfiles_enabled = getattr(attr, _RUNFILES_ENABLED_ATTR_NAME, None)
+
+    return runfiles_enabled[RunfilesEnabledInfo].value if runfiles_enabled else True

--- a/cargo/private/runfiles_maker/BUILD.bazel
+++ b/cargo/private/runfiles_maker/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//rust:defs.bzl", "rust_binary")
+
+rust_binary(
+    name = "runfiles_maker",
+    srcs = ["runfiles_maker.rs"],
+    edition = "2021",
+    visibility = ["//visibility:public"],
+)

--- a/cargo/private/runfiles_maker/runfiles_maker.rs
+++ b/cargo/private/runfiles_maker/runfiles_maker.rs
@@ -1,0 +1,71 @@
+//! A tool for building runfiles directories for Bazel environments that don't
+//! support runfiles or have runfiles disabled.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+struct Args {
+    pub output_dir: PathBuf,
+    pub runfiles: BTreeMap<PathBuf, PathBuf>,
+}
+
+impl Args {
+    fn parse() -> Self {
+        let args_file = std::env::args().nth(1).expect("No args file was passed.");
+
+        let content = std::fs::read_to_string(
+            args_file
+                .strip_prefix('@')
+                .expect("Param files should start with @"),
+        )
+        .unwrap();
+        let mut args = content.lines();
+
+        let output_dir = PathBuf::from(
+            args.next()
+                .unwrap_or_else(|| panic!("Not enough arguments provided.")),
+        );
+        let runfiles = args
+            .map(|s| {
+                let s = if s.starts_with('\'') && s.ends_with('\'') {
+                    s.trim_matches('\'')
+                } else {
+                    s
+                };
+                let (src, dest) = s
+                    .split_once('=')
+                    .unwrap_or_else(|| panic!("Unexpected runfiles argument: {}", s));
+                (PathBuf::from(src), PathBuf::from(dest))
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        assert!(!runfiles.is_empty(), "No runfiles found");
+
+        Args {
+            output_dir,
+            runfiles,
+        }
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+
+    for (src, dest) in args.runfiles.iter() {
+        let out_dest = args.output_dir.join(dest);
+        std::fs::create_dir_all(
+            out_dest
+                .parent()
+                .expect("The output location should have a valid parent."),
+        )
+        .expect("Failed to create output directory");
+        std::fs::copy(src, &out_dest).unwrap_or_else(|e| {
+            panic!(
+                "Failed to copy file {} -> {}\n{:?}",
+                src.display(),
+                out_dest.display(),
+                e
+            )
+        });
+    }
+}

--- a/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.75.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.anyhow-1.0.75.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.camino-1.1.6.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.camino-1.1.6.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.8.4.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.chrono-tz-0.8.4.bazel
@@ -101,6 +101,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
@@ -103,6 +103,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-queue-0.3.8.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-queue-0.3.8.bazel
@@ -101,6 +101,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -96,6 +96,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.generic-array-0.14.7.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -206,6 +206,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.libc-0.2.149.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libc-0.2.149.bazel
@@ -191,6 +191,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.libm-0.2.7.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.libm-0.2.7.bazel
@@ -98,6 +98,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.lock_api-0.4.11.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.lock_api-0.4.11.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
@@ -98,6 +98,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-integer-0.1.45.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-iter-0.1.43.bazel
@@ -101,6 +101,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.parking_lot_core-0.9.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.parking_lot_core-0.9.9.bazel
@@ -180,6 +180,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.rayon-core-1.12.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rayon-core-1.12.0.bazel
@@ -97,6 +97,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -303,6 +303,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.rustix-0.38.21.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.rustix-0.38.21.bazel
@@ -398,6 +398,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.semver-1.0.20.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.semver-1.0.20.bazel
@@ -101,6 +101,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.serde-1.0.190.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde-1.0.190.bazel
@@ -105,6 +105,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.108.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.serde_json-1.0.108.bazel
@@ -103,6 +103,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.syn-1.0.109.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.syn-1.0.109.bazel
@@ -109,6 +109,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.thiserror-1.0.50.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.thiserror-1.0.50.bazel
@@ -98,6 +98,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.typenum-1.16.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.typenum-1.16.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.valuable-0.1.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.valuable-0.1.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-0.2.87.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.87.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.87.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -113,6 +113,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/crate_universe/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.indexmap-1.8.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.indexmap-1.8.0.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.libc-0.2.119.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.libc-0.2.119.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.memchr-2.4.1.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.memchr-2.4.1.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-1.0.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-1.0.4.bazel
@@ -106,6 +106,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -97,6 +97,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.proc-macro2-1.0.36.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.proc-macro2-1.0.36.bazel
@@ -157,6 +157,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.pulldown-cmark-0.8.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.pulldown-cmark-0.8.0.bazel
@@ -98,6 +98,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.semver-1.0.6.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.semver-1.0.6.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.serde-1.0.136.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.serde-1.0.136.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.syn-1.0.86.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.syn-1.0.86.bazel
@@ -190,6 +190,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.unicase-2.6.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.unicase-2.6.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-0.3.9.bazel
@@ -108,6 +108,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_external/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_external/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/libc-0.2.158/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/libc-0.2.158/BUILD.bazel
@@ -155,6 +155,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/lock_api-0.4.12/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/lock_api-0.4.12/BUILD.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/parking_lot_core-0.9.10/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/parking_lot_core-0.9.10/BUILD.bazel
@@ -180,6 +180,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/proc-macro2-1.0.86/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/proc-macro2-1.0.86/BUILD.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/rustix-0.38.37/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/rustix-0.38.37/BUILD.bazel
@@ -325,6 +325,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_gnullvm-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_aarch64_msvc-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnu-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnu-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_gnullvm-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_i686_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_i686_msvc-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnu-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnu-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_gnullvm-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_manifests/crates/windows_x86_64_msvc-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/httparse-1.9.4/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/httparse-1.9.4/BUILD.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/libc-0.2.158/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/libc-0.2.158/BUILD.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/lock_api-0.4.12/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/lock_api-0.4.12/BUILD.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/parking_lot_core-0.9.10/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/parking_lot_core-0.9.10/BUILD.bazel
@@ -180,6 +180,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/proc-macro2-1.0.86/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/proc-macro2-1.0.86/BUILD.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/serde-1.0.210/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/serde-1.0.210/BUILD.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/serde_json-1.0.128/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/serde_json-1.0.128/BUILD.bazel
@@ -104,6 +104,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/slab-0.4.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/slab-0.4.9/BUILD.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/valuable-0.1.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/valuable-0.1.0/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-0.3.9/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-0.3.9/BUILD.bazel
@@ -104,6 +104,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-i686-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/winapi-x86_64-pc-windows-gnu-0.4.0/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_gnullvm-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_aarch64_msvc-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnu-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnu-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_gnullvm-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_i686_msvc-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnu-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnu-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnullvm-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_gnullvm-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_msvc-0.52.6/BUILD.bazel
+++ b/examples/crate_universe/vendor_local_pkgs/crates/windows_x86_64_msvc-0.52.6/BUILD.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.libc-0.2.158.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.libc-0.2.158.bazel
@@ -155,6 +155,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.lock_api-0.4.12.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.lock_api-0.4.12.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.10.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.parking_lot_core-0.9.10.bazel
@@ -180,6 +180,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.86.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.proc-macro2-1.0.86.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.rustix-0.38.37.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.rustix-0.38.37.bazel
@@ -325,6 +325,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnu-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_i686_msvc-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_manifests/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httparse-1.9.4.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.httparse-1.9.4.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.libc-0.2.158.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.libc-0.2.158.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.12.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.lock_api-0.4.12.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.9.10.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.parking_lot_core-0.9.10.bazel
@@ -180,6 +180,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.86.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.proc-macro2-1.0.86.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde-1.0.210.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde-1.0.210.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.128.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.serde_json-1.0.128.bazel
@@ -104,6 +104,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.slab-0.4.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.slab-0.4.9.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.valuable-0.1.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-0.3.9.bazel
@@ -104,6 +104,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnu-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnu-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_i686_msvc-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
+++ b/examples/crate_universe/vendor_remote_pkgs/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.anyhow-1.0.86.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.anyhow-1.0.86.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.axum-0.7.5.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.axum-0.7.5.bazel
@@ -115,6 +115,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.axum-core-0.4.3.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.axum-core-0.4.3.bazel
@@ -108,6 +108,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.backtrace-0.3.73.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.backtrace-0.3.73.bazel
@@ -285,6 +285,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.httparse-1.9.4.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.httparse-1.9.4.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
@@ -96,6 +96,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.libc-0.2.158.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.libc-0.2.158.bazel
@@ -155,6 +155,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.lock_api-0.4.12.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.lock_api-0.4.12.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.parking_lot_core-0.9.10.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.parking_lot_core-0.9.10.bazel
@@ -180,6 +180,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.prettyplease-0.2.22.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.prettyplease-0.2.22.bazel
@@ -97,6 +97,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.proc-macro2-1.0.86.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.proc-macro2-1.0.86.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.rustix-0.38.34.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.rustix-0.38.34.bazel
@@ -325,6 +325,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.rustversion-1.0.17.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.rustversion-1.0.17.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.serde-1.0.209.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.serde-1.0.209.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.slab-0.4.9.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.slab-0.4.9.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_aarch64_msvc-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnu-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnu-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_i686_gnullvm-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_i686_msvc-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_i686_msvc-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnu-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
+++ b/proto/prost/private/3rdparty/crates/BUILD.windows_x86_64_msvc-0.52.6.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.crossbeam-epoch-0.8.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.crossbeam-epoch-0.8.2.bazel
@@ -106,6 +106,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.crossbeam-utils-0.7.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.crossbeam-utils-0.7.2.bazel
@@ -102,6 +102,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.httpbis-0.7.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.httpbis-0.7.0.bazel
@@ -205,6 +205,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.kernel32-sys-0.2.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.kernel32-sys-0.2.2.bazel
@@ -96,6 +96,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.libc-0.2.139.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.libc-0.2.139.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.log-0.4.17.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.log-0.4.17.bazel
@@ -171,6 +171,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.maybe-uninit-2.0.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.maybe-uninit-2.0.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.memoffset-0.5.6.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.memoffset-0.5.6.bazel
@@ -98,6 +98,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.parking_lot-0.9.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.parking_lot-0.9.0.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.parking_lot_core-0.6.3.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.parking_lot_core-0.6.3.bazel
@@ -180,6 +180,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.protobuf-2.8.2.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.protobuf-2.8.2.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.slab-0.4.7.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.slab-0.4.7.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -108,6 +108,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/proto/protobuf/3rdparty/crates/BUILD.ws2_32-sys-0.2.1.bazel
+++ b/proto/protobuf/3rdparty/crates/BUILD.ws2_32-sys-0.2.1.bazel
@@ -96,6 +96,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -329,6 +329,7 @@ def collect_deps(
                 transitive_build_infos.append(depset([build_info]))
                 if build_info.link_search_paths:
                     transitive_link_search_paths.append(depset([build_info.link_search_paths]))
+                transitive_data.append(build_info.compile_data)
         else:
             fail("rust targets can only depend on rust_library, rust_*_library or cc_library " +
                  "targets.")
@@ -470,14 +471,12 @@ def get_linker_and_args(ctx, attr, crate_type, cc_toolchain, feature_configurati
 def _process_build_scripts(
         build_info,
         dep_info,
-        compile_inputs,
         include_link_flags = True):
     """Gathers the outputs from a target's `cargo_build_script` action.
 
     Args:
         build_info (BuildInfo): The target Build's dependency info.
         dep_info (DepInfo): The Depinfo provider form the target Crate's set of inputs.
-        compile_inputs (depset): A set of all files that will participate in the build.
         include_link_flags (bool, optional): Whether to include flags like `-l` that instruct the linker to search for a library.
 
     Returns:
@@ -488,8 +487,7 @@ def _process_build_scripts(
             - (depset[File]): All direct and transitive build flags from the current build info.
     """
     extra_inputs, out_dir, build_env_file, build_flags_files = _create_extra_input_args(build_info, dep_info, include_link_flags = include_link_flags)
-    compile_inputs = depset(transitive = [extra_inputs, compile_inputs])
-    return compile_inputs, out_dir, build_env_file, build_flags_files
+    return extra_inputs, out_dir, build_env_file, build_flags_files
 
 def _symlink_for_ambiguous_lib(actions, toolchain, crate_info, lib):
     """Constructs a disambiguating symlink for a library dependency.
@@ -780,13 +778,18 @@ def collect_inputs(
         ],
     )
 
+    build_script_compile_inputs, out_dir, build_env_file, build_flags_files = _process_build_scripts(
+        build_info = build_info,
+        dep_info = dep_info,
+        include_link_flags = include_link_flags,
+    )
+
     # For backwards compatibility, we also check the value of the `rustc_env_files` attribute when
     # `crate_info.rustc_env_files` is not populated.
     build_env_files = crate_info.rustc_env_files if crate_info.rustc_env_files else getattr(files, "rustc_env_files", [])
-    compile_inputs, out_dir, build_env_file, build_flags_files = _process_build_scripts(build_info, dep_info, compile_inputs, include_link_flags = include_link_flags)
     if build_env_file:
         build_env_files = [f for f in build_env_files] + [build_env_file]
-    compile_inputs = depset(build_env_files, transitive = [compile_inputs])
+    compile_inputs = depset(build_env_files, transitive = [build_script_compile_inputs, compile_inputs])
     return compile_inputs, out_dir, build_env_files, build_flags_files, linkstamp_outs, ambiguous_libs
 
 def construct_arguments(
@@ -1731,8 +1734,13 @@ def _create_extra_input_args(build_info, dep_info, include_link_flags = True):
 
         input_depsets.append(build_info.compile_data)
 
+    out_dir_compile_inputs = depset(
+        input_files,
+        transitive = [dep_info.link_search_path_files, dep_info.transitive_data] + input_depsets,
+    )
+
     return (
-        depset(input_files, transitive = [dep_info.link_search_path_files] + input_depsets),
+        out_dir_compile_inputs,
         out_dir,
         build_env_file,
         depset(build_flags_files, transitive = [dep_info.link_search_path_files]),

--- a/test/3rdparty/crates/BUILD.proc-macro2-1.0.86.bazel
+++ b/test/3rdparty/crates/BUILD.proc-macro2-1.0.86.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/test/3rdparty/crates/BUILD.serde-1.0.210.bazel
+++ b/test/3rdparty/crates/BUILD.serde-1.0.210.bazel
@@ -104,6 +104,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/test/3rdparty/crates/BUILD.serde_json-1.0.128.bazel
+++ b/test/3rdparty/crates/BUILD.serde_json-1.0.128.bazel
@@ -103,6 +103,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
@@ -83,6 +83,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -80,6 +80,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -142,6 +142,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.libc-0.2.147.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.libc-0.2.147.bazel
@@ -84,6 +84,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.memchr-2.5.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.memchr-2.5.0.bazel
@@ -83,6 +83,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -84,6 +84,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -84,6 +84,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -188,6 +188,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.serde-1.0.171.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.serde-1.0.171.bazel
@@ -88,6 +88,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
@@ -86,6 +86,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -91,6 +91,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -79,6 +79,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -79,6 +79,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -79,6 +79,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -79,6 +79,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -79,6 +79,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -79,6 +79,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -79,6 +79,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -79,6 +79,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/tools/rust_analyzer/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -79,6 +79,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.anyhow-1.0.71.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.crc32fast-1.3.2.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-epoch-0.9.15.bazel
@@ -103,6 +103,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.crossbeam-utils-0.8.16.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.doc-comment-0.3.3.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.doc-comment-0.3.3.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.errno-dragonfly-0.1.2.bazel
@@ -96,6 +96,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.httparse-1.8.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.httparse-1.8.0.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.iana-time-zone-haiku-0.1.2.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.indexmap-1.9.3.bazel
@@ -96,6 +96,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.io-lifetimes-1.0.11.bazel
@@ -102,6 +102,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.libc-0.2.150.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.libc-0.2.150.bazel
@@ -176,6 +176,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.memchr-2.5.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.memchr-2.5.0.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.memoffset-0.9.0.bazel
@@ -98,6 +98,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.mime_guess-2.0.4.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.mime_guess-2.0.4.bazel
@@ -101,6 +101,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.num-traits-0.2.15.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.proc-macro2-1.0.64.bazel
@@ -101,6 +101,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.quote-1.0.29.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.quote-1.0.29.bazel
@@ -100,6 +100,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.rayon-core-1.11.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.rayon-core-1.11.0.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.ring-0.17.5.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.ring-0.17.5.bazel
@@ -188,6 +188,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.rustix-0.37.23.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.rustix-0.37.23.bazel
@@ -303,6 +303,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.rustls-0.21.8.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.rustls-0.21.8.bazel
@@ -105,6 +105,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.semver-1.0.17.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.semver-1.0.17.bazel
@@ -99,6 +99,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.serde-1.0.171.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.serde-1.0.171.bazel
@@ -104,6 +104,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.serde_json-1.0.102.bazel
@@ -102,6 +102,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.syn-1.0.109.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.syn-1.0.109.bazel
@@ -108,6 +108,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.tempfile-3.6.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.tempfile-3.6.0.bazel
@@ -183,6 +183,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.unicase-2.6.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.unicase-2.6.0.bazel
@@ -97,6 +97,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-0.2.92.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-0.2.92.bazel
@@ -104,6 +104,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.92.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.wasm-bindgen-shared-0.2.92.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.winapi-0.3.9.bazel
@@ -110,6 +110,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_gnullvm-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_aarch64_msvc-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_gnu-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_i686_msvc-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnu-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_gnullvm-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",

--- a/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
+++ b/wasm_bindgen/3rdparty/crates/BUILD.windows_x86_64_msvc-0.48.0.bazel
@@ -95,6 +95,7 @@ cargo_build_script(
         allow_empty = True,
         exclude = [
             "**/* *",
+            "**/*.rs",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",


### PR DESCRIPTION
Partially addresses https://github.com/bazelbuild/rules_rust/issues/1156

This pull-request implements an additional change to enable this behavior which aggregates all transitive `BuildInfo.compile_data` into `Rustc` actions. While this seems to bloat these actions with unnecessary data, it addresses a catastrophic flaw in how Windows works at all.

As of Bazel 7.3.1, Windows does not run any actions in a sandbox (https://github.com/bazelbuild/bazel/discussions/18401), this means that references to the current working directory will be consistent since they always refer to the execroot. On top of this fact, `cargo_build_script` will assign [CARGO_MANIFEST_DIR](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates) to a [path within the runfiles directory of the build script](https://github.com/bazelbuild/rules_rust/blame/d9ee6172d1dfc2801ba809441668e60e797f89de/cargo/private/cargo_build_script.bzl#L218). The combination of these two facts leads crates like [windows_x86_64_msvc](https://crates.io/crates/windows_x86_64_msvc), which assign a linker path using `CARGO_MANIFEST_DIR` ([@windows_x86_64_msvc//build.rs](https://github.com/microsoft/windows-rs/blob/0.59.0/crates/targets/x86_64_msvc/build.rs#L1-L8)) to introduce un-tracked dependencies into dependent `Rustc` actions. This then leads to build failures if the `windows_x86_64_msvc` crate is ever a remote cache hit for the dependents as runfiles (or `.cargo_runfiles` in the case of this PR) are not fetched and will not exist on the host at link time.

This change addresses this issue of untracked dependencies by ensuring the runfiles of `cargo_build_script.script` targets are aggregated into `Rustc` actions.