### PR TITLE
[Prost] Remove extra generated modules and opt-in to transitively including deps

### DIFF
--- a/docs/src/flatten.md
+++ b/docs/src/flatten.md
@@ -795,8 +795,9 @@ Builds a Rust proc-macro crate.
 ## rust_prost_toolchain
 
 <pre>
-rust_prost_toolchain(<a href="#rust_prost_toolchain-name">name</a>, <a href="#rust_prost_toolchain-prost_opts">prost_opts</a>, <a href="#rust_prost_toolchain-prost_plugin">prost_plugin</a>, <a href="#rust_prost_toolchain-prost_plugin_flag">prost_plugin_flag</a>, <a href="#rust_prost_toolchain-prost_runtime">prost_runtime</a>, <a href="#rust_prost_toolchain-prost_types">prost_types</a>,
-                     <a href="#rust_prost_toolchain-proto_compiler">proto_compiler</a>, <a href="#rust_prost_toolchain-tonic_opts">tonic_opts</a>, <a href="#rust_prost_toolchain-tonic_plugin">tonic_plugin</a>, <a href="#rust_prost_toolchain-tonic_plugin_flag">tonic_plugin_flag</a>, <a href="#rust_prost_toolchain-tonic_runtime">tonic_runtime</a>)
+rust_prost_toolchain(<a href="#rust_prost_toolchain-name">name</a>, <a href="#rust_prost_toolchain-include_transitive_deps">include_transitive_deps</a>, <a href="#rust_prost_toolchain-prost_opts">prost_opts</a>, <a href="#rust_prost_toolchain-prost_plugin">prost_plugin</a>, <a href="#rust_prost_toolchain-prost_plugin_flag">prost_plugin_flag</a>,
+                     <a href="#rust_prost_toolchain-prost_runtime">prost_runtime</a>, <a href="#rust_prost_toolchain-prost_types">prost_types</a>, <a href="#rust_prost_toolchain-proto_compiler">proto_compiler</a>, <a href="#rust_prost_toolchain-tonic_opts">tonic_opts</a>, <a href="#rust_prost_toolchain-tonic_plugin">tonic_plugin</a>,
+                     <a href="#rust_prost_toolchain-tonic_plugin_flag">tonic_plugin_flag</a>, <a href="#rust_prost_toolchain-tonic_runtime">tonic_runtime</a>)
 </pre>
 
 Rust Prost toolchain rule.
@@ -807,6 +808,7 @@ Rust Prost toolchain rule.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_prost_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="rust_prost_toolchain-include_transitive_deps"></a>include_transitive_deps |  Whether to include transitive dependencies. If set to True, all transitive dependencies will directly accessible by the dependent crate.   | Boolean | optional |  `False`  |
 | <a id="rust_prost_toolchain-prost_opts"></a>prost_opts |  Additional options to add to Prost.   | List of strings | optional |  `[]`  |
 | <a id="rust_prost_toolchain-prost_plugin"></a>prost_plugin |  Additional plugins to add to Prost.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="rust_prost_toolchain-prost_plugin_flag"></a>prost_plugin_flag |  Prost plugin flag format. (e.g. `--plugin=protoc-gen-prost=%s`)   | String | optional |  `"--plugin=protoc-gen-prost=%s"`  |

