### PR TITLE
Mark cargo internal extension as reproducible

### DIFF
--- a/cargo/private/internal_extensions.bzl
+++ b/cargo/private/internal_extensions.bzl
@@ -1,5 +1,6 @@
 """Bzlmod module extensions that are only used internally"""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//cargo:deps.bzl", "cargo_dependencies")
 
 def _internal_deps_impl(module_ctx):

--- a/cargo/private/internal_extensions.bzl
+++ b/cargo/private/internal_extensions.bzl
@@ -12,10 +12,15 @@ def _internal_deps_impl(module_ctx):
     # is_dev_dep is ignored here. It's not relevant for internal_deps, as dev
     # dependencies are only relevant for module extensions that can be used
     # by other MODULES.
-    return module_ctx.extension_metadata(
-        root_module_direct_deps = [repo.repo for repo in direct_deps],
-        root_module_direct_dev_deps = [],
-    )
+    metadata_kwargs = {
+        "root_module_direct_deps": [repo.repo for repo in direct_deps],
+        "root_module_direct_dev_deps": [],
+    }
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        metadata_kwargs["reproducible"] = True
+
+    return module_ctx.extension_metadata(**metadata_kwargs)
 
 # This is named a single character to reduce the size of path names when running build scripts, to reduce the chance
 # of hitting the 260 character windows path name limit.


### PR DESCRIPTION
Since all repo from cargo_repositories are instantiated with the same attribute values. Saves an entry in the lockfile.