### PR TITLE
only set $CARGO if toolchain.cargo is set

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -361,8 +361,12 @@ def _cargo_build_script_impl(ctx):
     if use_default_shell_env:
         env.update(ctx.configuration.default_shell_env)
 
+    if toolchain.cargo:
+        env.update({
+            "CARGO": "${{pwd}}/{}".format(toolchain.cargo.path),
+        })
+
     env.update({
-        "CARGO": "${{pwd}}/{}".format(toolchain.cargo.path),
         "CARGO_CRATE_NAME": name_to_crate_name(pkg_name),
         "CARGO_MANIFEST_DIR": manifest_dir,
         "CARGO_PKG_NAME": pkg_name,


### PR DESCRIPTION
Follow-up from https://github.com/bazelbuild/rules_rust/pull/3245: `toolchain.cargo` is optional and might be missing for some custom toolchains; only attempt to set it up if it's present.