### PR TITLE
Explicitly disable bzlmod for rust_analyzer tests

### DIFF
--- a/test/rust_analyzer/rust_analyzer_test_runner.sh
+++ b/test/rust_analyzer/rust_analyzer_test_runner.sh
@@ -38,6 +38,9 @@ test_crate_repositories()
 EOF
 
     cat <<EOF >"${new_workspace}/.bazelrc"
+# TODO: support bzlmod
+common --noenable_bzlmod
+common --enable_workspace
 build --keep_going
 test --test_output=errors
 # The 'strict' config is used to ensure extra checks are run on the test


### PR DESCRIPTION
It already isn't using bzlmod (the runner creates WORKSPACE.bazel),
making this explicit allows the tests to be run under bazel 8.

(Some work would be required to make test/3rdparty work with bazelmod,
I don't understand what.)
