### PR TITLE
Added `rust_prost_transform` rule for modifying granular proto_library

### DIFF
--- a/docs/src/rust_prost.md
+++ b/docs/src/rust_prost.md
@@ -192,3 +192,57 @@ Rust Prost toolchain rule.
 | <a id="rust_prost_toolchain-tonic_runtime"></a>tonic_runtime |  The Tonic runtime crates to use.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 
+<a id="rust_prost_transform"></a>
+
+## rust_prost_transform
+
+<pre>
+rust_prost_transform(<a href="#rust_prost_transform-name">name</a>, <a href="#rust_prost_transform-deps">deps</a>, <a href="#rust_prost_transform-srcs">srcs</a>, <a href="#rust_prost_transform-prost_opts">prost_opts</a>, <a href="#rust_prost_transform-tonic_opts">tonic_opts</a>)
+</pre>
+
+A rule for transforming the outputs of `ProstGenProto` actions.
+
+This rule is used by adding it to the `data` attribute of `proto_library` targets. E.g.
+```python
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_rust_prost//:defs.bzl", "rust_prost_library", "rust_prost_transform")
+
+rust_prost_transform(
+    name = "a_transform",
+    srcs = [
+        "a_src.rs",
+    ],
+)
+
+proto_library(
+    name = "a_proto",
+    srcs = [
+        "a.proto",
+    ],
+    data = [
+        ":transform",
+    ],
+)
+
+rust_prost_library(
+    name = "a_rs_proto",
+    proto = ":a_proto",
+)
+```
+
+The `rust_prost_library` will spawn an action on the `a_proto` target which consumes the
+`a_transform` rule to provide a means of granularly modifying a proto library for `ProstGenProto`
+actions with minimal impact to other consumers.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="rust_prost_transform-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="rust_prost_transform-deps"></a>deps |  Additional dependencies to add to the compiled crate.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="rust_prost_transform-srcs"></a>srcs |  Additional source files to include in generated Prost source code.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="rust_prost_transform-prost_opts"></a>prost_opts |  Additional options to add to Prost.   | List of strings | optional |  `[]`  |
+| <a id="rust_prost_transform-tonic_opts"></a>tonic_opts |  Additional options to add to Tonic.   | List of strings | optional |  `[]`  |
+
+

--- a/extensions/prost/defs.bzl
+++ b/extensions/prost/defs.bzl
@@ -146,6 +146,11 @@ load(
     _rust_prost_library = "rust_prost_library",
     _rust_prost_toolchain = "rust_prost_toolchain",
 )
+load(
+    "//private:prost_transform.bzl",
+    _rust_prost_transform = "rust_prost_transform",
+)
 
 rust_prost_library = _rust_prost_library
 rust_prost_toolchain = _rust_prost_toolchain
+rust_prost_transform = _rust_prost_transform

--- a/extensions/prost/private/prost_transform.bzl
+++ b/extensions/prost/private/prost_transform.bzl
@@ -1,0 +1,88 @@
+"""Prost rules."""
+
+load("@rules_rust//rust:defs.bzl", "rust_common")
+
+ProstTransformInfo = provider(
+    doc = "Info about transformations to apply to Prost generated source code.",
+    fields = {
+        "deps": "List[DepVariantInfo]: Additional dependencies to compile into the Prost target.",
+        "prost_opts": "List[str]: Additional prost flags.",
+        "srcs": "Depset[File]: Additional source files to include in generated Prost source code.",
+        "tonic_opts": "List[str]: Additional tonic flags.",
+    },
+)
+
+def _rust_prost_transform_impl(ctx):
+    deps = []
+    for target in ctx.attr.deps:
+        deps.append(rust_common.dep_variant_info(
+            crate_info = target[rust_common.crate_info] if rust_common.crate_info in target else None,
+            dep_info = target[rust_common.dep_info] if rust_common.dep_info in target else None,
+            cc_info = target[CcInfo] if CcInfo in target else None,
+            build_info = None,
+        ))
+
+    # DefaultInfo is intentionally not returned here to avoid impacting other
+    # consumers of the `proto_library` target this rule is expected to be passed
+    # to.
+    return [ProstTransformInfo(
+        deps = deps,
+        prost_opts = ctx.attr.prost_opts,
+        srcs = depset(ctx.files.srcs),
+        tonic_opts = ctx.attr.tonic_opts,
+    )]
+
+rust_prost_transform = rule(
+    doc = """\
+A rule for transforming the outputs of `ProstGenProto` actions.
+
+This rule is used by adding it to the `data` attribute of `proto_library` targets. E.g.
+```python
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_rust_prost//:defs.bzl", "rust_prost_library", "rust_prost_transform")
+
+rust_prost_transform(
+    name = "a_transform",
+    srcs = [
+        "a_src.rs",
+    ],
+)
+
+proto_library(
+    name = "a_proto",
+    srcs = [
+        "a.proto",
+    ],
+    data = [
+        ":transform",
+    ],
+)
+
+rust_prost_library(
+    name = "a_rs_proto",
+    proto = ":a_proto",
+)
+```
+
+The `rust_prost_library` will spawn an action on the `a_proto` target which consumes the
+`a_transform` rule to provide a means of granularly modifying a proto library for `ProstGenProto`
+actions with minimal impact to other consumers.
+""",
+    implementation = _rust_prost_transform_impl,
+    attrs = {
+        "deps": attr.label_list(
+            doc = "Additional dependencies to add to the compiled crate.",
+            providers = [[rust_common.crate_info], [rust_common.crate_group_info]],
+        ),
+        "prost_opts": attr.string_list(
+            doc = "Additional options to add to Prost.",
+        ),
+        "srcs": attr.label_list(
+            doc = "Additional source files to include in generated Prost source code.",
+            allow_files = True,
+        ),
+        "tonic_opts": attr.string_list(
+            doc = "Additional options to add to Tonic.",
+        ),
+    },
+)

