### PR TITLE
rust_analyzer: Support passing a --config option to Bazel

### DIFF
--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -63,6 +63,7 @@ pub struct CrateSpecSource {
 
 pub fn get_crate_specs(
     bazel: &Path,
+    config: &Option<String>,
     workspace: &Path,
     execution_root: &Path,
     targets: &[String],
@@ -70,6 +71,10 @@ pub fn get_crate_specs(
 ) -> anyhow::Result<BTreeSet<CrateSpec>> {
     log::debug!("Get crate specs with targets: {:?}", targets);
     let target_pattern = format!("deps({})", targets.join("+"));
+    let config_args = match config {
+        Some(config) => vec!["--config", config],
+        None => Vec::new(),
+    };
 
     let aquery_output = Command::new(bazel)
         .current_dir(workspace)
@@ -77,6 +82,7 @@ pub fn get_crate_specs(
         .env_remove("BUILD_WORKING_DIRECTORY")
         .env_remove("BUILD_WORKSPACE_DIRECTORY")
         .arg("aquery")
+        .args(config_args)
         .arg("--include_aspects")
         .arg("--include_artifacts")
         .arg(format!(

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -10,11 +10,16 @@ mod rust_project;
 
 pub fn generate_crate_info(
     bazel: impl AsRef<Path>,
+    config: &Option<String>,
     workspace: impl AsRef<Path>,
     rules_rust: impl AsRef<str>,
     targets: &[String],
 ) -> anyhow::Result<()> {
     log::debug!("Building rust_analyzer_crate_spec files for {:?}", targets);
+    let config_args = match config {
+        Some(config) => vec!["--config", config],
+        None => Vec::new(),
+    };
 
     let output = Command::new(bazel.as_ref())
         .current_dir(workspace.as_ref())
@@ -22,6 +27,7 @@ pub fn generate_crate_info(
         .env_remove("BUILD_WORKING_DIRECTORY")
         .env_remove("BUILD_WORKSPACE_DIRECTORY")
         .arg("build")
+        .args(config_args)
         .arg("--norun_validations")
         .arg(format!(
             "--aspects={}//rust:defs.bzl%rust_analyzer_aspect",
@@ -42,8 +48,10 @@ pub fn generate_crate_info(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn write_rust_project(
     bazel: impl AsRef<Path>,
+    config: &Option<String>,
     workspace: impl AsRef<Path>,
     rules_rust_name: &impl AsRef<str>,
     targets: &[String],
@@ -53,6 +61,7 @@ pub fn write_rust_project(
 ) -> anyhow::Result<()> {
     let crate_specs = aquery::get_crate_specs(
         bazel.as_ref(),
+        config,
         workspace.as_ref(),
         execution_root.as_ref(),
         targets,

--- a/tools/rust_analyzer/main.rs
+++ b/tools/rust_analyzer/main.rs
@@ -36,6 +36,7 @@ fn main() -> anyhow::Result<()> {
     // Generate the crate specs.
     generate_crate_info(
         &config.bazel,
+        &config.config,
         workspace_root,
         rules_rust_name,
         &config.targets,
@@ -44,6 +45,7 @@ fn main() -> anyhow::Result<()> {
     // Use the generated files to write rust-project.json.
     write_rust_project(
         &config.bazel,
+        &config.config,
         workspace_root,
         &rules_rust_name,
         &config.targets,
@@ -119,6 +121,10 @@ struct Config {
     /// The path to the Bazel output user root. If not specified, uses the result of `bazel info output_base`.
     #[clap(long, env = "OUTPUT_BASE")]
     output_base: Option<PathBuf>,
+
+    /// A config to pass to Bazel invocations with `--config=<config>`.
+    #[clap(long)]
+    config: Option<String>,
 
     /// The path to a Bazel binary
     #[clap(long, default_value = "bazel")]


### PR DESCRIPTION
This is useful if you want to analyze code using a different configuration than the default.  An example of this might be under a different platform.