### PR TITLE
Only symlink package files

### DIFF
--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -865,8 +865,8 @@ def _symlink_for_non_generated_source(ctx, src_file, package_root):
         File: The created symlink if a non-generated file, or the file itself.
     """
 
-    if src_file.is_source or src_file.root.path != ctx.bin_dir.path:
-        src_short_path = paths.relativize(src_file.path, src_file.root.path)
+    src_short_path = paths.relativize(src_file.path, src_file.root.path)
+    if (src_file.is_source or src_file.root.path != ctx.bin_dir.path) and paths.starts_with(src_short_path, package_root):
         src_symlink = ctx.actions.declare_file(paths.relativize(src_short_path, package_root))
         ctx.actions.symlink(
             output = src_symlink,


### PR DESCRIPTION
Don't attempt to symlink files that are not in the package. This won't work anyway as `ctx.declare_file` doesn't allow declarations outside the package_root, and fixes issue where we attempted to symlink compile_data file from different package.

This fixes the specific issue in #3193, but unclear to me whether it's the _right_ fix or whether it fixes the real-world issue people have.