### PR TITLE
Improve workspace discovery logic

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -136,6 +136,7 @@ use_repo(
     "cui__tracing-0.1.40",
     "cui__tracing-subscriber-0.3.18",
     "cui__url-2.5.2",
+    "cui__walkdir-2.5.0",
 )
 
 crate_universe_internal_dev_deps = use_extension(

--- a/crate_universe/3rdparty/crates/BUILD.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bazel
@@ -210,3 +210,9 @@ alias(
     actual = "@cui__url-2.5.2//:url",
     tags = ["manual"],
 )
+
+alias(
+    name = "walkdir",
+    actual = "@cui__walkdir-2.5.0//:walkdir",
+    tags = ["manual"],
+)

--- a/crate_universe/3rdparty/crates/BUILD.gix-features-0.38.2.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.gix-features-0.38.2.bazel
@@ -102,7 +102,7 @@ rust_library(
         "@cui__prodash-28.0.0//:prodash",
         "@cui__sha1_smol-1.0.0//:sha1_smol",
         "@cui__thiserror-1.0.50//:thiserror",
-        "@cui__walkdir-2.3.3//:walkdir",
+        "@cui__walkdir-2.5.0//:walkdir",
     ] + select({
         "@rules_rust//rust/platform:aarch64-apple-darwin": [
             "@cui__libc-0.2.161//:libc",  # cfg(unix)

--- a/crate_universe/3rdparty/crates/BUILD.globwalk-0.8.1.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.globwalk-0.8.1.bazel
@@ -81,6 +81,6 @@ rust_library(
     deps = [
         "@cui__bitflags-1.3.2//:bitflags",
         "@cui__ignore-0.4.18//:ignore",
-        "@cui__walkdir-2.3.3//:walkdir",
+        "@cui__walkdir-2.5.0//:walkdir",
     ],
 )

--- a/crate_universe/3rdparty/crates/BUILD.ignore-0.4.18.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.ignore-0.4.18.bazel
@@ -87,7 +87,7 @@ rust_library(
         "@cui__regex-1.11.0//:regex",
         "@cui__same-file-1.0.6//:same_file",
         "@cui__thread_local-1.1.4//:thread_local",
-        "@cui__walkdir-2.3.3//:walkdir",
+        "@cui__walkdir-2.5.0//:walkdir",
     ] + select({
         "@rules_rust//rust/platform:aarch64-pc-windows-msvc": [
             "@cui__winapi-util-0.1.5//:winapi_util",  # cfg(windows)

--- a/crate_universe/3rdparty/crates/BUILD.walkdir-2.5.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.walkdir-2.5.0.bazel
@@ -77,7 +77,7 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "2.3.3",
+    version = "2.5.0",
     deps = [
         "@cui__same-file-1.0.6//:same_file",
     ] + select({

--- a/crate_universe/3rdparty/crates/defs.bzl
+++ b/crate_universe/3rdparty/crates/defs.bzl
@@ -323,6 +323,7 @@ _NORMAL_DEPENDENCIES = {
             "tracing": Label("@cui__tracing-0.1.40//:tracing"),
             "tracing-subscriber": Label("@cui__tracing-subscriber-0.3.18//:tracing_subscriber"),
             "url": Label("@cui__url-2.5.2//:url"),
+            "walkdir": Label("@cui__walkdir-2.5.0//:walkdir"),
         },
     },
     "crate_universe/tools/cross_installer": {
@@ -2615,12 +2616,12 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "cui__walkdir-2.3.3",
-        sha256 = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698",
+        name = "cui__walkdir-2.5.0",
+        sha256 = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/walkdir/2.3.3/download"],
-        strip_prefix = "walkdir-2.3.3",
-        build_file = Label("//crate_universe/3rdparty/crates:BUILD.walkdir-2.3.3.bazel"),
+        urls = ["https://static.crates.io/crates/walkdir/2.5.0/download"],
+        strip_prefix = "walkdir-2.5.0",
+        build_file = Label("//crate_universe/3rdparty/crates:BUILD.walkdir-2.5.0.bazel"),
     )
 
     maybe(
@@ -2923,5 +2924,6 @@ def crate_repositories():
         struct(repo = "cui__tracing-0.1.40", is_dev_dep = False),
         struct(repo = "cui__tracing-subscriber-0.3.18", is_dev_dep = False),
         struct(repo = "cui__url-2.5.2", is_dev_dep = False),
+        struct(repo = "cui__walkdir-2.5.0", is_dev_dep = False),
         struct(repo = "cui__maplit-1.0.2", is_dev_dep = True),
     ]

--- a/crate_universe/Cargo.lock
+++ b/crate_universe/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -1846,6 +1847,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "symlinked"
+version = "0.1.0"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,9 +2198,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",

--- a/crate_universe/Cargo.toml
+++ b/crate_universe/Cargo.toml
@@ -1,6 +1,46 @@
 [workspace]
 members = ["tools/cross_installer", "tools/urls_generator"]
-exclude = ["test_data"]
+exclude = [
+    "test_data/metadata/abspath",
+    "test_data/metadata/aliases",
+    "test_data/metadata/build_scripts",
+    "test_data/metadata/common",
+    "test_data/metadata/crate_combined_features",
+    "test_data/metadata/crate_optional_deps_disabled",
+    "test_data/metadata/crate_optional_deps_disabled_build_dep_enabled",
+    "test_data/metadata/crate_optional_deps_enabled",
+    "test_data/metadata/crate_renamed_optional_deps_disabled",
+    "test_data/metadata/crate_renamed_optional_deps_enabled",
+    "test_data/metadata/crate_types",
+    "test_data/metadata/example_proc_macro_dep",
+    "test_data/metadata/git_repos",
+    "test_data/metadata/has_package_metadata",
+    "test_data/metadata/host_specific_build_deps",
+    "test_data/metadata/multi_cfg_dep",
+    "test_data/metadata/multi_kind_proc_macro_dep",
+    "test_data/metadata/nested_build_dependencies",
+    "test_data/metadata/no_deps",
+    "test_data/metadata/resolver_2_deps",
+    "test_data/metadata/target_cfg_features",
+    "test_data/metadata/target_features",
+    "test_data/metadata/tree_data",
+    "test_data/metadata/workspace",
+    "test_data/metadata/workspace/child",
+    "test_data/metadata/workspace_path",
+    "test_data/metadata/workspace_path/child_a",
+    "test_data/metadata/workspace_path/child_b",
+    "test_data/test_data_passing_crate",
+    "test_data/workspace_examples/non-ws",
+    "test_data/workspace_examples/ws1",
+    "test_data/workspace_examples/ws1/ws1c1",
+    "test_data/workspace_examples/ws1/ws1c1/ws1c1c1",
+    "test_data/workspace_examples/ws1/ws1c2",
+    "test_data/workspace_examples/ws2",
+    "test_data/workspace_examples/ws2/ws2c1",
+    "test_data/workspace_examples/ws2/ws2excluded",
+    "test_data/workspace_examples/ws2/ws2excluded/ws2excluded2",
+    "test_data/workspace_examples/ws2/ws2excluded/ws2included",
+]
 
 [package]
 name = "cargo-bazel"

--- a/crate_universe/Cargo.toml
+++ b/crate_universe/Cargo.toml
@@ -51,6 +51,7 @@ toml = "0.8.19"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = "2.5.2"
+walkdir = "2.5.0"
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -112,6 +112,8 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, cargo
         ),
     )
 
+    nonhermetic_root_bazel_workspace_dir = module_ctx.path(Label("@@//:MODULE.bazel")).dirname
+
     splicing_output_dir = tag_path.get_child("splicing-output")
     splice_args = [
         "splice",
@@ -121,6 +123,8 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, cargo
         config_file,
         "--splicing-manifest",
         splicing_manifest,
+        "--nonhermetic-root-bazel-workspace-dir",
+        nonhermetic_root_bazel_workspace_dir,
     ]
     if cargo_lockfile:
         splice_args.extend([
@@ -153,7 +157,7 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, cargo
         "--lockfile",
         lockfile_path,
         "--nonhermetic-root-bazel-workspace-dir",
-        module_ctx.path(Label("@@//:MODULE.bazel")).dirname,
+        nonhermetic_root_bazel_workspace_dir,
         "--paths-to-track",
         paths_to_track_file,
         "--warnings-output-path",

--- a/crate_universe/private/splicing_utils.bzl
+++ b/crate_universe/private/splicing_utils.bzl
@@ -149,6 +149,8 @@ def splice_workspace_manifest(repository_ctx, generator, cargo_lockfile, splicin
         rustc,
         "--cargo-lockfile",
         cargo_lockfile,
+        "--nonhermetic-root-bazel-workspace-dir",
+        repository_ctx.workspace_root,
     ]
 
     # Optionally set the splicing workspace directory to somewhere within the repository directory

--- a/crate_universe/private/srcs.bzl
+++ b/crate_universe/private/srcs.bzl
@@ -28,6 +28,7 @@ CARGO_BAZEL_SRCS = [
     Label("//crate_universe:src/metadata/cargo_tree_rustc_wrapper.sh"),
     Label("//crate_universe:src/metadata/dependency.rs"),
     Label("//crate_universe:src/metadata/metadata_annotation.rs"),
+    Label("//crate_universe:src/metadata/workspace_discoverer.rs"),
     Label("//crate_universe:src/rendering.rs"),
     Label("//crate_universe:src/rendering/template_engine.rs"),
     Label("//crate_universe:src/rendering/templates/module_bzl.j2"),

--- a/crate_universe/src/metadata/cargo_bin.rs
+++ b/crate_universe/src/metadata/cargo_bin.rs
@@ -33,12 +33,6 @@ impl Cargo {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn with_cargo_home(mut self, path: PathBuf) -> Cargo {
-        self.cargo_home = Some(path);
-        self
-    }
-
     /// Returns a new `Command` for running this cargo.
     pub(crate) fn command(&self) -> Result<Command> {
         let mut command = Command::new(&self.path);

--- a/crate_universe/src/metadata/workspace_discoverer.rs
+++ b/crate_universe/src/metadata/workspace_discoverer.rs
@@ -1,0 +1,337 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use cargo_toml::Manifest;
+
+/// A description of Cargo.toml files and how they are related in workspaces.
+/// All `Utf8PathBuf` values are paths of Cargo.toml files.
+#[derive(Debug, PartialEq)]
+pub(crate) struct DiscoveredWorkspaces {
+    workspaces_to_members: BTreeMap<Utf8PathBuf, BTreeSet<Utf8PathBuf>>,
+    non_workspaces: BTreeSet<Utf8PathBuf>,
+}
+
+impl DiscoveredWorkspaces {
+    pub(crate) fn workspaces(&self) -> BTreeSet<Utf8PathBuf> {
+        self.workspaces_to_members.keys().cloned().collect()
+    }
+
+    pub(crate) fn all_workspaces_and_members(&self) -> BTreeSet<Utf8PathBuf> {
+        self.workspaces_to_members
+            .keys()
+            .chain(self.workspaces_to_members.values().flatten())
+            .cloned()
+            .collect()
+    }
+}
+
+pub(crate) fn discover_workspaces(
+    cargo_toml_paths: BTreeSet<Utf8PathBuf>,
+    known_manifests: &BTreeMap<Utf8PathBuf, Manifest>,
+    bazel_workspace_root: &Path,
+) -> Result<DiscoveredWorkspaces> {
+    let mut manifest_cache = ManifestCache {
+        cache: BTreeMap::new(),
+        known_manifests,
+    };
+    discover_workspaces_with_cache(cargo_toml_paths, bazel_workspace_root, &mut manifest_cache)
+}
+
+fn discover_workspaces_with_cache(
+    cargo_toml_paths: BTreeSet<Utf8PathBuf>,
+    bazel_workspace_root: &Path,
+    manifest_cache: &mut ManifestCache,
+) -> Result<DiscoveredWorkspaces> {
+    let mut discovered_workspaces = DiscoveredWorkspaces {
+        workspaces_to_members: BTreeMap::new(),
+        non_workspaces: BTreeSet::new(),
+    };
+
+    // First pass: Discover workspace parents.
+    for cargo_toml_path in cargo_toml_paths {
+        if let Some(workspace_parent) = discover_workspace_parent(&cargo_toml_path, manifest_cache)
+        {
+            discovered_workspaces
+                .workspaces_to_members
+                .insert(workspace_parent, BTreeSet::new());
+        } else {
+            discovered_workspaces.non_workspaces.insert(cargo_toml_path);
+        }
+    }
+
+    // Second pass: Find all child manifests.
+    for workspace_path in discovered_workspaces
+        .workspaces_to_members
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+    {
+        let workspace_manifest = manifest_cache.get(&workspace_path).unwrap();
+        'per_child: for entry in walkdir::WalkDir::new(workspace_path.parent().unwrap())
+            .follow_links(true)
+            .follow_root_links(true)
+            .into_iter()
+            // Avoid traversing the bazel-$workspace symlink which mirrors the whole source root.
+            // This is not super correct - technically the symlinks can be renamed,
+            // and technically people can create symlinks they care about which match this pattern to.
+            // But it's Good Enough.
+            .filter_entry(|e| {
+                if !e.path_is_symlink() {
+                    return true;
+                }
+                if e.path().parent().unwrap() != bazel_workspace_root {
+                    return true;
+                }
+                if let Some(file_name) = e.file_name().to_str() {
+                    if file_name.starts_with("bazel-") {
+                        return false;
+                    }
+                }
+                true
+            })
+        {
+            let entry =
+                entry.context("Failed to walk filesystem finding workspace Cargo.toml files")?;
+
+            if entry.file_name() != "Cargo.toml" {
+                continue;
+            }
+
+            let child_path = Utf8Path::from_path(entry.path())
+                .ok_or_else(|| anyhow!("Failed to parse {:?} as UTF-8", entry.path()))?
+                .to_path_buf();
+            if child_path == workspace_path {
+                continue;
+            }
+
+            let manifest = manifest_cache
+                .get(&child_path)
+                .ok_or_else(|| anyhow!("Failed to read manifest at {}", child_path))?;
+
+            let mut actual_workspace_path = workspace_path.clone();
+            if let Some(package) = manifest.package {
+                if let Some(explicit_workspace_path) = package.workspace {
+                    actual_workspace_path =
+                        child_path.parent().unwrap().join(explicit_workspace_path);
+                }
+            }
+            if !discovered_workspaces
+                .workspaces_to_members
+                .contains_key(&actual_workspace_path)
+            {
+                bail!("Found manifest at {} which is a member of the workspace at {} which isn't included in the crates_universe", child_path, actual_workspace_path);
+            }
+
+            for exclude in &workspace_manifest.workspace.as_ref().unwrap().exclude {
+                let exclude_path = workspace_path.parent().unwrap().join(exclude);
+                if exclude_path == child_path.parent().unwrap() {
+                    discovered_workspaces.non_workspaces.insert(child_path);
+                    continue 'per_child;
+                }
+            }
+
+            discovered_workspaces
+                .workspaces_to_members
+                .get_mut(&actual_workspace_path)
+                .unwrap()
+                .insert(child_path.clone());
+        }
+    }
+
+    Ok(discovered_workspaces)
+}
+
+fn discover_workspace_parent(
+    cargo_toml_path: &Utf8PathBuf,
+    manifest_cache: &mut ManifestCache,
+) -> Option<Utf8PathBuf> {
+    for parent_dir in cargo_toml_path.ancestors().skip(1) {
+        let maybe_cargo_toml_path = parent_dir.join("Cargo.toml");
+        let maybe_manifest = manifest_cache.get(&maybe_cargo_toml_path);
+        if let Some(manifest) = maybe_manifest {
+            if manifest.workspace.is_some() {
+                return Some(maybe_cargo_toml_path);
+            }
+        }
+    }
+    None
+}
+
+struct ManifestCache<'a> {
+    cache: BTreeMap<Utf8PathBuf, Option<Manifest>>,
+    known_manifests: &'a BTreeMap<Utf8PathBuf, Manifest>,
+}
+
+impl ManifestCache<'_> {
+    fn get(&mut self, path: &Utf8PathBuf) -> Option<Manifest> {
+        if let Some(manifest) = self.known_manifests.get(path) {
+            return Some(manifest.clone());
+        }
+        if let Some(maybe_manifest) = self.cache.get(path) {
+            return maybe_manifest.clone();
+        }
+        let maybe_manifest = if let Ok(manifest) = Manifest::from_path(path) {
+            Some(manifest)
+        } else {
+            None
+        };
+        self.cache.insert(path.clone(), maybe_manifest.clone());
+        maybe_manifest
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    // Both of these tests try to create the same symlink, so they can't run in parallel.
+    static FILESYSTEM_GUARD: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn test_discover() {
+        let _guard = FILESYSTEM_GUARD.lock().unwrap();
+        let r = runfiles::Runfiles::create().unwrap();
+        let root_dir =
+            runfiles::rlocation!(r, "rules_rust/crate_universe/test_data/workspace_examples")
+                .unwrap();
+        let root_dir = Utf8PathBuf::from_path_buf(root_dir).unwrap();
+
+        let _symlink = DeleteOnDropDirSymlink::symlink(
+            Path::new("..").join("symlinked"),
+            root_dir.join("ws1").join("bazel-ws1").into_std_path_buf(),
+        )
+        .unwrap();
+
+        let mut workspaces_to_members = BTreeMap::new();
+        workspaces_to_members.insert(
+            root_dir.join("ws1").join("Cargo.toml"),
+            BTreeSet::from([
+                // This isn't at the bazel repo root level, so gets included.
+                root_dir.join("ws1").join("bazel-ws1").join("Cargo.toml"),
+                root_dir.join("ws1").join("ws1c1").join("Cargo.toml"),
+                root_dir
+                    .join("ws1")
+                    .join("ws1c1")
+                    .join("ws1c1c1")
+                    .join("Cargo.toml"),
+                root_dir.join("ws1").join("ws1c2").join("Cargo.toml"),
+            ]),
+        );
+        workspaces_to_members.insert(
+            root_dir.join("ws2").join("Cargo.toml"),
+            BTreeSet::from([
+                root_dir.join("ws2").join("ws2c1").join("Cargo.toml"),
+                root_dir
+                    .join("ws2")
+                    .join("ws2excluded")
+                    .join("ws2included")
+                    .join("Cargo.toml"),
+            ]),
+        );
+        let non_workspaces = BTreeSet::from([
+            root_dir.join("non-ws").join("Cargo.toml"),
+            root_dir.join("ws2").join("ws2excluded").join("Cargo.toml"),
+            root_dir
+                .join("ws2")
+                .join("ws2excluded")
+                .join("ws2excluded2")
+                .join("Cargo.toml"),
+        ]);
+
+        let actual = discover_workspaces(
+            vec![
+                root_dir.join("ws1/ws1c1/Cargo.toml"),
+                root_dir.join("ws2/Cargo.toml"),
+                root_dir.join("non-ws/Cargo.toml"),
+            ]
+            .into_iter()
+            .collect(),
+            &BTreeMap::new(),
+            root_dir.as_std_path(),
+        )
+        .unwrap();
+        let expected = DiscoveredWorkspaces {
+            workspaces_to_members,
+            non_workspaces,
+        };
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_ignore_bazel_root_symlink() {
+        let _guard = FILESYSTEM_GUARD.lock().unwrap();
+        let r = runfiles::Runfiles::create().unwrap();
+        let root_dir =
+            runfiles::rlocation!(r, "rules_rust/crate_universe/test_data/workspace_examples")
+                .unwrap();
+        let root_dir = Utf8PathBuf::from_path_buf(root_dir).unwrap();
+
+        let _symlink = DeleteOnDropDirSymlink::symlink(
+            Path::new("..").join("symlinked"),
+            root_dir.join("ws1").join("bazel-ws1").into_std_path_buf(),
+        )
+        .unwrap();
+
+        let mut workspaces_to_members = BTreeMap::new();
+        workspaces_to_members.insert(
+            root_dir.join("ws1").join("Cargo.toml"),
+            BTreeSet::from([
+                root_dir.join("ws1").join("ws1c1").join("Cargo.toml"),
+                root_dir
+                    .join("ws1")
+                    .join("ws1c1")
+                    .join("ws1c1c1")
+                    .join("Cargo.toml"),
+                root_dir.join("ws1").join("ws1c2").join("Cargo.toml"),
+            ]),
+        );
+        let non_workspaces = BTreeSet::new();
+
+        let actual = discover_workspaces(
+            vec![root_dir.join("ws1/ws1c1/Cargo.toml")]
+                .into_iter()
+                .collect(),
+            &BTreeMap::new(),
+            root_dir.join("ws1").as_std_path(),
+        )
+        .unwrap();
+        let expected = DiscoveredWorkspaces {
+            workspaces_to_members,
+            non_workspaces,
+        };
+
+        assert_eq!(expected, actual);
+    }
+
+    struct DeleteOnDropDirSymlink(PathBuf);
+
+    impl DeleteOnDropDirSymlink {
+        #[cfg(unix)]
+        fn symlink<P: AsRef<Path>>(original: P, link: PathBuf) -> std::io::Result<Self> {
+            std::os::unix::fs::symlink(original, &link)?;
+            Ok(Self(link))
+        }
+
+        #[cfg(windows)]
+        fn symlink<P: AsRef<Path>>(original: P, link: PathBuf) -> std::io::Result<Self> {
+            std::os::windows::fs::symlink_dir(original, &link)?;
+            Ok(Self(link))
+        }
+    }
+
+    impl Drop for DeleteOnDropDirSymlink {
+        #[cfg(unix)]
+        fn drop(&mut self) {
+            std::fs::remove_file(&self.0).expect("Failed to delete symlink");
+        }
+        #[cfg(windows)]
+        fn drop(&mut self) {
+            std::fs::remove_dir(&self.0).expect("Failed to delete symlink");
+        }
+    }
+}

--- a/crate_universe/src/splicing/splicer.rs
+++ b/crate_universe/src/splicing/splicer.rs
@@ -1,15 +1,16 @@
 //! Utility for creating valid Cargo workspaces
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{bail, Context, Result};
-use cargo_toml::{Dependency, Manifest};
-use normpath::PathExt;
+use camino::{Utf8Path, Utf8PathBuf};
+use cargo_toml::Manifest;
 
 use crate::config::CrateId;
-use crate::splicing::{Cargo, SplicedManifest, SplicingManifest};
+use crate::metadata::discover_workspaces;
+use crate::splicing::{SplicedManifest, SplicingManifest};
 use crate::utils::starlark::Label;
 use crate::utils::symlink::{remove_symlink, symlink};
 
@@ -20,20 +21,20 @@ use super::{read_manifest, DirectPackageManifest, WorkspaceMetadata};
 pub(crate) enum SplicerKind<'a> {
     /// Splice a manifest which is represented by a Cargo workspace
     Workspace {
-        path: &'a PathBuf,
+        path: &'a Utf8PathBuf,
         manifest: &'a Manifest,
         splicing_manifest: &'a SplicingManifest,
     },
     /// Splice a manifest for a single package. This includes cases where
     /// were defined directly in Bazel.
     Package {
-        path: &'a PathBuf,
+        path: &'a Utf8PathBuf,
         manifest: &'a Manifest,
         splicing_manifest: &'a SplicingManifest,
     },
     /// Splice a manifest from multiple disjoint Cargo manifests.
     MultiPackage {
-        manifests: &'a BTreeMap<PathBuf, Manifest>,
+        manifests: &'a BTreeMap<Utf8PathBuf, Manifest>,
         splicing_manifest: &'a SplicingManifest,
     },
 }
@@ -43,91 +44,60 @@ const IGNORE_LIST: &[&str] = &[".git", "bazel-*", ".svn"];
 
 impl<'a> SplicerKind<'a> {
     pub(crate) fn new(
-        manifests: &'a BTreeMap<PathBuf, Manifest>,
+        manifests: &'a BTreeMap<Utf8PathBuf, Manifest>,
         splicing_manifest: &'a SplicingManifest,
-        cargo_bin: &Cargo,
+        nonhermetic_root_bazel_workspace_dir: &Path,
     ) -> Result<Self> {
-        // First check for any workspaces in the provided manifests
-        let workspace_owned: BTreeMap<&PathBuf, &Manifest> = manifests
-            .iter()
-            .filter(|(_, manifest)| is_workspace_owned(manifest))
-            .collect();
-
-        let mut root_workspace_pair: Option<(&PathBuf, &Manifest)> = None;
-
-        if !workspace_owned.is_empty() {
-            // Filter for the root workspace manifest info
-            let (workspace_roots, workspace_packages): (
-                BTreeMap<&PathBuf, &Manifest>,
-                BTreeMap<&PathBuf, &Manifest>,
-            ) = workspace_owned
-                .into_iter()
-                .partition(|(_, manifest)| is_workspace_root(manifest));
-
-            if workspace_roots.len() > 1 {
-                bail!("When splicing manifests, there can only be 1 root workspace manifest");
-            }
-
-            // This is an error case - we've detected some manifests are in a workspace, but can't
-            // find it.
-            // This block is just for trying to give as useful an error message as possible in this
-            // case.
-            if workspace_roots.is_empty() {
-                let sorted_manifests: BTreeSet<_> = manifests.keys().collect();
-                for manifest_path in sorted_manifests {
-                    let metadata_result = cargo_bin
-                        .metadata_command_with_options(manifest_path, Vec::new())?
-                        .no_deps()
-                        .exec();
-                    if let Ok(metadata) = metadata_result {
-                        let label = Label::from_absolute_path(
-                            metadata.workspace_root.join("Cargo.toml").as_std_path(),
-                        );
-                        if let Ok(label) = label {
-                            bail!("Missing root workspace manifest. Please add the following label to the `manifests` key: \"{}\"", label);
-                        }
-                    }
-                }
-                bail!("Missing root workspace manifest. Please add the label of the workspace root to the `manifests` key");
-            }
-
-            // Ensure all workspace owned manifests are members of the one workspace root
-            // UNWRAP: Safe because we've checked workspace_roots isn't empty.
-            let (root_manifest_path, root_manifest) = workspace_roots.into_iter().next().unwrap();
-            let external_workspace_members: BTreeSet<String> = workspace_packages
-                .into_iter()
-                .filter(|(manifest_path, _)| {
-                    !is_workspace_member(root_manifest, root_manifest_path, manifest_path)
-                })
-                .map(|(path, _)| path.to_string_lossy().to_string())
-                .collect();
-
-            if !external_workspace_members.is_empty() {
-                bail!("A package was provided that appears to be a part of another workspace.\nworkspace root: '{}'\nexternal packages: {:#?}", root_manifest_path.display(), external_workspace_members)
-            }
-
-            // UNWRAP: Safe because a Cargo.toml file must have a parent directory.
-            let root_manifest_dir = root_manifest_path.parent().unwrap();
-            let missing_manifests = Self::find_missing_manifests(
-                root_manifest,
-                root_manifest_dir,
-                &manifests
-                    .keys()
-                    .map(|p| {
-                        p.normalize()
-                            .with_context(|| format!("Failed to normalize path {p:?}"))
-                    })
-                    .collect::<Result<_, _>>()?,
-            )
-            .context("Identifying missing manifests")?;
-            if !missing_manifests.is_empty() {
-                bail!("Some manifests are not being tracked. Please add the following labels to the `manifests` key: {:#?}", missing_manifests);
-            }
-
-            root_workspace_pair = Some((root_manifest_path, root_manifest));
+        let workspaces = discover_workspaces(
+            manifests.keys().cloned().collect(),
+            manifests,
+            nonhermetic_root_bazel_workspace_dir,
+        )?;
+        let workspace_roots = workspaces.workspaces();
+        if workspace_roots.len() > 1 {
+            bail!("When splicing manifests, manifests are not allowed to from from different workspaces. Saw manifests which belong to the following workspaces: {}", workspace_roots.iter().map(|wr| wr.to_string()).collect::<Vec<_>>().join(", "));
         }
 
-        if let Some((path, manifest)) = root_workspace_pair {
+        let all_workspace_and_member_paths = workspaces.all_workspaces_and_members();
+        let mut missing_labels = Vec::new();
+        let mut missing_paths = Vec::new();
+        for manifest_path in &all_workspace_and_member_paths {
+            if !manifests.contains_key(manifest_path) {
+                if let Ok(label) = Label::from_absolute_path(manifest_path.as_path().as_std_path())
+                {
+                    missing_labels.push(label.to_string());
+                } else {
+                    missing_paths.push(manifest_path.to_string());
+                }
+            }
+        }
+        if !missing_labels.is_empty() || !missing_paths.is_empty() {
+            bail!(
+                "Some manifests are not being tracked.{}{}",
+                if !missing_labels.is_empty() {
+                    format!(
+                        "\nPlease add the following labels to the `manifests` key:\n {}.",
+                        missing_labels.join("\n ")
+                    )
+                } else {
+                    String::new()
+                },
+                if !missing_paths.is_empty() {
+                    format!(
+                        " Please add labels for the following paths to the `manifests` key:\n {}.",
+                        missing_paths.join("\n ")
+                    )
+                } else {
+                    String::new()
+                },
+            )
+        }
+
+        if let Some((path, manifest)) = workspace_roots
+            .iter()
+            .next()
+            .and_then(|path| manifests.get_key_value(path))
+        {
             Ok(Self::Workspace {
                 path,
                 manifest,
@@ -148,43 +118,9 @@ impl<'a> SplicerKind<'a> {
         }
     }
 
-    fn find_missing_manifests(
-        root_manifest: &Manifest,
-        root_manifest_dir: &Path,
-        known_manifest_paths: &BTreeSet<normpath::BasePathBuf>,
-    ) -> Result<BTreeSet<String>> {
-        let workspace_manifest_paths = root_manifest
-            .workspace
-            .as_ref()
-            .unwrap()
-            .members
-            .iter()
-            .map(|member| {
-                let path = root_manifest_dir.join(member).join("Cargo.toml");
-                path.normalize()
-                    .with_context(|| format!("Failed to normalize path {path:?}"))
-            })
-            .collect::<Result<BTreeSet<normpath::BasePathBuf>, _>>()?;
-
-        // Ensure all workspace members are present for the given workspace
-        workspace_manifest_paths
-            .into_iter()
-            .filter(|workspace_manifest_path| {
-                !known_manifest_paths.contains(workspace_manifest_path)
-            })
-            .map(|workspace_manifest_path| {
-                let label = Label::from_absolute_path(workspace_manifest_path.as_path())
-                    .with_context(|| {
-                        format!("Failed to identify label for path {workspace_manifest_path:?}")
-                    })?;
-                Ok(label.to_string())
-            })
-            .collect()
-    }
-
     /// Performs splicing based on the current variant.
     #[tracing::instrument(skip_all)]
-    pub(crate) fn splice(&self, workspace_dir: &Path) -> Result<SplicedManifest> {
+    pub(crate) fn splice(&self, workspace_dir: &Utf8Path) -> Result<SplicedManifest> {
         match self {
             SplicerKind::Workspace {
                 path,
@@ -206,8 +142,8 @@ impl<'a> SplicerKind<'a> {
     /// Implementation for splicing Cargo workspaces
     #[tracing::instrument(skip_all)]
     fn splice_workspace(
-        workspace_dir: &Path,
-        path: &&PathBuf,
+        workspace_dir: &Utf8Path,
+        path: &&Utf8PathBuf,
         manifest: &&Manifest,
         splicing_manifest: &&SplicingManifest,
     ) -> Result<SplicedManifest> {
@@ -217,10 +153,14 @@ impl<'a> SplicerKind<'a> {
             .expect("Every manifest should havee a parent directory");
 
         // Link the sources of the root manifest into the new workspace
-        symlink_roots(manifest_dir, workspace_dir, Some(IGNORE_LIST))?;
+        symlink_roots(
+            manifest_dir.as_std_path(),
+            workspace_dir.as_std_path(),
+            Some(IGNORE_LIST),
+        )?;
 
         // Optionally install the cargo config after contents have been symlinked
-        Self::setup_cargo_config(&splicing_manifest.cargo_config, workspace_dir)?;
+        Self::setup_cargo_config(&splicing_manifest.cargo_config, workspace_dir.as_std_path())?;
 
         // Add any additional depeendencies to the root package
         if !splicing_manifest.direct_packages.is_empty() {
@@ -235,7 +175,7 @@ impl<'a> SplicerKind<'a> {
         workspace_metadata.inject_into(&mut manifest)?;
 
         // Write the root manifest
-        write_root_manifest(&root_manifest_path, manifest)?;
+        write_root_manifest(root_manifest_path.as_std_path(), manifest)?;
 
         Ok(SplicedManifest::Workspace(root_manifest_path))
     }
@@ -243,8 +183,8 @@ impl<'a> SplicerKind<'a> {
     /// Implementation for splicing individual Cargo packages
     #[tracing::instrument(skip_all)]
     fn splice_package(
-        workspace_dir: &Path,
-        path: &&PathBuf,
+        workspace_dir: &Utf8Path,
+        path: &&Utf8PathBuf,
         manifest: &&Manifest,
         splicing_manifest: &&SplicingManifest,
     ) -> Result<SplicedManifest> {
@@ -253,10 +193,14 @@ impl<'a> SplicerKind<'a> {
             .expect("Every manifest should havee a parent directory");
 
         // Link the sources of the root manifest into the new workspace
-        symlink_roots(manifest_dir, workspace_dir, Some(IGNORE_LIST))?;
+        symlink_roots(
+            manifest_dir.as_std_path(),
+            workspace_dir.as_std_path(),
+            Some(IGNORE_LIST),
+        )?;
 
         // Optionally install the cargo config after contents have been symlinked
-        Self::setup_cargo_config(&splicing_manifest.cargo_config, workspace_dir)?;
+        Self::setup_cargo_config(&splicing_manifest.cargo_config, workspace_dir.as_std_path())?;
 
         // Ensure the root package manifest has a populated `workspace` member
         let mut manifest = (*manifest).clone();
@@ -278,7 +222,7 @@ impl<'a> SplicerKind<'a> {
         workspace_metadata.inject_into(&mut manifest)?;
 
         // Write the root manifest
-        write_root_manifest(&root_manifest_path, manifest)?;
+        write_root_manifest(root_manifest_path.as_std_path(), manifest)?;
 
         Ok(SplicedManifest::Package(root_manifest_path))
     }
@@ -286,17 +230,17 @@ impl<'a> SplicerKind<'a> {
     /// Implementation for splicing together multiple Cargo packages/workspaces
     #[tracing::instrument(skip_all)]
     fn splice_multi_package(
-        workspace_dir: &Path,
-        manifests: &&BTreeMap<PathBuf, Manifest>,
+        workspace_dir: &Utf8Path,
+        manifests: &&BTreeMap<Utf8PathBuf, Manifest>,
         splicing_manifest: &&SplicingManifest,
     ) -> Result<SplicedManifest> {
         let mut manifest = default_cargo_workspace_manifest(&splicing_manifest.resolver_version);
 
         // Optionally install a cargo config file into the workspace root.
-        Self::setup_cargo_config(&splicing_manifest.cargo_config, workspace_dir)?;
+        Self::setup_cargo_config(&splicing_manifest.cargo_config, workspace_dir.as_std_path())?;
 
         let installations =
-            Self::inject_workspace_members(&mut manifest, manifests, workspace_dir)?;
+            Self::inject_workspace_members(&mut manifest, manifests, workspace_dir.as_std_path())?;
 
         // Collect all patches from the manifests provided
         for (_, sub_manifest) in manifests.iter() {
@@ -305,7 +249,7 @@ impl<'a> SplicerKind<'a> {
                     "Duplicate `[patch]` entries detected in {:#?}",
                     manifests
                         .keys()
-                        .map(|p| p.display().to_string())
+                        .map(|p| p.to_string())
                         .collect::<Vec<String>>()
                 )
             })?;
@@ -322,14 +266,17 @@ impl<'a> SplicerKind<'a> {
 
         // Write the root manifest
         let root_manifest_path = workspace_dir.join("Cargo.toml");
-        write_root_manifest(&root_manifest_path, manifest)?;
+        write_root_manifest(root_manifest_path.as_std_path(), manifest)?;
 
         Ok(SplicedManifest::MultiPackage(root_manifest_path))
     }
 
     /// A helper for installing Cargo config files into the spliced workspace while also
     /// ensuring no other linked config file is available
-    fn setup_cargo_config(cargo_config_path: &Option<PathBuf>, workspace_dir: &Path) -> Result<()> {
+    fn setup_cargo_config(
+        cargo_config_path: &Option<Utf8PathBuf>,
+        workspace_dir: &Path,
+    ) -> Result<()> {
         // If the `.cargo` dir is a symlink, we'll need to relink it and ensure
         // a Cargo config file is omitted
         let dot_cargo_dir = workspace_dir.join(".cargo");
@@ -417,9 +364,9 @@ impl<'a> SplicerKind<'a> {
     /// Cargo workspace members.
     fn inject_workspace_members<'b>(
         root_manifest: &mut Manifest,
-        manifests: &'b BTreeMap<PathBuf, Manifest>,
+        manifests: &'b BTreeMap<Utf8PathBuf, Manifest>,
         workspace_dir: &Path,
-    ) -> Result<BTreeMap<&'b PathBuf, String>> {
+    ) -> Result<BTreeMap<&'b Utf8PathBuf, String>> {
         manifests
             .iter()
             .map(|(path, manifest)| {
@@ -442,7 +389,11 @@ impl<'a> SplicerKind<'a> {
 
                 let dest_package_dir = workspace_dir.join(package_name);
 
-                match symlink_roots(manifest_dir, &dest_package_dir, Some(IGNORE_LIST)) {
+                match symlink_roots(
+                    manifest_dir.as_std_path(),
+                    &dest_package_dir,
+                    Some(IGNORE_LIST),
+                ) {
                     Ok(_) => Ok((path, package_name.clone())),
                     Err(e) => Err(e),
                 }
@@ -520,23 +471,26 @@ impl<'a> SplicerKind<'a> {
 }
 
 pub(crate) struct Splicer {
-    workspace_dir: PathBuf,
-    manifests: BTreeMap<PathBuf, Manifest>,
+    workspace_dir: Utf8PathBuf,
+    manifests: BTreeMap<Utf8PathBuf, Manifest>,
     splicing_manifest: SplicingManifest,
 }
 
 impl Splicer {
-    pub(crate) fn new(workspace_dir: PathBuf, splicing_manifest: SplicingManifest) -> Result<Self> {
+    pub(crate) fn new(
+        workspace_dir: Utf8PathBuf,
+        splicing_manifest: SplicingManifest,
+    ) -> Result<Self> {
         // Load all manifests
         let manifests = splicing_manifest
             .manifests
             .keys()
             .map(|path| {
                 let m = read_manifest(path)
-                    .with_context(|| format!("Failed to read manifest at {}", path.display()))?;
+                    .with_context(|| format!("Failed to read manifest at {}", path))?;
                 Ok((path.clone(), m))
             })
-            .collect::<Result<BTreeMap<PathBuf, Manifest>>>()?;
+            .collect::<Result<BTreeMap<Utf8PathBuf, Manifest>>>()?;
 
         Ok(Self {
             workspace_dir,
@@ -546,9 +500,16 @@ impl Splicer {
     }
 
     /// Build a new workspace root
-    pub(crate) fn splice_workspace(&self, cargo: &Cargo) -> Result<SplicedManifest> {
-        SplicerKind::new(&self.manifests, &self.splicing_manifest, cargo)?
-            .splice(&self.workspace_dir)
+    pub(crate) fn splice_workspace(
+        &self,
+        nonhermetic_root_bazel_workspace_dir: &Path,
+    ) -> Result<SplicedManifest> {
+        SplicerKind::new(
+            &self.manifests,
+            &self.splicing_manifest,
+            nonhermetic_root_bazel_workspace_dir,
+        )?
+        .splice(&self.workspace_dir)
     }
 }
 const DEFAULT_SPLICING_PACKAGE_NAME: &str = "direct-cargo-bazel-deps";
@@ -599,48 +560,6 @@ pub(crate) fn default_cargo_workspace_manifest(
     manifest.workspace.as_mut().unwrap().members.pop();
 
     manifest
-}
-
-/// Determine whtether or not the manifest is a workspace root
-pub(crate) fn is_workspace_root(manifest: &Manifest) -> bool {
-    // Anything with any workspace data is considered a workspace
-    manifest.workspace.is_some()
-}
-
-/// Evaluates whether or not a manifest is considered a "workspace" manifest.
-/// See [Cargo workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html).
-pub(crate) fn is_workspace_owned(manifest: &Manifest) -> bool {
-    if is_workspace_root(manifest) {
-        return true;
-    }
-
-    // Additionally, anything that contains path dependencies is also considered a workspace
-    manifest.dependencies.iter().any(|(_, dep)| match dep {
-        Dependency::Detailed(dep) => dep.path.is_some(),
-        _ => false,
-    })
-}
-
-/// Determines whether or not a particular manifest is a workspace member to a given root manifest
-pub(crate) fn is_workspace_member(
-    root_manifest: &Manifest,
-    root_manifest_path: &Path,
-    manifest_path: &Path,
-) -> bool {
-    let members = match root_manifest.workspace.as_ref() {
-        Some(workspace) => &workspace.members,
-        None => return false,
-    };
-
-    let root_parent = root_manifest_path
-        .parent()
-        .expect("All manifest paths should have a parent");
-    let manifest_abs_path = root_parent.join(manifest_path);
-
-    members.iter().any(|member| {
-        let member_manifest_path = root_parent.join(member).join("Cargo.toml");
-        member_manifest_path == manifest_abs_path
-    })
 }
 
 pub(crate) fn write_root_manifest(path: &Path, manifest: cargo_toml::Manifest) -> Result<()> {
@@ -732,7 +651,6 @@ mod test {
     use std::str::FromStr;
 
     use cargo_metadata::PackageId;
-    use maplit::btreeset;
 
     use crate::splicing::Cargo;
 
@@ -763,7 +681,7 @@ mod test {
 
     /// Get cargo and rustc binaries the Bazel way
     #[cfg(not(feature = "cargo"))]
-    fn get_cargo_and_rustc_paths() -> (PathBuf, PathBuf) {
+    fn get_cargo_and_rustc_paths() -> (std::path::PathBuf, std::path::PathBuf) {
         let r = runfiles::Runfiles::create().unwrap();
         let cargo_path = runfiles::rlocation!(r, concat!("rules_rust/", env!("CARGO"))).unwrap();
         let rustc_path = runfiles::rlocation!(r, concat!("rules_rust/", env!("RUSTC"))).unwrap();
@@ -782,20 +700,20 @@ mod test {
         Cargo::new(cargo, rustc)
     }
 
-    fn generate_metadata(manifest_path: &Path) -> cargo_metadata::Metadata {
+    fn generate_metadata<P: AsRef<Path>>(manifest_path: P) -> cargo_metadata::Metadata {
         cargo()
-            .metadata_command_with_options(manifest_path, vec!["--offline".to_owned()])
+            .metadata_command_with_options(manifest_path.as_ref(), vec!["--offline".to_owned()])
             .unwrap()
             .exec()
             .unwrap()
     }
 
-    fn mock_cargo_toml(path: &Path, name: &str) -> cargo_toml::Manifest {
+    fn mock_cargo_toml<P: AsRef<Path>>(path: P, name: &str) -> cargo_toml::Manifest {
         mock_cargo_toml_with_dependencies(path, name, &[])
     }
 
-    fn mock_cargo_toml_with_dependencies(
-        path: &Path,
+    fn mock_cargo_toml_with_dependencies<P: AsRef<Path>>(
+        path: P,
         name: &str,
         deps: &[&str],
     ) -> cargo_toml::Manifest {
@@ -816,6 +734,7 @@ mod test {
         )))
         .unwrap();
 
+        let path = path.as_ref();
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(path, toml::to_string(&manifest).unwrap()).unwrap();
 
@@ -863,11 +782,14 @@ mod test {
 
         // Write workspace members
         for pkg in &["sub_pkg_a", "sub_pkg_b"] {
-            let manifest_path = cache_dir
-                .as_ref()
-                .join("root_pkg")
-                .join(pkg)
-                .join("Cargo.toml");
+            let manifest_path = Utf8PathBuf::try_from(
+                cache_dir
+                    .as_ref()
+                    .join("root_pkg")
+                    .join(pkg)
+                    .join("Cargo.toml"),
+            )
+            .unwrap();
             let deps = if pkg == &"sub_pkg_b" {
                 vec![r#"sub_pkg_a = { path = "../sub_pkg_a" }"#]
             } else {
@@ -903,7 +825,7 @@ mod test {
             File::create(workspace_root.join("WORKSPACE.bazel")).unwrap();
         }
         let root_pkg = workspace_root.join("root_pkg");
-        let manifest_path = root_pkg.join("Cargo.toml");
+        let manifest_path = Utf8PathBuf::try_from(root_pkg.join("Cargo.toml")).unwrap();
         fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
         fs::write(&manifest_path, toml::to_string(&manifest).unwrap()).unwrap();
         {
@@ -930,7 +852,8 @@ mod test {
 
         // Write workspace members
         for pkg in &["sub_pkg_a", "sub_pkg_b"] {
-            let manifest_path = cache_dir.as_ref().join(pkg).join("Cargo.toml");
+            let manifest_path =
+                Utf8PathBuf::try_from(cache_dir.as_ref().join(pkg).join("Cargo.toml")).unwrap();
             mock_cargo_toml(&manifest_path, pkg);
 
             splicing_manifest.manifests.insert(
@@ -960,7 +883,7 @@ mod test {
         {
             File::create(workspace_root.join("WORKSPACE.bazel")).unwrap();
         }
-        let manifest_path = workspace_root.join("Cargo.toml");
+        let manifest_path = Utf8PathBuf::try_from(workspace_root.join("Cargo.toml")).unwrap();
         fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
         fs::write(&manifest_path, toml::to_string(&manifest).unwrap()).unwrap();
 
@@ -982,7 +905,8 @@ mod test {
         let cache_dir = tempfile::tempdir().unwrap();
 
         // Add an additional package
-        let manifest_path = cache_dir.as_ref().join("root_pkg").join("Cargo.toml");
+        let manifest_path =
+            Utf8PathBuf::try_from(cache_dir.as_ref().join("root_pkg").join("Cargo.toml")).unwrap();
         mock_cargo_toml(&manifest_path, "root_pkg");
         splicing_manifest
             .manifests
@@ -997,7 +921,8 @@ mod test {
 
         // Add an additional package
         for pkg in &["pkg_a", "pkg_b", "pkg_c"] {
-            let manifest_path = cache_dir.as_ref().join(pkg).join("Cargo.toml");
+            let manifest_path =
+                Utf8PathBuf::try_from(cache_dir.as_ref().join(pkg).join("Cargo.toml")).unwrap();
             mock_cargo_toml(&manifest_path, pkg);
             splicing_manifest
                 .manifests
@@ -1053,9 +978,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo())
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         // Locate cargo
@@ -1096,9 +1021,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo())
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         // Locate cargo
@@ -1144,10 +1069,12 @@ mod test {
 
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
-        let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
-                .unwrap()
-                .splice_workspace(&cargo());
+        let workspace_manifest = Splicer::new(
+            Utf8PathBuf::try_from(workspace_root.as_ref().to_path_buf()).unwrap(),
+            splicing_manifest,
+        )
+        .unwrap()
+        .splice_workspace(Path::new("/doesnotexist"));
 
         assert!(workspace_manifest.is_err());
 
@@ -1172,17 +1099,19 @@ mod test {
 
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
-        let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
-                .unwrap()
-                .splice_workspace(&cargo());
+        let workspace_manifest = Splicer::new(
+            Utf8PathBuf::try_from(workspace_root.as_ref().to_path_buf()).unwrap(),
+            splicing_manifest,
+        )
+        .unwrap()
+        .splice_workspace(Path::new("/doesnotexist"));
 
         assert!(workspace_manifest.is_err());
 
         // Ensure both the missing manifests are mentioned in the error string
         let err_str = format!("{:?}", &workspace_manifest);
         assert!(
-            err_str.contains("Missing root workspace manifest")
+            err_str.contains("Some manifests are not being tracked")
                 && err_str.contains("//root_pkg:Cargo.toml")
         );
     }
@@ -1193,11 +1122,31 @@ mod test {
 
         // Add a new package from an existing external workspace
         let external_workspace_root = tempfile::tempdir().unwrap();
-        let external_manifest = external_workspace_root
-            .as_ref()
-            .join("external_workspace_member")
-            .join("Cargo.toml");
+        let external_manifest = Utf8PathBuf::try_from(
+            external_workspace_root
+                .as_ref()
+                .join("external_workspace_member")
+                .join("Cargo.toml"),
+        )
+        .unwrap();
         fs::create_dir_all(external_manifest.parent().unwrap()).unwrap();
+
+        fs::write(
+            external_workspace_root.as_ref().join("Cargo.toml"),
+            textwrap::dedent(
+                r#"
+                [workspace]
+                [package]
+                name = "external_workspace_root"
+                version = "0.0.1"
+
+                [lib]
+                path = "lib.rs"
+                "#,
+            ),
+        )
+        .unwrap();
+
         fs::write(
             &external_manifest,
             textwrap::dedent(
@@ -1208,9 +1157,6 @@ mod test {
 
                 [lib]
                 path = "lib.rs"
-
-                [dependencies]
-                neighbor = { path = "../neighbor" }
                 "#,
             ),
         )
@@ -1224,19 +1170,18 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo());
+                .splice_workspace(Path::new("/doesnotexist"));
 
         assert!(workspace_manifest.is_err());
 
         // Ensure both the external workspace member
         let err_str = format!("{:?}", &workspace_manifest);
-        let bytes_str = format!("{:?}", external_manifest.to_string_lossy());
         assert!(
             err_str
-                .contains("A package was provided that appears to be a part of another workspace.")
-                && err_str.contains(&bytes_str)
+                .contains("When splicing manifests, manifests are not allowed to from from different workspaces. Saw manifests which belong to the following workspaces:")
+                && err_str.contains(external_workspace_root.path().to_string_lossy().as_ref())
         );
     }
 
@@ -1262,9 +1207,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo())
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         let metadata = generate_metadata(workspace_manifest.as_path_buf());
@@ -1287,9 +1232,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo())
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         // Locate cargo
@@ -1324,9 +1269,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo())
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         // Check the default resolver version
@@ -1374,9 +1319,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo())
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         // Check the specified resolver version
@@ -1420,7 +1365,7 @@ mod test {
             return;
         }
 
-        let (mut splicing_manifest, cache_dir) = mock_splicing_manifest_with_multi_package();
+        let (mut splicing_manifest, _cache_dir) = mock_splicing_manifest_with_multi_package();
 
         // Add a "direct dependency" entry
         splicing_manifest.direct_packages.insert(
@@ -1434,9 +1379,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo().with_cargo_home(cache_dir.path().to_owned()))
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         // Check the default resolver version
@@ -1476,9 +1421,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo().with_cargo_home(cache_dir.path().to_owned()))
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         // Ensure the patches match the expected value
@@ -1539,9 +1484,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo().with_cargo_home(cache_dir.path().to_owned()))
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         // Ensure the patches match the expected value
@@ -1590,9 +1535,9 @@ mod test {
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
         let workspace_manifest =
-            Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+            Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
                 .unwrap()
-                .splice_workspace(&cargo().with_cargo_home(cache_dir.path().to_owned()))
+                .splice_workspace(Path::new("/doesnotexist"))
                 .unwrap();
 
         // Ensure the patches match the expected value
@@ -1632,9 +1577,9 @@ mod test {
 
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
-        let result = Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+        let result = Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
             .unwrap()
-            .splice_workspace(&cargo());
+            .splice_workspace(Path::new("/doesnotexist"));
 
         // Confirm conflicting patches have been detected
         assert!(result.is_err());
@@ -1648,15 +1593,15 @@ mod test {
 
         // Write a cargo config
         let temp_dir = tempfile::tempdir().unwrap();
-        let external_config = temp_dir.as_ref().join("config.toml");
+        let external_config = tempdir_utf8pathbuf(&temp_dir).join("config.toml");
         fs::write(&external_config, "# Cargo configuration file").unwrap();
         splicing_manifest.cargo_config = Some(external_config);
 
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
-        Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+        Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
             .unwrap()
-            .splice_workspace(&cargo())
+            .splice_workspace(Path::new("/doesnotexist"))
             .unwrap();
 
         let cargo_config = workspace_root.as_ref().join(".cargo").join("config.toml");
@@ -1681,15 +1626,15 @@ mod test {
 
         // Write a cargo config
         let temp_dir = tempfile::tempdir().unwrap();
-        let external_config = temp_dir.as_ref().join("config.toml");
+        let external_config = tempdir_utf8pathbuf(&temp_dir).join("config.toml");
         fs::write(&external_config, "# Cargo configuration file").unwrap();
         splicing_manifest.cargo_config = Some(external_config);
 
         // Splice the workspace
         let workspace_root = tempfile::tempdir().unwrap();
-        Splicer::new(workspace_root.as_ref().to_path_buf(), splicing_manifest)
+        Splicer::new(tempdir_utf8pathbuf(&workspace_root), splicing_manifest)
             .unwrap()
-            .splice_workspace(&cargo())
+            .splice_workspace(Path::new("/doesnotexist"))
             .unwrap();
 
         let cargo_config = workspace_root.as_ref().join(".cargo").join("config.toml");
@@ -1706,230 +1651,24 @@ mod test {
 
         // Write a cargo config
         let temp_dir = tempfile::tempdir().unwrap();
-        let dot_cargo_dir = temp_dir.as_ref().join(".cargo");
+        let dot_cargo_dir = tempdir_utf8pathbuf(&temp_dir).join(".cargo");
         fs::create_dir_all(&dot_cargo_dir).unwrap();
         let external_config = dot_cargo_dir.join("config.toml");
         fs::write(&external_config, "# Cargo configuration file").unwrap();
         splicing_manifest.cargo_config = Some(external_config.clone());
 
         // Splice the workspace
-        let workspace_root = temp_dir.as_ref().join("workspace_root");
+        let workspace_root = tempdir_utf8pathbuf(&temp_dir).join("workspace_root");
         let splicing_result = Splicer::new(workspace_root.clone(), splicing_manifest)
             .unwrap()
-            .splice_workspace(&cargo());
+            .splice_workspace(Path::new("/doesnotexist"));
 
         // Ensure cargo config files in parent directories lead to errors
         assert!(splicing_result.is_err());
         let err_str = splicing_result.err().unwrap().to_string();
         assert!(err_str.starts_with("A Cargo config file was found in a parent directory"));
-        assert!(err_str.contains(&format!("Workspace = {}", workspace_root.display())));
-        assert!(err_str.contains(&format!("Cargo config = {}", external_config.display())));
-    }
-
-    #[test]
-    fn find_missing_manifests_correct_without_root() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let root_manifest_dir = temp_dir.path();
-        touch(&root_manifest_dir.join("WORKSPACE.bazel"));
-        touch(&root_manifest_dir.join("BUILD.bazel"));
-        touch(&root_manifest_dir.join("Cargo.toml"));
-        touch(&root_manifest_dir.join("foo").join("Cargo.toml"));
-        touch(&root_manifest_dir.join("bar").join("BUILD.bazel"));
-        touch(&root_manifest_dir.join("bar").join("Cargo.toml"));
-
-        let known_manifest_paths = btreeset![
-            root_manifest_dir
-                .join("foo")
-                .join("Cargo.toml")
-                .normalize()
-                .unwrap(),
-            root_manifest_dir
-                .join("bar")
-                .join("Cargo.toml")
-                .normalize()
-                .unwrap(),
-        ];
-
-        let root_manifest: cargo_toml::Manifest = toml::toml! {
-            [workspace]
-            members = [
-                "foo",
-                "bar",
-            ]
-            [package]
-            name = "root_pkg"
-            version = "0.0.1"
-
-            [lib]
-            path = "lib.rs"
-        }
-        .try_into()
-        .unwrap();
-        let missing_manifests = SplicerKind::find_missing_manifests(
-            &root_manifest,
-            root_manifest_dir,
-            &known_manifest_paths,
-        )
-        .unwrap();
-        assert_eq!(missing_manifests, btreeset![]);
-    }
-
-    #[test]
-    fn find_missing_manifests_correct_with_root() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let root_manifest_dir = temp_dir.path();
-        touch(&root_manifest_dir.join("WORKSPACE.bazel"));
-        touch(&root_manifest_dir.join("BUILD.bazel"));
-        touch(&root_manifest_dir.join("Cargo.toml"));
-        touch(&root_manifest_dir.join("foo").join("Cargo.toml"));
-        touch(&root_manifest_dir.join("bar").join("BUILD.bazel"));
-        touch(&root_manifest_dir.join("bar").join("Cargo.toml"));
-
-        let known_manifest_paths = btreeset![
-            root_manifest_dir.join("Cargo.toml").normalize().unwrap(),
-            root_manifest_dir
-                .join("foo")
-                .join("Cargo.toml")
-                .normalize()
-                .unwrap(),
-            root_manifest_dir
-                .join("bar")
-                .join("Cargo.toml")
-                .normalize()
-                .unwrap(),
-        ];
-
-        let root_manifest: cargo_toml::Manifest = toml::toml! {
-            [workspace]
-            members = [
-                ".",
-                "foo",
-                "bar",
-            ]
-            [package]
-            name = "root_pkg"
-            version = "0.0.1"
-
-            [lib]
-            path = "lib.rs"
-        }
-        .try_into()
-        .unwrap();
-        let missing_manifests = SplicerKind::find_missing_manifests(
-            &root_manifest,
-            root_manifest_dir,
-            &known_manifest_paths,
-        )
-        .unwrap();
-        assert_eq!(missing_manifests, btreeset![]);
-    }
-
-    #[test]
-    fn find_missing_manifests_missing_root() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let root_manifest_dir = temp_dir.path();
-        touch(&root_manifest_dir.join("WORKSPACE.bazel"));
-        touch(&root_manifest_dir.join("BUILD.bazel"));
-        touch(&root_manifest_dir.join("Cargo.toml"));
-        touch(&root_manifest_dir.join("foo").join("Cargo.toml"));
-        touch(&root_manifest_dir.join("bar").join("BUILD.bazel"));
-        touch(&root_manifest_dir.join("bar").join("Cargo.toml"));
-
-        let known_manifest_paths = btreeset![
-            root_manifest_dir
-                .join("foo")
-                .join("Cargo.toml")
-                .normalize()
-                .unwrap(),
-            root_manifest_dir
-                .join("bar")
-                .join("Cargo.toml")
-                .normalize()
-                .unwrap(),
-        ];
-
-        let root_manifest: cargo_toml::Manifest = toml::toml! {
-            [workspace]
-            members = [
-                ".",
-                "foo",
-                "bar",
-            ]
-            [package]
-            name = "root_pkg"
-            version = "0.0.1"
-
-            [lib]
-            path = "lib.rs"
-        }
-        .try_into()
-        .unwrap();
-        let missing_manifests = SplicerKind::find_missing_manifests(
-            &root_manifest,
-            root_manifest_dir,
-            &known_manifest_paths,
-        )
-        .unwrap();
-        assert_eq!(missing_manifests, btreeset![String::from("//:Cargo.toml")]);
-    }
-
-    #[test]
-    fn find_missing_manifests_missing_nonroot() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let root_manifest_dir = temp_dir.path();
-        touch(&root_manifest_dir.join("WORKSPACE.bazel"));
-        touch(&root_manifest_dir.join("BUILD.bazel"));
-        touch(&root_manifest_dir.join("Cargo.toml"));
-        touch(&root_manifest_dir.join("foo").join("Cargo.toml"));
-        touch(&root_manifest_dir.join("bar").join("BUILD.bazel"));
-        touch(&root_manifest_dir.join("bar").join("Cargo.toml"));
-        touch(&root_manifest_dir.join("baz").join("BUILD.bazel"));
-        touch(&root_manifest_dir.join("baz").join("Cargo.toml"));
-
-        let known_manifest_paths = btreeset![
-            root_manifest_dir
-                .join("foo")
-                .join("Cargo.toml")
-                .normalize()
-                .unwrap(),
-            root_manifest_dir
-                .join("bar")
-                .join("Cargo.toml")
-                .normalize()
-                .unwrap(),
-        ];
-
-        let root_manifest: cargo_toml::Manifest = toml::toml! {
-            [workspace]
-            members = [
-                "foo",
-                "bar",
-                "baz",
-            ]
-            [package]
-            name = "root_pkg"
-            version = "0.0.1"
-
-            [lib]
-            path = "lib.rs"
-        }
-        .try_into()
-        .unwrap();
-        let missing_manifests = SplicerKind::find_missing_manifests(
-            &root_manifest,
-            root_manifest_dir,
-            &known_manifest_paths,
-        )
-        .unwrap();
-        assert_eq!(
-            missing_manifests,
-            btreeset![String::from("//baz:Cargo.toml")]
-        );
-    }
-
-    fn touch(path: &Path) {
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, []).unwrap();
+        assert!(err_str.contains(&format!("Workspace = {}", workspace_root)));
+        assert!(err_str.contains(&format!("Cargo config = {}", external_config)));
     }
 
     fn syn_dependency_detail() -> cargo_toml::DependencyDetail {
@@ -1946,5 +1685,9 @@ mod test {
             tag: Some("1.5.0".to_owned()),
             ..cargo_toml::DependencyDetail::default()
         }
+    }
+
+    fn tempdir_utf8pathbuf(tempdir: &tempfile::TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::try_from(tempdir.as_ref().to_path_buf()).unwrap()
     }
 }

--- a/crate_universe/test_data/workspace_examples/non-ws/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/non-ws/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "non-ws"
+version = "0.1.0"
+edition = "2021"

--- a/crate_universe/test_data/workspace_examples/non-ws/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/non-ws/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/symlinked/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/symlinked/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "symlinked"
+version = "0.1.0"
+edition = "2021"

--- a/crate_universe/test_data/workspace_examples/symlinked/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/symlinked/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/ws1/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/ws1/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+members = ["ws1c1", "ws1c2"]
+
+[package]
+name = "ws1"
+version = "0.1.0"
+edition = "2021"

--- a/crate_universe/test_data/workspace_examples/ws1/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/ws1/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/ws1/ws1c1/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/ws1/ws1c1/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ws1c1"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crate_universe/test_data/workspace_examples/ws1/ws1c1/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/ws1/ws1c1/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/ws1/ws1c1/ws1c1c1/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/ws1/ws1c1/ws1c1c1/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ws1c1c1"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crate_universe/test_data/workspace_examples/ws1/ws1c1/ws1c1c1/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/ws1/ws1c1/ws1c1c1/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/ws1/ws1c2/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/ws1/ws1c2/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ws1c2"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crate_universe/test_data/workspace_examples/ws1/ws1c2/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/ws1/ws1c2/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/ws2/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/ws2/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+exclude = ["ws2excluded", "ws2excluded/ws2excluded2"]
+[package]
+name = "ws2"
+version = "0.1.0"
+edition = "2021"

--- a/crate_universe/test_data/workspace_examples/ws2/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/ws2/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/ws2/ws2c1/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/ws2/ws2c1/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ws2c1"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crate_universe/test_data/workspace_examples/ws2/ws2c1/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/ws2/ws2c1/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/ws2/ws2excluded/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/ws2/ws2excluded/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ws2excluded"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crate_universe/test_data/workspace_examples/ws2/ws2excluded/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/ws2/ws2excluded/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/ws2/ws2excluded/ws2excluded2/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/ws2/ws2excluded/ws2excluded2/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ws2excluded2"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crate_universe/test_data/workspace_examples/ws2/ws2excluded/ws2excluded2/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/ws2/ws2excluded/ws2excluded2/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/test_data/workspace_examples/ws2/ws2excluded/ws2included/Cargo.toml
+++ b/crate_universe/test_data/workspace_examples/ws2/ws2excluded/ws2included/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ws2included"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crate_universe/test_data/workspace_examples/ws2/ws2excluded/ws2included/src/main.rs
+++ b/crate_universe/test_data/workspace_examples/ws2/ws2excluded/ws2included/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crate_universe/tests/cargo_integration_test.rs
+++ b/crate_universe/tests/cargo_integration_test.rs
@@ -115,6 +115,7 @@ fn run(repository_name: &str, manifests: HashMap<String, String>, lockfile: &str
         config,
         cargo,
         rustc,
+        nonhermetic_root_bazel_workspace_dir: PathBuf::from("/doesnotexist"),
     })
     .unwrap();
 

--- a/examples/crate_universe_local_path/MODULE.bazel
+++ b/examples/crate_universe_local_path/MODULE.bazel
@@ -20,8 +20,6 @@ crate = use_extension(
 crate.from_cargo(
     name = "bzlmod_crates_from_cargo_workspace",
     cargo_lockfile = "//crates_from_workspace:Cargo.lock",
-    manifests = [
-        "//crates_from_workspace:Cargo.toml",
-    ],
+    manifests = ["//crates_from_workspace:Cargo.toml"],
 )
 use_repo(crate, "bzlmod_crates_from_cargo_workspace")

--- a/examples/crate_universe_local_path/vendor_lazy_static.sh
+++ b/examples/crate_universe_local_path/vendor_lazy_static.sh
@@ -12,6 +12,12 @@ elif [[ "$#" -eq 1 ]]; then
     path_dep_path="$1"
     copy_to="crates_from_workspace/$1"
     mkdir -p "${copy_to}"
+    sed_i=(sed -i)
+    if [[ "$(uname)" == "Darwin" ]]; then
+      sed_i=(sed -i '')
+    fi
+    "${sed_i[@]}" -e 's#manifests = \["//crates_from_workspace:Cargo\.toml"\],#manifests = ["//crates_from_workspace:Cargo.toml", "//crates_from_workspace:'"$1"'/Cargo.toml"],#g' WORKSPACE.bazel
+    "${sed_i[@]}" -e 's#manifests = \["//crates_from_workspace:Cargo\.toml"\],#manifests = ["//crates_from_workspace:Cargo.toml", "//crates_from_workspace:'"$1"'/Cargo.toml"],#g' MODULE.bazel
 else
     echo >&2 "Usage: $0 [/path/to/copy/to]"
     echo >&2 "If no arg is passed, a tempdir will be created"


### PR DESCRIPTION
Previously we were assuming that any crate with a path dep lives in a
workspace, and any that doesn't isn't.

This isn't correct logic.
https://doc.rust-lang.org/cargo/reference/workspaces.html describes the
specification. We do filesystem traversal to detect implicit members.
This is a little more expensive, but much more correct.

This is a precursor for supporting path dependencies - the current
incorrect logic incorrectly identifies any Cargo.toml file containing a
path dependency as expecting to live in a workspace, which breaks some
use-cases.