### PR TITLE
Prep release 0.52.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "rules_rust",
-    version = "0.51.0",
+    version = "0.52.0",
 )
 
 bazel_dep(

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.51.0"
+VERSION = "0.52.0"


### PR DESCRIPTION
This has Bazel 8 compatibility fixes we want to get released before the first RC is cut next week.