### PR TITLE
Make crate module extension os and arch dependent

### DIFF
--- a/crate_universe/extension.bzl
+++ b/crate_universe/extension.bzl
@@ -582,6 +582,11 @@ _spec = tag_class(
     ),
 )
 
+_conditional_crate_args = {
+    "arch_dependent": True,
+    "os_dependent": True,
+} if bazel_features.external_deps.module_extension_has_os_arch_dependent else {}
+
 crate = module_extension(
     implementation = _crate_impl,
     tag_classes = dict(
@@ -590,4 +595,5 @@ crate = module_extension(
         from_specs = _from_specs,
         spec = _spec,
     ),
+    **_conditional_crate_args
 )


### PR DESCRIPTION
This PR is follow up to #2453 and marks the `crate` extension as `os_dependent` and `arch_dependent`.

For `crate.from_cargo`, the extension specifies reproducibility via the `reproducible` attribute of `extension_metadata` which makes Bazel skip the extension when writing the lockfile. 

But in the case of `crate.from_specs`, the current implementation marks the extension as non reproducible since the crates will not be backed by a lockfile.
And because the `crate` module extension depends on `rust_host_tools` (which are os / arch dependent), the entry in the lockfile for the module extension includes the checksum of the `rustc` and `cargo` binaries for whatever host it was resolved for.

This makes the bazel lock file platform dependent in that case.

This PR will result in a new os/arch specific entry in the lockfile for users of `crate.from_specs`.
And will have no impact for users of `crate.from_cargo`.

Thanks to @fmeum for the guidance.