### PR TITLE
Add support for ppc64le architecture

### DIFF
--- a/rust/platform/triple.bzl
+++ b/rust/platform/triple.bzl
@@ -120,7 +120,7 @@ def get_host_triple(repository_ctx, abi = None):
     # Detect the host's cpu architecture
 
     supported_architectures = {
-        "linux": ["aarch64", "x86_64", "s390x"],
+        "linux": ["aarch64", "x86_64", "s390x", "powerpc64le"],
         "macos": ["aarch64", "x86_64"],
         "windows": ["aarch64", "x86_64"],
     }
@@ -128,6 +128,9 @@ def get_host_triple(repository_ctx, abi = None):
     arch = repository_ctx.os.arch
     if arch == "amd64":
         arch = "x86_64"
+
+    if arch == "ppc64le":
+        arch = "powerpc64le"
 
     if "linux" in repository_ctx.os.name:
         _validate_cpu_architecture(arch, supported_architectures["linux"])

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -114,7 +114,7 @@ _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX = {
     "mipsel": None,
     "powerpc": "ppc",
     "powerpc64": None,
-    "powerpc64le": None,
+    "powerpc64le": "ppc64le",
     "riscv32": "riscv32",
     "riscv32imc": "riscv32",
     "riscv64": "riscv64",

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -43,6 +43,7 @@ DEFAULT_TOOLCHAIN_TRIPLES = {
     "aarch64-apple-darwin": "rust_macos_aarch64",
     "aarch64-pc-windows-msvc": "rust_windows_aarch64",
     "aarch64-unknown-linux-gnu": "rust_linux_aarch64",
+    "powerpc64le-unknown-linux-gnu": "rust_linux_powerpc64le",
     "s390x-unknown-linux-gnu": "rust_linux_s390x",
     "x86_64-apple-darwin": "rust_macos_x86_64",
     "x86_64-pc-windows-msvc": "rust_windows_x86_64",


### PR DESCRIPTION
Allow rules_rust module to be used on the ppc64le architecture.