### PR TITLE
Revert "Run CI without building runfiles links"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,9 +5,6 @@
 ## https://bazel.build/docs/best-practices#bazelrc-file
 ###############################################################################
 
-# Skip building runfiles links for faster builds.
-build --nobuild_runfile_links
-
 # https://bazel.build/reference/command-line-reference#flag--enable_platform_specific_config
 common --enable_platform_specific_config
 


### PR DESCRIPTION
Reverts bazelbuild/rules_rust#2340

It seems like there were cache hits that dodged an important issue
```
================================================================================
FAIL: //test/unit/crate_name:default/crate-name-test (see /private/var/tmp/_bazel_user/76282c66b0dfe3c5cb9a230bdc913a52/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/test/unit/crate_name/default/crate-name-test/test.log)
INFO: From Testing //test/unit/crate_name:default/crate-name-test:
==================== Test output for //test/unit/crate_name:default/crate-name-test:

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

/private/var/tmp/_bazel_user/76282c66b0dfe3c5cb9a230bdc913a52/sandbox/darwin-sandbox/3262/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/bazel_tools~remote_coverage_tools_extension~remote_coverage_tools/Main: Cannot locate runfiles directory. (Set $JAVA_RUNFILES to inhibit searching.)
```
This flag still cannot be flipped without breaking coverage it seems.