### PR TITLE
Avoid builds-without-the-bytes bug on Windows

### DIFF
--- a/cargo/private/BUILD.bazel
+++ b/cargo/private/BUILD.bazel
@@ -1,4 +1,12 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//rust:defs.bzl", "rust_binary")
+
+rust_binary(
+    name = "copy_file",
+    srcs = ["copy_file.rs"],
+    edition = "2021",
+    visibility = ["//visibility:public"],
+)
 
 bzl_library(
     name = "bzl_lib",

--- a/cargo/private/copy_file.rs
+++ b/cargo/private/copy_file.rs
@@ -1,0 +1,20 @@
+//! A tool for copying files and avoiding
+//! https://github.com/bazelbuild/bazel/issues/21747
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    let src = PathBuf::from(std::env::args().nth(1).expect("No source file provided"));
+    let dest = PathBuf::from(env::args().nth(2).expect("No destination provided"));
+
+    fs::copy(&src, &dest).unwrap_or_else(|e| {
+        panic!(
+            "Failed to copy file `{} -> {}`\n{:?}",
+            src.display(),
+            dest.display(),
+            e
+        )
+    });
+}


### PR DESCRIPTION
After https://github.com/bazelbuild/rules_rust/pull/2826 was merged, I started seeing flaky builds on Windows related to build script executables (https://github.com/bazelbuild/rules_rust/pull/2891#issuecomment-2363985009). This appears to be related to https://github.com/bazelbuild/bazel/issues/21747 so to avoid the issue, this change ensures that Windows build script executables are copied instead of symlinked.

