### PR TITLE
feat: Add workspace_cargo_toml attribute

### DIFF
--- a/crate_universe/private/crates_repository.bzl
+++ b/crate_universe/private/crates_repository.bzl
@@ -61,6 +61,7 @@ def _crates_repository_impl(repository_ctx):
             repository_ctx = repository_ctx,
             generator = generator,
             cargo_lockfile = lockfiles.cargo,
+            workspace_cargo_toml = repository_ctx.path(repository_ctx.attr.workspace_cargo_toml) if repository_ctx.attr.workspace_cargo_toml else None,
             splicing_manifest = splicing_manifest,
             config_path = config_path,
             cargo = cargo_path,
@@ -230,6 +231,9 @@ CARGO_BAZEL_REPIN=1 CARGO_BAZEL_REPIN_ONLY=crate_index bazel sync --only=crate_i
                 "should be used here, which will keep the versions used by cargo and bazel in sync."
             ),
             mandatory = True,
+        ),
+        "workspace_cargo_toml": attr.label(
+            doc = "The path to the workspace `Cargo.toml` file.",
         ),
         "compressed_windows_toolchain_names": attr.bool(
             doc = "Wether or not the toolchain names of windows toolchains are expected to be in a `compressed` format.",

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -326,6 +326,14 @@ def _crates_vendor_impl(ctx):
         ])
         cargo_bazel_runfiles.extend([ctx.file.cargo_lockfile])
 
+    # Add an optional `Cargo.toml` file.
+    if ctx.attr.workspace_cargo_toml:
+        args.extend([
+            "--workspace-cargo-toml",
+            _runfiles_path(ctx.file.workspace_cargo_toml, is_windows),
+        ])
+        cargo_bazel_runfiles.extend([ctx.file.workspace_cargo_toml])
+
     # Optionally include buildifier
     if ctx.attr.buildifier:
         args.extend(["--buildifier", _runfiles_path(ctx.executable.buildifier, is_windows)])
@@ -400,6 +408,10 @@ CRATES_VENDOR_ATTRS = {
     ),
     "cargo_lockfile": attr.label(
         doc = "The path to an existing `Cargo.lock` file",
+        allow_single_file = True,
+    ),
+    "workspace_cargo_toml": attr.label(
+        doc = "The path to the workspace's `Cargo.toml` file",
         allow_single_file = True,
     ),
     "generate_binaries": attr.bool(

--- a/crate_universe/private/splicing_utils.bzl
+++ b/crate_universe/private/splicing_utils.bzl
@@ -114,13 +114,14 @@ def create_splicing_manifest(repository_ctx):
 
     return splicing_manifest
 
-def splice_workspace_manifest(repository_ctx, generator, cargo_lockfile, splicing_manifest, config_path, cargo, rustc):
+def splice_workspace_manifest(repository_ctx, generator, workspace_cargo_toml, cargo_lockfile, splicing_manifest, config_path, cargo, rustc):
     """Splice together a Cargo workspace from various other manifests and package definitions
 
     Args:
         repository_ctx (repository_ctx): The rule's context object.
         generator (path): The `cargo-bazel` binary.
         cargo_lockfile (path): The path to a "Cargo.lock" file.
+        workspace_cargo_toml (path): The path to the workspace's "Cargo.toml" file.
         splicing_manifest (path): The path to a splicing manifest.
         config_path: The path to the config file (containing `cargo_bazel::config::Config`.)
         cargo (path): The path to a Cargo binary.
@@ -152,6 +153,12 @@ def splice_workspace_manifest(repository_ctx, generator, cargo_lockfile, splicin
         "--nonhermetic-root-bazel-workspace-dir",
         repository_ctx.workspace_root,
     ]
+
+    if workspace_cargo_toml:
+        arguments.extend([
+            "--workspace-cargo-toml",
+            workspace_cargo_toml,
+        ])
 
     # Optionally set the splicing workspace directory to somewhere within the repository directory
     # to improve the debugging experience.

--- a/crate_universe/src/cli/splice.rs
+++ b/crate_universe/src/cli/splice.rs
@@ -60,6 +60,10 @@ pub struct SpliceOptions {
 
     #[clap(long)]
     pub nonhermetic_root_bazel_workspace_dir: PathBuf,
+
+    // The path to the workspace cargo toml file
+    #[clap(long)]
+    pub workspace_cargo_toml: Option<Utf8PathBuf>,
 }
 
 /// Combine a set of disjoint manifests into a single workspace.
@@ -86,7 +90,10 @@ pub fn splice(opt: SpliceOptions) -> Result<()> {
 
     // Splice together the manifest
     let manifest_path = splicer
-        .splice_workspace(&opt.nonhermetic_root_bazel_workspace_dir)
+        .splice_workspace(
+            &opt.nonhermetic_root_bazel_workspace_dir,
+            opt.workspace_cargo_toml.as_deref(),
+        )
         .context("Failed to splice workspace")?;
 
     // Generate a lockfile

--- a/crate_universe/src/cli/vendor.rs
+++ b/crate_universe/src/cli/vendor.rs
@@ -82,6 +82,10 @@ pub struct VendorOptions {
     /// You basically never want to use this value.
     #[clap(long)]
     pub nonhermetic_root_bazel_workspace_dir: Utf8PathBuf,
+
+    /// The path to the workspace cargo toml file
+    #[clap(long)]
+    pub workspace_cargo_toml: Option<Utf8PathBuf>,
 }
 
 /// Run buildifier on a given file.
@@ -141,7 +145,10 @@ pub fn vendor(opt: VendorOptions) -> Result<()> {
 
     // Splice together the manifest
     let manifest_path = splicer
-        .splice_workspace(opt.nonhermetic_root_bazel_workspace_dir.as_std_path())
+        .splice_workspace(
+            opt.nonhermetic_root_bazel_workspace_dir.as_std_path(),
+            opt.workspace_cargo_toml.as_deref(),
+        )
         .context("Failed to splice workspace")?;
 
     // Gather a cargo lockfile


### PR DESCRIPTION
This PR adds a new workspace toml parameter to allow picking one cargo workspace file when there are multiple in the base repo. 

https://github.com/bazelbuild/rules_rust/issues/3059