### PR TITLE
Don't register rust_host_tools twice

### DIFF
--- a/rust/extensions.bzl
+++ b/rust/extensions.bzl
@@ -265,18 +265,6 @@ def _rust_host_tools_impl(module_ctx):
                 **attrs
             )
 
-        # If no tags were specified, create a default repository.
-        if not mod.tags.host_tools:
-            attrs = {
-                "name": "rust_host_tools",
-                "version": rust_common.default_version,
-            }
-            rust_toolchain_tools_repository(
-                exec_triple = host_triple.str,
-                target_triple = host_triple.str,
-                **attrs
-            )
-
     metadata_kwargs = {}
     if bazel_features.external_deps.extension_metadata_has_reproducible:
         metadata_kwargs["reproducible"] = True


### PR DESCRIPTION
The bazel-lsp uses `rust_host_tools` to perform some actions by using:

```starlark
rust_host_tools = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools") 
use_repo(rust_host_tools, "rust_host_tools")
```

See: https://github.com/cameron-martin/bazel-lsp/blob/19b799e528c884be6efeb108ed1840a4edff1330/MODULE.bazel#L14

It started failing when using rules_rust from HEAD after https://github.com/bazelbuild/rules_rust/pull/3148 because rules_rust's MODULE.bazel registers toolchain with the same name:

```starlark
rust_host_tools.host_tools(
    name = "rust_host_tools",
)
```

See: https://github.com/bazelbuild/rules_rust/blob/aae84e97c73eae2e6654e1a7e1b751d0c1f2ac9e/MODULE.bazel#L70