### PR TITLE
Added render_config and splicing_config to create_universe bzlmod

### DIFF
--- a/crate_universe/docs_bzlmod.bzl
+++ b/crate_universe/docs_bzlmod.bzl
@@ -147,7 +147,7 @@ crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
 
 crate.spec(package = "serde", features = ["derive"], version = "1.0")
 crate.spec(package = "serde_json", version = "1.0")
-crate.spec(package = "tokio", default_features=False, features = ["macros", "net", "rt-multi-thread"], version = "1.38")
+crate.spec(package = "tokio", default_features = False, features = ["macros", "net", "rt-multi-thread"], version = "1.38")
 
 crate.from_specs()
 use_repo(crate, "crates")

--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -5,8 +5,9 @@ load("@bazel_skylib//lib:structs.bzl", "structs")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//crate_universe/private:crates_vendor.bzl", "CRATES_VENDOR_ATTRS", "generate_config_file", "generate_splicing_manifest")
-load("//crate_universe/private:generate_utils.bzl", "CARGO_BAZEL_GENERATOR_SHA256", "CARGO_BAZEL_GENERATOR_URL", "GENERATOR_ENV_VARS", "render_config")
+load("//crate_universe/private:generate_utils.bzl", "CARGO_BAZEL_GENERATOR_SHA256", "CARGO_BAZEL_GENERATOR_URL", "GENERATOR_ENV_VARS", generate_render_config = "render_config")
 load("//crate_universe/private:local_crate_mirror.bzl", "local_crate_mirror")
+load("//crate_universe/private:splicing_utils.bzl", generate_splicing_config = "splicing_config")
 load("//crate_universe/private:urls.bzl", "CARGO_BAZEL_SHA256S", "CARGO_BAZEL_URLS")
 load("//rust/platform:triple.bzl", "get_host_triple")
 load("//rust/platform:triple_mappings.bzl", "system_to_binary_ext")
@@ -61,7 +62,88 @@ def _annotations_for_repo(module_annotations, repo_specific_annotations):
         _get_or_insert(annotations, crate, []).extend(values)
     return annotations
 
