### PR TITLE
Fix fix_next_arg condition

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -185,7 +185,7 @@ def _pwd_flags(args):
             if opt and path and not paths.is_absolute(path):
                 res.append("{}${{pwd}}/{}".format(opt, path))
             else:
-                fix_next_arg = (opt != None)
+                fix_next_arg = (opt and path == None)
                 res.append(arg)
 
     return res


### PR DESCRIPTION
Follow up to #2922 and #2917.

Before #2922 the only possible "else" with "opt"
was space separated flags. Now we get there for
already `is_absolute` path.