### PR TITLE
gen_rust_project: optimize aquery with many targets

### DIFF
--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -69,11 +69,7 @@ pub fn get_crate_specs(
     rules_rust_name: &str,
 ) -> anyhow::Result<BTreeSet<CrateSpec>> {
     log::debug!("Get crate specs with targets: {:?}", targets);
-    let target_pattern = targets
-        .iter()
-        .map(|t| format!("deps({t})"))
-        .collect::<Vec<_>>()
-        .join("+");
+    let target_pattern = format!("deps({})", targets.join("+"));
 
     let aquery_output = Command::new(bazel)
         .current_dir(workspace)


### PR DESCRIPTION
Hi, if I'm not mistaken, in Bazel `deps(a)+deps(b)` is equivalent to `deps(a+b)`. The latter is more efficient because it doesn't have to deduplicate common dependencies between a and b. This performance issue has been triggered in our configuration, as we track roughly 700 targets and 1600 transitive dependencies in our monorepo. 
Running `aquery` with the original implementation takes 15 seconds on my machine while the implementation proposed in this PR takes 1.5 seconds.  