--- a/docs/src/rust_proto.md
+++ b/docs/src/rust_proto.md
@@ -302,8 +302,9 @@ rust_binary(
 ## rust_prost_toolchain
 
 <pre>
-rust_prost_toolchain(<a href="#rust_prost_toolchain-name">name</a>, <a href="#rust_prost_toolchain-prost_opts">prost_opts</a>, <a href="#rust_prost_toolchain-prost_plugin">prost_plugin</a>, <a href="#rust_prost_toolchain-prost_plugin_flag">prost_plugin_flag</a>, <a href="#rust_prost_toolchain-prost_runtime">prost_runtime</a>, <a href="#rust_prost_toolchain-prost_types">prost_types</a>,
-                     <a href="#rust_prost_toolchain-proto_compiler">proto_compiler</a>, <a href="#rust_prost_toolchain-tonic_opts">tonic_opts</a>, <a href="#rust_prost_toolchain-tonic_plugin">tonic_plugin</a>, <a href="#rust_prost_toolchain-tonic_plugin_flag">tonic_plugin_flag</a>, <a href="#rust_prost_toolchain-tonic_runtime">tonic_runtime</a>)
+rust_prost_toolchain(<a href="#rust_prost_toolchain-name">name</a>, <a href="#rust_prost_toolchain-include_transitive_deps">include_transitive_deps</a>, <a href="#rust_prost_toolchain-prost_opts">prost_opts</a>, <a href="#rust_prost_toolchain-prost_plugin">prost_plugin</a>, <a href="#rust_prost_toolchain-prost_plugin_flag">prost_plugin_flag</a>,
+                     <a href="#rust_prost_toolchain-prost_runtime">prost_runtime</a>, <a href="#rust_prost_toolchain-prost_types">prost_types</a>, <a href="#rust_prost_toolchain-proto_compiler">proto_compiler</a>, <a href="#rust_prost_toolchain-tonic_opts">tonic_opts</a>, <a href="#rust_prost_toolchain-tonic_plugin">tonic_plugin</a>,
+                     <a href="#rust_prost_toolchain-tonic_plugin_flag">tonic_plugin_flag</a>, <a href="#rust_prost_toolchain-tonic_runtime">tonic_runtime</a>)
 </pre>
 
 Rust Prost toolchain rule.
@@ -314,6 +315,7 @@ Rust Prost toolchain rule.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="rust_prost_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="rust_prost_toolchain-include_transitive_deps"></a>include_transitive_deps |  Whether to include transitive dependencies. If set to True, all transitive dependencies will directly accessible by the dependent crate.   | Boolean | optional |  `False`  |
 | <a id="rust_prost_toolchain-prost_opts"></a>prost_opts |  Additional options to add to Prost.   | List of strings | optional |  `[]`  |
 | <a id="rust_prost_toolchain-prost_plugin"></a>prost_plugin |  Additional plugins to add to Prost.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="rust_prost_toolchain-prost_plugin_flag"></a>prost_plugin_flag |  Prost plugin flag format. (e.g. `--plugin=protoc-gen-prost=%s`)   | String | optional |  `"--plugin=protoc-gen-prost=%s"`  |

--- a/proto/prost/private/BUILD.bazel
+++ b/proto/prost/private/BUILD.bazel
@@ -36,6 +36,9 @@ bzl_library(
 
 rust_library_group(
     name = "prost_runtime",
+    visibility = [
+        "//proto/prost:__subpackages__",
+    ],
     deps = [
         "//proto/prost/private/3rdparty/crates:prost",
     ],
@@ -43,6 +46,9 @@ rust_library_group(
 
 rust_library_group(
     name = "tonic_runtime",
+    visibility = [
+        "//proto/prost:__subpackages__",
+    ],
     deps = [
         ":prost_runtime",
         "//proto/prost/private/3rdparty/crates:tonic",

--- a/proto/prost/private/prost.bzl
+++ b/proto/prost/private/prost.bzl
@@ -53,6 +53,7 @@ def _compile_proto(ctx, crate_name, proto_info, deps, prost_toolchain, rustfmt_t
     proto_compiler = prost_toolchain.proto_compiler
     tools = depset([proto_compiler.executable])
 
+    direct_crate_names = [dep[ProstProtoInfo].dep_variant_info.crate_info.name for dep in deps]
     additional_args = ctx.actions.args()
 
     # Prost process wrapper specific args
@@ -61,6 +62,7 @@ def _compile_proto(ctx, crate_name, proto_info, deps, prost_toolchain, rustfmt_t
     additional_args.add("--out_librs={}".format(lib_rs.path))
     additional_args.add("--package_info_output={}".format("{}={}".format(crate_name, package_info_file.path)))
     additional_args.add("--deps_info={}".format(deps_info_file.path))
+    additional_args.add("--direct_dep_crate_names={}".format(",".join(direct_crate_names)))
     additional_args.add("--prost_opt=compile_well_known_types")
     additional_args.add("--descriptor_set={}".format(proto_info.direct_descriptor_set.path))
     additional_args.add_all(prost_toolchain.prost_opts, format_each = "--prost_opt=%s")
@@ -199,7 +201,7 @@ def _rust_prost_aspect_impl(target, ctx):
     runtime_deps = []
 
     rustfmt_toolchain = ctx.toolchains["@rules_rust//rust/rustfmt:toolchain_type"]
-    prost_toolchain = ctx.toolchains["@rules_rust//proto/prost:toolchain_type"]
+    prost_toolchain = ctx.toolchains[TOOLCHAIN_TYPE]
     for prost_runtime in [prost_toolchain.prost_runtime, prost_toolchain.tonic_runtime]:
         if not prost_runtime:
             continue
@@ -316,12 +318,18 @@ def _rust_prost_library_impl(ctx):
     rust_proto_info = proto_dep[ProstProtoInfo]
     dep_variant_info = rust_proto_info.dep_variant_info
 
+    prost_toolchain = ctx.toolchains[TOOLCHAIN_TYPE]
+
+    transitive = []
+    if prost_toolchain.include_transitive_deps:
+        transitive = [rust_proto_info.transitive_dep_infos]
+
     return [
         DefaultInfo(files = depset([dep_variant_info.crate_info.output])),
         rust_common.crate_group_info(
             dep_variant_infos = depset(
                 [dep_variant_info],
-                transitive = [rust_proto_info.transitive_dep_infos],
+                transitive = transitive,
             ),
         ),
         RustAnalyzerGroupInfo(deps = [proto_dep[RustAnalyzerInfo]]),
@@ -343,6 +351,9 @@ rust_prost_library = rule(
             cfg = "exec",
         ),
     },
+    toolchains = [
+        TOOLCHAIN_TYPE,
+    ],
 )
 
 def _rust_prost_toolchain_impl(ctx):
@@ -375,6 +386,7 @@ def _rust_prost_toolchain_impl(ctx):
         tonic_plugin = ctx.attr.tonic_plugin,
         tonic_plugin_flag = ctx.attr.tonic_plugin_flag,
         tonic_runtime = ctx.attr.tonic_runtime,
+        include_transitive_deps = ctx.attr.include_transitive_deps,
     )]
 
 rust_prost_toolchain = rule(
@@ -382,6 +394,10 @@ rust_prost_toolchain = rule(
     doc = "Rust Prost toolchain rule.",
     fragments = ["proto"],
     attrs = dict({
+        "include_transitive_deps": attr.bool(
+            doc = "Whether to include transitive dependencies. If set to True, all transitive dependencies will directly accessible by the dependent crate.",
+            default = False,
+        ),
         "prost_opts": attr.string_list(
             doc = "Additional options to add to Prost.",
         ),

--- a/proto/prost/private/protoc_wrapper.rs
+++ b/proto/prost/private/protoc_wrapper.rs
@@ -82,11 +82,13 @@ impl Module {
         let current_name = module_parts[0].to_string();
 
         // Insert empty module if it doesn't exist.
-        self.submodules.entry(current_name.clone()).or_insert_with(|| Module {
-            name: current_name.clone(),
-            contents: "".to_string(),
-            submodules: BTreeMap::new(),
-        });
+        self.submodules
+            .entry(current_name.clone())
+            .or_insert_with(|| Module {
+                name: current_name.clone(),
+                contents: "".to_string(),
+                submodules: BTreeMap::new(),
+            });
 
         let current_module = self.submodules.get_mut(&current_name).unwrap();
 

--- a/proto/prost/private/tests/package_imports/package_importer_test.rs
+++ b/proto/prost/private/tests/package_imports/package_importer_test.rs
@@ -1,7 +1,7 @@
 //! Tests package importing with the same package name.
 
-use package_import_proto::package::import::A;
 use package_importer_proto::package::import::B;
+use package_importer_proto::package_import_proto::package::import::A;
 
 #[test]
 fn test_package_importer() {

--- a/proto/prost/private/tests/sanitized_modules/sanitized_modules_test.rs
+++ b/proto/prost/private/tests/sanitized_modules/sanitized_modules_test.rs
@@ -3,8 +3,8 @@
 
 use bar_proto::b_ar::b_az::qaz::qu_x::bar::Baz as BazMessage;
 use bar_proto::b_ar::b_az::qaz::qu_x::Bar as BarMessage;
-use foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::foo::NestedFoo as NestedFooMessage;
-use foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::Foo as FooMessage;
+use bar_proto::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::foo::NestedFoo as NestedFooMessage;
+use bar_proto::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::Foo as FooMessage;
 
 #[test]
 fn test_packages() {

--- a/proto/prost/private/tests/transitive_dependencies/BUILD.bazel
+++ b/proto/prost/private/tests/transitive_dependencies/BUILD.bazel
@@ -30,6 +30,8 @@ rust_test(
     edition = "2021",
     deps = [
         ":a_rs_proto",
+        # Add b_proto as a dependency directly to ensure compatibility with `a.proto`'s imports.
+        "//proto/prost/private/tests/transitive_dependencies/b:b_rs_proto",
     ],
 )
 

--- a/proto/prost/private/tests/transitive_dependencies/BUILD.bazel
+++ b/proto/prost/private/tests/transitive_dependencies/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//proto/prost:defs.bzl", "rust_prost_library")
+load("//proto/prost:defs.bzl", "rust_prost_library", "rust_prost_toolchain")
 load("//rust:defs.bzl", "rust_test")
+load(":transition.bzl", "extra_toolchain_wrapper")
 
 package(default_visibility = ["//proto/prost/private/tests:__subpackages__"])
 
@@ -30,4 +31,39 @@ rust_test(
     deps = [
         ":a_rs_proto",
     ],
+)
+
+# Test with transitively included dependencies.
+extra_toolchain_wrapper(
+    name = "a_rs_proto_with_transitive_deps",
+    dep = ":a_rs_proto",
+    toolchain = ":prost_toolchain_transitive_includes_enabled",
+)
+
+rust_test(
+    name = "transitive_deps_test",
+    srcs = ["transitive_deps_test.rs"],
+    edition = "2021",
+    deps = [
+        ":a_rs_proto_with_transitive_deps",
+    ],
+)
+
+toolchain(
+    name = "prost_toolchain_transitive_includes_enabled",
+    toolchain = ":prost_toolchain_transitive_includes_enabled_impl",
+    toolchain_type = "//proto/prost:toolchain_type",
+)
+
+rust_prost_toolchain(
+    name = "prost_toolchain_transitive_includes_enabled_impl",
+    # This is the important delta from the default toolchain.
+    include_transitive_deps = True,
+    prost_plugin = "//proto/prost/private/3rdparty/crates:protoc-gen-prost__protoc-gen-prost",
+    prost_plugin_flag = "--plugin=protoc-gen-prost=%s",
+    prost_runtime = "//proto/prost/private:prost_runtime",
+    prost_types = "//proto/prost/private/3rdparty/crates:prost-types",
+    tonic_plugin = "//proto/prost/private/3rdparty/crates:protoc-gen-tonic__protoc-gen-tonic",
+    tonic_plugin_flag = "--plugin=protoc-gen-tonic=%s",
+    tonic_runtime = "//proto/prost/private:tonic_runtime",
 )

--- a/proto/prost/private/tests/transitive_dependencies/a_test.rs
+++ b/proto/prost/private/tests/transitive_dependencies/a_test.rs
@@ -1,14 +1,13 @@
 //! Tests transitive dependencies.
 
 use a_proto::a::A;
-use a_proto::b_proto::a::b::B;
 use a_proto::b_proto::c_proto::a::b::c::C;
 use a_proto::duration_proto::google::protobuf::Duration;
 use a_proto::timestamp_proto::google::protobuf::Timestamp;
 use a_proto::types_proto::Types;
 
 #[test]
-fn test_b() {
+fn test_a() {
     let duration = Duration {
         seconds: 1,
         nanos: 2,
@@ -16,7 +15,8 @@ fn test_b() {
 
     let a = A {
         name: "a".to_string(),
-        b: Some(B {
+        // Ensure the external `b_proto` dependency is compatible with `a_proto`'s `B`.
+        b: Some(b_proto::a::b::B {
             name: "b".to_string(),
             c: Some(C {
                 name: "c".to_string(),

--- a/proto/prost/private/tests/transitive_dependencies/a_test.rs
+++ b/proto/prost/private/tests/transitive_dependencies/a_test.rs
@@ -1,11 +1,11 @@
 //! Tests transitive dependencies.
 
 use a_proto::a::A;
-use b_proto::a::b::B;
-use c_proto::a::b::c::C;
-use duration_proto::google::protobuf::Duration;
-use timestamp_proto::google::protobuf::Timestamp;
-use types_proto::Types;
+use a_proto::b_proto::a::b::B;
+use a_proto::b_proto::c_proto::a::b::c::C;
+use a_proto::duration_proto::google::protobuf::Duration;
+use a_proto::timestamp_proto::google::protobuf::Timestamp;
+use a_proto::types_proto::Types;
 
 #[test]
 fn test_b() {

--- a/proto/prost/private/tests/transitive_dependencies/b/b_test.rs
+++ b/proto/prost/private/tests/transitive_dependencies/b/b_test.rs
@@ -1,7 +1,7 @@
 //! Tests transitive dependencies.
 
 use b_proto::a::b::B;
-use c_proto::a::b::c::C;
+use b_proto::c_proto::a::b::c::C;
 
 #[test]
 fn test_b() {

--- a/proto/prost/private/tests/transitive_dependencies/b/c/c_test.rs
+++ b/proto/prost/private/tests/transitive_dependencies/b/c/c_test.rs
@@ -1,8 +1,8 @@
 //! Tests transitive dependencies.
 
-use any_proto::google::protobuf::Any;
 use c_proto::a::b::c::C;
-use duration_proto::google::protobuf::Duration;
+use c_proto::any_proto::google::protobuf::Any;
+use c_proto::duration_proto::google::protobuf::Duration;
 
 #[test]
 fn test_c() {

--- a/proto/prost/private/tests/transitive_dependencies/transition.bzl
+++ b/proto/prost/private/tests/transitive_dependencies/transition.bzl
@@ -2,16 +2,16 @@
 
 load("//rust:defs.bzl", "rust_common")
 
-def _extra_toolchain_transition_impl(_settings, attr):
+def _extra_toolchain_transition_impl(settings, attr):
     return {
         "//command_line_option:extra_toolchains": [
             attr.toolchain,
-        ],
+        ] + settings["//command_line_option:extra_toolchains"],
     }
 
 _extra_toolchain_transition = transition(
     implementation = _extra_toolchain_transition_impl,
-    inputs = [],
+    inputs = ["//command_line_option:extra_toolchains"],
     outputs = ["//command_line_option:extra_toolchains"],
 )
 
@@ -23,6 +23,7 @@ def _extra_toolchain_wrapper_impl(ctx):
 
 extra_toolchain_wrapper = rule(
     implementation = _extra_toolchain_wrapper_impl,
+    doc = "Transition rule used for unit testing the prost toolchains.",
     attrs = {
         "dep": attr.label(),
         "toolchain": attr.label(),

--- a/proto/prost/private/tests/transitive_dependencies/transition.bzl
+++ b/proto/prost/private/tests/transitive_dependencies/transition.bzl
@@ -1,0 +1,32 @@
+load("//rust:defs.bzl", "rust_common")
+
+def _extra_toolchain_transition_impl(_settings, attr):
+    return {
+        "//command_line_option:extra_toolchains": [
+            attr.toolchain,
+        ],
+    }
+
+_extra_toolchain_transition = transition(
+    implementation = _extra_toolchain_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:extra_toolchains"],
+)
+
+def _extra_toolchain_wrapper_impl(ctx):
+    return [
+        ctx.attr.dep[DefaultInfo],
+        ctx.attr.dep[rust_common.crate_group_info],
+    ]
+
+extra_toolchain_wrapper = rule(
+    implementation = _extra_toolchain_wrapper_impl,
+    attrs = {
+        "dep": attr.label(),
+        "toolchain": attr.label(),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    cfg = _extra_toolchain_transition,
+)

--- a/proto/prost/private/tests/transitive_dependencies/transition.bzl
+++ b/proto/prost/private/tests/transitive_dependencies/transition.bzl
@@ -1,3 +1,5 @@
+"""Transition rule for the transitive dependencies test case."""
+
 load("//rust:defs.bzl", "rust_common")
 
 def _extra_toolchain_transition_impl(_settings, attr):

--- a/proto/prost/private/tests/transitive_dependencies/transitive_deps_test.rs
+++ b/proto/prost/private/tests/transitive_dependencies/transitive_deps_test.rs
@@ -1,0 +1,29 @@
+//! Tests transitive dependencies reexport compatibility
+//!
+//! a_proto reexports b_proto, which reexports c_proto.
+//! a_proto::b_proto's B should be the exact same as b_proto's B.
+
+#[test]
+fn test_reexports() {
+    assert_eq!(
+        a_proto::b_proto::a::b::B::default(),
+        b_proto::a::b::B::default()
+    );
+
+    let c_from_reexport = a_proto::b_proto::c_proto::a::b::c::C {
+        name: "c".to_string(),
+        any: Default::default(),
+        duration: Some(duration_proto::google::protobuf::Duration {
+            seconds: 1,
+            nanos: 0,
+        }),
+    };
+
+    // Ensure they're compatible. This would fail to compile if `C` was not using the same transitive dependency.
+    let b = b_proto::a::b::B {
+        name: "b".to_string(),
+        empty: Default::default(),
+        c: Some(c_from_reexport),
+    };
+    assert_eq!(b.name, "b");
+}

--- a/proto/prost/private/tests/well_known_types/well_known_types_test.rs
+++ b/proto/prost/private/tests/well_known_types/well_known_types_test.rs
@@ -1,20 +1,20 @@
 //! Tests the Google well-known types.
 
-use any_proto::google::protobuf::Any;
-use api_proto::google::protobuf::{Api, Method, Mixin};
-use compiler_plugin_proto::google::protobuf::compiler::Version;
-use descriptor_proto::google::protobuf::DescriptorProto;
-use duration_proto::google::protobuf::Duration;
-use empty_proto::google::protobuf::Empty;
-use field_mask_proto::google::protobuf::FieldMask;
-use source_context_proto::google::protobuf::SourceContext;
-use struct_proto::google::protobuf::Struct;
-use struct_proto::google::protobuf::Value;
-use timestamp_proto::google::protobuf::Timestamp;
-use type_proto::google::protobuf::field::{Cardinality, Kind};
-use type_proto::google::protobuf::{Field, Option, Syntax, Type};
+use well_known_types_proto::any_proto::google::protobuf::Any;
+use well_known_types_proto::api_proto::google::protobuf::{Api, Method, Mixin};
+use well_known_types_proto::compiler_plugin_proto::google::protobuf::compiler::Version;
+use well_known_types_proto::descriptor_proto::google::protobuf::DescriptorProto;
+use well_known_types_proto::duration_proto::google::protobuf::Duration;
+use well_known_types_proto::empty_proto::google::protobuf::Empty;
+use well_known_types_proto::field_mask_proto::google::protobuf::FieldMask;
+use well_known_types_proto::source_context_proto::google::protobuf::SourceContext;
+use well_known_types_proto::struct_proto::google::protobuf::Struct;
+use well_known_types_proto::struct_proto::google::protobuf::Value;
+use well_known_types_proto::timestamp_proto::google::protobuf::Timestamp;
+use well_known_types_proto::type_proto::google::protobuf::field::{Cardinality, Kind};
+use well_known_types_proto::type_proto::google::protobuf::{Field, Option, Syntax, Type};
 use well_known_types_proto::wkt::WellKnownTypes;
-use wrappers_proto::google::protobuf::{
+use well_known_types_proto::wrappers_proto::google::protobuf::{
     BoolValue, BytesValue, DoubleValue, FloatValue, Int32Value, Int64Value, StringValue,
     UInt32Value, UInt64Value,
 };


### PR DESCRIPTION
This PR makes two changes:
1. It removes the duplicately generated code in the prost `lib.rs`.
2. It allows opting into transitively including all of the proto deps.

## Duplicately generated code.

Previously there was a bug where we generated the same code at every proto package level. This created separate Rust types for each module which made it easy to accidentally import an incompatible type.

Before:
```rust
// @generated

pub mod b_ar {
    pub mod b_az {
        pub mod qaz {
            pub mod qu_x {
                // @generated
                // This file is @generated by prost-build.
                #[allow(clippy::derive_partial_eq_without_eq)]
                #[derive(Clone, PartialEq, ::prost::Message)]
                pub struct Bar {
                    #[prost(string, tag = "1")]
                    pub name: ::prost::alloc::string::String,
                    #[prost(message, optional, tag = "2")]
                    pub foo: ::core::option::Option<
                        ::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::Foo,
                    >,
                    #[prost(message, optional, tag = "3")]
                    pub nested_foo: ::core::option::Option<
                        ::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::foo::NestedFoo,
                    >,
                }
                /// Nested message and enum types in `Bar`.
                pub mod bar {
                    #[allow(clippy::derive_partial_eq_without_eq)]
                    #[derive(Clone, PartialEq, ::prost::Message)]
                    pub struct Baz {
                        #[prost(string, tag = "4")]
                        pub name: ::prost::alloc::string::String,
                    }
                }
                // @@protoc_insertion_point(module)
            }
        }
    }
}
pub mod b_az {
    pub mod qaz {
        pub mod qu_x {
            // @generated
            // This file is @generated by prost-build.
            #[allow(clippy::derive_partial_eq_without_eq)]
            #[derive(Clone, PartialEq, ::prost::Message)]
            pub struct Bar {
                #[prost(string, tag = "1")]
                pub name: ::prost::alloc::string::String,
                #[prost(message, optional, tag = "2")]
                pub foo:
                    ::core::option::Option<::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::Foo>,
                #[prost(message, optional, tag = "3")]
                pub nested_foo: ::core::option::Option<
                    ::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::foo::NestedFoo,
                >,
            }
            /// Nested message and enum types in `Bar`.
            pub mod bar {
                #[allow(clippy::derive_partial_eq_without_eq)]
                #[derive(Clone, PartialEq, ::prost::Message)]
                pub struct Baz {
                    #[prost(string, tag = "4")]
                    pub name: ::prost::alloc::string::String,
                }
            }
            // @@protoc_insertion_point(module)
        }
    }
}
pub mod qaz {
    pub mod qu_x {
        // @generated
        // This file is @generated by prost-build.
        #[allow(clippy::derive_partial_eq_without_eq)]
        #[derive(Clone, PartialEq, ::prost::Message)]
        pub struct Bar {
            #[prost(string, tag = "1")]
            pub name: ::prost::alloc::string::String,
            #[prost(message, optional, tag = "2")]
            pub foo: ::core::option::Option<::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::Foo>,
            #[prost(message, optional, tag = "3")]
            pub nested_foo: ::core::option::Option<
                ::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::foo::NestedFoo,
            >,
        }
        /// Nested message and enum types in `Bar`.
        pub mod bar {
            #[allow(clippy::derive_partial_eq_without_eq)]
            #[derive(Clone, PartialEq, ::prost::Message)]
            pub struct Baz {
                #[prost(string, tag = "4")]
                pub name: ::prost::alloc::string::String,
            }
        }
        // @@protoc_insertion_point(module)
    }
}
pub mod qu_x {
    // @generated
    // This file is @generated by prost-build.
    #[allow(clippy::derive_partial_eq_without_eq)]
    #[derive(Clone, PartialEq, ::prost::Message)]
    pub struct Bar {
        #[prost(string, tag = "1")]
        pub name: ::prost::alloc::string::String,
        #[prost(message, optional, tag = "2")]
        pub foo: ::core::option::Option<::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::Foo>,
        #[prost(message, optional, tag = "3")]
        pub nested_foo: ::core::option::Option<
            ::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::foo::NestedFoo,
        >,
    }
    /// Nested message and enum types in `Bar`.
    pub mod bar {
        #[allow(clippy::derive_partial_eq_without_eq)]
        #[derive(Clone, PartialEq, ::prost::Message)]
        pub struct Baz {
            #[prost(string, tag = "4")]
            pub name: ::prost::alloc::string::String,
        }
    }
    // @@protoc_insertion_point(module)
}

```

Now:
```rust
// @generated

pub use foo_proto;

pub mod b_ar {
    pub mod b_az {
        pub mod qaz {
            pub mod qu_x {
                // @generated
                // This file is @generated by prost-build.
                #[allow(clippy::derive_partial_eq_without_eq)]
                #[derive(Clone, PartialEq, ::prost::Message)]
                pub struct Bar {
                    #[prost(string, tag = "1")]
                    pub name: ::prost::alloc::string::String,
                    #[prost(message, optional, tag = "2")]
                    pub foo: ::core::option::Option<
                        ::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::Foo,
                    >,
                    #[prost(message, optional, tag = "3")]
                    pub nested_foo: ::core::option::Option<
                        ::foo_proto::foo::quu_x::co_rg_e::grault::ga_rply::foo::NestedFoo,
                    >,
                }
                /// Nested message and enum types in `Bar`.
                pub mod bar {
                    #[allow(clippy::derive_partial_eq_without_eq)]
                    #[derive(Clone, PartialEq, ::prost::Message)]
                    pub struct Baz {
                        #[prost(string, tag = "4")]
                        pub name: ::prost::alloc::string::String,
                    }
                }
                // @@protoc_insertion_point(module)
            }
        }
    }
}
```

## Including transitive depenencies.

Because the proto rules rely on aspects, we are compiling targets which may not be directly accessible as a label in Bazel. Out of convenience, the original implementation automatically included all transitive dependencies to the `rust_library` or `rust_binary` that depended on the proto crate. 

As an example, let's say we have the following hierarchy:
```
my_crate -> a.proto
a.proto -> b.proto
b.proto -> c.proto
```
The previous setup made it possible for `my_crate` to directly import `a_proto`, `b_proto`, and `c_proto`.

This is problematic though because it leads to significant crate dependency bloat. `my_crate` may only use `a_proto` directly but it now also depends on the unused crates `b_proto` and `c_proto`.


This PR makes every generated crate re-export its direct dependencies. So, for the same example we now can import via those reexports:
```rust
//! my_crate
use a_proto::A;
use a_proto::b_proto::B;
use a_proto::b_proto::c_proto::C;
```

This means that you can also add the rustc flag `-Dunused_crate_dependencies` to ensure you're not depending on crates which are unused. In our monorepo we've had to disable this flag for crates depending on protos.

If you need to depend on an intermediate crate directly, you can just add a `rust_prost_library` definition and since it's all generated with aspects, it will be the identical underlying crate.

Finally, if you really want the extra crates included, you can set the flag `include_transitive_deps` on the prost toolchain and that will bring back the previous behavior.
