### PR TITLE
Fix typos with calculating flags for lto setting

### DIFF
--- a/rust/private/lto.bzl
+++ b/rust/private/lto.bzl
@@ -101,10 +101,10 @@ def construct_lto_arguments(ctx, toolchain, crate_info):
     if mode in ["thin", "fat", "off"] and not is_exec_configuration(ctx):
         args.append("lto={}".format(mode))
 
-    if format in ["unspecified", "object_and_bitcode"]:
+    if mode == "unspecified" or format == "object_and_bitcode":
         # Embedding LLVM bitcode in object files is `rustc's` default.
         args.extend([])
-    elif format in ["off", "only_object"]:
+    elif mode == "off" or format == "only_object":
         args.extend(["embed-bitcode=no"])
     elif format == "only_bitcode":
         args.extend(["linker-plugin-lto"])

--- a/test/unit/lto/lto_test_suite.bzl
+++ b/test/unit/lto/lto_test_suite.bzl
@@ -39,7 +39,7 @@ def _lto_test_impl(ctx, lto_setting, embed_bitcode, linker_plugin):
     return analysistest.end(env)
 
 def _lto_level_default(ctx):
-    return _lto_test_impl(ctx, None, "no", False)
+    return _lto_test_impl(ctx, None, None, False)
 
 _lto_level_default_test = analysistest.make(
     _lto_level_default,


### PR DESCRIPTION
Fixed typos in #3104

Default behavior was incorrect as the `unspecified` should have no-op on the compile flags. However this was not the case due to incorrect conditions.

#3104 could break users who are already having special LTO flags but with custom toolchains.

I will have some additional fixes but this seemed more urgent to me to keep the old behavior intact before 0.56.0

cc: @ParkMyCar , @UebelAndre 