### PR TITLE
Fix bzlmod support for bazel 6

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "rules_rust",
-    version = "0.54.0",
+    version = "0.54.1",
 )
 
 bazel_dep(

--- a/rust/extensions.bzl
+++ b/rust/extensions.bzl
@@ -71,7 +71,10 @@ def _rust_impl(module_ctx):
                 register_toolchains = False,
                 aliases = toolchain.aliases,
             )
-    return module_ctx.extension_metadata(reproducible = True)
+    metadata_kwargs = {}
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        metadata_kwargs["reproducible"] = True
+    return module_ctx.extension_metadata(**metadata_kwargs)
 
 _COMMON_TAG_KWARGS = dict(
     allocator_library = attr.string(

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.54.0"
+VERSION = "0.54.1"


### PR DESCRIPTION
I'm not going to bother adding a new test for this as Bazel 8 is just around the corner and Bazel 6 is about to be dropped.