### PR TITLE
Quote environ when injecting into crates vendor wrapper

### DIFF
--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -30,7 +30,7 @@ fi
 # --default_system_javabase set to the empty string, but if you provide a path,
 # it may set it to a value (eg. "/usr/local/buildtools/java/jdk11").
 exec env - \\
-${{_ENVIRON[@]}} \\
+"${{_ENVIRON[@]}}" \\
 {env} \\
     "{bin}" \\
     {args} \\


### PR DESCRIPTION
Slight tweak to the logic in https://github.com/bazelbuild/rules_rust/pull/2862 (cc: @UebelAndre)

My `$PATH` variable has spaces in it and I hit an error like
```
env: Support/JetBrains/Toolbox/scripts:/Users/ryanpbrewster/.bin:/Users/ryanpbrewster/config/bin:/Users/ryanpbrewster/.local/bin:/Applications/Visual: No such file or directory                                                                     
```

If I manually modify `bazel-bin/rust/crates_vendor.sh` to modify
```
exec env - \
${_ENVIRON[@]} \
```
into
```
exec env - \
"${_ENVIRON[@]}" \
```
it starts working.