### PR TITLE
Mark rust module extension as reproducible

### DIFF
--- a/rust/extensions.bzl
+++ b/rust/extensions.bzl
@@ -71,6 +71,11 @@ def _rust_impl(module_ctx):
                 register_toolchains = False,
             )
 
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return mctx.extension_metadata(reproducible = True)
+
+    return mctx.extension_metadata()
+
 _COMMON_TAG_KWARGS = dict(
     allocator_library = attr.string(
         doc = "Target that provides allocator functions when rust_library targets are embedded in a cc_binary.",


### PR DESCRIPTION
All toolchains are already backed by integrity so marking the extension as reproducible to save a entry in the lockfile.