### PR TITLE
Add per-target link flags in the right place

### DIFF
--- a/bindgen/private/bindgen.bzl
+++ b/bindgen/private/bindgen.bzl
@@ -303,7 +303,7 @@ def _rust_bindgen_impl(ctx):
             open_arg = True
             continue
 
-    _, _, linker_env = get_linker_and_args(ctx, ctx.attr, "bin", cc_toolchain, feature_configuration, None)
+    _, _, linker_env = get_linker_and_args(ctx, "bin", cc_toolchain, feature_configuration, None)
     env.update(**linker_env)
 
     # Set the dynamic linker search path so that clang uses the libstdcxx from the toolchain.

--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -385,7 +385,7 @@ def _cargo_build_script_impl(ctx):
     # Pull in env vars which may be required for the cc_toolchain to work (e.g. on OSX, the SDK version).
     # We hope that the linker env is sufficient for the whole cc_toolchain.
     cc_toolchain, feature_configuration = find_cc_toolchain(ctx)
-    linker, link_args, linker_env = get_linker_and_args(ctx, ctx.attr, "bin", cc_toolchain, feature_configuration, None)
+    linker, link_args, linker_env = get_linker_and_args(ctx, "bin", cc_toolchain, feature_configuration, None)
     env.update(**linker_env)
     env["LD"] = linker
     env["LDFLAGS"] = " ".join(_pwd_flags(link_args))

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -18,5 +18,5 @@ use hello_lib::greeter;
 
 fn main() {
     let hello = greeter::Greeter::new("Hello");
-    hello.greet("world");
+    hello.greet("world!");
 }

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -398,12 +398,11 @@ def get_cc_user_link_flags(ctx):
     """
     return ctx.fragments.cpp.linkopts
 
-def get_linker_and_args(ctx, attr, crate_type, cc_toolchain, feature_configuration, rpaths, add_flags_for_binary = False):
+def get_linker_and_args(ctx, crate_type, cc_toolchain, feature_configuration, rpaths, add_flags_for_binary = False):
     """Gathers cc_common linker information
 
     Args:
         ctx (ctx): The current target's context object
-        attr (struct): Attributes to use in gathering linker args
         crate_type (str): The target crate's type (i.e. "bin", "proc-macro", etc.).
         cc_toolchain (CcToolchain): cc_toolchain for which we are creating build variables.
         feature_configuration (FeatureConfiguration): Feature configuration to be queried.
