### PR TITLE
[Bugfix] protos with the same package name prefix fail to compile

### DIFF
--- a/proto/prost/private/tests/shared_package_prefix/BUILD.bazel
+++ b/proto/prost/private/tests/shared_package_prefix/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_rust//rust:defs.bzl", "rust_test")
+load("//proto/prost:defs.bzl", "rust_prost_library")
+
+proto_library(
+    name = "shared_pkg_prefix_proto",
+    srcs = [
+        "pkg.foo.a.proto",
+        "pkg.foo.b.proto",
+        "pkg.c.proto",
+    ],
+)
+
+rust_prost_library(
+    name = "shared_pkg_prefix_rs_proto",
+    proto = ":shared_pkg_prefix_proto",
+)
+
+rust_test(
+    name = "shared_pkg_prefix_test",
+    srcs = ["shared_pkg_prefix_test.rs"],
+    edition = "2021",
+    deps = [
+        ":shared_pkg_prefix_rs_proto",
+    ],
+)

--- a/proto/prost/private/tests/shared_package_prefix/pkg.c.proto
+++ b/proto/prost/private/tests/shared_package_prefix/pkg.c.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package pkg;
+
+message CMessage {
+    string name = 1;
+}

--- a/proto/prost/private/tests/shared_package_prefix/pkg.foo.a.proto
+++ b/proto/prost/private/tests/shared_package_prefix/pkg.foo.a.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package pkg.foo;
+
+import "proto/prost/private/tests/shared_package_prefix/pkg.c.proto";
+
+message AMessage {
+    string name = 1;
+    CMessage c = 2;
+}

--- a/proto/prost/private/tests/shared_package_prefix/pkg.foo.b.proto
+++ b/proto/prost/private/tests/shared_package_prefix/pkg.foo.b.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package pkg.foo;
+
+message BMessage {
+    string name = 1;
+}

--- a/proto/prost/private/tests/shared_package_prefix/shared_pkg_prefix_test.rs
+++ b/proto/prost/private/tests/shared_package_prefix/shared_pkg_prefix_test.rs
@@ -1,0 +1,22 @@
+use shared_pkg_prefix_proto::pkg::foo::AMessage;
+use shared_pkg_prefix_proto::pkg::foo::BMessage;
+use shared_pkg_prefix_proto::pkg::CMessage;
+
+#[test]
+fn test_packages() {
+    let pkg_b = BMessage {
+        name: "pkg_b".to_string(),
+    };
+    let pkg_c = CMessage {
+        name: "pkg_c".to_string(),
+    };
+    let pkg_a = AMessage {
+        name: "pkg_a".to_string(),
+        c: Some(pkg_c.clone()),
+    };
+
+    assert_eq!(pkg_a.name, "pkg_a");
+    assert_eq!(pkg_a.c.unwrap().name, "pkg_c");
+    assert_eq!(pkg_b.name, "pkg_b");
+    assert_eq!(pkg_c.name, "pkg_c");
+}


### PR DESCRIPTION
When proto files sharing the same package name prefixes reference types from each other, protoc_wrapper will generate code with incorrect module scope resulting in the following compilation error:

```
error[E0412]: cannot find type `CMessage` in module `super`
  --> bazel-out/darwin_arm64-fastbuild/bin/proto/prost/private/tests/shared_package_prefix/shared_pkg_prefix_proto.lib.rs:21:46
   |
21 |         pub c: ::core::option::Option<super::CMessage>,
   |                                              ^^^^^^^^ not found in `super`
   |
help: consider importing this struct
   |
15 +     use crate::pkg::CMessage;
   |
help: if you import `CMessage`, refer to it directly
   |
21 -         pub c: ::core::option::Option<super::CMessage>,
21 +         pub c: ::core::option::Option<CMessage>,
```

This Patch refactors the module tree walk implementation to ensure generated rust code are wrapped with the correct rust module hierarchy.