### PR TITLE
Made `cargo_build_script` `streams` output group optional.

### DIFF
--- a/cargo/settings/BUILD.bazel
+++ b/cargo/settings/BUILD.bazel
@@ -27,3 +27,10 @@ string_list_flag(
         ".so",
     ],
 )
+
+# A flag which adds a `streams` output group to `cargo_build_script` targets that contain
+# the raw `stderr` and `stdout` streams from the build script.
+bool_flag(
+    name = "debug_std_streams_output_group",
+    build_setting_default = False,
+)


### PR DESCRIPTION
This change introduces the `--@rules_rust//cargo/settings:debug_std_streams_output_group` flag which can be used to enable the `streams` output group on `cargo_build_script` targets. For greater reproducibility, the flag is defaulted to `false`.

closes https://github.com/bazelbuild/rules_rust/issues/2974