### PR TITLE
Replace uses of rules_cc/cc:toolchain_utils.bzl

### DIFF
--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -15,7 +15,7 @@
 """Utility functions not specific to the rust toolchain."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", find_rules_cc_toolchain = "find_cpp_toolchain")
+load("@bazel_tools//tools/cpp:find_cc_toolchain.bzl", find_rules_cc_toolchain = "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(":compat.bzl", "abs")


### PR DESCRIPTION
It was deprecated.