### PR TITLE
fix!: correctly determine crate dependencies and features common to all supported targets

### DIFF
--- a/crate_universe/tests/cargo_integration_test.rs
+++ b/crate_universe/tests/cargo_integration_test.rs
@@ -152,54 +152,59 @@ fn feature_generator() {
 
     assert_eq!(
         json!({
-            "common": {
-                "deps": [
-                    "arrayvec 0.7.2",
-                    "bitflags 1.3.2",
-                    "fxhash 0.2.1",
-                    "log 0.4.17",
-                    "naga 0.10.0",
-                    "parking_lot 0.12.1",
-                    "profiling 1.0.7",
-                    "raw-window-handle 0.5.0",
-                    "thiserror 1.0.37",
-                    "wgpu-types 0.14.1",
-                ],
-                "features": [
-                    "default",
-                ],
-            },
             "selects": {
                 "x86_64-apple-darwin": {
                     "deps": [
+                        "arrayvec 0.7.2",
+                        "bitflags 1.3.2",
                         "block 0.1.6",
                         "core-graphics-types 0.1.1",
                         "foreign-types 0.3.2",
+                        "fxhash 0.2.1",
+                        "log 0.4.17",
                         "metal 0.24.0",
+                        "naga 0.10.0",
                         "objc 0.2.7",
+                        "parking_lot 0.12.1",
+                        "profiling 1.0.7",
+                        "raw-window-handle 0.5.0",
+                        "thiserror 1.0.37",
+                        "wgpu-types 0.14.1",
                     ],
                     "features": [
                         "block",
+                        "default",
                         "foreign-types",
                         "metal",
                     ],
                 },
                 "x86_64-pc-windows-msvc": {
                     "deps": [
+                        "arrayvec 0.7.2",
                         "ash 0.37.1+1.3.235",
                         "bit-set 0.5.3",
+                        "bitflags 1.3.2",
                         "d3d12 0.5.0",
+                        "fxhash 0.2.1",
                         "gpu-alloc 0.5.3",
                         "gpu-descriptor 0.2.3",
                         "libloading 0.7.4",
+                        "log 0.4.17",
+                        "naga 0.10.0",
+                        "parking_lot 0.12.1",
+                        "profiling 1.0.7",
                         "range-alloc 0.1.2",
+                        "raw-window-handle 0.5.0",
                         "renderdoc-sys 0.7.1",
                         "smallvec 1.10.0",
+                        "thiserror 1.0.37",
+                        "wgpu-types 0.14.1",
                         "winapi 0.3.9",
                     ],
                     "features": [
                         "ash",
                         "bit-set",
+                        "default",
                         "dx11",
                         "dx12",
                         "gpu-alloc",
@@ -211,21 +216,33 @@ fn feature_generator() {
                         "renderdoc-sys",
                         "smallvec",
                         "vulkan",
+
                     ],
                 },
                 "x86_64-unknown-linux-gnu": {
                     "deps": [
+                        "arrayvec 0.7.2",
                         "ash 0.37.1+1.3.235",
+                        "bitflags 1.3.2",
+                        "fxhash 0.2.1",
                         "glow 0.11.2",
                         "gpu-alloc 0.5.3",
                         "gpu-descriptor 0.2.3",
                         "khronos-egl 4.1.0",
                         "libloading 0.7.4",
+                        "log 0.4.17",
+                        "naga 0.10.0",
+                        "parking_lot 0.12.1",
+                        "profiling 1.0.7",
+                        "raw-window-handle 0.5.0",
                         "renderdoc-sys 0.7.1",
                         "smallvec 1.10.0",
+                        "thiserror 1.0.37",
+                        "wgpu-types 0.14.1",
                     ],
                     "features": [
                         "ash",
+                        "default",
                         "egl",
                         "gles",
                         "glow",
@@ -544,32 +561,37 @@ fn host_specific_build_deps() {
 
     assert_eq!(
         json!({
-            "common": {
-                "deps": [
-                    "bitflags 2.6.0",
-                ],
-                "features": [
-                    "alloc",
-                    "default",
-                    "fs",
-                    "libc-extra-traits",
-                    "std",
-                    "use-libc-auxv",
-                ],
-            },
             // Note that there is no `wasm32-unknown-unknown` or `x86_64-pc-windows-msvc` entry
             // since these platforms do not depend on `rustix`. The chain breaks due to the
             // conditions here: https://github.com/Stebalien/tempfile/blob/v3.11.0/Cargo.toml#L25-L33
             "selects": {
                 "x86_64-apple-darwin": {
                     "deps": [
+                        "bitflags 2.6.0",
                         "errno 0.3.9",
                         "libc 0.2.158",
+                    ],
+                    "features": [
+                        "alloc",
+                        "default",
+                        "fs",
+                        "libc-extra-traits",
+                        "std",
+                        "use-libc-auxv",
                     ],
                 },
                 "x86_64-unknown-linux-gnu": {
                     "deps": [
+                        "bitflags 2.6.0",
                         "linux-raw-sys 0.4.14",
+                    ],
+                    "features": [
+                        "alloc",
+                        "default",
+                        "fs",
+                        "libc-extra-traits",
+                        "std",
+                        "use-libc-auxv",
                     ],
                 },
             },
@@ -579,28 +601,30 @@ fn host_specific_build_deps() {
 
     assert_eq!(
         json!({
-            "common": {
-                "deps": [
-                    "cfg-if 1.0.0",
-                    "fastrand 2.1.1",
-                    "once_cell 1.19.0",
-                ],
-            },
             // Note that windows does not contain `rustix` and instead `windows-sys`.
             // This shows correct detection of exec platform constraints.
             "selects": {
                 "x86_64-apple-darwin": {
                     "deps": [
+                        "cfg-if 1.0.0",
+                        "fastrand 2.1.1",
+                        "once_cell 1.19.0",
                         "rustix 0.38.36",
                     ],
                 },
                 "x86_64-pc-windows-msvc": {
                     "deps": [
+                        "cfg-if 1.0.0",
+                        "fastrand 2.1.1",
+                        "once_cell 1.19.0",
                         "windows-sys 0.59.0",
                     ],
                 },
                 "x86_64-unknown-linux-gnu": {
                     "deps": [
+                        "cfg-if 1.0.0",
+                        "fastrand 2.1.1",
+                        "once_cell 1.19.0",
                         "rustix 0.38.36",
                     ],
                 },

--- a/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "72bc62e0cc45a664f35df0f1386d5f120cb84ca55fbf7ace99dd99c526b5b308",
+  "checksum": "95a6f1706c40594b70a4070a568ceda5e1e8e6e387e24d59645b5c9201f91f30",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",
@@ -437,10 +437,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-apple-darwin": [
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -793,10 +834,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-apple-darwin": [
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.4.1"
@@ -1608,12 +1690,79 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "syn",
-            "syn-error"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "syn",
+              "syn-error"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "syn",
+              "syn-error"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -1628,13 +1777,94 @@
             {
               "id": "quote 1.0.23",
               "target": "quote"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "syn 1.0.109",
+                "target": "syn"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "proc_macro_deps": {
@@ -1799,11 +2029,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -1878,11 +2162,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -2426,27 +2764,155 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "clone-impls",
-            "default",
-            "derive",
-            "full",
-            "parsing",
-            "printing",
-            "proc-macro",
-            "quote"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "i686-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "i686-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-unknown-freebsd": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ]
+          }
         },
         "deps": {
           "common": [
             {
               "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.23",
-              "target": "quote"
             },
             {
               "id": "syn 1.0.109",
@@ -2457,7 +2923,92 @@
               "target": "unicode_ident"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "1.0.109"
@@ -2761,11 +3312,17 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "wasm32-wasi": [
+              "default",
+              "std"
+            ],
+            "wasm32-wasip1": [
+              "default",
+              "std"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.11.0+wasi-snapshot-preview1"
@@ -2819,20 +3376,48 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "consoleapi",
-            "errhandlingapi",
-            "fileapi",
-            "minwinbase",
-            "minwindef",
-            "processenv",
-            "std",
-            "winbase",
-            "wincon",
-            "winerror",
-            "winnt"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "minwinbase",
+              "minwindef",
+              "processenv",
+              "std",
+              "winbase",
+              "wincon",
+              "winerror",
+              "winnt"
+            ],
+            "i686-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "minwinbase",
+              "minwindef",
+              "processenv",
+              "std",
+              "winbase",
+              "wincon",
+              "winerror",
+              "winnt"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "minwinbase",
+              "minwindef",
+              "processenv",
+              "std",
+              "winbase",
+              "wincon",
+              "winerror",
+              "winnt"
+            ]
+          }
         },
         "deps": {
           "common": [

--- a/examples/crate_universe/cargo_conditional_deps/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_conditional_deps/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "59be2ecd05a76e24ac796ef59c99aa8df9951f6f5a9e7985ae284c673013baa0",
+  "checksum": "ceedae0ebf7765906eb5ca282cf919fa7ec9b6ed417c32589c420ace0c6a6a37",
   "crates": {
     "autocfg 1.1.0": {
       "name": "autocfg",
@@ -70,10 +70,36 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "edition": "2018",
         "version": "1.3.2"
@@ -195,12 +221,54 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "extra_traits",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "extra_traits",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "extra_traits",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "extra_traits",
+              "std"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "default",
+              "extra_traits",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "extra_traits",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "extra_traits",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "extra_traits",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "extra_traits",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "extra_traits",
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -271,10 +339,36 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -341,44 +435,342 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "acct",
-            "aio",
-            "default",
-            "dir",
-            "env",
-            "event",
-            "feature",
-            "fs",
-            "hostname",
-            "inotify",
-            "ioctl",
-            "kmod",
-            "memoffset",
-            "mman",
-            "mount",
-            "mqueue",
-            "net",
-            "personality",
-            "pin-utils",
-            "poll",
-            "process",
-            "pthread",
-            "ptrace",
-            "quota",
-            "reboot",
-            "resource",
-            "sched",
-            "signal",
-            "socket",
-            "term",
-            "time",
-            "ucontext",
-            "uio",
-            "user",
-            "zerocopy"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "acct",
+              "aio",
+              "default",
+              "dir",
+              "env",
+              "event",
+              "feature",
+              "fs",
+              "hostname",
+              "inotify",
+              "ioctl",
+              "kmod",
+              "memoffset",
+              "mman",
+              "mount",
+              "mqueue",
+              "net",
+              "personality",
+              "pin-utils",
+              "poll",
+              "process",
+              "pthread",
+              "ptrace",
+              "quota",
+              "reboot",
+              "resource",
+              "sched",
+              "signal",
+              "socket",
+              "term",
+              "time",
+              "ucontext",
+              "uio",
+              "user",
+              "zerocopy"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "acct",
+              "aio",
+              "default",
+              "dir",
+              "env",
+              "event",
+              "feature",
+              "fs",
+              "hostname",
+              "inotify",
+              "ioctl",
+              "kmod",
+              "memoffset",
+              "mman",
+              "mount",
+              "mqueue",
+              "net",
+              "personality",
+              "pin-utils",
+              "poll",
+              "process",
+              "pthread",
+              "ptrace",
+              "quota",
+              "reboot",
+              "resource",
+              "sched",
+              "signal",
+              "socket",
+              "term",
+              "time",
+              "ucontext",
+              "uio",
+              "user",
+              "zerocopy"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "acct",
+              "aio",
+              "default",
+              "dir",
+              "env",
+              "event",
+              "feature",
+              "fs",
+              "hostname",
+              "inotify",
+              "ioctl",
+              "kmod",
+              "memoffset",
+              "mman",
+              "mount",
+              "mqueue",
+              "net",
+              "personality",
+              "pin-utils",
+              "poll",
+              "process",
+              "pthread",
+              "ptrace",
+              "quota",
+              "reboot",
+              "resource",
+              "sched",
+              "signal",
+              "socket",
+              "term",
+              "time",
+              "ucontext",
+              "uio",
+              "user",
+              "zerocopy"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "acct",
+              "aio",
+              "default",
+              "dir",
+              "env",
+              "event",
+              "feature",
+              "fs",
+              "hostname",
+              "inotify",
+              "ioctl",
+              "kmod",
+              "memoffset",
+              "mman",
+              "mount",
+              "mqueue",
+              "net",
+              "personality",
+              "pin-utils",
+              "poll",
+              "process",
+              "pthread",
+              "ptrace",
+              "quota",
+              "reboot",
+              "resource",
+              "sched",
+              "signal",
+              "socket",
+              "term",
+              "time",
+              "ucontext",
+              "uio",
+              "user",
+              "zerocopy"
+            ],
+            "i686-unknown-linux-gnu": [
+              "acct",
+              "aio",
+              "default",
+              "dir",
+              "env",
+              "event",
+              "feature",
+              "fs",
+              "hostname",
+              "inotify",
+              "ioctl",
+              "kmod",
+              "memoffset",
+              "mman",
+              "mount",
+              "mqueue",
+              "net",
+              "personality",
+              "pin-utils",
+              "poll",
+              "process",
+              "pthread",
+              "ptrace",
+              "quota",
+              "reboot",
+              "resource",
+              "sched",
+              "signal",
+              "socket",
+              "term",
+              "time",
+              "ucontext",
+              "uio",
+              "user",
+              "zerocopy"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "acct",
+              "aio",
+              "default",
+              "dir",
+              "env",
+              "event",
+              "feature",
+              "fs",
+              "hostname",
+              "inotify",
+              "ioctl",
+              "kmod",
+              "memoffset",
+              "mman",
+              "mount",
+              "mqueue",
+              "net",
+              "personality",
+              "pin-utils",
+              "poll",
+              "process",
+              "pthread",
+              "ptrace",
+              "quota",
+              "reboot",
+              "resource",
+              "sched",
+              "signal",
+              "socket",
+              "term",
+              "time",
+              "ucontext",
+              "uio",
+              "user",
+              "zerocopy"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "acct",
+              "aio",
+              "default",
+              "dir",
+              "env",
+              "event",
+              "feature",
+              "fs",
+              "hostname",
+              "inotify",
+              "ioctl",
+              "kmod",
+              "memoffset",
+              "mman",
+              "mount",
+              "mqueue",
+              "net",
+              "personality",
+              "pin-utils",
+              "poll",
+              "process",
+              "pthread",
+              "ptrace",
+              "quota",
+              "reboot",
+              "resource",
+              "sched",
+              "signal",
+              "socket",
+              "term",
+              "time",
+              "ucontext",
+              "uio",
+              "user",
+              "zerocopy"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "acct",
+              "aio",
+              "default",
+              "dir",
+              "env",
+              "event",
+              "feature",
+              "fs",
+              "hostname",
+              "inotify",
+              "ioctl",
+              "kmod",
+              "memoffset",
+              "mman",
+              "mount",
+              "mqueue",
+              "net",
+              "personality",
+              "pin-utils",
+              "poll",
+              "process",
+              "pthread",
+              "ptrace",
+              "quota",
+              "reboot",
+              "resource",
+              "sched",
+              "signal",
+              "socket",
+              "term",
+              "time",
+              "ucontext",
+              "uio",
+              "user",
+              "zerocopy"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "acct",
+              "aio",
+              "default",
+              "dir",
+              "env",
+              "event",
+              "feature",
+              "fs",
+              "hostname",
+              "inotify",
+              "ioctl",
+              "kmod",
+              "memoffset",
+              "mman",
+              "mount",
+              "mqueue",
+              "net",
+              "personality",
+              "pin-utils",
+              "poll",
+              "process",
+              "pthread",
+              "ptrace",
+              "quota",
+              "reboot",
+              "resource",
+              "sched",
+              "signal",
+              "socket",
+              "term",
+              "time",
+              "ucontext",
+              "uio",
+              "user",
+              "zerocopy"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -395,19 +787,102 @@
               "target": "libc"
             },
             {
-              "id": "memoffset 0.7.1",
-              "target": "memoffset"
-            },
-            {
-              "id": "pin-utils 0.1.0",
-              "target": "pin_utils"
-            },
-            {
               "id": "static_assertions 1.1.0",
               "target": "static_assertions"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "memoffset 0.7.1",
+                "target": "memoffset"
+              },
+              {
+                "id": "pin-utils 0.1.0",
+                "target": "pin_utils"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "memoffset 0.7.1",
+                "target": "memoffset"
+              },
+              {
+                "id": "pin-utils 0.1.0",
+                "target": "pin_utils"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "memoffset 0.7.1",
+                "target": "memoffset"
+              },
+              {
+                "id": "pin-utils 0.1.0",
+                "target": "pin_utils"
+              }
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              {
+                "id": "memoffset 0.7.1",
+                "target": "memoffset"
+              },
+              {
+                "id": "pin-utils 0.1.0",
+                "target": "pin_utils"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "memoffset 0.7.1",
+                "target": "memoffset"
+              },
+              {
+                "id": "pin-utils 0.1.0",
+                "target": "pin_utils"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "memoffset 0.7.1",
+                "target": "memoffset"
+              },
+              {
+                "id": "pin-utils 0.1.0",
+                "target": "pin_utils"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "memoffset 0.7.1",
+                "target": "memoffset"
+              },
+              {
+                "id": "pin-utils 0.1.0",
+                "target": "pin_utils"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "memoffset 0.7.1",
+                "target": "memoffset"
+              },
+              {
+                "id": "pin-utils 0.1.0",
+                "target": "pin_utils"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "memoffset 0.7.1",
+                "target": "memoffset"
+              },
+              {
+                "id": "pin-utils 0.1.0",
+                "target": "pin_utils"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.26.2"
@@ -521,7 +996,8 @@
       "aarch64-unknown-fuchsia"
     ],
     "aarch64-unknown-linux-gnu": [
-      "aarch64-unknown-linux-gnu"
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu"
     ],
     "aarch64-unknown-nixos-gnu": [
       "aarch64-unknown-nixos-gnu"
@@ -610,7 +1086,8 @@
       "x86_64-unknown-fuchsia"
     ],
     "x86_64-unknown-linux-gnu": [
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "x86_64-unknown-nixos-gnu": [
       "x86_64-unknown-nixos-gnu"

--- a/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "85ace51890ea8af96208646d5ad3605b2b0d82475631ef0aa45487557550ead3",
+  "checksum": "b63b55fd999e059e78cc27d0b163b05d4bedf7feb8a29969884bd4f4adee2f93",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -1607,11 +1607,17 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "wasm32-wasi": [
+              "default",
+              "std"
+            ],
+            "wasm32-wasip1": [
+              "default",
+              "std"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.9.0+wasi-snapshot-preview1"
@@ -1665,17 +1671,39 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "consoleapi",
-            "errhandlingapi",
-            "fileapi",
-            "handleapi",
-            "minwinbase",
-            "minwindef",
-            "processenv",
-            "winbase"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "handleapi",
+              "minwinbase",
+              "minwindef",
+              "processenv",
+              "winbase"
+            ],
+            "i686-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "handleapi",
+              "minwinbase",
+              "minwindef",
+              "processenv",
+              "winbase"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "handleapi",
+              "minwinbase",
+              "minwindef",
+              "processenv",
+              "winbase"
+            ]
+          }
         },
         "deps": {
           "common": [

--- a/examples/crate_universe/complicated_dependencies/cargo-bazel-lock.json
+++ b/examples/crate_universe/complicated_dependencies/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "dc978ad414fb0f5ad2be4c7c980f674c2681de5dc239cce00ae81f6b47f4ed6f",
+  "checksum": "cd1440ada6db7ff0ee9fb56461aad8babdc1a8710959a736be4ff905ca5a23e9",
   "crates": {
     "aho-corasick 1.1.3": {
       "name": "aho-corasick",
@@ -82,10 +82,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "runtime"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "runtime"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "runtime"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "runtime"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "runtime"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "runtime"
+            ],
+            "i686-pc-windows-msvc": [
+              "runtime"
+            ],
+            "i686-unknown-linux-gnu": [
+              "runtime"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "runtime"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "runtime"
+            ],
+            "x86_64-apple-darwin": [
+              "runtime"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "runtime"
+            ],
+            "x86_64-unknown-freebsd": [
+              "runtime"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "runtime"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "runtime"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -550,19 +591,177 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "clang_3_5",
-            "clang_3_6",
-            "clang_3_7",
-            "clang_3_8",
-            "clang_3_9",
-            "clang_4_0",
-            "clang_5_0",
-            "clang_6_0",
-            "libloading",
-            "runtime"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "i686-pc-windows-msvc": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "i686-unknown-linux-gnu": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "x86_64-apple-darwin": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "x86_64-unknown-freebsd": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "clang_3_5",
+              "clang_3_6",
+              "clang_3_7",
+              "clang_3_8",
+              "clang_3_9",
+              "clang_4_0",
+              "clang_5_0",
+              "clang_6_0",
+              "libloading",
+              "runtime"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -577,13 +776,94 @@
             {
               "id": "libc 0.2.154",
               "target": "libc"
-            },
-            {
-              "id": "libloading 0.8.3",
-              "target": "libloading"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "libloading 0.8.3",
+                "target": "libloading"
+              }
+            ]
+          }
         },
         "edition": "2015",
         "version": "1.7.0"
@@ -798,10 +1078,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -937,11 +1258,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [],
@@ -1343,11 +1718,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "alloc",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "alloc",
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "alloc",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "alloc",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "alloc",
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "alloc",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "alloc",
+              "std"
+            ]
+          }
         },
         "edition": "2021",
         "version": "2.7.2"
@@ -1389,10 +1818,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "std"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.2.1"
@@ -1434,11 +1904,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "alloc",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "alloc",
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "alloc",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "alloc",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "alloc",
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "alloc",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "alloc",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "alloc",
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -1591,11 +2115,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -1658,11 +2236,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -1713,18 +2345,163 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "std",
-            "unicode",
-            "unicode-age",
-            "unicode-bool",
-            "unicode-case",
-            "unicode-gencat",
-            "unicode-perl",
-            "unicode-script",
-            "unicode-segment"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "i686-pc-windows-msvc": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "i686-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-apple-darwin": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-unknown-freebsd": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -1779,33 +2556,336 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "alloc",
-            "meta",
-            "nfa-pikevm",
-            "nfa-thompson",
-            "std",
-            "syntax",
-            "unicode",
-            "unicode-age",
-            "unicode-bool",
-            "unicode-case",
-            "unicode-gencat",
-            "unicode-perl",
-            "unicode-script",
-            "unicode-segment",
-            "unicode-word-boundary"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "i686-pc-windows-msvc": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "i686-unknown-linux-gnu": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "x86_64-apple-darwin": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "x86_64-unknown-freebsd": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "alloc",
+              "meta",
+              "nfa-pikevm",
+              "nfa-thompson",
+              "std",
+              "syntax",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment",
+              "unicode-word-boundary"
+            ]
+          }
         },
         "deps": {
-          "common": [
-            {
-              "id": "regex-syntax 0.8.3",
-              "target": "regex_syntax"
-            }
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "regex-syntax 0.8.3",
+                "target": "regex_syntax"
+              }
+            ]
+          }
         },
         "edition": "2021",
         "version": "0.4.6"
@@ -1847,18 +2927,163 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "std",
-            "unicode",
-            "unicode-age",
-            "unicode-bool",
-            "unicode-case",
-            "unicode-gencat",
-            "unicode-perl",
-            "unicode-script",
-            "unicode-segment"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "i686-pc-windows-msvc": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "i686-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-apple-darwin": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-unknown-freebsd": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "std",
+              "unicode",
+              "unicode-age",
+              "unicode-bool",
+              "unicode-case",
+              "unicode-gencat",
+              "unicode-perl",
+              "unicode-script",
+              "unicode-segment"
+            ]
+          }
         },
         "edition": "2021",
         "version": "0.8.3"
@@ -1900,11 +3125,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ]
+          }
         },
         "edition": "2015",
         "version": "1.1.0"
@@ -1946,11 +3225,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ]
+          }
         },
         "edition": "2015",
         "version": "1.3.0"
@@ -1992,18 +3325,163 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "clone-impls",
-            "default",
-            "derive",
-            "extra-traits",
-            "full",
-            "parsing",
-            "printing",
-            "proc-macro",
-            "visit-mut"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "i686-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "i686-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "x86_64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "x86_64-unknown-freebsd": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "visit-mut"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -2012,15 +3490,96 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.36",
-              "target": "quote"
-            },
-            {
               "id": "unicode-ident 1.0.12",
               "target": "unicode_ident"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.36",
+                "target": "quote"
+              }
+            ]
+          }
         },
         "edition": "2021",
         "version": "2.0.60"
