### PR TITLE
Fix keyword handling in prost wrapper

### DIFF
--- a/proto/prost/private/tests/keywords/BUILD.bazel
+++ b/proto/prost/private/tests/keywords/BUILD.bazel
@@ -5,9 +5,21 @@ load("//rust:defs.bzl", "rust_test")
 package(default_visibility = ["//proto/prost/private/tests:__subpackages__"])
 
 proto_library(
+    name = "imported_keyword_proto",
+    srcs = [
+        "imported_keyword.proto",
+    ],
+    strip_import_prefix = "/proto/prost/private/tests/keywords",
+)
+
+proto_library(
     name = "mod_named_mod_proto",
     srcs = [
         "mod_named_mod.proto",
+    ],
+    strip_import_prefix = "/proto/prost/private/tests/keywords",
+    deps = [
+        ":imported_keyword_proto",
     ],
 )
 
@@ -16,11 +28,17 @@ rust_prost_library(
     proto = ":mod_named_mod_proto",
 )
 
+rust_prost_library(
+    name = "imported_keyword_rs_proto",
+    proto = ":imported_keyword_proto",
+)
+
 rust_test(
     name = "mod_named_mod_test",
     srcs = ["mod_named_mod_test.rs"],
     edition = "2021",
     deps = [
+        ":imported_keyword_rs_proto",
         ":mod_named_mod_rs_proto",
     ],
 )

--- a/proto/prost/private/tests/keywords/imported_keyword.proto
+++ b/proto/prost/private/tests/keywords/imported_keyword.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package imported.type;
+
+message B {
+    string name = 1;
+}

--- a/proto/prost/private/tests/keywords/mod_named_mod.proto
+++ b/proto/prost/private/tests/keywords/mod_named_mod.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package mod;
 
+import "imported_keyword.proto";
+
 message A {
     string name = 1;
+    imported.type.B b = 2;
 }

--- a/proto/prost/private/tests/keywords/mod_named_mod_test.rs
+++ b/proto/prost/private/tests/keywords/mod_named_mod_test.rs
@@ -1,11 +1,15 @@
 //! Tests module names that are keywords.
 
+use imported_keyword_proto::imported::r#type::B;
 use mod_named_mod_proto::r#mod::A;
 
 #[test]
 fn test_nested_messages() {
     let a = A {
         name: "a".to_string(),
+        b: Some(B {
+            name: "b".to_string(),
+        }),
     };
 
     assert_eq!(a.name, "a");


### PR DESCRIPTION
## What?
Fixes Prost: Handling of reserved keywords in package names is broken #2884

## How?
Added escaping on Rust keywords in proto package names