### PR TITLE
Revert #2911 and #2922

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "rules_rust",
-    version = "0.52.1",
+    version = "0.52.2",
 )
 
 bazel_dep(

--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -153,7 +153,25 @@ def get_cc_compile_args_and_env(cc_toolchain, feature_configuration):
     )
     return cc_c_args, cc_cxx_args, cc_env
 
-def _pwd_flags(args):
+def _pwd_flags_sysroot(args):
+    """Prefix execroot-relative paths of known arguments with ${pwd}.
+
+    Args:
+        args (list): List of tool arguments.
+
+    Returns:
+        list: The modified argument list.
+    """
+    res = []
+    for arg in args:
+        s, opt, path = arg.partition("--sysroot=")
+        if s == "" and not paths.is_absolute(path):
+            res.append("{}${{pwd}}/{}".format(opt, path))
+        else:
+            res.append(arg)
+    return res
+
+def _pwd_flags_isystem(args):
     """Prefix execroot-relative paths of known arguments with ${pwd}.
 
     Args:
@@ -164,31 +182,18 @@ def _pwd_flags(args):
     """
     res = []
     fix_next_arg = False
-
-    flags = ["-fsanitize-ignorelist", "-isystem", "--sysroot"]
-
-    def split_flag(flag):
-        if flag in flags:
-            return (flag, None)
-        for flag in flags:
-            s, opt, path = arg.partition(flag + "=")
-            if s == "":
-                return (opt, path)
-        return (None, None)
-
     for arg in args:
         if fix_next_arg and not paths.is_absolute(arg):
             res.append("${{pwd}}/{}".format(arg))
-            fix_next_arg = False
         else:
-            opt, path = split_flag(arg)
-            if opt and path:
-                res.append("{}${{pwd}}/{}".format(opt, path))
-            else:
-                fix_next_arg = (opt != None)
-                res.append(arg)
+            res.append(arg)
+
+        fix_next_arg = arg == "-isystem"
 
     return res
+
+def _pwd_flags(args):
+    return _pwd_flags_isystem(_pwd_flags_sysroot(args))
 
 def _feature_enabled(ctx, feature_name, default = False):
     """Check if a feature is enabled.

--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -182,7 +182,7 @@ def _pwd_flags(args):
             fix_next_arg = False
         else:
             opt, path = split_flag(arg)
-            if opt and path and not paths.is_absolute(path):
+            if opt and path:
                 res.append("{}${{pwd}}/{}".format(opt, path))
             else:
                 fix_next_arg = (opt != None)

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.52.1"
+VERSION = "0.52.2"


### PR DESCRIPTION
Revert "Restore lost "is_absolute" (#2922)"

This reverts commit 2a85e13c74239d2a0d0c47a37f10a4c9739fa5e6.

Revert "Use absolute path with "-fsanitize-ignorelist" (#2911)"

This reverts commit 9594fa70b5b6f556a7b4f57ca0ac7c48149bf280.