### PR TITLE
Fix release workflow on macos

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         # Create a job for each target triple
         include:
-          - os: macOS-14
+          - os: macOS-13
             env:
               TARGET: "aarch64-apple-darwin"
           - os: ubuntu-20.04
@@ -59,7 +59,7 @@ jobs:
           - os: windows-2022
             env:
               TARGET: "aarch64-pc-windows-msvc"
-          - os: macOS-14
+          - os: macOS-13
             env:
               TARGET: "x86_64-apple-darwin"
           - os: ubuntu-20.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,10 +88,10 @@ jobs:
           TARGET: "${{ matrix.env.TARGET }}"
       - name: Setup macos build tooling
         run: |
-          sudo xcode-select -s /Applications/Xcode_13.1.app/Contents/Developer/
+          sudo xcode-select -s /Applications/Xcode_15.2.0.app/Contents/Developer/
           # Set SDK environment variables
-          echo "SDKROOT=$(xcrun -sdk macosx12.0 --show-sdk-path)" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx12.0 --show-sdk-platform-version)" >> $GITHUB_ENV
+          echo "SDKROOT=$(xcrun -sdk macosx13.0 --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx13.0 --show-sdk-platform-version)" >> $GITHUB_ENV
         if: startswith(matrix.os, 'macos')
       - name: Setup Windows Bazelrc
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         # Create a job for each target triple
         include:
-          - os: macos-12
+          - os: macOS-14
             env:
               TARGET: "aarch64-apple-darwin"
           - os: ubuntu-20.04
@@ -59,7 +59,7 @@ jobs:
           - os: windows-2022
             env:
               TARGET: "aarch64-pc-windows-msvc"
-          - os: macos-12
+          - os: macOS-14
             env:
               TARGET: "x86_64-apple-darwin"
           - os: ubuntu-20.04


### PR DESCRIPTION
This avoids the following error
```

The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721

```