### PR TITLE
Handle debug info packages separately when using `cc_common.link`

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1335,7 +1335,7 @@ def rustc_compile_action(
     # types that benefit from having debug information in a separate file.
     pdb_file = None
     dsym_folder = None
-    if crate_info.type in ("cdylib", "bin"):
+    if crate_info.type in ("cdylib", "bin") and not experimental_use_cc_common_link:
         if toolchain.target_os == "windows" and compilation_mode.strip_level == "none":
             pdb_file = ctx.actions.declare_file(crate_info.output.basename[:-len(crate_info.output.extension)] + "pdb", sibling = crate_info.output)
             action_outputs.append(pdb_file)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1463,6 +1463,11 @@ def rustc_compile_action(
             # Append the name of the library
             output_relative_to_package = output_relative_to_package + output_lib
 
+        additional_linker_outputs = []
+        if crate_info.type in ("cdylib", "bin") and cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "generate_pdb_file"):
+            pdb_file = ctx.actions.declare_file(crate_info.output.basename[:-len(crate_info.output.extension)] + "pdb", sibling = crate_info.output)
+            additional_linker_outputs.append(pdb_file)
+
         cc_common.link(
             actions = ctx.actions,
             feature_configuration = feature_configuration,
@@ -1472,6 +1477,7 @@ def rustc_compile_action(
             name = output_relative_to_package,
             stamp = ctx.attr.stamp,
             output_type = "executable" if crate_info.type == "bin" else "dynamic_library",
+            additional_outputs = additional_linker_outputs,
         )
 
         outputs = [crate_info.output]

--- a/test/cc_common_link/unit/cc_common_link_test.bzl
+++ b/test/cc_common_link/unit/cc_common_link_test.bzl
@@ -65,11 +65,16 @@ def _use_cc_common_link_test(ctx):
 
     output_groups = tut[OutputGroupInfo]
     asserts.false(env, hasattr(output_groups, "dsym_folder"), "Expected no dsym_folder output group")
-    asserts.false(env, hasattr(output_groups, "pdb_file"), "Expected no pdb_file output group")
+    asserts.equals(
+        env,
+        ctx.attr.expect_pdb,
+        hasattr(output_groups, "pdb_file"),
+        "Expected " + ("" if ctx.attr.expect_pdb else "no ") + "pdb_file output group",
+    )
 
     return analysistest.end(env)
 
-use_cc_common_link_test = analysistest.make(_use_cc_common_link_test)
+use_cc_common_link_test = analysistest.make(_use_cc_common_link_test, attrs = {"expect_pdb": attr.bool()})
 
 def _custom_malloc_test(ctx):
     env = analysistest.begin(ctx)
@@ -104,6 +109,18 @@ def _cc_common_link_test_targets():
     use_cc_common_link_on_target(
         name = "bin_with_cc_common_link",
         target = ":bin",
+    )
+
+    rust_binary(
+        name = "bin_with_pdb",
+        srcs = ["bin.rs"],
+        edition = "2018",
+        features = ["generate_pdb_file"],
+    )
+
+    use_cc_common_link_on_target(
+        name = "bin_with_cc_common_link_with_pdb",
+        target = ":bin_with_pdb",
     )
 
     rust_shared_library(
@@ -147,6 +164,15 @@ def _cc_common_link_test_targets():
     )
 
     use_cc_common_link_test(
+        name = "use_cc_common_link_on_binary_with_pdb",
+        target_under_test = ":bin_with_cc_common_link_with_pdb",
+        expect_pdb = select({
+            "@platforms//os:windows": True,
+            "//conditions:default": False,
+        }),
+    )
+
+    use_cc_common_link_test(
         name = "use_cc_common_link_on_test",
         target_under_test = ":test_with_cc_common_link",
     )
@@ -178,6 +204,7 @@ def cc_common_link_test_suite(name):
         name = name,
         tests = [
             "use_cc_common_link_on_binary",
+            "use_cc_common_link_on_binary_with_pdb",
             "use_cc_common_link_on_test",
             "use_cc_common_link_on_crate_test",
             "use_cc_common_link_on_cdylib",

--- a/test/cc_common_link/unit/cc_common_link_test.bzl
+++ b/test/cc_common_link/unit/cc_common_link_test.bzl
@@ -31,7 +31,7 @@ use_cc_common_link_transition = transition(
 )
 
 def _use_cc_common_link_on_target_impl(ctx):
-    return [ctx.attr.target[0][DepActionsInfo]]
+    return [ctx.attr.target[0][DepActionsInfo], ctx.attr.target[0][OutputGroupInfo]]
 
 use_cc_common_link_on_target = rule(
     implementation = _use_cc_common_link_on_target_impl,
@@ -62,6 +62,10 @@ def _use_cc_common_link_test(ctx):
 
     has_cpp_link_action = len([action for action in registered_actions if action.mnemonic == "CppLink"]) > 0
     asserts.true(env, has_cpp_link_action, "Expected that the target registers a CppLink action")
+
+    output_groups = tut[OutputGroupInfo]
+    asserts.false(env, hasattr(output_groups, "dsym_folder"), "Expected no dsym_folder output group")
+    asserts.false(env, hasattr(output_groups, "pdb_file"), "Expected no pdb_file output group")
 
     return analysistest.end(env)
 


### PR DESCRIPTION
Debug info packages (`dSYM`, `pdb`) are created by `rustc` only if you link with `rustc`. When linking with `cc_common`, they should be handled by the cc toolchain or a custom aspect. Declaring them prematurely can cause conflicts.

This PR removes the `dsym_folder` declaration if `cc_common.link` is being used - since cc_common doesn't support dsym generation yet. It postpones the declaration of `pdb_file` after checking with the cpp features first.