### PR TITLE
feat: cross language LTO

### DIFF
--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "clippy_toml",
     "codegen_units",
     "error_format",
+    "experimental_cross_language_lto",
     "experimental_link_std_dylib",
     "experimental_per_crate_rustc_flag",
     "experimental_use_cc_common_link",
@@ -59,6 +60,8 @@ clippy_toml()
 codegen_units()
 
 error_format()
+
+experimental_cross_language_lto()
 
 experimental_link_std_dylib()
 

--- a/rust/settings/settings.bzl
+++ b/rust/settings/settings.bzl
@@ -56,6 +56,17 @@ def lto():
         build_setting_default = "unspecified",
     )
 
+def experimental_cross_language_lto():
+    """A build setting which specifies whether or not to specify `linker-plugin-lto` and perform \
+    cross language optimizations.
+
+    See: <https://doc.rust-lang.org/rustc/linker-plugin-lto.html>
+    """
+    bool_flag(
+        name = "experimental_cross_language_lto",
+        build_setting_default = False,
+    )
+
 def rename_first_party_crates():
     """A flag controlling whether to rename first-party crates such that their names \
     encode the Bazel package and target name, instead of just the target name.

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -698,6 +698,7 @@ def _rust_toolchain_impl(ctx):
         _rename_first_party_crates = rename_first_party_crates,
         _third_party_dir = third_party_dir,
         _pipelined_compilation = pipelined_compilation,
+        _experimental_cross_language_lto = ctx.attr._experimental_cross_language_lto[BuildSettingInfo].value,
         _experimental_link_std_dylib = _experimental_link_std_dylib(ctx),
         _experimental_use_cc_common_link = _experimental_use_cc_common_link(ctx),
         _experimental_use_global_allocator = experimental_use_global_allocator,
@@ -884,6 +885,9 @@ rust_toolchain = rule(
         ),
         "_codegen_units": attr.label(
             default = Label("//rust/settings:codegen_units"),
+        ),
+        "_experimental_cross_language_lto": attr.label(
+            default = Label("//rust/settings:experimental_cross_language_lto"),
         ),
         "_experimental_use_coverage_metadata_files": attr.label(
             default = Label("//rust/settings:experimental_use_coverage_metadata_files"),


### PR DESCRIPTION
If you're using Clang for your C toolchain, it's possible to do cross language optimizations between Rust and C, see Rust's [Linker-plugin-based LTO docs](https://doc.rust-lang.org/rustc/linker-plugin-lto.html) for more info.

This PR adds a new `@rules_rust//rust/settings:experimental_cross_language_lto` (off by default) which when building a Rust binary will set `-Clinker-plugin-lto`. If LTO is enabled for both Rust and C will then delay optimizations to the linker, resulting in cross language optimizations.

This feature is _highly_ experimental. To have it work correctly you need to be using a Clang toolchain with `lld` as the linker that is recent enough to understand the bitcode emitted by `rustc`. There is much more we can do here to make the feature more stable, but this seemed like a good starting point?