### PR TITLE
Allow rust_wasm_bindgen rules to re-expose rust-analyzer providers

### DIFF
--- a/docs/src/rust_wasm_bindgen_rules_js.md
+++ b/docs/src/rust_wasm_bindgen_rules_js.md
@@ -21,7 +21,7 @@ Generates javascript and typescript bindings for a webassembly module using [was
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="js_rust_wasm_bindgen-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="js_rust_wasm_bindgen-bindgen_flags"></a>bindgen_flags |  Flags to pass directly to the bindgen executable. See https://github.com/rustwasm/wasm-bindgen/ for details.   | List of strings | optional |  `[]`  |
+| <a id="js_rust_wasm_bindgen-bindgen_flags"></a>bindgen_flags |  Flags to pass directly to the wasm-bindgen executable. See https://github.com/rustwasm/wasm-bindgen/ for details.   | List of strings | optional |  `[]`  |
 | <a id="js_rust_wasm_bindgen-target"></a>target |  The type of output to generate. See https://rustwasm.github.io/wasm-bindgen/reference/deployment.html for details.   | String | optional |  `"bundler"`  |
 | <a id="js_rust_wasm_bindgen-target_arch"></a>target_arch |  The target architecture to use for the wasm-bindgen command line option.   | String | optional |  `"wasm32"`  |
 | <a id="js_rust_wasm_bindgen-wasm_file"></a>wasm_file |  The `.wasm` file or crate to generate bindings for.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |

--- a/extensions/wasm_bindgen/rules_js/defs.bzl
+++ b/extensions/wasm_bindgen/rules_js/defs.bzl
@@ -1,6 +1,9 @@
 """Rust WASM-bindgen rules for interfacing with aspect-build/rules_js"""
 
 load("@aspect_rules_js//js:providers.bzl", "js_info")
+
+# buildifier: disable=bzl-visibility
+load("@rules_rust//rust/private:providers.bzl", "RustAnalyzerGroupInfo", "RustAnalyzerInfo")
 load("//private:wasm_bindgen.bzl", "WASM_BINDGEN_ATTR", "rust_wasm_bindgen_action")
 
 def _js_rust_wasm_bindgen_impl(ctx):
@@ -11,10 +14,10 @@ def _js_rust_wasm_bindgen_impl(ctx):
         toolchain = toolchain,
         wasm_file = ctx.attr.wasm_file,
         target_output = ctx.attr.target,
-        bindgen_flags = ctx.attr.bindgen_flags,
+        flags = ctx.attr.bindgen_flags,
     )
 
-    return [
+    providers = [
         DefaultInfo(
             files = depset([info.wasm], transitive = [info.js, info.ts]),
         ),
@@ -28,6 +31,14 @@ def _js_rust_wasm_bindgen_impl(ctx):
             transitive_types = info.ts,
         ),
     ]
+
+    if RustAnalyzerGroupInfo in ctx.attr.wasm_file:
+        providers.append(ctx.attr.wasm_file[RustAnalyzerGroupInfo])
+
+    if RustAnalyzerInfo in ctx.attr.wasm_file:
+        providers.append(ctx.attr.wasm_file[RustAnalyzerInfo])
+
+    return providers
 
 js_rust_wasm_bindgen = rule(
     doc = """\

--- a/extensions/wasm_bindgen/rules_nodejs/defs.bzl
+++ b/extensions/wasm_bindgen/rules_nodejs/defs.bzl
@@ -1,6 +1,9 @@
 """Rust WASM-bindgen rules for interfacing with bazelbuild/rules_nodejs"""
 
 load("@rules_nodejs//nodejs:providers.bzl", "DeclarationInfo", "JSModuleInfo")
+
+# buildifier: disable=bzl-visibility
+load("@rules_rust//rust/private:providers.bzl", "RustAnalyzerGroupInfo", "RustAnalyzerInfo")
 load("//private:wasm_bindgen.bzl", "WASM_BINDGEN_ATTR", "rust_wasm_bindgen_action")
 
 def _nodejs_rust_wasm_bindgen_impl(ctx):
@@ -11,14 +14,14 @@ def _nodejs_rust_wasm_bindgen_impl(ctx):
         toolchain = toolchain,
         wasm_file = ctx.attr.wasm_file,
         target_output = ctx.attr.target,
-        bindgen_flags = ctx.attr.bindgen_flags,
+        flags = ctx.attr.bindgen_flags,
     )
 
     # Return a structure that is compatible with the deps[] of a ts_library.
     declarations = info.ts
     es5_sources = info.js
 
-    return [
+    providers = [
         DefaultInfo(
             files = depset([info.wasm], transitive = [info.js, info.ts]),
         ),
@@ -33,6 +36,14 @@ def _nodejs_rust_wasm_bindgen_impl(ctx):
         ),
         info,
     ]
+
+    if RustAnalyzerGroupInfo in ctx.attr.wasm_file:
+        providers.append(ctx.attr.wasm_file[RustAnalyzerGroupInfo])
+
+    if RustAnalyzerInfo in ctx.attr.wasm_file:
+        providers.append(ctx.attr.wasm_file[RustAnalyzerInfo])
+
+    return providers
 
 nodejs_rust_wasm_bindgen = rule(
     doc = """\


### PR DESCRIPTION
This is useful for targets which are gated behind `target_compatible_with = ["@platforms//os:wasm32"]` but developers still want them to analyzed by rust-analyzer.