@@ -2114,19 +3673,45 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "errhandlingapi",
-            "fileapi",
-            "handleapi",
-            "minwinbase",
-            "minwindef",
-            "processthreadsapi",
-            "synchapi",
-            "winbase",
-            "winerror",
-            "winnt"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "errhandlingapi",
+              "fileapi",
+              "handleapi",
+              "minwinbase",
+              "minwindef",
+              "processthreadsapi",
+              "synchapi",
+              "winbase",
+              "winerror",
+              "winnt"
+            ],
+            "i686-pc-windows-msvc": [
+              "errhandlingapi",
+              "fileapi",
+              "handleapi",
+              "minwinbase",
+              "minwindef",
+              "processthreadsapi",
+              "synchapi",
+              "winbase",
+              "winerror",
+              "winnt"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "errhandlingapi",
+              "fileapi",
+              "handleapi",
+              "minwinbase",
+              "minwindef",
+              "processthreadsapi",
+              "synchapi",
+              "winbase",
+              "winerror",
+              "winnt"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -2966,7 +4551,8 @@
       "aarch64-unknown-fuchsia"
     ],
     "aarch64-unknown-linux-gnu": [
-      "aarch64-unknown-linux-gnu"
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu"
     ],
     "aarch64-unknown-nixos-gnu": [
       "aarch64-unknown-nixos-gnu"
@@ -3095,7 +4681,8 @@
       "x86_64-unknown-fuchsia"
     ],
     "x86_64-unknown-linux-gnu": [
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "x86_64-unknown-nixos-gnu": [
       "x86_64-unknown-nixos-gnu"

--- a/examples/crate_universe/multi_package/cargo-bazel-lock.json
+++ b/examples/crate_universe/multi_package/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "5f9f542fb5d7f755899484d25795cd4d59335d6d218294af5ed485a22cd0c779",
+  "checksum": "9751d882524af7cf6a8caa259826f62c55400a7b20efe8591bf6c912c657b35e",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",
@@ -336,11 +336,145 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "async-io",
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "async-io",
+              "default"
+            ],
+            "aarch64-apple-ios": [
+              "async-io",
+              "default"
+            ],
+            "aarch64-apple-ios-sim": [
+              "async-io",
+              "default"
+            ],
+            "aarch64-linux-android": [
+              "async-io",
+              "default"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "async-io",
+              "default"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "async-io",
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "async-io",
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "async-io",
+              "default"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "async-io",
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "async-io",
+              "default"
+            ],
+            "armv7-linux-androideabi": [
+              "async-io",
+              "default"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "async-io",
+              "default"
+            ],
+            "i686-apple-darwin": [
+              "async-io",
+              "default"
+            ],
+            "i686-linux-android": [
+              "async-io",
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "async-io",
+              "default"
+            ],
+            "i686-unknown-freebsd": [
+              "async-io",
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "async-io",
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "async-io",
+              "default"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "async-io",
+              "default"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "async-io",
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "async-io",
+              "default"
+            ],
+            "thumbv7em-none-eabi": [
+              "async-io",
+              "default"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "async-io",
+              "default"
+            ],
+            "wasm32-wasi": [
+              "async-io",
+              "default"
+            ],
+            "wasm32-wasip1": [
+              "async-io",
+              "default"
+            ],
+            "x86_64-apple-darwin": [
+              "async-io",
+              "default"
+            ],
+            "x86_64-apple-ios": [
+              "async-io",
+              "default"
+            ],
+            "x86_64-linux-android": [
+              "async-io",
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "async-io",
+              "default"
+            ],
+            "x86_64-unknown-freebsd": [
+              "async-io",
+              "default"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "async-io",
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "async-io",
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "async-io",
+              "default"
+            ],
+            "x86_64-unknown-none": [
+              "async-io",
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -351,10 +485,6 @@
             {
               "id": "async-executor 1.5.0",
               "target": "async_executor"
-            },
-            {
-              "id": "async-io 1.12.0",
-              "target": "async_io"
             },
             {
               "id": "async-lock 2.7.0",
@@ -373,7 +503,212 @@
               "target": "once_cell"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "aarch64-apple-ios": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "aarch64-apple-ios-sim": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "aarch64-linux-android": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "aarch64-unknown-fuchsia": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "armv7-linux-androideabi": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "i686-apple-darwin": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "i686-linux-android": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "i686-unknown-freebsd": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "riscv32imc-unknown-none-elf": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "riscv64gc-unknown-none-elf": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "thumbv7em-none-eabi": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "thumbv8m.main-none-eabi": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "wasm32-wasi": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "wasm32-wasip1": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "x86_64-apple-ios": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "x86_64-linux-android": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "x86_64-unknown-fuchsia": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ],
+            "x86_64-unknown-none": [
+              {
+                "id": "async-io 1.12.0",
+                "target": "async_io"
+              }
+            ]
+          }
         },
         "edition": "2021",
         "version": "2.3.1"
