### PR TITLE
Disable `--incompatible_autoload_externally=` as it's unusable in Bazel8

### DIFF
--- a/examples/all_crate_deps/.bazelrc
+++ b/examples/all_crate_deps/.bazelrc
@@ -12,4 +12,5 @@ build --incompatible_disallow_empty_glob
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=

--- a/examples/all_deps_vendor/.bazelrc
+++ b/examples/all_deps_vendor/.bazelrc
@@ -45,7 +45,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Rust configuration

--- a/examples/bazel_env/.bazelrc
+++ b/examples/bazel_env/.bazelrc
@@ -34,7 +34,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/examples/compile_opt/.bazelrc
+++ b/examples/compile_opt/.bazelrc
@@ -10,7 +10,8 @@ build --incompatible_disallow_empty_glob
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 # in optimized build we will use thin lto
 common:opt -c opt

--- a/examples/crate_universe/.bazelrc
+++ b/examples/crate_universe/.bazelrc
@@ -27,7 +27,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/examples/crate_universe_local_path/.bazelrc
+++ b/examples/crate_universe_local_path/.bazelrc
@@ -57,7 +57,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/examples/cross_compile/.bazelrc
+++ b/examples/cross_compile/.bazelrc
@@ -45,7 +45,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Rust configuration

--- a/examples/hello_world/.bazelrc
+++ b/examples/hello_world/.bazelrc
@@ -42,7 +42,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Rust configuration

--- a/examples/hello_world_no_cargo/.bazelrc
+++ b/examples/hello_world_no_cargo/.bazelrc
@@ -45,7 +45,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Rust configuration

--- a/examples/musl_cross_compiling/.bazelrc
+++ b/examples/musl_cross_compiling/.bazelrc
@@ -57,7 +57,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/examples/nix_cross_compiling/.bazelrc
+++ b/examples/nix_cross_compiling/.bazelrc
@@ -73,7 +73,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/examples/override_target/.bazelrc
+++ b/examples/override_target/.bazelrc
@@ -12,4 +12,5 @@ build --incompatible_disallow_empty_glob
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=

--- a/examples/proto/.bazelrc
+++ b/examples/proto/.bazelrc
@@ -45,7 +45,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 common --incompatible_enable_proto_toolchain_resolution
 

--- a/examples/proto_with_toolchain/.bazelrc
+++ b/examples/proto_with_toolchain/.bazelrc
@@ -45,7 +45,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 common --incompatible_enable_proto_toolchain_resolution
 

--- a/examples/sys/.bazelrc
+++ b/examples/sys/.bazelrc
@@ -45,7 +45,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Rust configuration

--- a/extensions/bindgen/.bazelrc
+++ b/extensions/bindgen/.bazelrc
@@ -57,7 +57,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/extensions/mdbook/.bazelrc
+++ b/extensions/mdbook/.bazelrc
@@ -57,7 +57,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/extensions/prost/.bazelrc
+++ b/extensions/prost/.bazelrc
@@ -57,7 +57,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/extensions/protobuf/.bazelrc
+++ b/extensions/protobuf/.bazelrc
@@ -61,7 +61,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/extensions/wasm_bindgen/.bazelrc
+++ b/extensions/wasm_bindgen/.bazelrc
@@ -57,7 +57,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod

--- a/test/no_std/.bazelrc
+++ b/test/no_std/.bazelrc
@@ -57,7 +57,8 @@ build --nolegacy_external_runfiles
 build --incompatible_merge_fixed_and_default_shell_env
 
 # https://github.com/bazelbuild/bazel/issues/23043.
-build --incompatible_autoload_externally=
+# TODO: Re-enable after https://github.com/bazelbuild/bazel/issues/24871 is addressed
+# build --incompatible_autoload_externally=
 
 ###############################################################################
 ## Bzlmod


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/24871 will need to be addressed somehow where unnecessary "built-ins" are either not forcibly pulled in or all built-ins conform to this flag.