### PR TITLE
Add proc_macro_deps for rust_doc_test

### DIFF
--- a/docs/src/flatten.md
+++ b/docs/src/flatten.md
@@ -512,7 +512,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 ## rust_doc_test
 
 <pre>
-rust_doc_test(<a href="#rust_doc_test-name">name</a>, <a href="#rust_doc_test-deps">deps</a>, <a href="#rust_doc_test-crate">crate</a>)
+rust_doc_test(<a href="#rust_doc_test-name">name</a>, <a href="#rust_doc_test-deps">deps</a>, <a href="#rust_doc_test-crate">crate</a>, <a href="#rust_doc_test-proc_macro_deps">proc_macro_deps</a>)
 </pre>
 
 Runs Rust documentation tests.
@@ -560,6 +560,7 @@ Running `bazel test //hello_lib:hello_lib_doc_test` will run all documentation t
 | <a id="rust_doc_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="rust_doc_test-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other `rust_library` targets or `cc_library` targets if linking a native library.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="rust_doc_test-crate"></a>crate |  The label of the target to generate code documentation for. `rust_doc_test` can generate HTML code documentation for the source files of `rust_library` or `rust_binary` targets.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="rust_doc_test-proc_macro_deps"></a>proc_macro_deps |  List of `rust_proc_macro` targets used to help build this library target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 
 
 <a id="rust_grpc_library"></a>

--- a/docs/src/rust_doc.md
+++ b/docs/src/rust_doc.md
@@ -69,7 +69,7 @@ Running `bazel build //hello_lib:hello_lib_doc` will build a zip file containing
 ## rust_doc_test
 
 <pre>
-rust_doc_test(<a href="#rust_doc_test-name">name</a>, <a href="#rust_doc_test-deps">deps</a>, <a href="#rust_doc_test-crate">crate</a>)
+rust_doc_test(<a href="#rust_doc_test-name">name</a>, <a href="#rust_doc_test-deps">deps</a>, <a href="#rust_doc_test-crate">crate</a>, <a href="#rust_doc_test-proc_macro_deps">proc_macro_deps</a>)
 </pre>
 
 Runs Rust documentation tests.
@@ -117,5 +117,6 @@ Running `bazel test //hello_lib:hello_lib_doc_test` will run all documentation t
 | <a id="rust_doc_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="rust_doc_test-deps"></a>deps |  List of other libraries to be linked to this library target.<br><br>These can be either other `rust_library` targets or `cc_library` targets if linking a native library.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="rust_doc_test-crate"></a>crate |  The label of the target to generate code documentation for. `rust_doc_test` can generate HTML code documentation for the source files of `rust_library` or `rust_binary` targets.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="rust_doc_test-proc_macro_deps"></a>proc_macro_deps |  List of `rust_proc_macro` targets used to help build this library target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 
 

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -110,6 +110,7 @@ def _rust_doc_test_impl(ctx):
 
     crate = ctx.attr.crate[rust_common.crate_info]
     deps = transform_deps(ctx.attr.deps)
+    proc_macro_deps = transform_deps(ctx.attr.proc_macro_deps)
 
     crate_info = rust_common.create_crate_info(
         name = crate.name,
@@ -117,7 +118,7 @@ def _rust_doc_test_impl(ctx):
         root = crate.root,
         srcs = crate.srcs,
         deps = depset(deps, transitive = [crate.deps]),
-        proc_macro_deps = crate.proc_macro_deps,
+        proc_macro_deps = depset(proc_macro_deps, transitive = [crate.proc_macro_deps]),
         aliases = crate.aliases,
         output = crate.output,
         edition = crate.edition,
@@ -206,6 +207,13 @@ rust_doc_test = rule(
                 linking a native library.
             """),
             providers = [[CrateInfo], [CcInfo]],
+        ),
+        "proc_macro_deps": attr.label_list(
+            doc = dedent("""\
+                List of `rust_proc_macro` targets used to help build this library target.
+            """),
+            cfg = "exec",
+            providers = [rust_common.crate_info],
         ),
         "_cc_toolchain": attr.label(
             doc = (

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -162,7 +162,7 @@ rustdoc_with_json_error_format_test = analysistest.make(_rustdoc_with_json_error
     str(Label("//:error_format")): "json",
 })
 
-def _target_maker(rule_fn, name, rustdoc_deps = [], **kwargs):
+def _target_maker(rule_fn, name, rustdoc_deps = [], rustdoc_proc_macro_deps = [], **kwargs):
     rule_fn(
         name = name,
         edition = "2018",
@@ -184,6 +184,7 @@ def _target_maker(rule_fn, name, rustdoc_deps = [], **kwargs):
         name = "{}_doctest".format(name),
         crate = ":{}".format(name),
         deps = rustdoc_deps,
+        proc_macro_deps = rustdoc_proc_macro_deps,
     )
 
 def _define_targets():
@@ -248,6 +249,13 @@ def _define_targets():
         name = "lib_with_proc_macro_in_docs",
         srcs = ["procmacro_in_rustdoc.rs"],
         proc_macro_deps = [":rustdoc_proc_macro"],
+    )
+
+    _target_maker(
+        rust_library,
+        name = "lib_with_proc_macro_only_in_docs",
+        srcs = ["procmacro_in_rustdoc.rs"],
+        rustdoc_proc_macro_deps = [":rustdoc_proc_macro"],
     )
 
     _target_maker(


### PR DESCRIPTION
This allows representing doctests that
depend on proc macros their crate do not depend on.
