### PR TITLE
cargo: Allow disabling the `default_shell_env` for build scripts

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -350,9 +350,8 @@ def _cargo_build_script_impl(ctx):
 
     # If enabled, start with the default shell env, which contains any --action_env
     # settings passed in on the command line and defaults like $PATH.
-    if ctx.attr.use_default_shell_env {
+    if ctx.attr.use_default_shell_env:
         env.update(ctx.configuration.default_shell_env)
-    }
 
     env.update({
         "CARGO_CRATE_NAME": name_to_crate_name(pkg_name),

--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -346,9 +346,13 @@ def _cargo_build_script_impl(ctx):
 
     cc_toolchain = find_cpp_toolchain(ctx)
 
-    # Start with the default shell env, which contains any --action_env
-    # settings passed in on the command line.
-    env = dict(ctx.configuration.default_shell_env)
+    env = dict({})
+
+    # If enabled, start with the default shell env, which contains any --action_env
+    # settings passed in on the command line and defaults like $PATH.
+    if ctx.attr.use_default_shell_env {
+        env.update(ctx.configuration.default_shell_env)
+    }
 
     env.update({
         "CARGO_CRATE_NAME": name_to_crate_name(pkg_name),
@@ -534,9 +538,9 @@ def _cargo_build_script_impl(ctx):
         progress_message = "Running Cargo build script {}".format(pkg_name),
         env = env,
         toolchain = None,
-        # Set use_default_shell_env so that $PATH is set, as tools like Cmake
-        # may want to probe $PATH for helper tools.
-        use_default_shell_env = True,
+        # If enabled, sets the $PATH environment variable so tools like `cmake`
+        # can probe $PATH for helper tools. Defaults to `True`.
+        use_default_shell_env = ctx.attr.use_default_shell_env,
     )
 
     return [
@@ -624,6 +628,14 @@ cargo_build_script = rule(
             doc = "Tools required by the build script.",
             allow_files = True,
             cfg = "exec",
+        ),
+        "use_default_shell_env": attr.bool(
+            doc = dedent("""\
+                Whether or not to include the default shell environment for the build
+                script action. By default Bazel's `default_shell_env` is set for build
+                script actions so crates like `cmake` can probe $PATH to find tools.
+            """),
+            default = True,
         ),
         "version": attr.string(
             doc = "The semantic version (semver) of the crate",


### PR DESCRIPTION
This PR adds a new boolean attribute to `cargo_build_script` rules called `use_default_shell_env` which is set to `True` by default.

The goal here is to make Cargo Build Scripts more hermetic. If you set `use_default_shell_env` to false, local environment variables like `PATH` should not get set for build scripts, preventing them from relying on tools not provided by Bazel.

Note: I considered adding a global `use_default_shell_env_for_cargo_build_scripts` setting, but couldn't figure out a good way to make the global setting work with this attribute. e.g. if you disable `use_default_shell_env` globally, ideally you still have a way to enable it for an individual crate, but I couldn't figure out how to set the defaults for the global setting and this local attr to get that to work

Related to https://github.com/bazelbuild/rules_rust/issues/2665