### PR TITLE
Stop using config.string(allow_multiple = True)

### DIFF
--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -43,7 +43,7 @@ clippy_flag = rule(
         "Multiple uses are accumulated and appended after the extra_rustc_flags."
     ),
     implementation = _clippy_flag_impl,
-    build_setting = config.string(flag = True, allow_multiple = True),
+    build_setting = config.string_list(flag = True, repeatable = True),
 )
 
 def _clippy_flags_impl(ctx):

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2212,7 +2212,7 @@ extra_rustc_flag = rule(
         "Multiple uses are accumulated and appended after the extra_rustc_flags."
     ),
     implementation = _extra_rustc_flag_impl,
-    build_setting = config.string(flag = True, allow_multiple = True),
+    build_setting = config.string_list(flag = True, repeatable = True),
 )
 
 def _extra_exec_rustc_flags_impl(ctx):
@@ -2237,7 +2237,7 @@ extra_exec_rustc_flag = rule(
         "Multiple uses are accumulated and appended after the extra_exec_rustc_flags."
     ),
     implementation = _extra_exec_rustc_flag_impl,
-    build_setting = config.string(flag = True, allow_multiple = True),
+    build_setting = config.string_list(flag = True, repeatable = True),
 )
 
 def _per_crate_rustc_flag_impl(ctx):
@@ -2253,7 +2253,7 @@ per_crate_rustc_flag = rule(
         "Multiple uses are accumulated."
     ),
     implementation = _per_crate_rustc_flag_impl,
-    build_setting = config.string(flag = True, allow_multiple = True),
+    build_setting = config.string_list(flag = True, repeatable = True),
 )
 
 def _no_std_impl(ctx):

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -212,7 +212,7 @@ clippy_flags(
 
 clippy_flag(
     name = "clippy_flag",
-    build_setting_default = "",
+    build_setting_default = [],
     visibility = ["//visibility:public"],
 )
 
@@ -228,7 +228,7 @@ extra_rustc_flags(
 
 extra_rustc_flag(
     name = "extra_rustc_flag",
-    build_setting_default = "",
+    build_setting_default = [],
     visibility = ["//visibility:public"],
 )
 
@@ -244,12 +244,12 @@ extra_exec_rustc_flags(
 
 extra_exec_rustc_flag(
     name = "extra_exec_rustc_flag",
-    build_setting_default = "",
+    build_setting_default = [],
     visibility = ["//visibility:public"],
 )
 
 per_crate_rustc_flag(
     name = "experimental_per_crate_rustc_flag",
-    build_setting_default = "",
+    build_setting_default = [],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
According to the Bazel documentation, this option is deprecated. config.string_list(repeatable = True) should be used instead.