-def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, cargo_lockfile = None, manifests = {}, packages = {}):
+def _collect_render_config(module, repository):
+    """Collect the render_config for the given crate_universe module.
+
+    Args:
+        module (StarlarkBazelModule): The current `crate` module.
+        repository (str): The name of the repository to collect the config for.
+
+    Returns:
+        dict: The rendering config to use.
+    """
+
+    config = None
+    for raw_config in module.tags.render_config:
+        if not raw_config.repositories:
+            continue
+
+        if not repository in raw_config.repositories:
+            continue
+
+        if config:
+            fail("Multiple render configs provided for module `{}`. Only 1 is allowed.".format(
+                module.name,
+            ))
+
+        config_kwargs = {attr: getattr(raw_config, attr) for attr in dir(raw_config)}
+
+        if "repositories" in config_kwargs:
+            config_kwargs.pop("repositories")
+
+        # bzlmod doesn't allow passing `None` as a default parameter to indicate a value was
+        # not provided. So for backward compatibility, certain empty values are assumed to be
+        # not provided and thus are converted explicitly to `None`.
+        for null_defaults in ["vendor_mode", "regen_command", "default_package_name"]:
+            if config_kwargs[null_defaults] == "":
+                config_kwargs[null_defaults] = None
+
+        config = json.decode(generate_render_config(**config_kwargs))
+
+    if not config:
+        config = json.decode(generate_render_config())
+
+    if not config["regen_command"]:
+        config["regen_command"] = "bazel mod show_repo '{}'".format(module.name)
+
+    return config
+
+def _collect_splicing_config(module, repository):
+    """Collect the splicing_config for the given crate_universe module.
+
+    Args:
+        module (StarlarkBazelModule): The current `crate` module.
+        repository (str): The name of the repository to collect the config for.
+
+    Returns:
+        dict: The splicing config to use.
+    """
+    config = None
+    for raw_config in module.tags.splicing_config:
+        if not raw_config.repositories:
+            continue
+
+        if not repository in raw_config.repositories:
+            continue
+
+        if config:
+            fail("Multiple render configs provided for module `{}`. Only 1 is allowed.".format(
+                module.name,
+            ))
+
+        config_kwargs = {attr: getattr(raw_config, attr) for attr in dir(raw_config)}
+
+        if "repositories" in config_kwargs:
+            config_kwargs.pop("repositories")
+
+        config = json.decode(generate_splicing_config(**config_kwargs))
+
+    if not config:
+        config = json.decode(generate_splicing_config())
+
+    return config
+
+def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, render_config, splicing_config, cargo_lockfile = None, manifests = {}, packages = {}):
     """Generates repositories for the transitive closure of crates defined by manifests and packages.
 
     Args:
@@ -69,6 +151,8 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, cargo
         cargo_bazel (function): A function that can be called to execute cargo_bazel.
         cfg (object): The module tag from `from_cargo` or `from_specs`
         annotations (dict): The set of annotation tag classes that apply to this closure, keyed by crate name.
+        render_config (dict): The render config to use.
+        splicing_config (dict): The splicing config to use.
         cargo_lockfile (path): Path to Cargo.lock, if we have one. This is optional for `from_specs` closures.
         manifests (dict): The set of Cargo.toml manifests that apply to this closure, if any, keyed by path.
         packages (dict): The set of extra cargo crate tags that apply to this closure, if any, keyed by package name.
@@ -76,9 +160,6 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, cargo
 
     tag_path = module_ctx.path(cfg.name)
 
-    rendering_config = json.decode(render_config(
-        regen_command = "Run 'cargo update [--workspace]'",
-    ))
     config_file = tag_path.get_child("config.json")
     module_ctx.file(
         config_file,
@@ -94,7 +175,7 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, cargo
             output_pkg = cfg.name,
             workspace_name = cfg.name,
             generate_binaries = cfg.generate_binaries,
-            render_config = rendering_config,
+            render_config = render_config,
             repository_ctx = module_ctx,
         ),
     )
@@ -105,7 +186,7 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, cargo
         executable = False,
         content = generate_splicing_manifest(
             packages = packages,
-            splicing_config = cfg.splicing_config,
+            splicing_config = splicing_config,
             cargo_config = cfg.cargo_config,
             manifests = manifests,
             manifest_to_path = module_ctx.path,
@@ -239,7 +320,7 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, cargo
             )
         elif "Path" in repo:
             options = {
-                "config": rendering_config,
+                "config": render_config,
                 "crate_context": crate,
                 "platform_conditions": contents["conditions"],
                 "supported_platform_triples": cfg.supported_platform_triples,
@@ -454,6 +535,9 @@ def _crate_impl(module_ctx):
                 repo_specific_annotations.get(cfg.name),
             )
 
+            render_config = _collect_render_config(module = mod)
+            splicing_config = _collect_splicing_config(module = mod)
+
             cargo_lockfile = module_ctx.path(cfg.cargo_lockfile)
             manifests = {str(module_ctx.path(m)): str(m) for m in cfg.manifests}
             _generate_hub_and_spokes(
@@ -462,6 +546,8 @@ def _crate_impl(module_ctx):
                 cfg = cfg,
                 annotations = annotations,
                 cargo_lockfile = cargo_lockfile,
+                render_config = render_config,
+                splicing_config = splicing_config,
                 manifests = manifests,
             )
 
@@ -476,12 +562,17 @@ def _crate_impl(module_ctx):
                 repo_specific_annotations.get(cfg.name),
             )
 
+            render_config = _collect_render_config(mod, cfg.name)
+            splicing_config = _collect_splicing_config(mod, cfg.name)
+
             packages = {p.package: _package_to_json(p) for p in mod.tags.spec}
             _generate_hub_and_spokes(
                 module_ctx = module_ctx,
                 cargo_bazel = cargo_bazel,
                 cfg = cfg,
                 annotations = annotations,
+                render_config = render_config,
+                splicing_config = splicing_config,
                 packages = packages,
             )
 
@@ -510,13 +601,13 @@ _from_cargo = tag_class(
         "cargo_lockfile": CRATES_VENDOR_ATTRS["cargo_lockfile"],
         "generate_binaries": CRATES_VENDOR_ATTRS["generate_binaries"],
         "generate_build_scripts": CRATES_VENDOR_ATTRS["generate_build_scripts"],
-        "splicing_config": CRATES_VENDOR_ATTRS["splicing_config"],
         "supported_platform_triples": CRATES_VENDOR_ATTRS["supported_platform_triples"],
     },
 )
 
 # This should be kept in sync with crate_universe/private/crate.bzl.
 _annotation = tag_class(
+    doc = "A collection of extra attributes and settings for a particular crate.",
     attrs = {
         "additive_build_file": attr.label(
             doc = "A file containing extra contents to write to the bottom of generated BUILD files.",
@@ -651,13 +742,13 @@ _from_specs = tag_class(
         "cargo_config": CRATES_VENDOR_ATTRS["cargo_config"],
         "generate_binaries": CRATES_VENDOR_ATTRS["generate_binaries"],
         "generate_build_scripts": CRATES_VENDOR_ATTRS["generate_build_scripts"],
-        "splicing_config": CRATES_VENDOR_ATTRS["splicing_config"],
         "supported_platform_triples": CRATES_VENDOR_ATTRS["supported_platform_triples"],
     },
 )
 
 # This should be kept in sync with crate_universe/private/crate.bzl.
 _spec = tag_class(
+    doc = "A constructor for a crate dependency.",
     attrs = {
         "artifact": attr.string(
             doc = "Set to 'bin' to pull in a binary crate as an artifact dependency. Requires a nightly Cargo.",
@@ -694,6 +785,90 @@ _spec = tag_class(
     },
 )
 
+_splicing_config = tag_class(
+    doc = "Various settings used to configure Cargo manifest splicing behavior.",
+    attrs = {
+        "repositories": attr.string_list(
+            doc = "A list of repository names specified from `crate.from_cargo(name=...)` that this annotation is applied to. Defaults to all repositories.",
+            default = [],
+        ),
+    } | {
+        "resolver_version": attr.string(
+            doc = "The [resolver version](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) to use in generated Cargo manifests. This flag is **only** used when splicing a manifest from direct package definitions. See `crates_repository::packages`",
+            default = "2",
+        ),
+    },
+)
+
+_render_config = tag_class(
+    doc = """\
+Various settings used to configure rendered outputs.
+
+The template parameters each support a select number of format keys. A description of each key
+can be found below where the supported keys for each template can be found in the parameter docs
+
+| key | definition |
+| --- | --- |
+| `name` | The name of the crate. Eg `tokio` |
+| `repository` | The rendered repository name for the crate. Directly relates to `crate_repository_template`. |
+| `triple` | A platform triple. Eg `x86_64-unknown-linux-gnu` |
+| `version` | The crate version. Eg `1.2.3` |
+| `target` | The library or binary target of the crate |
+| `file` | The basename of a file |
+""",
+    attrs = {
+        "repositories": attr.string_list(
+            doc = "A list of repository names specified from `crate.from_cargo(name=...)` that this annotation is applied to. Defaults to all repositories.",
+            default = [],
+        ),
+    } | {
+        "build_file_template": attr.string(
+            doc = "The base template to use for BUILD file names. The available format keys are [`{name}`, {version}`].",
+            default = "//:BUILD.{name}-{version}.bazel",
+        ),
+        "crate_label_template": attr.string(
+            doc = "The base template to use for crate labels. The available format keys are [`{repository}`, `{name}`, `{version}`, `{target}`].",
+            default = "@{repository}__{name}-{version}//:{target}",
+        ),
+        "crate_repository_template": attr.string(
+            doc = "The base template to use for Crate label repository names. The available format keys are [`{repository}`, `{name}`, `{version}`].",
+            default = "{repository}__{name}-{version}",
+        ),
+        "crates_module_template": attr.string(
+            doc = "The pattern to use for the `defs.bzl` and `BUILD.bazel` file names used for the crates module. The available format keys are [`{file}`].",
+            default = "//:{file}",
+        ),
+        "default_alias_rule": attr.string(
+            doc = "Alias rule to use when generating aliases for all crates.  Acceptable values are 'alias', 'dbg'/'fastbuild'/'opt' (transitions each crate's `compilation_mode`)  or a string representing a rule in the form '<label to .bzl>:<rule>' that takes a single label parameter 'actual'. See '@crate_index//:alias_rules.bzl' for an example.",
+            default = "alias",
+        ),
+        "default_package_name": attr.string(
+            doc = "The default package name to use in the rendered macros. This affects the auto package detection of things like `all_crate_deps`.",
+            default = "",
+        ),
+        "generate_rules_license_metadata": attr.bool(
+            doc = "Whether to generate rules license metedata.",
+            default = False,
+        ),
+        "generate_target_compatible_with": attr.bool(
+            doc = "Whether to generate `target_compatible_with` annotations on the generated BUILD files.  This catches a `target_triple` being targeted that isn't declared in `supported_platform_triples`.",
+            default = True,
+        ),
+        "platforms_template": attr.string(
+            doc = "The base template to use for platform names. See [platforms documentation](https://docs.bazel.build/versions/main/platforms.html). The available format keys are [`{triple}`].",
+            default = "@rules_rust//rust/platform:{triple}",
+        ),
+        "regen_command": attr.string(
+            doc = "An optional command to demonstrate how generated files should be regenerated.",
+            default = "",
+        ),
+        "vendor_mode": attr.string(
+            doc = "An optional configuration for rendering content to be rendered into repositories.",
+            default = "",
+        ),
+    },
+)
+
 _conditional_crate_args = {
     "arch_dependent": True,
     "os_dependent": True,
@@ -706,7 +881,9 @@ crate = module_extension(
         "annotation": _annotation,
         "from_cargo": _from_cargo,
         "from_specs": _from_specs,
+        "render_config": _render_config,
         "spec": _spec,
+        "splicing_config": _splicing_config,
     },
     **_conditional_crate_args
 )

--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -530,13 +530,13 @@ def _crate_impl(module_ctx):
             local_repos.append(cfg.name)
 
         for cfg in mod.tags.from_cargo:
+            render_config = _collect_render_config(mod, cfg.name)
+            splicing_config = _collect_splicing_config(mod, cfg.name)
+
             annotations = _annotations_for_repo(
                 module_annotations,
                 repo_specific_annotations.get(cfg.name),
             )
-
-            render_config = _collect_render_config(module = mod)
-            splicing_config = _collect_splicing_config(module = mod)
 
             cargo_lockfile = module_ctx.path(cfg.cargo_lockfile)
             manifests = {str(module_ctx.path(m)): str(m) for m in cfg.manifests}

--- a/docs/src/crate_universe_bzlmod.md
+++ b/docs/src/crate_universe_bzlmod.md
@@ -148,7 +148,7 @@ crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
 
 crate.spec(package = "serde", features = ["derive"], version = "1.0")
 crate.spec(package = "serde_json", version = "1.0")
-crate.spec(package = "tokio", default_features=False, features = ["macros", "net", "rt-multi-thread"], version = "1.38")
+crate.spec(package = "tokio", default_features = False, features = ["macros", "net", "rt-multi-thread"], version = "1.38")
 
 crate.from_specs()
 use_repo(crate, "crates")
@@ -340,10 +340,15 @@ crate.annotation(<a href="#crate.annotation-deps">deps</a>, <a href="#crate.anno
                  <a href="#crate.annotation-patch_args">patch_args</a>, <a href="#crate.annotation-patch_tool">patch_tool</a>, <a href="#crate.annotation-patches">patches</a>, <a href="#crate.annotation-proc_macro_deps">proc_macro_deps</a>, <a href="#crate.annotation-repositories">repositories</a>, <a href="#crate.annotation-rustc_env">rustc_env</a>,
                  <a href="#crate.annotation-rustc_env_files">rustc_env_files</a>, <a href="#crate.annotation-rustc_flags">rustc_flags</a>, <a href="#crate.annotation-shallow_since">shallow_since</a>, <a href="#crate.annotation-version">version</a>)
 crate.from_cargo(<a href="#crate.from_cargo-name">name</a>, <a href="#crate.from_cargo-cargo_config">cargo_config</a>, <a href="#crate.from_cargo-cargo_lockfile">cargo_lockfile</a>, <a href="#crate.from_cargo-generate_binaries">generate_binaries</a>, <a href="#crate.from_cargo-generate_build_scripts">generate_build_scripts</a>,
-                 <a href="#crate.from_cargo-manifests">manifests</a>, <a href="#crate.from_cargo-splicing_config">splicing_config</a>, <a href="#crate.from_cargo-supported_platform_triples">supported_platform_triples</a>)
-crate.from_specs(<a href="#crate.from_specs-name">name</a>, <a href="#crate.from_specs-cargo_config">cargo_config</a>, <a href="#crate.from_specs-generate_binaries">generate_binaries</a>, <a href="#crate.from_specs-generate_build_scripts">generate_build_scripts</a>, <a href="#crate.from_specs-splicing_config">splicing_config</a>,
+                 <a href="#crate.from_cargo-manifests">manifests</a>, <a href="#crate.from_cargo-supported_platform_triples">supported_platform_triples</a>)
+crate.from_specs(<a href="#crate.from_specs-name">name</a>, <a href="#crate.from_specs-cargo_config">cargo_config</a>, <a href="#crate.from_specs-generate_binaries">generate_binaries</a>, <a href="#crate.from_specs-generate_build_scripts">generate_build_scripts</a>,
                  <a href="#crate.from_specs-supported_platform_triples">supported_platform_triples</a>)
+crate.render_config(<a href="#crate.render_config-build_file_template">build_file_template</a>, <a href="#crate.render_config-crate_label_template">crate_label_template</a>, <a href="#crate.render_config-crate_repository_template">crate_repository_template</a>,
+                    <a href="#crate.render_config-crates_module_template">crates_module_template</a>, <a href="#crate.render_config-default_alias_rule">default_alias_rule</a>, <a href="#crate.render_config-default_package_name">default_package_name</a>,
+                    <a href="#crate.render_config-generate_rules_license_metadata">generate_rules_license_metadata</a>, <a href="#crate.render_config-generate_target_compatible_with">generate_target_compatible_with</a>,
+                    <a href="#crate.render_config-platforms_template">platforms_template</a>, <a href="#crate.render_config-regen_command">regen_command</a>, <a href="#crate.render_config-repositories">repositories</a>, <a href="#crate.render_config-vendor_mode">vendor_mode</a>)
 crate.spec(<a href="#crate.spec-artifact">artifact</a>, <a href="#crate.spec-branch">branch</a>, <a href="#crate.spec-default_features">default_features</a>, <a href="#crate.spec-features">features</a>, <a href="#crate.spec-git">git</a>, <a href="#crate.spec-lib">lib</a>, <a href="#crate.spec-package">package</a>, <a href="#crate.spec-rev">rev</a>, <a href="#crate.spec-tag">tag</a>, <a href="#crate.spec-version">version</a>)
+crate.splicing_config(<a href="#crate.splicing_config-repositories">repositories</a>, <a href="#crate.splicing_config-resolver_version">resolver_version</a>)
 </pre>
 
 Crate universe module extensions.
@@ -354,6 +359,8 @@ Crate universe module extensions.
 <a id="crate.annotation"></a>
 
 ### annotation
+
+A collection of extra attributes and settings for a particular crate.
 
 **Attributes**
 
@@ -414,7 +421,6 @@ Generates a repo @crates from a Cargo.toml / Cargo.lock pair.
 | <a id="crate.from_cargo-generate_binaries"></a>generate_binaries |  Whether to generate `rust_binary` targets for all the binary crates in every package. By default only the `rust_library` targets are generated.   | Boolean | optional |  `False`  |
 | <a id="crate.from_cargo-generate_build_scripts"></a>generate_build_scripts |  Whether or not to generate [cargo build scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html) by default.   | Boolean | optional |  `True`  |
 | <a id="crate.from_cargo-manifests"></a>manifests |  A list of Cargo manifests (`Cargo.toml` files).   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="crate.from_cargo-splicing_config"></a>splicing_config |  The configuration flags to use for splicing Cargo maniests. Use `//crate_universe:defs.bzl\%rsplicing_config` to generate the value for this field. If unset, the defaults defined there will be used.   | String | optional |  `""`  |
 | <a id="crate.from_cargo-supported_platform_triples"></a>supported_platform_triples |  A set of all platform triples to consider when generating dependencies.   | List of strings | optional |  `["aarch64-apple-darwin", "aarch64-apple-ios", "aarch64-apple-ios-sim", "aarch64-linux-android", "aarch64-pc-windows-msvc", "aarch64-unknown-fuchsia", "aarch64-unknown-linux-gnu", "aarch64-unknown-nixos-gnu", "aarch64-unknown-nto-qnx710", "arm-unknown-linux-gnueabi", "armv7-linux-androideabi", "armv7-unknown-linux-gnueabi", "i686-apple-darwin", "i686-linux-android", "i686-pc-windows-msvc", "i686-unknown-freebsd", "i686-unknown-linux-gnu", "powerpc-unknown-linux-gnu", "riscv32imc-unknown-none-elf", "riscv64gc-unknown-none-elf", "s390x-unknown-linux-gnu", "thumbv7em-none-eabi", "thumbv8m.main-none-eabi", "wasm32-unknown-unknown", "wasm32-wasip1", "x86_64-apple-darwin", "x86_64-apple-ios", "x86_64-linux-android", "x86_64-pc-windows-msvc", "x86_64-unknown-freebsd", "x86_64-unknown-fuchsia", "x86_64-unknown-linux-gnu", "x86_64-unknown-nixos-gnu", "x86_64-unknown-none"]`  |
 
 <a id="crate.from_specs"></a>
@@ -431,12 +437,48 @@ Generates a repo @crates from the defined `spec` tags.
 | <a id="crate.from_specs-cargo_config"></a>cargo_config |  A [Cargo configuration](https://doc.rust-lang.org/cargo/reference/config.html) file.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="crate.from_specs-generate_binaries"></a>generate_binaries |  Whether to generate `rust_binary` targets for all the binary crates in every package. By default only the `rust_library` targets are generated.   | Boolean | optional |  `False`  |
 | <a id="crate.from_specs-generate_build_scripts"></a>generate_build_scripts |  Whether or not to generate [cargo build scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html) by default.   | Boolean | optional |  `True`  |
-| <a id="crate.from_specs-splicing_config"></a>splicing_config |  The configuration flags to use for splicing Cargo maniests. Use `//crate_universe:defs.bzl\%rsplicing_config` to generate the value for this field. If unset, the defaults defined there will be used.   | String | optional |  `""`  |
 | <a id="crate.from_specs-supported_platform_triples"></a>supported_platform_triples |  A set of all platform triples to consider when generating dependencies.   | List of strings | optional |  `["aarch64-apple-darwin", "aarch64-apple-ios", "aarch64-apple-ios-sim", "aarch64-linux-android", "aarch64-pc-windows-msvc", "aarch64-unknown-fuchsia", "aarch64-unknown-linux-gnu", "aarch64-unknown-nixos-gnu", "aarch64-unknown-nto-qnx710", "arm-unknown-linux-gnueabi", "armv7-linux-androideabi", "armv7-unknown-linux-gnueabi", "i686-apple-darwin", "i686-linux-android", "i686-pc-windows-msvc", "i686-unknown-freebsd", "i686-unknown-linux-gnu", "powerpc-unknown-linux-gnu", "riscv32imc-unknown-none-elf", "riscv64gc-unknown-none-elf", "s390x-unknown-linux-gnu", "thumbv7em-none-eabi", "thumbv8m.main-none-eabi", "wasm32-unknown-unknown", "wasm32-wasip1", "x86_64-apple-darwin", "x86_64-apple-ios", "x86_64-linux-android", "x86_64-pc-windows-msvc", "x86_64-unknown-freebsd", "x86_64-unknown-fuchsia", "x86_64-unknown-linux-gnu", "x86_64-unknown-nixos-gnu", "x86_64-unknown-none"]`  |
+
+<a id="crate.render_config"></a>
+
+### render_config
+
+Various settings used to configure rendered outputs.
+
+The template parameters each support a select number of format keys. A description of each key
+can be found below where the supported keys for each template can be found in the parameter docs
+
+| key | definition |
+| --- | --- |
+| `name` | The name of the crate. Eg `tokio` |
+| `repository` | The rendered repository name for the crate. Directly relates to `crate_repository_template`. |
+| `triple` | A platform triple. Eg `x86_64-unknown-linux-gnu` |
+| `version` | The crate version. Eg `1.2.3` |
+| `target` | The library or binary target of the crate |
+| `file` | The basename of a file |
+
+**Attributes**
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="crate.render_config-build_file_template"></a>build_file_template |  The base template to use for BUILD file names. The available format keys are [`{name}`, {version}`].   | String | optional |  `"//:BUILD.{name}-{version}.bazel"`  |
+| <a id="crate.render_config-crate_label_template"></a>crate_label_template |  The base template to use for crate labels. The available format keys are [`{repository}`, `{name}`, `{version}`, `{target}`].   | String | optional |  `"@{repository}__{name}-{version}//:{target}"`  |
+| <a id="crate.render_config-crate_repository_template"></a>crate_repository_template |  The base template to use for Crate label repository names. The available format keys are [`{repository}`, `{name}`, `{version}`].   | String | optional |  `"{repository}__{name}-{version}"`  |
+| <a id="crate.render_config-crates_module_template"></a>crates_module_template |  The pattern to use for the `defs.bzl` and `BUILD.bazel` file names used for the crates module. The available format keys are [`{file}`].   | String | optional |  `"//:{file}"`  |
+| <a id="crate.render_config-default_alias_rule"></a>default_alias_rule |  Alias rule to use when generating aliases for all crates.  Acceptable values are 'alias', 'dbg'/'fastbuild'/'opt' (transitions each crate's `compilation_mode`)  or a string representing a rule in the form '<label to .bzl>:<rule>' that takes a single label parameter 'actual'. See '@crate_index//:alias_rules.bzl' for an example.   | String | optional |  `"alias"`  |
+| <a id="crate.render_config-default_package_name"></a>default_package_name |  The default package name to use in the rendered macros. This affects the auto package detection of things like `all_crate_deps`.   | String | optional |  `""`  |
+| <a id="crate.render_config-generate_rules_license_metadata"></a>generate_rules_license_metadata |  Whether to generate rules license metedata.   | Boolean | optional |  `False`  |
+| <a id="crate.render_config-generate_target_compatible_with"></a>generate_target_compatible_with |  Whether to generate `target_compatible_with` annotations on the generated BUILD files.  This catches a `target_triple` being targeted that isn't declared in `supported_platform_triples`.   | Boolean | optional |  `True`  |
+| <a id="crate.render_config-platforms_template"></a>platforms_template |  The base template to use for platform names. See [platforms documentation](https://docs.bazel.build/versions/main/platforms.html). The available format keys are [`{triple}`].   | String | optional |  `"@rules_rust//rust/platform:{triple}"`  |
+| <a id="crate.render_config-regen_command"></a>regen_command |  An optional command to demonstrate how generated files should be regenerated.   | String | optional |  `""`  |
+| <a id="crate.render_config-repositories"></a>repositories |  A list of repository names specified from `crate.from_cargo(name=...)` that this annotation is applied to. Defaults to all repositories.   | List of strings | optional |  `[]`  |
+| <a id="crate.render_config-vendor_mode"></a>vendor_mode |  An optional configuration for rendering content to be rendered into repositories.   | String | optional |  `""`  |
 
 <a id="crate.spec"></a>
 
 ### spec
+
+A constructor for a crate dependency.
 
 **Attributes**
 
@@ -452,5 +494,18 @@ Generates a repo @crates from the defined `spec` tags.
 | <a id="crate.spec-rev"></a>rev |  The git revision of the remote crate. Tied with the `git` param. Only one of branch, tag or rev may be specified.   | String | optional |  `""`  |
 | <a id="crate.spec-tag"></a>tag |  The git tag of the remote crate. Tied with the `git` param. Only one of branch, tag or rev may be specified. Specifying `rev` is recommended for fully-reproducible builds.   | String | optional |  `""`  |
 | <a id="crate.spec-version"></a>version |  The exact version of the crate. Cannot be used with `git`.   | String | optional |  `""`  |
+
+<a id="crate.splicing_config"></a>
+
+### splicing_config
+
+Various settings used to configure Cargo manifest splicing behavior.
+
+**Attributes**
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="crate.splicing_config-repositories"></a>repositories |  A list of repository names specified from `crate.from_cargo(name=...)` that this annotation is applied to. Defaults to all repositories.   | List of strings | optional |  `[]`  |
+| <a id="crate.splicing_config-resolver_version"></a>resolver_version |  The [resolver version](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) to use in generated Cargo manifests. This flag is **only** used when splicing a manifest from direct package definitions. See `crates_repository::packages`   | String | optional |  `"2"`  |
 
 


### PR DESCRIPTION
There was previously no way to set `render_config` values with `bzlmod` and `splicing_config` was a bit awkward in it's current implementation by needing to inline a json encoded string. This change adds a `tag_class` to manage the interaction for each config.