@@ -1525,11 +1860,145 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "aarch64-apple-ios": [
+              "default",
+              "std"
+            ],
+            "aarch64-apple-ios-sim": [
+              "default",
+              "std"
+            ],
+            "aarch64-linux-android": [
+              "default",
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "default",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "armv7-linux-androideabi": [
+              "default",
+              "std"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "i686-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "i686-linux-android": [
+              "default",
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "i686-unknown-freebsd": [
+              "default",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "default",
+              "std"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "default",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "thumbv7em-none-eabi": [
+              "default",
+              "std"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "default",
+              "std"
+            ],
+            "wasm32-wasi": [
+              "default",
+              "std"
+            ],
+            "wasm32-wasip1": [
+              "default",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "x86_64-apple-ios": [
+              "default",
+              "std"
+            ],
+            "x86_64-linux-android": [
+              "default",
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-none": [
+              "default",
+              "std"
+            ]
+          }
         },
         "edition": "2018",
         "version": "4.3.0"
@@ -1937,10 +2406,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-apple-darwin": [
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "edition": "2021",
         "version": "3.12.0"
@@ -4232,12 +4742,169 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-apple-ios": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-apple-ios-sim": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-linux-android": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "armv7-linux-androideabi": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "i686-apple-darwin": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "i686-linux-android": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "i686-unknown-freebsd": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "thumbv7em-none-eabi": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-apple-ios": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-linux-android": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-none": [
+              "alloc",
+              "default",
+              "std"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.3.26"
@@ -4554,24 +5221,30 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "futures",
-            "futures-channel",
-            "futures-core"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "default",
+              "futures",
+              "futures-channel",
+              "futures-core"
+            ],
+            "wasm32-wasi": [
+              "default",
+              "futures",
+              "futures-channel",
+              "futures-core"
+            ],
+            "wasm32-wasip1": [
+              "default",
+              "futures",
+              "futures-channel",
+              "futures-core"
+            ]
+          }
         },
         "deps": {
           "common": [
-            {
-              "id": "futures-channel 0.3.26",
-              "target": "futures_channel"
-            },
-            {
-              "id": "futures-core 0.3.26",
-              "target": "futures_core"
-            },
             {
               "id": "js-sys 0.3.61",
               "target": "js_sys"
@@ -4581,7 +5254,38 @@
               "target": "wasm_bindgen"
             }
           ],
-          "selects": {}
+          "selects": {
+            "wasm32-unknown-unknown": [
+              {
+                "id": "futures-channel 0.3.26",
+                "target": "futures_channel"
+              },
+              {
+                "id": "futures-core 0.3.26",
+                "target": "futures_core"
+              }
+            ],
+            "wasm32-wasi": [
+              {
+                "id": "futures-channel 0.3.26",
+                "target": "futures_channel"
+              },
+              {
+                "id": "futures-core 0.3.26",
+                "target": "futures_core"
+              }
+            ],
+            "wasm32-wasip1": [
+              {
+                "id": "futures-channel 0.3.26",
+                "target": "futures_channel"
+              },
+              {
+                "id": "futures-core 0.3.26",
+                "target": "futures_core"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.2.6"
@@ -4710,10 +5414,105 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "raw"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "raw"
+            ],
+            "aarch64-apple-ios": [
+              "raw"
+            ],
+            "aarch64-apple-ios-sim": [
+              "raw"
+            ],
+            "aarch64-linux-android": [
+              "raw"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "raw"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "raw"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "raw"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "raw"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "raw"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "raw"
+            ],
+            "armv7-linux-androideabi": [
+              "raw"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "raw"
+            ],
+            "i686-apple-darwin": [
+              "raw"
+            ],
+            "i686-linux-android": [
+              "raw"
+            ],
+            "i686-pc-windows-msvc": [
+              "raw"
+            ],
+            "i686-unknown-freebsd": [
+              "raw"
+            ],
+            "i686-unknown-linux-gnu": [
+              "raw"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "raw"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "raw"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "raw"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "raw"
+            ],
+            "thumbv7em-none-eabi": [
+              "raw"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "raw"
+            ],
+            "x86_64-apple-darwin": [
+              "raw"
+            ],
+            "x86_64-apple-ios": [
+              "raw"
+            ],
+            "x86_64-linux-android": [
+              "raw"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "raw"
+            ],
+            "x86_64-unknown-freebsd": [
+              "raw"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "raw"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "raw"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "raw"
+            ],
+            "x86_64-unknown-none": [
+              "raw"
+            ]
+          }
         },
         "edition": "2021",
         "version": "0.12.3"
@@ -5828,10 +6627,105 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "std"
+            ],
+            "aarch64-apple-ios": [
+              "std"
+            ],
+            "aarch64-apple-ios-sim": [
+              "std"
+            ],
+            "aarch64-linux-android": [
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "std"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "std"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "std"
+            ],
+            "armv7-linux-androideabi": [
+              "std"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "std"
+            ],
+            "i686-apple-darwin": [
+              "std"
+            ],
+            "i686-linux-android": [
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "std"
+            ],
+            "i686-unknown-freebsd": [
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "std"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "std"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "std"
+            ],
+            "thumbv7em-none-eabi": [
+              "std"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "std"
+            ],
+            "x86_64-apple-ios": [
+              "std"
+            ],
+            "x86_64-linux-android": [
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "std"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-none": [
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -5950,10 +6844,105 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-apple-ios": [
+              "default"
+            ],
+            "aarch64-apple-ios-sim": [
+              "default"
+            ],
+            "aarch64-linux-android": [
+              "default"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "armv7-linux-androideabi": [
+              "default"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "i686-apple-darwin": [
+              "default"
+            ],
+            "i686-linux-android": [
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "default"
+            ],
+            "i686-unknown-freebsd": [
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "default"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default"
+            ],
+            "thumbv7em-none-eabi": [
+              "default"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "default"
+            ],
+            "x86_64-apple-darwin": [
+              "default"
+            ],
+            "x86_64-apple-ios": [
+              "default"
+            ],
+            "x86_64-linux-android": [
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-none": [
+              "default"
+            ]
+          }
         },
         "edition": "2018",
         "version": "2.7.1"
