### PR TITLE
fix: add 'manual' option for `//rust/settings/lto`

### DIFF
--- a/rust/private/lto.bzl
+++ b/rust/private/lto.bzl
@@ -3,6 +3,8 @@
 load("//rust/private:utils.bzl", "is_exec_configuration")
 
 _LTO_MODES = [
+    # Do nothing, let the user manually handle LTO.
+    "manual",
     # Default. No mode has been explicitly set, rustc will do "thin local" LTO
     # between the codegen units of a single crate.
     "unspecified",
@@ -94,8 +96,12 @@ def construct_lto_arguments(ctx, toolchain, crate_info):
         list: A list of strings that are valid flags for 'rustc'.
     """
     mode = toolchain._lto.mode
-    format = _determine_lto_object_format(ctx, toolchain, crate_info)
 
+    # The user is handling LTO on their own, don't add any arguments.
+    if mode == "manual":
+        return []
+
+    format = _determine_lto_object_format(ctx, toolchain, crate_info)
     args = []
 
     if mode in ["thin", "fat", "off"] and not is_exec_configuration(ctx):

--- a/rust/private/lto.bzl
+++ b/rust/private/lto.bzl
@@ -66,8 +66,6 @@ def _determine_lto_object_format(ctx, toolchain, crate_info):
         return "only_object"
 
     perform_linking = crate_info.type in ["bin", "staticlib", "cdylib"]
-
-    # is_linkable = crate_info.type in ["lib", "rlib", "dylib", "proc-macro"]
     is_dynamic = crate_info.type in ["dylib", "cdylib", "proc-macro"]
     needs_object = perform_linking or is_dynamic
 
@@ -107,10 +105,10 @@ def construct_lto_arguments(ctx, toolchain, crate_info):
     if mode in ["thin", "fat", "off"] and not is_exec_configuration(ctx):
         args.append("lto={}".format(mode))
 
-    if format in ["unspecified", "object_and_bitcode"]:
+    if format == "object_and_bitcode":
         # Embedding LLVM bitcode in object files is `rustc's` default.
         args.extend([])
-    elif format in ["off", "only_object"]:
+    elif format == "only_object":
         args.extend(["embed-bitcode=no"])
     elif format == "only_bitcode":
         args.extend(["linker-plugin-lto"])

--- a/test/unit/lto/lto_test_suite.bzl
+++ b/test/unit/lto/lto_test_suite.bzl
@@ -46,6 +46,14 @@ _lto_level_default_test = analysistest.make(
     config_settings = {},
 )
 
+def _lto_level_manual(ctx):
+    return _lto_test_impl(ctx, None, None, False)
+
+_lto_level_manual_test = analysistest.make(
+    _lto_level_manual,
+    config_settings = {str(Label("//rust/settings:lto")): "manual"},
+)
+
 def _lto_level_off(ctx):
     return _lto_test_impl(ctx, "off", "no", False)
 
@@ -97,6 +105,11 @@ def lto_test_suite(name):
         target_under_test = ":lib",
     )
 
+    _lto_level_manual_test(
+        name = "lto_level_manual_test",
+        target_under_test = ":lib",
+    )
+
     _lto_level_off_test(
         name = "lto_level_off_test",
         target_under_test = ":lib",
@@ -116,6 +129,7 @@ def lto_test_suite(name):
         name = name,
         tests = [
             ":lto_level_default_test",
+            ":lto_level_manual_test",
             ":lto_level_off_test",
             ":lto_level_thin_test",
             ":lto_level_fat_test",


### PR DESCRIPTION
Related to https://github.com/bazelbuild/rules_rust/pull/3119

Adds an option named "manual" to `//rust/settings/lto` which was introduced in https://github.com/bazelbuild/rules_rust/pull/3104. When set to "manual" we will not automatically set any flags so users with customized setups can configure the relevant flags on their own.

FWIW this was an oversight and IMO should have been included in the original PR. Apologies to anyone who stumbled over this or encountered build issues!