### PR TITLE
Use `--remote_download_all` when building `rust_analyzer_crate_spec`s

### DIFF
--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -23,6 +23,7 @@ pub fn generate_crate_info(
         .env_remove("BUILD_WORKSPACE_DIRECTORY")
         .arg("build")
         .arg("--norun_validations")
+        .arg("--remote_download_all")
         .arg(format!(
             "--aspects={}//rust:defs.bzl%rust_analyzer_aspect",
             rules_rust.as_ref()


### PR DESCRIPTION
This fixes #3170, by ensuring that transitive deps like procmacro dylibs are fetched from the disk-cache.

This works in my case, but it's unclear to me if this has unintended consequences for people running remote builds etc, and this can easily be addressed by users manually by adding `build --remote_download_all` to their .bazelrc too if you prefer not merging this.