### PR TITLE
Fix `override_targets` keys in docs

### DIFF
--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -169,8 +169,8 @@ def _annotation(
         rustc_flags (list, optional): A list of strings to set on a crate's `rust_library::rustc_flags` attribute.
         shallow_since (str, optional): An optional timestamp used for crates originating from a git repository
             instead of a crate registry. This flag optimizes fetching the source code.
-        override_targets (dict, optional): A dictionary of alternate tagets to use when something depends on this crate to allow
-            the parent repo to provide its own version of this dependency. Keys can be `proc_marco`, `build_script`, `lib`, `bin`.
+        override_targets (dict, optional): A dictionary of alternate targets to use when something depends on this crate to allow
+            the parent repo to provide its own version of this dependency. Keys can be `proc-marco`, `custom-build`, `lib`, `bin`.
 
     Returns:
         string: A json encoded string containing the specified version and separately all other inputs.

--- a/docs/src/crate_universe.md
+++ b/docs/src/crate_universe.md
@@ -519,7 +519,7 @@ A collection of extra attributes and settings for a particular crate
 | <a id="crate.annotation-rustc_env_files"></a>rustc_env_files |  A list of labels to set on a crate's `rust_library::rustc_env_files` attribute.   |  `None` |
 | <a id="crate.annotation-rustc_flags"></a>rustc_flags |  A list of strings to set on a crate's `rust_library::rustc_flags` attribute.   |  `None` |
 | <a id="crate.annotation-shallow_since"></a>shallow_since |  An optional timestamp used for crates originating from a git repository instead of a crate registry. This flag optimizes fetching the source code.   |  `None` |
-| <a id="crate.annotation-override_targets"></a>override_targets |  A dictionary of alternate tagets to use when something depends on this crate to allow the parent repo to provide its own version of this dependency. Keys can be `proc-macro`, `custom-build`, `lib`, `bin`.   |  `None` |
+| <a id="crate.annotation-override_targets"></a>override_targets |  A dictionary of alternate targets to use when something depends on this crate to allow the parent repo to provide its own version of this dependency. Keys can be `proc-marco`, `custom-build`, `lib`, `bin`.   |  `None` |
 
 **RETURNS**
 

--- a/docs/src/crate_universe.md
+++ b/docs/src/crate_universe.md
@@ -519,7 +519,7 @@ A collection of extra attributes and settings for a particular crate
 | <a id="crate.annotation-rustc_env_files"></a>rustc_env_files |  A list of labels to set on a crate's `rust_library::rustc_env_files` attribute.   |  `None` |
 | <a id="crate.annotation-rustc_flags"></a>rustc_flags |  A list of strings to set on a crate's `rust_library::rustc_flags` attribute.   |  `None` |
 | <a id="crate.annotation-shallow_since"></a>shallow_since |  An optional timestamp used for crates originating from a git repository instead of a crate registry. This flag optimizes fetching the source code.   |  `None` |
-| <a id="crate.annotation-override_targets"></a>override_targets |  A dictionary of alternate tagets to use when something depends on this crate to allow the parent repo to provide its own version of this dependency. Keys can be `proc_marco`, `build_script`, `lib`, `bin`.   |  `None` |
+| <a id="crate.annotation-override_targets"></a>override_targets |  A dictionary of alternate tagets to use when something depends on this crate to allow the parent repo to provide its own version of this dependency. Keys can be `proc-macro`, `custom-build`, `lib`, `bin`.   |  `None` |
 
 **RETURNS**
 


### PR DESCRIPTION
Updates the documentation to match the implementation: https://github.com/bazelbuild/rules_rust/blob/144d34fdaa3c3c5fe27a9666b760aa31aa9155a5/crate_universe/src/context/crate_context.rs#L65-L74