### PR TITLE
rust_test(crate=foo) inherits foo.aliases

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -346,6 +346,8 @@ def _rust_test_impl(ctx):
             ctx.attr.rustc_env,
             data_paths,
         ))
+        aliases = dict(crate.aliases)
+        aliases.update(ctx.attr.aliases)
 
         # Build the test binary using the dependency's srcs.
         crate_info_dict = dict(
@@ -355,7 +357,7 @@ def _rust_test_impl(ctx):
             srcs = depset(srcs, transitive = [crate.srcs]),
             deps = depset(deps, transitive = [crate.deps]),
             proc_macro_deps = depset(proc_macro_deps, transitive = [crate.proc_macro_deps]),
-            aliases = ctx.attr.aliases,
+            aliases = aliases,
             output = output,
             rustc_output = generate_output_diagnostics(ctx, output),
             edition = crate.edition,

--- a/test/renamed_deps/BUILD.bazel
+++ b/test/renamed_deps/BUILD.bazel
@@ -41,10 +41,6 @@ rust_test(
 
 rust_test(
     name = "mod3_test",
-    aliases = {
-        ":mod1": "alias_a",
-        ":mod2": "alias_b",
-    },
     crate = ":mod3",
     edition = "2018",
 )


### PR DESCRIPTION
Inline tests compile the same set of source files as the original crate.
The set of aliases required will be the same or occasionally a superset.
We shouldn't make users repeat them across targets.
