### PR TITLE
Improve consolidation of rust-analyzer crate specs with generated sources

### DIFF
--- a/test/rust_analyzer/generated_srcs_test/rust_project_json_test.rs
+++ b/test/rust_analyzer/generated_srcs_test/rust_project_json_test.rs
@@ -48,7 +48,9 @@ mod tests {
             .find(|c| &c.display_name == "generated_srcs")
             .unwrap();
         assert!(gen.root_module.starts_with("/"));
-        assert!(gen.root_module.ends_with("/lib.rs"));
+        assert!(gen
+            .root_module
+            .ends_with("rules_rust_test_rust_analyzer/lib.rs"));
 
         let include_dirs = &gen.source.as_ref().unwrap().include_dirs;
         assert!(include_dirs.len() == 1);

--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -208,6 +208,15 @@ fn consolidate_crate_specs(crate_specs: Vec<CrateSpec>) -> anyhow::Result<BTreeS
                     existing.proc_macro_dylib_path.replace(dylib_path.clone());
                 }
             }
+
+            // Prefer using workspace for root_module path if possible.
+            // A test crate might get an __EXEC_ROOT__-based root_module when depending
+            // on a library crate with mixed generated sources, for example.
+            if existing.root_module.starts_with("__EXEC_ROOT__")
+                && spec.root_module.starts_with("__WORKSPACE__")
+            {
+                existing.root_module = spec.root_module;
+            }
         } else {
             consolidated_specs.insert(spec.crate_id.clone(), spec);
         }

--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -181,6 +181,15 @@ fn consolidate_crate_specs(crate_specs: Vec<CrateSpec>) -> anyhow::Result<BTreeS
             spec.cfg.retain(|cfg| !existing.cfg.contains(cfg));
             existing.cfg.extend(spec.cfg);
 
+            match (existing.source.as_mut(), spec.source) {
+                (None, new @ Some(_)) => existing.source = new,
+                (Some(existing_source), Some(new_source)) => {
+                    existing_source.exclude_dirs.extend(new_source.exclude_dirs);
+                    existing_source.include_dirs.extend(new_source.include_dirs);
+                }
+                _ => (),
+            }
+
             // display_name should match the library's crate name because Rust Analyzer
             // seems to use display_name for matching crate entries in rust-project.json
             // against symbols in source files. For more details, see


### PR DESCRIPTION
I have pretty much the exact setup that is tested in `test/rust_analyzer/generated_srcs_test`, which currently seems to fail on the main branch (at least on my machine).

Explicitly, the issue is that when consolidating the specs for a `rust_library` with a mix of generated and non-generated sources and a corresponding `rust_test` with `crate` set to the library, the following is wrong in the generated `rust-project.json` if the file for the test crate is evaluted first:
* The `"source"`-field is unpopulated
* The `"root_module"`-field points to a symlink(?) in the execroot instead of the `lib.rs` file that is in the workspace.
This confuses rust-analyzer.

I don't know the `rules_rust` codebase well enough to say whether this is the correct place to address these issues, and I see @sam-mccall is curently working on related stuff, so I just made the smallest possible change that fixed my issue.

Feel free to just take this as a bug-report if that's more convenient!