--- a/extensions/prost/private/tests/transform/BUILD.bazel
+++ b/extensions/prost/private/tests/transform/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_rust//rust:defs.bzl", "rust_test")
+load("//:defs.bzl", "rust_prost_library", "rust_prost_transform")
+
+package(default_visibility = ["//private/tests:__subpackages__"])
+
+rust_prost_transform(
+    name = "transform",
+    srcs = ["a_src.rs"],
+)
+
+proto_library(
+    name = "a_proto",
+    srcs = [
+        "a.proto",
+    ],
+    data = [
+        ":transform",
+    ],
+    strip_import_prefix = "/private/tests/transform",
+    deps = [
+        "//private/tests/transform/b:b_proto",
+        "//private/tests/types:types_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+rust_prost_library(
+    name = "a_rs_proto",
+    proto = ":a_proto",
+)
+
+rust_test(
+    name = "a_test",
+    srcs = ["a_test.rs"],
+    edition = "2021",
+    deps = [
+        ":a_rs_proto",
+        # Add b_proto as a dependency directly to ensure compatibility with `a.proto`'s imports.
+        "//private/tests/transform/b:b_rs_proto",
+    ],
+)

--- a/extensions/prost/private/tests/transform/a.proto
+++ b/extensions/prost/private/tests/transform/a.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+import "b/b.proto";
+import "types/types.proto";
+
+package a;
+
+message A {
+    string name = 1;
+
+    a.b.B b = 2;
+
+    google.protobuf.Timestamp timestamp = 3;
+
+    google.protobuf.Duration duration = 4;
+
+    Types types = 5;
+}

--- a/extensions/prost/private/tests/transform/a_src.rs
+++ b/extensions/prost/private/tests/transform/a_src.rs
@@ -1,0 +1,9 @@
+// Additional source code for `a.proto`.
+
+use std::fmt::{Display, Formatter, Result};
+
+impl Display for crate::a::A {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "Display of: A")
+    }
+}

