### PR TITLE
Merge all runfiles of `@bazel_tools//tools/bash/runfiles`

### DIFF
--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -471,7 +471,7 @@ def _crates_vendor_impl(ctx):
 
     runfiles = ctx.runfiles(files = cargo_bazel_runfiles, transitive_files = toolchain.all_files)
     if runner.basename.endswith(".sh"):
-        runfiles = runfiles.merge(ctx.attr._runfiles_lib[DefaultInfo].default_runfiles)
+        runfiles = runfiles.merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
 
     return DefaultInfo(
         files = depset([runner]),

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -469,15 +469,13 @@ def _crates_vendor_impl(ctx):
         is_executable = True,
     )
 
+    runfiles = ctx.runfiles(files = cargo_bazel_runfiles, transitive_files = toolchain.all_files)
     if runner.basename.endswith(".sh"):
-        cargo_bazel_runfiles.append(ctx.file._bash_runfiles)
+        runfiles = runfiles.merge(ctx.attr._runfiles_lib[DefaultInfo].default_runfiles)
 
     return DefaultInfo(
         files = depset([runner]),
-        runfiles = ctx.runfiles(
-            files = cargo_bazel_runfiles,
-            transitive_files = toolchain.all_files,
-        ),
+        runfiles = runfiles,
         executable = runner,
     )
 
@@ -579,7 +577,6 @@ CRATES_VENDOR_ATTRS = {
     "_bash_runfiles": attr.label(
         doc = "The runfiles library for bash.",
         cfg = "target",
-        allow_single_file = True,
         default = Label("@bazel_tools//tools/bash/runfiles"),
     ),
 }


### PR DESCRIPTION
As `@bazel_tools//tools/bash/runfiles` is now an alias to `@rules_shell//shell/runfiles` with Bazel@HEAD, consumers must properly merge all its runfiles rather than assuming that the `sh_library` target just consists of a single file.

Work towards https://github.com/bazelbuild/examples/pull/557#issuecomment-2677865427