### PR TITLE
Forward clippy, rustfmt, and rust-analyzer through wasm_bindgen

### DIFF
--- a/extensions/wasm_bindgen/test/BUILD.bazel
+++ b/extensions/wasm_bindgen/test/BUILD.bazel
@@ -26,6 +26,7 @@ rust_binary(
     name = "hello_world_bin_wasm",
     srcs = ["main.rs"],
     edition = "2018",
+    target_compatible_with = ["@platforms//cpu:wasm32"],
     deps = [
         "@rules_rust_wasm_bindgen//3rdparty:wasm_bindgen",
     ],
@@ -35,6 +36,7 @@ rust_shared_library(
     name = "hello_world_lib_wasm",
     srcs = ["main.rs"],
     edition = "2018",
+    target_compatible_with = ["@platforms//cpu:wasm32"],
     deps = [
         "@rules_rust_wasm_bindgen//3rdparty:wasm_bindgen",
     ],


### PR DESCRIPTION
This allows targets gated by `target_compatible_with = ["@platforms//cpu:wasm32"]` to have clippy and rustfmt run on them as well as include those targets in rust-analyzer outputs.