### PR TITLE
cargo_build_script: Add support for `-fsanitize-ignorelist=`

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -192,8 +192,26 @@ def _pwd_flags_isystem(args):
 
     return res
 
+def _pwd_flags_fsanitize_ignorelist(args):
+    """Prefix execroot-relative paths of known arguments with ${pwd}.
+
+    Args:
+        args (list): List of tool arguments.
+
+    Returns:
+        list: The modified argument list.
+    """
+    res = []
+    for arg in args:
+        s, opt, path = arg.partition("-fsanitize-ignorelist=")
+        if s == "" and not paths.is_absolute(path):
+            res.append("{}${{pwd}}/{}".format(opt, path))
+        else:
+            res.append(arg)
+    return res
+
 def _pwd_flags(args):
-    return _pwd_flags_isystem(_pwd_flags_sysroot(args))
+    return _pwd_flags_fsanitize_ignorelist(_pwd_flags_isystem(_pwd_flags_sysroot(args)))
 
 def _feature_enabled(ctx, feature_name, default = False):
     """Check if a feature is enabled.

--- a/test/cargo_build_script/cc_args_and_env/BUILD.bazel
+++ b/test/cargo_build_script/cc_args_and_env/BUILD.bazel
@@ -1,11 +1,11 @@
 load(
     "cc_args_and_env_test.bzl",
+    "fsanitize_ignorelist_absolute_test",
+    "fsanitize_ignorelist_relative_test",
     "isystem_absolute_test",
     "isystem_relative_test",
     "sysroot_absolute_test",
     "sysroot_relative_test",
-    "fsanitize_ignorelist_absolute_test",
-    "fsanitize_ignorelist_relative_test",
 )
 
 sysroot_relative_test(name = "sysroot_relative_test")

--- a/test/cargo_build_script/cc_args_and_env/BUILD.bazel
+++ b/test/cargo_build_script/cc_args_and_env/BUILD.bazel
@@ -4,6 +4,8 @@ load(
     "isystem_relative_test",
     "sysroot_absolute_test",
     "sysroot_relative_test",
+    "fsanitize_ignorelist_absolute_test",
+    "fsanitize_ignorelist_relative_test",
 )
 
 sysroot_relative_test(name = "sysroot_relative_test")
@@ -13,3 +15,7 @@ sysroot_absolute_test(name = "sysroot_absolute_test")
 isystem_relative_test(name = "isystem_relative_test")
 
 isystem_absolute_test(name = "isystem_absolute_test")
+
+fsanitize_ignorelist_absolute_test(name = "fsanitize_ignorelist_absolute_test")
+
+fsanitize_ignorelist_relative_test(name = "fsanitize_ignorelist_relative_test")

--- a/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -194,3 +194,25 @@ def isystem_absolute_test(name):
         target_under_test = "%s/cargo_build_script" % name,
         expected_cflags = ["-isystem /test/absolute/path"],
     )
+
+def fsanitize_ignorelist_relative_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = ["-fsanitize-ignorelist=test/relative/path"],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = ["-fsanitize-ignorelist=${pwd}/test/relative/path"],
+    )
+
+def fsanitize_ignorelist_absolute_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = ["-fsanitize-ignorelist=/test/absolute/path"],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = ["-fsanitize-ignorelist=/test/absolute/path"],
+    )


### PR DESCRIPTION
This is trivial copy/paste implementation, to
minimize regression probability.

Previously it was combined with refactoring, but
introduced regression and was reverted #2911.

This time I split refactoring into follow up PR.
