### PR TITLE
Ensure crate_universe modules don't override intermediates for debugging

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -629,7 +629,8 @@ def _generate_hub_and_spokes(
             cargo_lockfile = cargo_lockfile,
             splicing_manifest = splicing_manifest,
             config_path = config_file,
-            output_dir = module_ctx.path("{}/{}".format(tag_path, "splicing-output")),
+            output_dir = tag_path.get_child("splicing-output"),
+            debug_workspace_dir = tag_path.get_child("splicing-workspace"),
         )
 
         # If a cargo lockfile was not provided, use the splicing lockfile.
@@ -638,7 +639,7 @@ def _generate_hub_and_spokes(
 
         # Create a fallback lockfile to be parsed downstream.
         if lockfile == None:
-            lockfile = module_ctx.path("cargo-bazel-lock.json")
+            lockfile = tag_path.get_child("cargo-bazel-lock.json")
             module_ctx.file(lockfile, "")
 
         kwargs.update({
@@ -648,8 +649,8 @@ def _generate_hub_and_spokes(
     # The workspace root when one is explicitly provided.
     nonhermetic_root_bazel_workspace_dir = module_ctx.path(Label("@@//:MODULE.bazel")).dirname
 
-    paths_to_track_file = module_ctx.path("paths_to_track.json")
-    warnings_output_file = module_ctx.path("warnings_output.json")
+    paths_to_track_file = tag_path.get_child("paths_to_track.json")
+    warnings_output_file = tag_path.get_child("warnings_output.json")
 
     # Run the generator
     module_ctx.report_progress("Generating crate BUILD files for `{}`".format(cfg.name))

--- a/crate_universe/private/splicing_utils.bzl
+++ b/crate_universe/private/splicing_utils.bzl
@@ -121,7 +121,8 @@ def splice_workspace_manifest(
         cargo_lockfile,
         splicing_manifest,
         config_path,
-        output_dir):
+        output_dir,
+        debug_workspace_dir = None):
     """Splice together a Cargo workspace from various other manifests and package definitions
 
     Args:
@@ -131,6 +132,7 @@ def splice_workspace_manifest(
         splicing_manifest (path): The path to a splicing manifest.
         config_path (path): The path to the config file (containing `cargo_bazel::config::Config`.)
         output_dir (path): THe location in which to write splicing outputs.
+        debug_workspace_dir (path): The location in which to save splicing outputs for future review.
 
     Returns:
         path: The path to a Cargo metadata json file found in the spliced workspace root.
@@ -156,9 +158,11 @@ def splice_workspace_manifest(
     # Optionally set the splicing workspace directory to somewhere within the repository directory
     # to improve the debugging experience.
     if CARGO_BAZEL_DEBUG in repository_ctx.os.environ:
+        if debug_workspace_dir == None:
+            debug_workspace_dir = repository_ctx.path("splicing-workspace")
         arguments.extend([
             "--workspace-dir",
-            repository_ctx.path("splicing-workspace"),
+            debug_workspace_dir,
         ])
 
     env = {}

--- a/crate_universe/src/splicing/splicer.rs
+++ b/crate_universe/src/splicing/splicer.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_toml::Manifest;
+use tracing::debug;
 
 use crate::config::CrateId;
 use crate::metadata::discover_workspaces;
@@ -349,6 +350,7 @@ impl<'a> SplicerKind<'a> {
                 fs::create_dir_all(&dot_cargo_dir)?;
             }
 
+            debug!("Using Cargo config: {}", cargo_config_path);
             fs::copy(cargo_config_path, dot_cargo_dir.join("config.toml"))?;
         }
 


### PR DESCRIPTION
This way all files are available for introspection after generation.