### PR TITLE
rust_analyzer: don't build a tree of RustAnalyzerInfos

### DIFF
--- a/extensions/prost/private/prost.bzl
+++ b/extensions/prost/private/prost.bzl
@@ -261,7 +261,10 @@ def _rust_prost_aspect_impl(target, ctx):
     # https://github.com/rust-analyzer/rust-analyzer/blob/2021-11-15/crates/project_model/src/workspace.rs#L529-L531
     cfgs = ["test", "debug_assertions"]
 
+    crate_id = "prost-" + crate_info.root.path
+
     rust_analyzer_info = write_rust_analyzer_spec_file(ctx, ctx.rule.attr, ctx.label, RustAnalyzerInfo(
+        id = crate_id,
         aliases = {},
         crate = dep_variant_info.crate_info,
         cfgs = cfgs,
@@ -332,7 +335,10 @@ def _rust_prost_library_impl(ctx):
                 transitive = transitive,
             ),
         ),
-        RustAnalyzerGroupInfo(deps = [proto_dep[RustAnalyzerInfo]]),
+        RustAnalyzerGroupInfo(
+            crate_specs = proto_dep[RustAnalyzerInfo].crate_specs
+            deps = proto_dep[RustAnalyzerInfo].deps,
+        ),
     ]
 
 rust_prost_library = rule(

--- a/extensions/prost/private/prost.bzl
+++ b/extensions/prost/private/prost.bzl
@@ -261,7 +261,7 @@ def _rust_prost_aspect_impl(target, ctx):
     # https://github.com/rust-analyzer/rust-analyzer/blob/2021-11-15/crates/project_model/src/workspace.rs#L529-L531
     cfgs = ["test", "debug_assertions"]
 
-    crate_id = "prost-" + crate_info.root.path
+    crate_id = "prost-" + dep_variant_info.crate_info.root.path
 
     rust_analyzer_info = write_rust_analyzer_spec_file(ctx, ctx.rule.attr, ctx.label, RustAnalyzerInfo(
         id = crate_id,
@@ -336,7 +336,7 @@ def _rust_prost_library_impl(ctx):
             ),
         ),
         RustAnalyzerGroupInfo(
-            crate_specs = proto_dep[RustAnalyzerInfo].crate_specs
+            crate_specs = proto_dep[RustAnalyzerInfo].crate_specs,
             deps = proto_dep[RustAnalyzerInfo].deps,
         ),
     ]

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -172,7 +172,7 @@ RustAnalyzerInfo = provider(
 RustAnalyzerGroupInfo = provider(
     doc = "RustAnalyzerGroupInfo holds multiple RustAnalyzerInfos",
     fields = {
-        "deps": "List[String]: crate IDs of direct dependencies",
         "crate_specs": "Depset[File]: transitive closure of OutputGroupInfo files",
+        "deps": "List[String]: crate IDs of direct dependencies",
     },
 )

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -157,13 +157,14 @@ TestCrateInfo = provider(
 RustAnalyzerInfo = provider(
     doc = "RustAnalyzerInfo holds rust crate metadata for targets",
     fields = {
-        "aliases": "Dict[RustAnalyzerInfo, String]: Replacement names these targets should be known as in Rust code",
+        "aliases": "Dict[String, String]: Maps crate IDs to Replacement names these targets should be known as in Rust code",
         "build_info": "BuildInfo: build info for this crate if present",
         "cfgs": "List[String]: features or other compilation `--cfg` settings",
         "crate": "CrateInfo: Crate information.",
         "crate_specs": "Depset[File]: transitive closure of OutputGroupInfo files",
-        "deps": "List[RustAnalyzerInfo]: direct dependencies",
+        "deps": "List[String]: IDs of direct dependency crates",
         "env": "Dict[String: String]: Environment variables, used for the `env!` macro",
+        "id": "String: Arbitrary unique ID for this crate",
         "proc_macro_dylib_path": "File: compiled shared library output of proc-macro rule",
     },
 )
@@ -171,6 +172,7 @@ RustAnalyzerInfo = provider(
 RustAnalyzerGroupInfo = provider(
     doc = "RustAnalyzerGroupInfo holds multiple RustAnalyzerInfos",
     fields = {
-        "deps": "List[RustAnalyzerInfo]: direct dependencies",
+        "deps": "List[String]: crate IDs of direct dependencies",
+        "crate_specs": "Depset[File]: transitive closure of OutputGroupInfo files",
     },
 )

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -81,8 +81,8 @@ def _accumulate_rust_analyzer_info(deps_details, dep):
         deps_details.crate_specs.append(dep[RustAnalyzerInfo].crate_specs)
     if RustAnalyzerGroupInfo in dep:
         for expanded_dep in dep[RustAnalyzerGroupInfo].deps:
-            deps_details.label_to_id[expanded_dep.crate.owner] = expanded_dep
-            deps_details.crate_specs.append(dep[RustAnalyzerGroupInfo].crate_specs)
+            deps_details.label_to_id[expanded_dep] = expanded_dep
+        deps_details.crate_specs.extend(dep[RustAnalyzerGroupInfo].crate_specs)
 
 def _rust_analyzer_aspect_impl(target, ctx):
     if (rust_common.crate_info not in target and

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -103,7 +103,7 @@ def _rust_analyzer_aspect_impl(target, ctx):
     crate_specs = []  # [depset of File - transitive crate_spec.json files]
     attrs = ctx.rule.attr
     all_deps = getattr(attrs, "deps", []) + getattr(attrs, "proc_macro_deps", []) + \
-               [dep for dep in [getattr(attrs, "crate", None), getattr(attrs, "actual")] if dep != None]
+               [dep for dep in [getattr(attrs, "crate", None), getattr(attrs, "actual", None)] if dep != None]
     for dep in all_deps:
         if RustAnalyzerInfo in dep:
             label_to_id[dep.label] = dep[RustAnalyzerInfo].id

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -82,7 +82,7 @@ def _accumulate_rust_analyzer_info(deps_details, dep):
     if RustAnalyzerGroupInfo in dep:
         for expanded_dep in dep[RustAnalyzerGroupInfo].deps:
             deps_details.label_to_id[expanded_dep] = expanded_dep
-        deps_details.crate_specs.extend(dep[RustAnalyzerGroupInfo].crate_specs)
+        deps_details.crate_specs.append(dep[RustAnalyzerGroupInfo].crate_specs)
 
 def _rust_analyzer_aspect_impl(target, ctx):
     if (rust_common.crate_info not in target and


### PR DESCRIPTION
This patch adds an `id` to RustAnalyzerInfo, and replace all the recursive RustAnalyzerInfos with the respective crate `id`s.
This fixes RustAnalyzerInfos becoming exponentially expensive to build in the presence of aliases.

---

Before this patch, `RustAnalyzerInfo.deps` contains the RustAnalyzerInfo of the target crate's deps, and so on recursively.
This forms a graph of Infos where there is one Info per target, but multiple paths from one target to another.
e.g. these could all point to `bar`: `foo.deps[0] == foo.deps[1].deps[0] == foo.aliases[0]`.

If we walk `foo` as a tree, we will see `bar` multiple times. Two operations that do this are `print(info)` and `{info: 42}` which hashes the object. As the graph grows, the number of paths grows combinatorically.

`RustAnalyzerInfo.aliases` is defined as a dict from `RustAnalyzerInfo => string`, so building this triggers the slowdown.

It would be possible to fix this by e.g. replacing this dict with a list of pairs.
However the work `rust_analyzer_aspect` does is fundamentally local and does not need a recursive data structure. Eliminating it means we can freely use these values as keys, print them, etc.

---

Timings for `ra_ap_rust-analyzer` (which heavily aliases its deps):

```
blaze build //third_party/bazel_rules/rules_rust/tools/rust_analyzer:gen_rust_project; \
time blaze run //third_party/bazel_rules/rules_rust/tools/rust_analyzer:gen_rust_project -- //third_party/rust/ra_ap_rust_analyzer/...

===Before===
Executed in  211.06 secs    fish           external
   usr time    0.24 secs    0.00 micros    0.24 secs
   sys time    1.24 secs  604.00 micros    1.24 sec

===After===
Executed in    3.24 secs    fish           external
   usr time    0.15 secs  389.00 micros    0.15 secs
   sys time    1.18 secs  125.00 micros    1.18 secs
```
