### PR TITLE
Add opt-out from merging cc_lib object files in bindgen

### DIFF
--- a/bindgen/private/bindgen.bzl
+++ b/bindgen/private/bindgen.bzl
@@ -78,6 +78,9 @@ def rust_bindgen_library(
     ):
         if shared in kwargs:
             bindgen_kwargs.update({shared: kwargs[shared]})
+    if "merge_cc_lib_objects_into_rlib" in kwargs:
+        bindgen_kwargs.update({"merge_cc_lib_objects_into_rlib": kwargs["merge_cc_lib_objects_into_rlib"]})
+        kwargs.pop("merge_cc_lib_objects_into_rlib")
 
     rust_bindgen(
         name = name + "__bindgen",
@@ -334,22 +337,28 @@ def _rust_bindgen_impl(ctx):
         toolchain = None,
     )
 
-    return [
-        _generate_cc_link_build_info(ctx, cc_lib),
-        # As in https://github.com/bazelbuild/rules_rust/pull/2361, we want
-        # to link cc_lib to the direct parent (rlib) using `-lstatic=<cc_lib>`
-        # rustc flag. Hence, we do not need to provide the whole CcInfo of
-        # cc_lib because it will cause the downstream binary to link the cc_lib
-        # again. The CcInfo here only contains the custom link flags (i.e.
-        # linkopts attribute) specified by users in cc_lib.
-        CcInfo(
-            linking_context = cc_common.create_linking_context(
-                linker_inputs = depset([cc_common.create_linker_input(
-                    owner = ctx.label,
-                    user_link_flags = _get_user_link_flags(cc_lib),
-                )]),
+    if ctx.attr.merge_cc_lib_objects_into_rlib:
+        providers = [
+            _generate_cc_link_build_info(ctx, cc_lib),
+            # As in https://github.com/bazelbuild/rules_rust/pull/2361, we want
+            # to link cc_lib to the direct parent (rlib) using `-lstatic=<cc_lib>`
+            # rustc flag. Hence, we do not need to provide the whole CcInfo of
+            # cc_lib because it will cause the downstream binary to link the cc_lib
+            # again. The CcInfo here only contains the custom link flags (i.e.
+            # linkopts attribute) specified by users in cc_lib.
+            CcInfo(
+                linking_context = cc_common.create_linking_context(
+                    linker_inputs = depset([cc_common.create_linker_input(
+                        owner = ctx.label,
+                        user_link_flags = _get_user_link_flags(cc_lib),
+                    )]),
+                ),
             ),
-        ),
+        ]
+    else:
+        providers = [cc_lib[CcInfo]]
+
+    return providers + [
         OutputGroupInfo(
             bindgen_bindings = depset([output]),
             bindgen_c_thunks = depset(([c_output] if wrap_static_fns else [])),
@@ -379,6 +388,11 @@ rust_bindgen = rule(
         "wrap_static_fns": attr.bool(
             doc = "Whether to create a separate .c file for static fns. Requires nightly toolchain, and a header that actually needs this feature (otherwise bindgen won't generate the file and Bazel complains).",
             default = False,
+        ),
+        "merge_cc_lib_objects_into_rlib": attr.bool(
+            doc = ("When True, objects from `cc_lib` will be copied into the `rlib` archive produced by " +
+                   "the rust_library that depends on this `rust_bindgen` rule (using `BuildInfo` provider)"),
+            default = True,
         ),
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),

--- a/test/bindgen/bindgen_test.bzl
+++ b/test/bindgen/bindgen_test.bzl
@@ -2,7 +2,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rust//bindgen:defs.bzl", "rust_bindgen_library")
-load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 
 def _test_cc_linkopt_impl(env, target):
@@ -44,10 +44,58 @@ def _test_cc_linkopt(name):
         impl = _test_cc_linkopt_impl,
     )
 
+def _test_cc_lib_object_merging_impl(env, target):
+    env.expect.that_collection(target.actions).has_size(3)
+    env.expect.that_action(target.actions[0]).mnemonic().contains("RustBindgen")
+    env.expect.that_action(target.actions[1]).mnemonic().contains("FileWrite")
+    env.expect.that_action(target.actions[1]).content().contains("-lstatic=test_cc_lib_object_merging_cc")
+    env.expect.that_action(target.actions[2]).mnemonic().contains("FileWrite")
+    env.expect.that_action(target.actions[2]).content().contains("-Lnative=")
+
+def _test_cc_lib_object_merging_disabled_impl(env, target):
+    # no FileWrite actions writing arg files registered
+    env.expect.that_collection(target.actions).has_size(1)
+    env.expect.that_action(target.actions[0]).mnemonic().contains("RustBindgen")
+
+def _test_cc_lib_object_merging(name):
+    cc_library(name = name + "_cc", hdrs = ["simple.h"], srcs = ["simple.cc"])
+
+    rust_bindgen_library(
+        name = name + "_rust_bindgen",
+        cc_lib = name + "_cc",
+        header = "simple.h",
+        tags = ["manual"],
+    )
+
+    analysis_test(
+        name = name,
+        target = name + "_rust_bindgen__bindgen",
+        impl = _test_cc_lib_object_merging_impl,
+    )
+
+def _test_cc_lib_object_merging_disabled(name):
+    cc_library(name = name + "_cc", hdrs = ["simple.h"], srcs = ["simple.cc"])
+
+    rust_bindgen_library(
+        name = name + "_rust_bindgen",
+        cc_lib = name + "_cc",
+        header = "simple.h",
+        tags = ["manual"],
+        merge_cc_lib_objects_into_rlib = False,
+    )
+
+    analysis_test(
+        name = name,
+        target = name + "_rust_bindgen__bindgen",
+        impl = _test_cc_lib_object_merging_disabled_impl,
+    )
+
 def bindgen_test_suite(name):
     test_suite(
         name = name,
         tests = [
             _test_cc_linkopt,
+            _test_cc_lib_object_merging,
+            _test_cc_lib_object_merging_disabled,
         ],
     )


### PR DESCRIPTION
This is a ~rollback of
https://github.com/bazelbuild/rules_rust/pull/2590, as it turns out the current behavior is incomatible with
https://bazel.build/docs/user-manual#dynamic-mode (which is very hard to use in the OSS because of
https://github.com/bazelbuild/bazel/issues/4135).

In short, the dynamic mode works as follows:

* Each cc_library produces object files that are used to produce
    * a static library (often not materialized but objects get passed as `--start-lib`/`--end-lib` to the linker),
    * a shared library (only containing the objects, not transitive dependencies),
    * and an interface library (produced from .so by "stripping function bodies").
* When linking binaries, by default we use the static linking.
* When linking tests, by default we use interface libraries for linking, and shared libraries for test execution.

The motivation for this is to avoid lengthy linking actions when all that has changed between previous build is the method body (therefore Bazel produces the same interface library, so we don't need to reexecute linking action).

We do not support dynamic mode in rules_rust yet.

The current bindgen behavior works by taking object from `cc_lib`, and merging them into the `rlib` output. When dynamic_mode is on, we now have a linking action that has the rlib early on the command line, and then interface libraries of dependencies of the `cc_lib`, and then the interface library of the `cc_lib`. For reasons, lld prefers statically defined symbols, it sees that the `rlib` defines the same symbols as `cc_lib` but statically, and errors out with `backward reference detected`, even though `cc_lib` is positioned correctly.

The fix for us is to not merge objects.