@@ -1006,7 +1005,7 @@ def construct_arguments(
             else:
                 rpaths = depset()
 
-            ld, link_args, link_env = get_linker_and_args(ctx, attr, crate_info.type, cc_toolchain, feature_configuration, rpaths, add_flags_for_binary = add_flags_for_binary)
+            ld, link_args, link_env = get_linker_and_args(ctx, crate_info.type, cc_toolchain, feature_configuration, rpaths, add_flags_for_binary = add_flags_for_binary)
 
             env.update(link_env)
             rustc_flags.add(ld, format = "--codegen=linker=%s")

--- a/test/linker_inputs_propagation/BUILD.bazel
+++ b/test/linker_inputs_propagation/BUILD.bazel
@@ -139,6 +139,7 @@ cc_test(
     srcs = ["baz.cc"],
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
     deps = [":sharedlib_uses_shared_foo"],

--- a/test/linker_inputs_propagation/BUILD.bazel
+++ b/test/linker_inputs_propagation/BUILD.bazel
@@ -118,6 +118,7 @@ cc_test(
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//:incompatible"],
         "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
     deps = [":staticlib_uses_foo"],

--- a/test/linker_inputs_propagation/BUILD.bazel
+++ b/test/linker_inputs_propagation/BUILD.bazel
@@ -21,9 +21,6 @@ cc_library(
         "foo_shared.cc",
     ],
     hdrs = ["foo_shared.h"],
-    target_compatible_with = [
-        "@platforms//os:linux",
-    ],
 )
 
 cc_library(
@@ -84,10 +81,6 @@ rust_static_library(
     name = "staticlib_uses_foo",
     srcs = ["bar_uses_foo.rs"],
     edition = "2018",
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
     deps = [":foo"],
 )
 
@@ -102,10 +95,6 @@ rust_shared_library(
     name = "sharedlib_uses_foo",
     srcs = ["bar_uses_foo.rs"],
     edition = "2018",
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
     deps = [":foo"],
 )
 
@@ -113,10 +102,6 @@ rust_static_library(
     name = "staticlib_uses_shared_foo",
     srcs = ["bar_uses_shared_foo.rs"],
     edition = "2018",
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
     deps = [":import_foo_shared"],
 )
 
@@ -124,50 +109,48 @@ rust_static_library(
     name = "sharedlib_uses_shared_foo",
     srcs = ["bar_uses_shared_foo.rs"],
     edition = "2018",
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
     deps = [":import_foo_shared"],
 )
 
 cc_test(
     name = "depends_on_foo_via_staticlib",
     srcs = ["baz.cc"],
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
+    target_compatible_with = select({
+        "@platforms//os:linux": ["@platforms//:incompatible"],
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":staticlib_uses_foo"],
 )
 
 cc_test(
     name = "depends_on_foo_via_sharedlib",
     srcs = ["baz.cc"],
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
+    target_compatible_with = select({
+        "@platforms//os:linux": ["@platforms//:incompatible"],
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":sharedlib_uses_foo"],
 )
 
 cc_test(
     name = "depends_on_shared_foo_via_sharedlib",
     srcs = ["baz.cc"],
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":sharedlib_uses_shared_foo"],
 )
 
 cc_test(
     name = "depends_on_shared_foo_via_staticlib",
     srcs = ["baz.cc"],
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//os:windows",
-    ],
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":staticlib_uses_shared_foo"],
 )
 
@@ -175,5 +158,9 @@ rust_binary(
     name = "depends_on_foo_with_redundant_linkopts",
     srcs = ["main_uses_foo.rs"],
     edition = "2021",
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":rlib_uses_foo_with_redundant_linkopts"],
 )

--- a/test/linker_inputs_propagation/BUILD.bazel
+++ b/test/linker_inputs_propagation/BUILD.bazel
@@ -150,6 +150,7 @@ cc_test(
     srcs = ["baz.cc"],
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
     deps = [":staticlib_uses_shared_foo"],

--- a/test/linker_inputs_propagation/BUILD.bazel
+++ b/test/linker_inputs_propagation/BUILD.bazel
@@ -130,6 +130,7 @@ cc_test(
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//:incompatible"],
         "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
     deps = [":sharedlib_uses_foo"],

--- a/test/linker_inputs_propagation/BUILD.bazel
+++ b/test/linker_inputs_propagation/BUILD.bazel
@@ -173,7 +173,7 @@ cc_test(
 
 rust_binary(
     name = "depends_on_foo_with_redundant_linkopts",
-    edition = "2021",
     srcs = ["main_uses_foo.rs"],
+    edition = "2021",
     deps = [":rlib_uses_foo_with_redundant_linkopts"],
 )

--- a/test/linker_inputs_propagation/BUILD.bazel
+++ b/test/linker_inputs_propagation/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library", "cc_test")
 load(
     "@rules_rust//rust:defs.bzl",
+    "rust_binary",
     "rust_library",
     "rust_shared_library",
     "rust_static_library",
@@ -23,6 +24,15 @@ cc_library(
     target_compatible_with = [
         "@platforms//os:linux",
     ],
+)
+
+cc_library(
+    name = "foo_with_linkopts",
+    srcs = [
+        "foo_shared.cc",
+    ],
+    hdrs = ["foo_shared.h"],
+    linkopts = ["-L/doesnotexist"],
 )
 
 cc_binary(
@@ -79,6 +89,13 @@ rust_static_library(
         "@platforms//os:windows",
     ],
     deps = [":foo"],
+)
+
+rust_library(
+    name = "rlib_uses_foo_with_redundant_linkopts",
+    srcs = ["bar_uses_shared_foo.rs"],
+    edition = "2018",
+    deps = [":foo_with_linkopts"],
 )
 
 rust_shared_library(
@@ -152,4 +169,11 @@ cc_test(
         "@platforms//os:windows",
     ],
     deps = [":staticlib_uses_shared_foo"],
+)
+
+rust_binary(
+    name = "depends_on_foo_with_redundant_linkopts",
+    edition = "2021",
+    srcs = ["main_uses_foo.rs"],
+    deps = [":rlib_uses_foo_with_redundant_linkopts"],
 )

--- a/test/linker_inputs_propagation/BUILD.bazel
+++ b/test/linker_inputs_propagation/BUILD.bazel
@@ -93,7 +93,7 @@ rust_static_library(
 
 rust_library(
     name = "rlib_uses_foo_with_redundant_linkopts",
-    srcs = ["bar_uses_shared_foo.rs"],
+    srcs = ["bar_uses_shared_foo_for_rust.rs"],
     edition = "2018",
     deps = [":foo_with_linkopts"],
 )

--- a/test/linker_inputs_propagation/bar_uses_shared_foo_for_rust.rs
+++ b/test/linker_inputs_propagation/bar_uses_shared_foo_for_rust.rs
@@ -1,0 +1,12 @@
+extern "C" {
+    pub fn foo() -> i32;
+}
+
+/** Safety doc.
+
+  # Safety
+
+*/
+pub fn double_foo() -> i32 {
+    2 * unsafe { foo() }
+}

--- a/test/linker_inputs_propagation/main_uses_foo.rs
+++ b/test/linker_inputs_propagation/main_uses_foo.rs
@@ -1,0 +1,7 @@
+extern "C" {
+    fn double_foo() -> i32;
+}
+
+fn main() {
+  println!("{}", unsafe { double_foo() });
+}

--- a/test/linker_inputs_propagation/main_uses_foo.rs
+++ b/test/linker_inputs_propagation/main_uses_foo.rs
@@ -1,7 +1,5 @@
-extern "C" {
-    fn double_foo() -> i32;
-}
+use rlib_uses_foo_with_redundant_linkopts::double_foo;
 
 fn main() {
-  println!("{}", unsafe { double_foo() });
+  println!("{}", double_foo());
 }

--- a/test/linker_inputs_propagation/main_uses_foo.rs
+++ b/test/linker_inputs_propagation/main_uses_foo.rs
@@ -1,5 +1,5 @@
 use rlib_uses_foo_with_redundant_linkopts::double_foo;
 
 fn main() {
-  println!("{}", double_foo());
+    println!("{}", double_foo());
 }

--- a/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
+++ b/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
@@ -26,6 +26,7 @@ def _dependency_linkopts_are_propagated_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
     link_action = [action for action in tut.actions if action.mnemonic == "Rustc"][0]
+
     # Expect a library's own linkopts to come after the flags we create to link them.
     # This is required, because linkopts are ordered and the linker will only apply later ones when resolving symbols required for earlier ones.
     # This means that if one of our transitive deps has a linkopt like `-lfoo`, the dep will see the symbols of foo at link time.
@@ -42,7 +43,7 @@ def _contains_input(inputs, name):
 
 def _contains_in_order(haystack, needle):
     for i in range(len(haystack)):
-        if haystack[i:i+len(needle)] == needle:
+        if haystack[i:i + len(needle)] == needle:
             return True
     return False
 

--- a/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
+++ b/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
@@ -1,6 +1,6 @@
 """Unittests for propagation of linker inputs through Rust libraries"""
 
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 
 def _shared_lib_is_propagated_test_impl(ctx):
     env = analysistest.begin(ctx)
@@ -8,7 +8,7 @@ def _shared_lib_is_propagated_test_impl(ctx):
     link_action = [action for action in tut.actions if action.mnemonic == "CppLink"][0]
 
     lib_name = _get_lib_name(ctx, name = "foo_shared")
-    asserts.true(env, _contains_input(link_action.inputs, lib_name))
+    _assert_contains_input(env, link_action.inputs, lib_name)
 
     return analysistest.end(env)
 
@@ -18,7 +18,7 @@ def _static_lib_is_not_propagated_test_impl(ctx):
     link_action = [action for action in tut.actions if action.mnemonic == "CppLink"][0]
 
     lib_name = _get_lib_name(ctx, name = "foo")
-    asserts.false(env, _contains_input(link_action.inputs, lib_name))
+    asserts.false(env, _assert_contains_input(env, link_action.inputs, lib_name))
 
     return analysistest.end(env)
 
@@ -30,22 +30,22 @@ def _dependency_linkopts_are_propagated_test_impl(ctx):
     # Expect a library's own linkopts to come after the flags we create to link them.
     # This is required, because linkopts are ordered and the linker will only apply later ones when resolving symbols required for earlier ones.
     # This means that if one of our transitive deps has a linkopt like `-lfoo`, the dep will see the symbols of foo at link time.
-    asserts.true(env, _contains_in_order(link_action.argv, ["-lstatic=foo_with_linkopts", "-Clink-arg=-lfoo_with_linkopts", "--codegen=link-arg=-L/doesnotexist"]))
+    _assert_contains_in_order(env, link_action.argv, ["-lstatic=foo_with_linkopts", "-Clink-arg=-lfoo_with_linkopts", "--codegen=link-arg=-L/doesnotexist"])
     return analysistest.end(env)
 
-def _contains_input(inputs, name):
+def _assert_contains_input(env, inputs, name):
     for input in inputs.to_list():
         # We cannot check for name equality because rlib outputs contain
         # a hash in their name.
         if input.basename.startswith(name):
-            return True
-    return False
+            return
+    unittest.fail(env, "Expected {} to contain a library starting with {}".format(inputs.to_list(), name))
 
-def _contains_in_order(haystack, needle):
+def _assert_contains_in_order(env, haystack, needle):
     for i in range(len(haystack)):
         if haystack[i:i + len(needle)] == needle:
-            return True
-    return False
+            return
+    unittest.fail(env, "Expected {} to contain {}".format(haystack, needle))
 
 def _get_lib_name(ctx, name):
     if ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]):
@@ -113,5 +113,6 @@ def linker_inputs_propagation_test_suite(name):
             ":depends_on_shared_foo_via_staticlib",
             ":depends_on_foo_via_sharedlib",
             ":depends_on_shared_foo_via_sharedlib",
+            ":dependency_linkopts_are_propagated",
         ],
     )


### PR DESCRIPTION
Previously we were adding these early on in the link args.

This was a bug - if some transitive dep foo has a linkopt of `-lbar`, the `-lbar` needs to be later in the link args list than `-lfoo`.

Rather than arbitrarily adding them early on and hoping things work, this adds the args for each library just after we add a dependency on that library.