### PR TITLE
Remove the unused implicit attribute `_cc_toolchains`.

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -654,9 +654,6 @@ cargo_build_script = rule(
         "_cargo_manifest_dir_filename_suffixes_to_retain": attr.label(
             default = Label("//cargo/settings:cargo_manifest_dir_filename_suffixes_to_retain"),
         ),
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_debug_std_streams_output_group": attr.label(
             default = Label("//cargo/settings:debug_std_streams_output_group"),
         ),

--- a/extensions/bindgen/private/bindgen.bzl
+++ b/extensions/bindgen/private/bindgen.bzl
@@ -394,9 +394,6 @@ rust_bindgen = rule(
             doc = "Whether to create a separate .c file for static fns. Requires nightly toolchain, and a header that actually needs this feature (otherwise bindgen won't generate the file and Bazel complains).",
             default = False,
         ),
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_process_wrapper": attr.label(
             default = Label("@rules_rust//util/process_wrapper"),
             executable = True,

--- a/extensions/protobuf/proto.bzl
+++ b/extensions/protobuf/proto.bzl
@@ -311,9 +311,6 @@ rust_proto_library = rule(
                 file of arguments to rustc: `@$(location //package:target)`.
             """,
         ),
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_optional_output_wrapper": attr.label(
             executable = True,
             cfg = "exec",

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -219,13 +219,6 @@ rust_clippy_aspect = aspect(
             doc = "Value of the `capture_clippy_output` build setting",
             default = Label("//rust/settings:capture_clippy_output"),
         ),
-        "_cc_toolchain": attr.label(
-            doc = (
-                "Required attribute to access the cc_toolchain. See [Accessing the C++ toolchain]" +
-                "(https://docs.bazel.build/versions/master/integrating-with-rules-cc.html#accessing-the-c-toolchain)"
-            ),
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_clippy_flag": attr.label(
             doc = "Arguments to pass to clippy." +
                   "Multiple uses are accumulated and appended after the extra_rustc_flags.",

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -529,14 +529,6 @@ def _stamp_attribute(default_value):
 
 # Internal attributes core to Rustc actions.
 RUSTC_ATTRS = {
-    "_cc_toolchain": attr.label(
-        doc = (
-            "In order to use find_cc_toolchain, your rule has to depend " +
-            "on C++ toolchain. See `@rules_cc//cc:find_cc_toolchain.bzl` " +
-            "docs for details."
-        ),
-        default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-    ),
     "_error_format": attr.label(
         default = Label("//rust/settings:error_format"),
     ),

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -310,10 +310,6 @@ rust_doc = rule(
                 file of arguments to rustc: `@$(location //package:target)`.
             """),
         ),
-        "_cc_toolchain": attr.label(
-            doc = "In order to use find_cpp_toolchain, you must define the '_cc_toolchain' attribute on your rule or aspect.",
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_dir_zipper": attr.label(
             doc = "A tool that orchestrates the creation of zip archives for rustdoc outputs.",
             default = Label("//util/dir_zipper"),

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -215,14 +215,6 @@ rust_doc_test = rule(
             cfg = "exec",
             providers = [rust_common.crate_info],
         ),
-        "_cc_toolchain": attr.label(
-            doc = (
-                "In order to use find_cc_toolchain, your rule has to depend " +
-                "on C++ toolchain. See @rules_cc//cc:find_cc_toolchain.bzl " +
-                "docs for details."
-            ),
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_process_wrapper": attr.label(
             doc = "A process wrapper for running rustdoc on all platforms",
             cfg = "exec",

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -874,6 +874,7 @@ rust_toolchain = rule(
                 "For more details see: https://docs.bazel.build/versions/master/skylark/rules.html#configurations"
             ),
         ),
+        # TODO: #3115 - Remove this attribute.
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),

--- a/test/unit/consistent_crate_name/with_modified_crate_name.bzl
+++ b/test/unit/consistent_crate_name/with_modified_crate_name.bzl
@@ -59,9 +59,6 @@ with_modified_crate_name = rule(
         "src": attr.label(
             allow_single_file = [".rs"],
         ),
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_error_format": attr.label(
             default = Label("//rust/settings:error_format"),
         ),

--- a/test/unit/force_all_deps_direct/generator.bzl
+++ b/test/unit/force_all_deps_direct/generator.bzl
@@ -76,9 +76,6 @@ generator = rule(
             doc = "List of other libraries to be linked to this library target.",
             providers = [CrateInfo],
         ),
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_error_format": attr.label(
             default = Label("//rust/settings:error_format"),
         ),

--- a/test/unit/pipelined_compilation/wrap.bzl
+++ b/test/unit/pipelined_compilation/wrap.bzl
@@ -84,9 +84,6 @@ wrap = rule(
         "crate_name": attr.string(),
         "generate_metadata": attr.bool(default = False),
         "target": attr.label(),
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_error_format": attr.label(
             default = Label("//rust/settings:error_format"),
         ),


### PR DESCRIPTION
CC toolchains are gathered from the line:
```
toolchains = use_cc_toolchains(),
```

Keep toolchain usage of _cc_toolchain with a TODO to remove it.

See #3115 for details.