### PR TITLE
Allow crate_universe modules to specify rust versions

### DIFF
--- a/examples/crate_universe/MODULE.bazel
+++ b/examples/crate_universe/MODULE.bazel
@@ -269,8 +269,8 @@ crate_index_cargo_bindeps.from_cargo(
     name = "crate_index_cargo_bindeps",
     cargo_lockfile = "//cargo_bindeps:Cargo.lock",
     generate_binaries = True,
-    host_tools_repo = "rust_host_tools_nightly",
     manifests = ["//cargo_bindeps:Cargo.toml"],
+    rust_version = "nightly",
 )
 use_repo(
     crate_index_cargo_bindeps,

--- a/rust/extensions.bzl
+++ b/rust/extensions.bzl
@@ -1,9 +1,15 @@
 """Module extensions for using rules_rust with bzlmod"""
 
 load("@bazel_features//:features.bzl", "bazel_features")
-load("//rust:defs.bzl", "rust_common")
-load("//rust:repositories.bzl", "DEFAULT_TOOLCHAIN_TRIPLES", "rust_register_toolchains", "rust_repository_set", "rust_toolchain_tools_repository")
+load(
+    "//rust:repositories.bzl",
+    "DEFAULT_TOOLCHAIN_TRIPLES",
+    "rust_register_toolchains",
+    "rust_repository_set",
+    "rust_toolchain_tools_repository",
+)
 load("//rust/platform:triple.bzl", "get_host_triple")
+load("//rust/private:common.bzl", "rust_common")
 load(
     "//rust/private:repository_utils.bzl",
     "DEFAULT_EXTRA_TARGET_TRIPLES",

--- a/test/load_arbitrary_tool/load_arbitrary_tool_test.bzl
+++ b/test/load_arbitrary_tool/load_arbitrary_tool_test.bzl
@@ -11,6 +11,7 @@ def _load_arbitrary_tool_test_impl(repository_ctx):
     # Download cargo
     load_arbitrary_tool(
         ctx = repository_ctx,
+        attrs = repository_ctx.attr,
         tool_name = "cargo",
         tool_subdirectories = ["cargo"],
         version = "1.53.0",


### PR DESCRIPTION
This change updates bzlmod crate_universe to allow modules to specify the version of rust used for splicing. Previously `rust_host_tools` and `rust_host_tools_nightly` were the only repositories available to consumers which both had fixed rust versions specified by `rules_rust`. This change gives users easy control of this value now.

closes https://github.com/bazelbuild/rules_rust/issues/3286