### PR TITLE
Ignore symlinks in workspace discovery

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -517,8 +517,6 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, rende
         ),
     )
 
-    nonhermetic_root_bazel_workspace_dir = module_ctx.path(Label("@@//:MODULE.bazel")).dirname
-
     splicing_output_dir = tag_path.get_child("splicing-output")
     splice_args = [
         "splice",
@@ -528,8 +526,6 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, rende
         config_file,
         "--splicing-manifest",
         splicing_manifest,
-        "--nonhermetic-root-bazel-workspace-dir",
-        nonhermetic_root_bazel_workspace_dir,
     ]
     if cargo_lockfile:
         splice_args.extend([
@@ -542,6 +538,8 @@ def _generate_hub_and_spokes(*, module_ctx, cargo_bazel, cfg, annotations, rende
     # repos.
     lockfile_path = tag_path.get_child("lockfile.json")
     module_ctx.file(lockfile_path, "")
+
+    nonhermetic_root_bazel_workspace_dir = module_ctx.path(Label("@@//:MODULE.bazel")).dirname
 
     paths_to_track_file = module_ctx.path("paths-to-track")
     warnings_output_file = module_ctx.path("warnings-output-file")

--- a/crate_universe/private/splicing_utils.bzl
+++ b/crate_universe/private/splicing_utils.bzl
@@ -149,8 +149,6 @@ def splice_workspace_manifest(repository_ctx, generator, cargo_lockfile, splicin
         rustc,
         "--cargo-lockfile",
         cargo_lockfile,
-        "--nonhermetic-root-bazel-workspace-dir",
-        repository_ctx.workspace_root,
     ]
 
     # Optionally set the splicing workspace directory to somewhere within the repository directory

--- a/crate_universe/src/cli/splice.rs
+++ b/crate_universe/src/cli/splice.rs
@@ -57,9 +57,6 @@ pub struct SpliceOptions {
     /// The path to a rustc binary for use with Cargo
     #[clap(long, env = "RUSTC")]
     pub rustc: PathBuf,
-
-    #[clap(long)]
-    pub nonhermetic_root_bazel_workspace_dir: PathBuf,
 }
 
 /// Combine a set of disjoint manifests into a single workspace.
@@ -86,7 +83,7 @@ pub fn splice(opt: SpliceOptions) -> Result<()> {
 
     // Splice together the manifest
     let manifest_path = splicer
-        .splice_workspace(&opt.nonhermetic_root_bazel_workspace_dir)
+        .splice_workspace()
         .context("Failed to splice workspace")?;
 
     // Generate a lockfile

--- a/crate_universe/src/cli/vendor.rs
+++ b/crate_universe/src/cli/vendor.rs
@@ -141,7 +141,7 @@ pub fn vendor(opt: VendorOptions) -> Result<()> {
 
     // Splice together the manifest
     let manifest_path = splicer
-        .splice_workspace(opt.nonhermetic_root_bazel_workspace_dir.as_std_path())
+        .splice_workspace()
         .context("Failed to splice workspace")?;
 
     // Gather a cargo lockfile

--- a/crate_universe/src/metadata/workspace_discoverer.rs
+++ b/crate_universe/src/metadata/workspace_discoverer.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -30,18 +29,16 @@ impl DiscoveredWorkspaces {
 pub(crate) fn discover_workspaces(
     cargo_toml_paths: BTreeSet<Utf8PathBuf>,
     known_manifests: &BTreeMap<Utf8PathBuf, Manifest>,
-    bazel_workspace_root: &Path,
 ) -> Result<DiscoveredWorkspaces> {
     let mut manifest_cache = ManifestCache {
         cache: BTreeMap::new(),
         known_manifests,
     };
-    discover_workspaces_with_cache(cargo_toml_paths, bazel_workspace_root, &mut manifest_cache)
+    discover_workspaces_with_cache(cargo_toml_paths, &mut manifest_cache)
 }
 
 fn discover_workspaces_with_cache(
     cargo_toml_paths: BTreeSet<Utf8PathBuf>,
-    bazel_workspace_root: &Path,
     manifest_cache: &mut ManifestCache,
 ) -> Result<DiscoveredWorkspaces> {
     let mut discovered_workspaces = DiscoveredWorkspaces {
@@ -288,7 +285,6 @@ mod test {
             .into_iter()
             .collect(),
             &BTreeMap::new(),
-            root_dir.as_std_path(),
         )
         .unwrap();
 
@@ -323,7 +319,6 @@ mod test {
                 .into_iter()
                 .collect(),
             &BTreeMap::new(),
-            root_dir.join("ws1").as_std_path(),
         )
         .unwrap();
 
@@ -352,7 +347,6 @@ mod test {
                 .into_iter()
                 .collect(),
             &BTreeMap::new(),
-            root_dir.as_std_path(),
         )
         .unwrap();
 
@@ -411,7 +405,6 @@ mod test {
             .into_iter()
             .collect(),
             &BTreeMap::new(),
-            root_dir.as_std_path(),
         )
         .unwrap();
 

--- a/crate_universe/tests/cargo_integration_test.rs
+++ b/crate_universe/tests/cargo_integration_test.rs
@@ -115,7 +115,6 @@ fn run(repository_name: &str, manifests: HashMap<String, String>, lockfile: &str
         config,
         cargo,
         rustc,
-        nonhermetic_root_bazel_workspace_dir: PathBuf::from("/doesnotexist"),
     })
     .unwrap();
 


### PR DESCRIPTION
There are edge-cases around bazel output symlinks which are fiddly to cover, and I wouldn't expect people to have symlinks between crates within their local workspace. If they do, they can use the explicit `members` property of the Cargo.toml workspace to explicitly include it.