### PR TITLE
Replace symlinks in the output of cargo build scripts

### DIFF
--- a/test/cargo_build_script/resolve_abs_symlink_out_dir/BUILD.bazel
+++ b/test/cargo_build_script/resolve_abs_symlink_out_dir/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//cargo:defs.bzl", "cargo_build_script")
+load("//rust:defs.bzl", "rust_test")
+
+# We are testing the cargo build script behavior that it correctly resolves absolute path symlinks in the out_dir.
+# Additionally, it keeps out_dir relative symlinks intact.
+
+cargo_build_script(
+    name = "symlink_build_rs",
+    srcs = ["build.rs"],
+    data = ["data.txt"],
+    edition = "2018",
+)
+
+rust_test(
+    name = "test",
+    srcs = ["test.rs"],
+    data = [":symlink_build_rs"],
+    edition = "2018",
+    deps = [":symlink_build_rs"],
+)

--- a/test/cargo_build_script/resolve_abs_symlink_out_dir/build.rs
+++ b/test/cargo_build_script/resolve_abs_symlink_out_dir/build.rs
@@ -1,0 +1,28 @@
+use std::path::{Path, PathBuf};
+
+#[cfg(target_family = "unix")]
+fn symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) {
+    std::os::unix::fs::symlink(original, link).unwrap();
+}
+
+#[cfg(target_family = "windows")]
+fn symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) {
+    std::os::windows::fs::symlink_file(original, link).unwrap();
+}
+
+fn main() {
+    let path = "data.txt";
+    if !PathBuf::from(path).exists() {
+        panic!("File does not exist in path.");
+    }
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let out_dir = PathBuf::from(&out_dir);
+    let original_cwd = std::env::current_dir().unwrap();
+    std::fs::copy(&path, &out_dir.join("data.txt")).unwrap();
+    std::env::set_current_dir(&out_dir).unwrap();
+    std::fs::create_dir("nested").unwrap();
+    symlink("data.txt", "relative_symlink.txt");
+    symlink("../data.txt", "nested/relative_symlink.txt");
+    std::env::set_current_dir(&original_cwd).unwrap();
+    println!("{}", out_dir.display());
+}

--- a/test/cargo_build_script/resolve_abs_symlink_out_dir/data.txt
+++ b/test/cargo_build_script/resolve_abs_symlink_out_dir/data.txt
@@ -1,0 +1,1 @@
+Resolved symlink file or relative symlink

--- a/test/cargo_build_script/resolve_abs_symlink_out_dir/test.rs
+++ b/test/cargo_build_script/resolve_abs_symlink_out_dir/test.rs
@@ -1,0 +1,17 @@
+#[test]
+pub fn test_compile_data_resolved_symlink() {
+    let data = include_str!(concat!(env!("OUT_DIR"), "/data.txt"));
+    assert_eq!("Resolved symlink file or relative symlink\n", data);
+}
+
+#[test]
+pub fn test_compile_data_relative_symlink() {
+    let data = include_str!(concat!(env!("OUT_DIR"), "/relative_symlink.txt"));
+    assert_eq!("Resolved symlink file or relative symlink\n", data);
+}
+
+#[test]
+pub fn test_compile_data_relative_nested_symlink() {
+    let data = include_str!(concat!(env!("OUT_DIR"), "/nested/relative_symlink.txt"));
+    assert_eq!("Resolved symlink file or relative symlink\n", data);
+}


### PR DESCRIPTION
#2948 breaks building of rdkafka with `cmake` because of dangling symlinks.

When building with latest version we get the following error:
```
ERROR: /home/wincent/.cache/bazel/_bazel_wincent/394c4c1d21c5490d4a70260a2cfccaf5/external/rules_rust~~crate~crates__rdkafka-sys-4.8.0-2.3.0/BUILD.bazel:68:19: error while validating output tree artifact external/rules_rust~~crate~crates__rdkafka-sys-4.8.0-2.3.0/_bs.out_dir: child lib/cmake/RdKafka/FindLZ4.cmake is a dangling symbolic link
ERROR: /home/wincent/.cache/bazel/_bazel_wincent/394c4c1d21c5490d4a70260a2cfccaf5/external/rules_rust~~crate~crates__rdkafka-sys-4.8.0-2.3.0/BUILD.bazel:68:19: Running Cargo build script rdkafka-sys failed: not all outputs were created or valid
Target @@rules_rust~~crate~crates__rdkafka-0.37.0//:rdkafka failed to build
Use --verbose_failures to see the command lines of failed build steps.
ERROR: /home/wincent/.cache/bazel/_bazel_wincent/394c4c1d21c5490d4a70260a2cfccaf5/external/rules_rust~~crate~crates__rdkafka-sys-4.8.0-2.3.0/BUILD.bazel:18:13 Compiling Rust rlib rdkafka_sys v4.8.0+2.3.0 (7 files) failed: not all outputs were created or valid
```