### PR TITLE
rust_analyzer: generate more reqired sources

### DIFF
--- a/extensions/prost/private/prost.bzl
+++ b/extensions/prost/private/prost.bzl
@@ -279,7 +279,6 @@ def _rust_prost_aspect_impl(target, ctx):
             package_info = package_info_file,
         ),
         rust_analyzer_info,
-        OutputGroupInfo(rust_generated_srcs = [lib_rs]),
     ]
 
 rust_prost_aspect = aspect(

--- a/extensions/protobuf/proto.bzl
+++ b/extensions/protobuf/proto.bzl
@@ -233,7 +233,6 @@ def _rust_proto_compile(protos, descriptor_sets, imports, crate_name, ctx, is_gr
         ),
         output_hash = output_hash,
     )
-    providers.append(OutputGroupInfo(rust_generated_srcs = srcs))
     return providers
 
 def _rust_protogrpc_library_impl(ctx, is_grpc):

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -146,9 +146,21 @@ def _rust_analyzer_aspect_impl(target, ctx):
         build_info = build_info,
     ))
 
+    # The sources rust-analyzer needs to parse this crate.
+    # Exposed as an output group so they can be generated if needed.
+    # Direct-dependencies only trades accuracy for speed - re-evaluate?
+    required_srcs = depset(
+      transitive = [crate_info.srcs] + [dep.crate.srcs for dep in dep_infos],
+      # target.json is also required (in fact rust-analyzer may crash if it's missing)
+      direct = [toolchain.target_json for toolchain in [toolchain] if toolchain.target_json],
+    )
+
     return [
         rust_analyzer_info,
-        OutputGroupInfo(rust_analyzer_crate_spec = rust_analyzer_info.crate_specs),
+        OutputGroupInfo(
+          rust_analyzer_crate_spec = rust_analyzer_info.crate_specs,
+          rust_analyzer_srcs = required_srcs,
+        ),
     ]
 
 def find_proc_macro_dylib_path(toolchain, target):

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -27,7 +27,7 @@ pub fn generate_crate_info(
             "--aspects={}//rust:defs.bzl%rust_analyzer_aspect",
             rules_rust.as_ref()
         ))
-        .arg("--output_groups=rust_analyzer_crate_spec,rust_generated_srcs")
+        .arg("--output_groups=rust_analyzer_crate_spec,rust_analyzer_srcs")
         .args(targets)
         .output()?;
 


### PR DESCRIPTION
The existing support for this has limitations:

- only works for sources that are specially tagged (rust_generated_srcs).
  I've removed this mechanism as it's no longer needed.
- only provides sources of the directly selected library, but
  rust-analyzer needs to parse its dependencies too.
- is missing the target.json file, which rust-analyzer requires to
  parse the library (it invokes rustc --print cfg --target=...)

The dependency depth to generate sources for is a tradeoff. More layers
of deps will give more accurate analysis but be slower to generate.

My guess is that in the end we'll want full transitive sources, but
direct deps should be a non-controversial starting point. (Without these
sources, rust-analyzer can't understand the direct API usage at all).
We can change this later and probably need to reconcile with #3028.
