### PR TITLE
Add `build_script_link_deps` to crate annotation system.

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -1083,6 +1083,9 @@ _annotation = tag_class(
         "build_script_env": attr.string_dict(
             doc = "Additional environment variables to set on a crate's `cargo_build_script::env` attribute.",
         ),
+        "build_script_link_deps": _relative_label_list(
+            doc = "A list of labels to add to a crate's `cargo_build_script::link_deps` attribute.",
+        ),
         "build_script_proc_macro_deps": _relative_label_list(
             doc = "A list of labels to add to a crate's `cargo_build_script::proc_macro_deps` attribute.",
         ),

--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -93,6 +93,7 @@ def _annotation(
         build_script_data_glob = None,
         build_script_deps = None,
         build_script_env = None,
+        build_script_link_deps = None,
         build_script_proc_macro_deps = None,
         build_script_rundir = None,
         build_script_rustc_env = None,
@@ -135,6 +136,7 @@ def _annotation(
         build_script_deps (list, optional): A list of labels to add to a crate's `cargo_build_script::deps` attribute.
         build_script_env (dict, optional): Additional environment variables to set on a crate's
             `cargo_build_script::env` attribute.
+        build_script_link_deps:  A list of labels to add to a crate's `cargo_build_script::link_deps` attribute.
         build_script_proc_macro_deps (list, optional): A list of labels to add to a crate's
             `cargo_build_script::proc_macro_deps` attribute.
         build_script_rundir (str, optional): An override for the build script's rundir attribute.
@@ -196,6 +198,7 @@ def _annotation(
             build_script_data_glob = build_script_data_glob,
             build_script_deps = _stringify_list(build_script_deps),
             build_script_env = build_script_env,
+            build_script_link_deps = build_script_link_deps,
             build_script_proc_macro_deps = _stringify_list(build_script_proc_macro_deps),
             build_script_rundir = build_script_rundir,
             build_script_rustc_env = build_script_rustc_env,

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -281,6 +281,10 @@ pub(crate) struct CrateAnnotations {
     /// [deps](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-deps) attribute.
     pub(crate) build_script_deps: Option<Select<BTreeSet<Label>>>,
 
+    /// Additional dependencies to pass to a build script's
+    /// [link_deps](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-link_deps) attribute.
+    pub(crate) build_script_link_deps: Option<Select<BTreeSet<Label>>>,
+
     /// Additional data to pass to a build script's
     /// [proc_macro_deps](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-proc_macro_deps) attribute.
     pub(crate) build_script_proc_macro_deps: Option<Select<BTreeSet<Label>>>,
@@ -404,6 +408,7 @@ impl Add for CrateAnnotations {
             rustc_env_files: select_merge(self.rustc_env_files, rhs.rustc_env_files),
             rustc_flags: select_merge(self.rustc_flags, rhs.rustc_flags),
             build_script_deps: select_merge(self.build_script_deps, rhs.build_script_deps),
+            build_script_link_deps: select_merge(self.build_script_link_deps, rhs.build_script_link_deps),
             build_script_proc_macro_deps: select_merge(self.build_script_proc_macro_deps, rhs.build_script_proc_macro_deps),
             build_script_compile_data: select_merge(self.build_script_compile_data, rhs.build_script_compile_data),
             build_script_data: select_merge(self.build_script_data, rhs.build_script_data),

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -618,6 +618,12 @@ impl CrateContext {
                     attrs.extra_deps = Select::merge(attrs.extra_deps.clone(), extra.clone());
                 }
 
+                //Link Deps
+                if let Some(extra) = &crate_extra.build_script_link_deps {
+                    attrs.extra_link_deps =
+                        Select::merge(attrs.extra_link_deps.clone(), extra.clone())
+                }
+
                 // Proc macro deps
                 if let Some(extra) = &crate_extra.build_script_proc_macro_deps {
                     attrs.extra_proc_macro_deps =

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -290,7 +290,7 @@ mod test {
         );
 
         assert_eq!(
-            Digest("1b234facd16c77da17df02dc1bad7bcd08154883d27c04fc35aadb36b3c305a6".to_owned()),
+            Digest("2c4ee31fbefac161d2f3c6cae7fb8995c6311e292386a0500ac84e2586589dae".to_owned()),
             digest,
         );
     }

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "07feae63b62c36dfcee6215163c2da995f5b8a3a4086cbaedadc0edf9463fc2f",
+  "checksum": "c2498f19defd6d3a2461a4f13fc911297131c751189a07bcb6f50ec50bbb5c2d",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9178d0ef0fe03c0b7b5b1ce979b0aa90433f33d0aee48da3a99a22926ccd0d0c",
+  "checksum": "de69dd9816441d185331c72ec4688207925f1b226d5bd088b24c9275237fad28",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "77603e5382a2c6122f03edee856500632417d73756a3d24f8c9080f2f7a6ab49",
+  "checksum": "f1d35c24a12de8768e9eecd38950effecf870637e05d227f4924e6150a92d265",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e579ea2e2b66d6f7e33113955b0b9e9b5b582a41e6194c14b0ede4b49ca3c0ce",
+  "checksum": "f7b1c20279b69f092d077064059fa660f8bf45d0ccdad7326bbba1ad30c08b5f",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3f48b251668fbd406111656111a51c9f1504236674ca3ae7d77767b49d6c2fc2",
+  "checksum": "be6e10e57d0876aa9f6fba965fca771a5891561dd2a04f74029d5d8ae057a987",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6aa0731d453b4467b5797d1d34ddf154e29b1442e925240cf0b6f787e5b2e9d6",
+  "checksum": "7357d7295675d8d653d494d1ee7cfc655ee04dd8ab2c9671d66e7fb566e77f12",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
+++ b/examples/crate_universe/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "889e394dae4027cb52a1ca48d6d6d44e9bf64b1e8dccce56104a410177c53929",
+  "checksum": "d6750b52319cc49cc85828ec55198c09f6f9ffba255eb45d3b746e2d2a82c689",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_aliases/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "e985ca3e92ec28cd5b0cf8ee7d46ba727eda72186f64be00faa47e109561aaf8",
+  "checksum": "d86496b65cb91af092038b607413de15b97d63d8edf06c398a6a2033d44fbe3f",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",

--- a/examples/crate_universe/complicated_dependencies/cargo-bazel-lock.json
+++ b/examples/crate_universe/complicated_dependencies/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "52bca190a4bda51b65fe97ec6aa227e01ea1af0a25534f515568aef033659d02",
+  "checksum": "35109a72ff97bb88953ce5751e815f04ef5285812c251a9a7b85952eba38cc75",
   "crates": {
     "aho-corasick 1.1.3": {
       "name": "aho-corasick",

--- a/examples/crate_universe/multi_package/cargo-bazel-lock.json
+++ b/examples/crate_universe/multi_package/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "985f695fedf96095a31d1856541fddf127526108fa26b26348fb458728e010b5",
+  "checksum": "090ed5d9ab9ca9840a6c42ba376df22fad031a0274d55205fe03ff18b0f7cfdd",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",

--- a/examples/crate_universe/override_target/cargo-bazel-lock.json
+++ b/examples/crate_universe/override_target/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4043503d038710c239799b58a44f93b83d97cab4a9a71f4c8a6036fe68a3bb2f",
+  "checksum": "4905873a0bf3c12aa3dc0db025161ce96a705509c08f1351e22209dc4ab21ddb",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/nix_cross_compiling/bazel/cargo/cargo-bazel-lock.json
+++ b/examples/nix_cross_compiling/bazel/cargo/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6c5fb12247044adb918a985e85611f7e4702265275eacefc48326fb4162c3dfd",
+  "checksum": "e35792be934393e29fcd3c04c72bc2c85c962cc51de9b7a1d01c49f85fd92762",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",

--- a/test/unit/crate_name/crate_name_test.bzl
+++ b/test/unit/crate_name/crate_name_test.bzl
@@ -73,7 +73,7 @@ def _no_extra_filename_test_impl(ctx):
     assert_argv_contains_prefix_not(env, tut.actions[0], "--codegen=metadata=")
     assert_argv_contains_prefix_not(env, tut.actions[0], "--codegen=extra-filename=")
     return analysistest.end(env)
- 
+
 def _default_crate_name_rust_test_suite_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
@@ -197,7 +197,7 @@ def _crate_name_test():
         srcs = ["lib.rs"],
         edition = "2018",
     )
-    
+
     rust_test_suite(
         name = "default/crate-name-rust-test-suite",
         srcs = ["foo.bar.main.rs"],


### PR DESCRIPTION
[`link_deps` is a property of `cargo_build_script`](https://bazelbuild.github.io/rules_rust/cargo.html#cargo_build_script-link_deps). This PR adds that ability to add it to third party crates via an annotation.