--- a/extensions/prost/private/tests/transform/a_test.rs
+++ b/extensions/prost/private/tests/transform/a_test.rs
@@ -1,0 +1,55 @@
+//! Tests transitive dependencies.
+
+use a_proto::a::A;
+use a_proto::b_proto::c_proto::a::b::c::C;
+use a_proto::duration_proto::google::protobuf::Duration;
+use a_proto::timestamp_proto::google::protobuf::Timestamp;
+use a_proto::types_proto::Types;
+
+#[test]
+fn test_a() {
+    let duration = Duration {
+        seconds: 1,
+        nanos: 2,
+    };
+
+    let a = A {
+        name: "a".to_string(),
+        // Ensure the external `b_proto` dependency is compatible with `a_proto`'s `B`.
+        b: Some(b_proto::a::b::B {
+            name: "b".to_string(),
+            c: Some(C {
+                name: "c".to_string(),
+            }),
+            ..Default::default()
+        }),
+        timestamp: Some(Timestamp {
+            seconds: 1,
+            nanos: 2,
+        }),
+        duration: Some(duration),
+        types: Some(Types::default()),
+    };
+
+    assert_eq!(
+        "Display of: A",
+        format!("{}", a),
+        "Unexpected `Display` implementation for {:#?}",
+        a
+    );
+}
+
+#[test]
+fn test_b() {
+    use b_proto::Greeting;
+
+    let b = b_proto::a::b::B {
+        name: "b".to_string(),
+        c: Some(C {
+            name: "c".to_string(),
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!("Hallo, Bazel, my name is B!", b.greet("Bazel"));
+}

--- a/extensions/prost/private/tests/transform/b/BUILD.bazel
+++ b/extensions/prost/private/tests/transform/b/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//:defs.bzl", "rust_prost_library", "rust_prost_transform")
+
+package(default_visibility = ["//private/tests:__subpackages__"])
+
+rust_library(
+    name = "greeting",
+    srcs = ["greeting.rs"],
+    edition = "2021",
+)
+
+rust_prost_transform(
+    name = "transform",
+    srcs = ["b_src.rs"],
+    deps = [":greeting"],
+)
+
+proto_library(
+    name = "b_proto",
+    srcs = [
+        "b.proto",
+    ],
+    data = [
+        ":transform",
+    ],
+    strip_import_prefix = "/private/tests/transform",
+    deps = [
+        "//private/tests/transform/b/c:c_proto",
+        "@com_google_protobuf//:empty_proto",
+    ],
+)
+
+rust_prost_library(
+    name = "b_rs_proto",
+    proto = ":b_proto",
+)
+
+rust_test(
+    name = "b_test",
+    srcs = ["b_test.rs"],
+    edition = "2021",
+    deps = [
+        ":b_rs_proto",
+        ":greeting",
+    ],
+)

--- a/extensions/prost/private/tests/transform/b/b.proto
+++ b/extensions/prost/private/tests/transform/b/b.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "b/c/c.proto";
+
+package a.b;
+
+message B {
+    string name = 1;
+
+    google.protobuf.Empty empty = 2;
+
+    a.b.c.C c = 3;
+}

--- a/extensions/prost/private/tests/transform/b/b_src.rs
+++ b/extensions/prost/private/tests/transform/b/b_src.rs
@@ -1,0 +1,9 @@
+// Additional source code for `b.proto`.
+
+pub use greeting::Greeting;
+
+impl Greeting for crate::a::b::B {
+    fn greet(&self, name: &str) -> String {
+        format!("Hallo, {}, my name is B!", name)
+    }
+}

--- a/extensions/prost/private/tests/transform/b/b_test.rs
+++ b/extensions/prost/private/tests/transform/b/b_test.rs
@@ -1,0 +1,19 @@
+//! Tests transitive dependencies.
+
+use b_proto::a::b::B;
+use b_proto::c_proto::a::b::c::C;
+
+use greeting::Greeting;
+
+#[test]
+fn test_b() {
+    let b = B {
+        name: "b".to_string(),
+        c: Some(C {
+            name: "c".to_string(),
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!("Hallo, Bazel, my name is B!", b.greet("Bazel"));
+}

--- a/extensions/prost/private/tests/transform/b/c/BUILD.bazel
+++ b/extensions/prost/private/tests/transform/b/c/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_rust//rust:defs.bzl", "rust_test")
+load("//:defs.bzl", "rust_prost_library", "rust_prost_transform")
+
+package(default_visibility = ["//private/tests:__subpackages__"])
+
+rust_prost_transform(
+    name = "transform_1",
+    prost_opts = [
+        "type_attribute=.=#[derive(Hash)]",
+    ],
+)
+
+rust_prost_transform(
+    name = "transform_2",
+    prost_opts = [
+        "type_attribute=.=#[derive(Eq)]",
+    ],
+)
+
+proto_library(
+    name = "c_proto",
+    srcs = [
+        "c.proto",
+    ],
+    data = [
+        ":transform_1",
+        ":transform_2",
+    ],
+    strip_import_prefix = "/private/tests/transform",
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+    ],
+)
+
+rust_prost_library(
+    name = "c_rs_proto",
+    proto = ":c_proto",
+)
+
+rust_test(
+    name = "c_test",
+    srcs = ["c_test.rs"],
+    edition = "2021",
+    deps = [
+        ":c_rs_proto",
+    ],
+)

--- a/extensions/prost/private/tests/transform/b/c/c.proto
+++ b/extensions/prost/private/tests/transform/b/c/c.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package a.b.c;
+
+message C {
+    string name = 1;
+}

--- a/extensions/prost/private/tests/transform/b/c/c_test.rs
+++ b/extensions/prost/private/tests/transform/b/c/c_test.rs
@@ -1,0 +1,16 @@
+//! Tests transitive dependencies.
+
+use std::collections::HashSet;
+
+use c_proto::a::b::c::C;
+
+#[test]
+fn test_c() {
+    let c = C {
+        name: "c".to_string(),
+    };
+
+    // This shows that Hash and Eq are implemented for C
+    let set = HashSet::from([c]);
+    assert_eq!(set.len(), 1, "{:#?}", set);
+}

--- a/extensions/prost/private/tests/transform/b/greeting.rs
+++ b/extensions/prost/private/tests/transform/b/greeting.rs
@@ -1,0 +1,5 @@
+//! Implement a trait which is used to generate greetings.
+
+pub trait Greeting {
+    fn greet(&self, name: &str) -> String;
+}


### PR DESCRIPTION
This new rule is to support granular modifications to existing `proto_library` targets without adding duplicate actions to the build graph depending on what `rust_prost_library` target was consumed.

closes https://github.com/bazelbuild/rules_rust/issues/2045