@@ -7095,18 +8084,68 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "proc-macro-crate",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "proc-macro-crate",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "proc-macro-crate",
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
-            {
-              "id": "proc-macro-crate 1.3.1",
-              "target": "proc_macro_crate"
-            },
             {
               "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
@@ -7120,7 +8159,92 @@
               "target": "syn"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "proc-macro-crate 1.3.1",
+                "target": "proc_macro_crate"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.5.11"
@@ -7875,11 +8999,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -7954,11 +9132,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -9848,10 +11080,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-apple-darwin": [
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -10133,11 +11406,105 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "channel",
-            "iterator"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "channel",
+              "iterator"
+            ],
+            "aarch64-apple-ios": [
+              "channel",
+              "iterator"
+            ],
+            "aarch64-apple-ios-sim": [
+              "channel",
+              "iterator"
+            ],
+            "aarch64-linux-android": [
+              "channel",
+              "iterator"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "channel",
+              "iterator"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "channel",
+              "iterator"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "channel",
+              "iterator"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "channel",
+              "iterator"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "channel",
+              "iterator"
+            ],
+            "armv7-linux-androideabi": [
+              "channel",
+              "iterator"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "channel",
+              "iterator"
+            ],
+            "i686-apple-darwin": [
+              "channel",
+              "iterator"
+            ],
+            "i686-linux-android": [
+              "channel",
+              "iterator"
+            ],
+            "i686-unknown-freebsd": [
+              "channel",
+              "iterator"
+            ],
+            "i686-unknown-linux-gnu": [
+              "channel",
+              "iterator"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "channel",
+              "iterator"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "channel",
+              "iterator"
+            ],
+            "x86_64-apple-darwin": [
+              "channel",
+              "iterator"
+            ],
+            "x86_64-apple-ios": [
+              "channel",
+              "iterator"
+            ],
+            "x86_64-linux-android": [
+              "channel",
+              "iterator"
+            ],
+            "x86_64-unknown-freebsd": [
+              "channel",
+              "iterator"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "channel",
+              "iterator"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "channel",
+              "iterator"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "channel",
+              "iterator"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -10547,30 +11914,197 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "clone-impls",
-            "default",
-            "derive",
-            "extra-traits",
-            "full",
-            "parsing",
-            "printing",
-            "proc-macro",
-            "quote",
-            "visit",
-            "visit-mut"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "i686-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "i686-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-unknown-freebsd": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ]
+          }
         },
         "deps": {
           "common": [
             {
               "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.23",
-              "target": "quote"
             },
             {
               "id": "syn 1.0.109",
@@ -10581,7 +12115,92 @@
               "target": "unicode_ident"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "1.0.109"
@@ -11722,12 +13341,169 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "logging",
-            "tls12"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "aarch64-apple-ios": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "aarch64-apple-ios-sim": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "aarch64-linux-android": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "armv7-linux-androideabi": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "i686-apple-darwin": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "i686-linux-android": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "i686-unknown-freebsd": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "thumbv7em-none-eabi": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "x86_64-apple-ios": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "x86_64-linux-android": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "logging",
+              "tls12"
+            ],
+            "x86_64-unknown-none": [
+              "default",
+              "logging",
+              "tls12"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -11786,12 +13562,169 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "codec",
-            "default",
-            "tracing"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "aarch64-apple-ios": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "aarch64-apple-ios-sim": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "aarch64-linux-android": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "armv7-linux-androideabi": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "i686-apple-darwin": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "i686-linux-android": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "i686-pc-windows-msvc": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "i686-unknown-freebsd": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "i686-unknown-linux-gnu": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "thumbv7em-none-eabi": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "x86_64-apple-darwin": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "x86_64-apple-ios": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "x86_64-linux-android": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "x86_64-unknown-freebsd": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "codec",
+              "default",
+              "tracing"
+            ],
+            "x86_64-unknown-none": [
+              "codec",
+              "default",
+              "tracing"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -11814,13 +13747,202 @@
             {
               "id": "tokio 1.26.0",
               "target": "tokio"
-            },
-            {
-              "id": "tracing 0.1.37",
-              "target": "tracing"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "aarch64-apple-ios": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "aarch64-apple-ios-sim": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "aarch64-linux-android": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "aarch64-unknown-fuchsia": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "armv7-linux-androideabi": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "i686-apple-darwin": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "i686-linux-android": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "i686-unknown-freebsd": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "riscv32imc-unknown-none-elf": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "riscv64gc-unknown-none-elf": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "thumbv7em-none-eabi": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "thumbv8m.main-none-eabi": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "x86_64-apple-ios": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "x86_64-linux-android": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "x86_64-unknown-fuchsia": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ],
+            "x86_64-unknown-none": [
+              {
+                "id": "tracing 0.1.37",
+                "target": "tracing"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.7.7"
@@ -11900,10 +14022,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-apple-darwin": [
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -12849,11 +15012,17 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "wasm32-wasi": [
+              "default",
+              "std"
+            ],
+            "wasm32-wasip1": [
+              "default",
+              "std"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.11.0+wasi-snapshot-preview1"
@@ -12907,12 +15076,24 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "spans",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "default",
+              "spans",
+              "std"
+            ],
+            "wasm32-wasi": [
+              "default",
+              "spans",
+              "std"
+            ],
+            "wasm32-wasip1": [
+              "default",
+              "spans",
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -12984,10 +15165,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "spans"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "spans"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "spans"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "spans"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "spans"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "spans"
+            ],
+            "i686-pc-windows-msvc": [
+              "spans"
+            ],
+            "i686-unknown-linux-gnu": [
+              "spans"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "spans"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "spans"
+            ],
+            "x86_64-apple-darwin": [
+              "spans"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "spans"
+            ],
+            "x86_64-unknown-freebsd": [
+              "spans"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "spans"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "spans"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -13125,10 +15347,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "spans"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "spans"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "spans"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "spans"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "spans"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "spans"
+            ],
+            "i686-pc-windows-msvc": [
+              "spans"
+            ],
+            "i686-unknown-linux-gnu": [
+              "spans"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "spans"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "spans"
+            ],
+            "x86_64-apple-darwin": [
+              "spans"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "spans"
+            ],
+            "x86_64-unknown-freebsd": [
+              "spans"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "spans"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "spans"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -13183,10 +15446,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "spans"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "spans"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "spans"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "spans"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "spans"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "spans"
+            ],
+            "i686-pc-windows-msvc": [
+              "spans"
+            ],
+            "i686-unknown-linux-gnu": [
+              "spans"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "spans"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "spans"
+            ],
+            "x86_64-apple-darwin": [
+              "spans"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "spans"
+            ],
+            "x86_64-unknown-freebsd": [
+              "spans"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "spans"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "spans"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -13322,26 +15626,59 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "Blob",
-            "BlobPropertyBag",
-            "EventTarget",
-            "File",
-            "FormData",
-            "Headers",
-            "ReadableStream",
-            "Request",
-            "RequestCredentials",
-            "RequestInit",
-            "RequestMode",
-            "Response",
-            "ServiceWorkerGlobalScope",
-            "Window",
-            "WorkerGlobalScope"
-          ],
+          "common": [],
           "selects": {
             "wasm32-unknown-unknown": [
-              "Crypto"
+              "Blob",
+              "BlobPropertyBag",
+              "Crypto",
+              "EventTarget",
+              "File",
+              "FormData",
+              "Headers",
+              "ReadableStream",
+              "Request",
+              "RequestCredentials",
+              "RequestInit",
+              "RequestMode",
+              "Response",
+              "ServiceWorkerGlobalScope",
+              "Window",
+              "WorkerGlobalScope"
+            ],
+            "wasm32-wasi": [
+              "Blob",
+              "BlobPropertyBag",
+              "EventTarget",
+              "File",
+              "FormData",
+              "Headers",
+              "ReadableStream",
+              "Request",
+              "RequestCredentials",
+              "RequestInit",
+              "RequestMode",
+              "Response",
+              "ServiceWorkerGlobalScope",
+              "Window",
+              "WorkerGlobalScope"
+            ],
+            "wasm32-wasip1": [
+              "Blob",
+              "BlobPropertyBag",
+              "EventTarget",
+              "File",
+              "FormData",
+              "Headers",
+              "ReadableStream",
+              "Request",
+              "RequestCredentials",
+              "RequestInit",
+              "RequestMode",
+              "Response",
+              "ServiceWorkerGlobalScope",
+              "Window",
+              "WorkerGlobalScope"
             ]
           }
         },
@@ -13513,10 +15850,18 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "null-overlapped-wakeups-patch"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "null-overlapped-wakeups-patch"
+            ],
+            "i686-pc-windows-msvc": [
+              "null-overlapped-wakeups-patch"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "null-overlapped-wakeups-patch"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -13598,26 +15943,66 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "handleapi",
-            "impl-debug",
-            "impl-default",
-            "libloaderapi",
-            "minwinbase",
-            "minwindef",
-            "ntsecapi",
-            "timezoneapi",
-            "wincrypt",
-            "winerror",
-            "winnt",
-            "winreg",
-            "winsock2",
-            "ws2def",
-            "ws2ipdef",
-            "ws2tcpip",
-            "wtypesbase"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "handleapi",
+              "impl-debug",
+              "impl-default",
+              "libloaderapi",
+              "minwinbase",
+              "minwindef",
+              "ntsecapi",
+              "timezoneapi",
+              "wincrypt",
+              "winerror",
+              "winnt",
+              "winreg",
+              "winsock2",
+              "ws2def",
+              "ws2ipdef",
+              "ws2tcpip",
+              "wtypesbase"
+            ],
+            "i686-pc-windows-msvc": [
+              "handleapi",
+              "impl-debug",
+              "impl-default",
+              "libloaderapi",
+              "minwinbase",
+              "minwindef",
+              "ntsecapi",
+              "timezoneapi",
+              "wincrypt",
+              "winerror",
+              "winnt",
+              "winreg",
+              "winsock2",
+              "ws2def",
+              "ws2ipdef",
+              "ws2tcpip",
+              "wtypesbase"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "handleapi",
+              "impl-debug",
+              "impl-default",
+              "libloaderapi",
+              "minwinbase",
+              "minwindef",
+              "ntsecapi",
+              "timezoneapi",
+              "wincrypt",
+              "winerror",
+              "winnt",
+              "winreg",
+              "winsock2",
+              "ws2def",
+              "ws2ipdef",
+              "ws2tcpip",
+              "wtypesbase"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -13825,24 +16210,60 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Security_Authentication",
-            "Win32_Security_Authentication_Identity",
-            "Win32_Security_Credentials",
-            "Win32_Security_Cryptography",
-            "Win32_System",
-            "Win32_System_IO",
-            "Win32_System_Memory",
-            "Win32_System_Threading",
-            "Win32_System_WindowsProgramming",
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "Win32",
+              "Win32_Foundation",
+              "Win32_Networking",
+              "Win32_Networking_WinSock",
+              "Win32_Security",
+              "Win32_Security_Authentication",
+              "Win32_Security_Authentication_Identity",
+              "Win32_Security_Credentials",
+              "Win32_Security_Cryptography",
+              "Win32_System",
+              "Win32_System_IO",
+              "Win32_System_Memory",
+              "Win32_System_Threading",
+              "Win32_System_WindowsProgramming",
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "Win32",
+              "Win32_Foundation",
+              "Win32_Networking",
+              "Win32_Networking_WinSock",
+              "Win32_Security",
+              "Win32_Security_Authentication",
+              "Win32_Security_Authentication_Identity",
+              "Win32_Security_Credentials",
+              "Win32_Security_Cryptography",
+              "Win32_System",
+              "Win32_System_IO",
+              "Win32_System_Memory",
+              "Win32_System_Threading",
+              "Win32_System_WindowsProgramming",
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "Win32",
+              "Win32_Foundation",
+              "Win32_Networking",
+              "Win32_Networking_WinSock",
+              "Win32_Security",
+              "Win32_Security_Authentication",
+              "Win32_Security_Authentication_Identity",
+              "Win32_Security_Credentials",
+              "Win32_Security_Cryptography",
+              "Win32_System",
+              "Win32_System_IO",
+              "Win32_System_Memory",
+              "Win32_System_Threading",
+              "Win32_System_WindowsProgramming",
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [],
@@ -13961,23 +16382,57 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_System_IO",
-            "Win32_System_Pipes",
-            "Win32_System_SystemServices",
-            "Win32_System_WindowsProgramming",
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "Win32",
+              "Win32_Foundation",
+              "Win32_Networking",
+              "Win32_Networking_WinSock",
+              "Win32_Security",
+              "Win32_Storage",
+              "Win32_Storage_FileSystem",
+              "Win32_System",
+              "Win32_System_Console",
+              "Win32_System_IO",
+              "Win32_System_Pipes",
+              "Win32_System_SystemServices",
+              "Win32_System_WindowsProgramming",
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "Win32",
+              "Win32_Foundation",
+              "Win32_Networking",
+              "Win32_Networking_WinSock",
+              "Win32_Security",
+              "Win32_Storage",
+              "Win32_Storage_FileSystem",
+              "Win32_System",
+              "Win32_System_Console",
+              "Win32_System_IO",
+              "Win32_System_Pipes",
+              "Win32_System_SystemServices",
+              "Win32_System_WindowsProgramming",
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "Win32",
+              "Win32_Foundation",
+              "Win32_Networking",
+              "Win32_Networking_WinSock",
+              "Win32_Security",
+              "Win32_Storage",
+              "Win32_Storage_FileSystem",
+              "Win32_System",
+              "Win32_System_Console",
+              "Win32_System_IO",
+              "Win32_System_Pipes",
+              "Win32_System_SystemServices",
+              "Win32_System_WindowsProgramming",
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [],
@@ -14622,12 +17077,79 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "alloc",
+              "default",
+              "std"
+            ]
+          }
         },
         "edition": "2021",
         "version": "0.3.3"

--- a/examples/crate_universe/no_cargo_manifests/cargo-bazel-lock.json
+++ b/examples/crate_universe/no_cargo_manifests/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "fc68bac1f7716fee683f636af22b11d286dbb45c059a18372d3c647531097be4",
+  "checksum": "f3aa2b6db66e4e57a0ffd01480c07d1f1830691f64bb93d63f2bc45d547bd019",
   "crates": {
     "async-trait 0.1.64": {
       "name": "async-trait",
@@ -1778,11 +1778,137 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "aarch64-apple-ios": [
+              "default",
+              "std"
+            ],
+            "aarch64-apple-ios-sim": [
+              "default",
+              "std"
+            ],
+            "aarch64-linux-android": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-fuchsia": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "default",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "armv7-linux-androideabi": [
+              "default",
+              "std"
+            ],
+            "armv7-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "i686-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "i686-linux-android": [
+              "default",
+              "std"
+            ],
+            "i686-unknown-freebsd": [
+              "default",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "riscv32imc-unknown-none-elf": [
+              "default",
+              "std"
+            ],
+            "riscv64gc-unknown-none-elf": [
+              "default",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "thumbv7em-none-eabi": [
+              "default",
+              "std"
+            ],
+            "thumbv8m.main-none-eabi": [
+              "default",
+              "std"
+            ],
+            "wasm32-unknown-unknown": [
+              "default",
+              "std"
+            ],
+            "wasm32-wasi": [
+              "default",
+              "std"
+            ],
+            "wasm32-wasip1": [
+              "default",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "x86_64-apple-ios": [
+              "default",
+              "std"
+            ],
+            "x86_64-linux-android": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-fuchsia": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-none": [
+              "default",
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -2826,11 +2952,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -2905,11 +3085,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -3611,30 +3845,197 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "clone-impls",
-            "default",
-            "derive",
-            "extra-traits",
-            "full",
-            "parsing",
-            "printing",
-            "proc-macro",
-            "quote",
-            "visit",
-            "visit-mut"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "i686-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "i686-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-unknown-freebsd": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "extra-traits",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote",
+              "visit",
+              "visit-mut"
+            ]
+          }
         },
         "deps": {
           "common": [
             {
               "id": "proc-macro2 1.0.51",
               "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.23",
-              "target": "quote"
             },
             {
               "id": "syn 1.0.109",
@@ -3645,7 +4046,92 @@
               "target": "unicode_ident"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.23",
+                "target": "quote"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "1.0.109"
@@ -5268,11 +5754,17 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "wasm32-wasi": [
+              "default",
+              "std"
+            ],
+            "wasm32-wasip1": [
+              "default",
+              "std"
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.11.0+wasi-snapshot-preview1"
@@ -5326,16 +5818,36 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "consoleapi",
-            "errhandlingapi",
-            "fileapi",
-            "handleapi",
-            "processenv",
-            "ws2ipdef",
-            "ws2tcpip"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "handleapi",
+              "processenv",
+              "ws2ipdef",
+              "ws2tcpip"
+            ],
+            "i686-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "handleapi",
+              "processenv",
+              "ws2ipdef",
+              "ws2tcpip"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "handleapi",
+              "processenv",
+              "ws2ipdef",
+              "ws2tcpip"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -5543,25 +6055,63 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_System_IO",
-            "Win32_System_LibraryLoader",
-            "Win32_System_Pipes",
-            "Win32_System_SystemServices",
-            "Win32_System_Threading",
-            "Win32_System_WindowsProgramming",
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "Win32",
+              "Win32_Foundation",
+              "Win32_Networking",
+              "Win32_Networking_WinSock",
+              "Win32_Security",
+              "Win32_Storage",
+              "Win32_Storage_FileSystem",
+              "Win32_System",
+              "Win32_System_Console",
+              "Win32_System_IO",
+              "Win32_System_LibraryLoader",
+              "Win32_System_Pipes",
+              "Win32_System_SystemServices",
+              "Win32_System_Threading",
+              "Win32_System_WindowsProgramming",
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "Win32",
+              "Win32_Foundation",
+              "Win32_Networking",
+              "Win32_Networking_WinSock",
+              "Win32_Security",
+              "Win32_Storage",
+              "Win32_Storage_FileSystem",
+              "Win32_System",
+              "Win32_System_Console",
+              "Win32_System_IO",
+              "Win32_System_LibraryLoader",
+              "Win32_System_Pipes",
+              "Win32_System_SystemServices",
+              "Win32_System_Threading",
+              "Win32_System_WindowsProgramming",
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "Win32",
+              "Win32_Foundation",
+              "Win32_Networking",
+              "Win32_Networking_WinSock",
+              "Win32_Security",
+              "Win32_Storage",
+              "Win32_Storage_FileSystem",
+              "Win32_System",
+              "Win32_System_Console",
+              "Win32_System_IO",
+              "Win32_System_LibraryLoader",
+              "Win32_System_Pipes",
+              "Win32_System_SystemServices",
+              "Win32_System_Threading",
+              "Win32_System_WindowsProgramming",
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [],

--- a/examples/crate_universe/using_cxx/cargo-bazel-lock.json
+++ b/examples/crate_universe/using_cxx/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f56264a830f95c58f95f6b381314a888926dd242ec2abf41fd6d2434eb712fab",
+  "checksum": "5d41f2b0bb14ab9dda728b16001f3004b64610d7e3e326d1942427e7229050e4",
   "crates": {
     "cc 1.0.82": {
       "name": "cc",
@@ -156,10 +156,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default"
+            ],
+            "i686-pc-windows-msvc": [
+              "default"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-apple-darwin": [
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "edition": "2021",
         "version": "1.0.109"
@@ -309,11 +350,53 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -468,11 +551,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -535,11 +672,65 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "proc-macro"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "i686-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-apple-darwin": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-freebsd": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "proc-macro"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "proc-macro"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -590,17 +781,149 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "clone-impls",
-            "default",
-            "derive",
-            "full",
-            "parsing",
-            "printing",
-            "proc-macro",
-            "quote"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "i686-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "i686-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-apple-darwin": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-unknown-freebsd": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "clone-impls",
+              "default",
+              "derive",
+              "full",
+              "parsing",
+              "printing",
+              "proc-macro",
+              "quote"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -609,15 +932,96 @@
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.32",
-              "target": "quote"
-            },
-            {
               "id": "unicode-ident 1.0.11",
               "target": "unicode_ident"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "aarch64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "arm-unknown-linux-gnueabi": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "i686-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "i686-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "powerpc-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "s390x-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "x86_64-pc-windows-msvc": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-freebsd": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "quote 1.0.32",
+                "target": "quote"
+              }
+            ]
+          }
         },
         "edition": "2021",
         "version": "2.0.28"
@@ -694,7 +1098,8 @@
       "aarch64-unknown-fuchsia"
     ],
     "aarch64-unknown-linux-gnu": [
-      "aarch64-unknown-linux-gnu"
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu"
     ],
     "aarch64-unknown-nixos-gnu": [
       "aarch64-unknown-nixos-gnu"
@@ -798,7 +1203,8 @@
       "x86_64-unknown-fuchsia"
     ],
     "x86_64-unknown-linux-gnu": [
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "x86_64-unknown-nixos-gnu": [
       "x86_64-unknown-nixos-gnu"

--- a/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.Bazel.lock
+++ b/examples/crate_universe/using_cxx/cxxbridge-cmd.Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4ce263703fc55e73dbbd9ec2b2b1861be82bc9b9c8cbdb59d045db3355ddf241",
+  "checksum": "da5dc26d23af86a9cbdefd498c9be5314d49d5394f761ab43f05a661b707ae98",
   "crates": {
     "anstyle 1.0.1": {
       "name": "anstyle",
@@ -714,19 +714,45 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "consoleapi",
-            "errhandlingapi",
-            "fileapi",
-            "minwindef",
-            "processenv",
-            "std",
-            "winbase",
-            "wincon",
-            "winerror",
-            "winnt"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "minwindef",
+              "processenv",
+              "std",
+              "winbase",
+              "wincon",
+              "winerror",
+              "winnt"
+            ],
+            "i686-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "minwindef",
+              "processenv",
+              "std",
+              "winbase",
+              "wincon",
+              "winerror",
+              "winnt"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "consoleapi",
+              "errhandlingapi",
+              "fileapi",
+              "minwindef",
+              "processenv",
+              "std",
+              "winbase",
+              "wincon",
+              "winerror",
+              "winnt"
+            ]
+          }
         },
         "deps": {
           "common": [


### PR DESCRIPTION
Currently, "common" deps and features in selects in generated lockfiles are not always common to all target platforms in the presence of conditional dependencies. This change ensures that common deps and features for a crate are common to all supported targets, not just those targets for which the crate dependency is enabled.

Unfortunately this results in a size explosion for some generated lockfiles. I believe this is mostly because the examples consider all target triples, and certain triples (in particular, `wasm32-unknown-unknown` for `examples/crate_universe/multi_package/cargo-bazel-lock.json`) break the commonality. When `supported_platform_triples` is specified, the impact should be less severe.