### PR TITLE
Do not cache rustc info in deps resolver

### DIFF
--- a/crate_universe/src/metadata/cargo_tree_resolver.rs
+++ b/crate_universe/src/metadata/cargo_tree_resolver.rs
@@ -150,6 +150,7 @@ impl TreeResolver {
                     // host triple instead of the host triple detected by rustc.
                     .env("RUSTC_WRAPPER", rustc_wrapper)
                     .env("HOST_TRIPLE", host_triple)
+                    .env("CARGO_CACHE_RUSTC_INFO", "0")
                     .current_dir(manifest_path.parent().expect("All manifests should have a valid parent."))
                     .arg("tree")
                     .arg("--manifest-path")

--- a/crate_universe/tests/cargo_integration_test.rs
+++ b/crate_universe/tests/cargo_integration_test.rs
@@ -526,16 +526,24 @@ fn host_specific_build_deps() {
     }
 
     let r = runfiles::Runfiles::create().unwrap();
+
+    let src_cargo_toml = runfiles::rlocation!(
+        r,
+        "rules_rust/crate_universe/test_data/metadata/host_specific_build_deps/Cargo.toml"
+    )
+    .unwrap();
+
+    // Put Cargo.toml into writable directory structure and create target/ directory to verify that
+    // cargo does not incorrectly cache rustc info in target/.rustc_info.json file.
+    let scratch = tempfile::tempdir().unwrap();
+    let cargo_toml = scratch.path().join("Cargo.toml");
+    fs::copy(src_cargo_toml, &cargo_toml).unwrap();
+    fs::create_dir(scratch.path().join("target")).unwrap();
+
     let metadata = run(
         "host_specific_build_deps",
         HashMap::from([(
-            runfiles::rlocation!(
-                r,
-                "rules_rust/crate_universe/test_data/metadata/host_specific_build_deps/Cargo.toml"
-            )
-            .unwrap()
-            .to_string_lossy()
-            .to_string(),
+            cargo_toml.to_string_lossy().to_string(),
             "//:test_input".to_string(),
         )]),
         "rules_rust/crate_universe/test_data/metadata/host_specific_build_deps/Cargo.lock",


### PR DESCRIPTION
The cargo_tree_resolver discovers dependencies by executing `cargo tree` for different host and target triples. This procedure breaks when cargo successfully but incorrectly caches rustc info. Incorrect cache hit may happen because cache key does not take into account HOST_TRIPLE env variable used by `rules_rust` to force rustc to report it's built for different host.

The caching may happen if one has target/ directory in repo, or it was created through running some commands outside of bazel.

# Details

- After recent fixes to support properly bzlmod
(https://github.com/bazelbuild/rules_rust/pull/3034) noticed issues under windows when building bazel-lsp: https://github.com/cameron-martin/bazel-lsp/issues/92

- Cargo may cache rustc info in target/.rustc_info.json : https://github.com/rust-lang/cargo/blob/769f622e12db0001431d8ae36d1093fb8727c5d9/src/cargo/util/rustc.rs#L163

- The rules_rust hacks rustc by setting HOST_TRIPLE: https://github.com/bazelbuild/rules_rust/blob/3aecdbedba0c001d0660ff631aeccb35d94ff3a7/crate_universe/src/metadata/cargo_tree_resolver.rs#L152

- The HOST_TRIPLE env variable is not taken into account by cargo when checking whether cached rustc info is valid:
https://github.com/rust-lang/cargo/blob/769f622e12db0001431d8ae36d1093fb8727c5d9/src/cargo/util/rustc.rs#L320