### PR TITLE
Add support for `CARGO_BAZEL_DEBUG=TRACE` level logging

### DIFF
--- a/crate_universe/src/cli.rs
+++ b/crate_universe/src/cli.rs
@@ -7,12 +7,14 @@ mod splice;
 mod vendor;
 
 use clap::Parser;
-use tracing::{Level, Subscriber};
+use tracing::Subscriber;
 use tracing_subscriber::fmt::format::{Format, Full};
 use tracing_subscriber::fmt::time::SystemTime;
 use tracing_subscriber::fmt::{FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::FmtSubscriber;
+
+pub use tracing::Level as LogLevel;
 
 pub use self::generate::GenerateOptions;
 pub use self::query::QueryOptions;
@@ -92,7 +94,7 @@ impl LoggingFormatEvent {
 }
 
 /// Initialize logging for one of the cli options.
-pub fn init_logging(name: &str, verbose: bool) {
+pub fn init_logging(name: &str, level: LogLevel) {
     if !EXPECTED_LOGGER_NAMES.contains(&name) {
         panic!(
             "Unexpected logger name {}, use of one of {:?}",
@@ -100,13 +102,9 @@ pub fn init_logging(name: &str, verbose: bool) {
         );
     }
 
-    // a builder for `FmtSubscriber`.
     let subscriber = FmtSubscriber::builder()
-        // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
-        // will be written to stdout.
-        .with_max_level(if verbose { Level::DEBUG } else { Level::INFO })
+        .with_max_level(level)
         .event_format(LoggingFormatEvent::new(name))
-        // completes the builder.
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");

--- a/crate_universe/src/main.rs
+++ b/crate_universe/src/main.rs
@@ -6,27 +6,36 @@ fn main() -> cli::Result<()> {
     // Parse arguments
     let opt = cli::parse_args();
 
-    let verbose_logging = std::env::var("CARGO_BAZEL_DEBUG").is_ok();
+    let level = match std::env::var("CARGO_BAZEL_DEBUG") {
+        Ok(var) => {
+            if var == "TRACE" {
+                crate::cli::LogLevel::TRACE
+            } else {
+                crate::cli::LogLevel::DEBUG
+            }
+        }
+        Err(_) => crate::cli::LogLevel::INFO,
+    };
 
     match opt {
         cli::Options::Generate(opt) => {
-            cli::init_logging("Generate", verbose_logging);
+            cli::init_logging("Generate", level);
             cli::generate(opt)
         }
         cli::Options::Splice(opt) => {
-            cli::init_logging("Splice", verbose_logging);
+            cli::init_logging("Splice", level);
             cli::splice(opt)
         }
         cli::Options::Query(opt) => {
-            cli::init_logging("Query", verbose_logging);
+            cli::init_logging("Query", level);
             cli::query(opt)
         }
         cli::Options::Vendor(opt) => {
-            cli::init_logging("Vendor", verbose_logging);
+            cli::init_logging("Vendor", level);
             cli::vendor(opt)
         }
         cli::Options::Render(opt) => {
-            cli::init_logging("Render", verbose_logging);
+            cli::init_logging("Render", level);
             cli::render(opt)
         }
     }


### PR DESCRIPTION
Some of the logging was insanely verbose, so I've opted to add it to `Level::TRACE`.  This level can be enabled by setting the environment variable `CARGO_BAZEL_DEBUG=TRACE`.