### PR TITLE
cargo_build_script: Add regression test for revert #2925

### DIFF
--- a/test/cargo_build_script/cc_args_and_env/BUILD.bazel
+++ b/test/cargo_build_script/cc_args_and_env/BUILD.bazel
@@ -5,12 +5,15 @@ load(
     "isystem_absolute_test",
     "isystem_relative_test",
     "sysroot_absolute_test",
+    "sysroot_absolute2_test",
     "sysroot_relative_test",
 )
 
 sysroot_relative_test(name = "sysroot_relative_test")
 
 sysroot_absolute_test(name = "sysroot_absolute_test")
+
+sysroot_absolute2_test(name = "sysroot_absolute2_test")
 
 isystem_relative_test(name = "isystem_relative_test")
 

--- a/test/cargo_build_script/cc_args_and_env/BUILD.bazel
+++ b/test/cargo_build_script/cc_args_and_env/BUILD.bazel
@@ -5,7 +5,7 @@ load(
     "isystem_absolute_test",
     "isystem_relative_test",
     "sysroot_absolute_test",
-    "sysroot_absolute2_test",
+    "sysroot_next_absolute_test",
     "sysroot_relative_test",
 )
 
@@ -13,7 +13,7 @@ sysroot_relative_test(name = "sysroot_relative_test")
 
 sysroot_absolute_test(name = "sysroot_absolute_test")
 
-sysroot_absolute2_test(name = "sysroot_absolute2_test")
+sysroot_next_absolute_test(name = "sysroot_next_absolute_test")
 
 isystem_relative_test(name = "isystem_relative_test")
 

--- a/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -173,7 +173,7 @@ def sysroot_absolute_test(name):
         expected_cflags = ["--sysroot=/test/absolute/sysroot"],
     )
 
-def sysroot_absolute2_test(name):
+def sysroot_next_absolute_test(name):
     cargo_build_script_with_extra_cc_compile_flags(
         name = "%s/cargo_build_script" % name,
         extra_cc_compile_flags = ["--sysroot=/test/absolute/sysroot", "test/relative/another"],

--- a/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -173,6 +173,17 @@ def sysroot_absolute_test(name):
         expected_cflags = ["--sysroot=/test/absolute/sysroot"],
     )
 
+def sysroot_absolute2_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = ["--sysroot=/test/absolute/sysroot", "test/relative/another"],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = ["--sysroot=/test/absolute/sysroot", "test/relative/another"],
+    )
+
 def isystem_relative_test(name):
     cargo_build_script_with_extra_cc_compile_flags(
         name = "%s/cargo_build_script" % name,

--- a/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -83,7 +83,7 @@ def _cc_args_and_env_analysis_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
     cargo_action = tut[DepActionsInfo].actions[0]
-    cflags = cargo_action.env["CFLAGS"]
+    cflags = cargo_action.env["CFLAGS"].split(" ")
     for flag in ctx.attr.expected_cflags:
         asserts.true(
             env,
@@ -181,7 +181,7 @@ def isystem_relative_test(name):
     cc_args_and_env_analysis_test(
         name = name,
         target_under_test = "%s/cargo_build_script" % name,
-        expected_cflags = ["-isystem ${pwd}/test/relative/path"],
+        expected_cflags = ["-isystem", "${pwd}/test/relative/path"],
     )
 
 def isystem_absolute_test(name):
@@ -192,7 +192,7 @@ def isystem_absolute_test(name):
     cc_args_and_env_analysis_test(
         name = name,
         target_under_test = "%s/cargo_build_script" % name,
-        expected_cflags = ["-isystem /test/absolute/path"],
+        expected_cflags = ["-isystem", "/test/absolute/path"],
     )
 
 def fsanitize_ignorelist_relative_test(name):


### PR DESCRIPTION
#2931 added tests for _pwd_flags, however 
the test as-is passes with #2911 and #2922,
which still caused problems and reverted.
Here I introduce a test case for likely
unfixed in reverted #2925.

The test needs strictter check for cflags. As-ls
`flag in cflags` is a just substring search and
very weak test for abs path.

For #2917