### PR TITLE
fix: add NIX_LDs vars to work on NixOS

### DIFF
--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -163,6 +163,8 @@ impl Digest {
             OsStr::new("HOME"),
             OsStr::new("HOMEDRIVE"),
             OsStr::new("PATHEXT"),
+            OsStr::new("NIX_LD"),
+            OsStr::new("NIX_LD_LIBRARY_PATH"),
         ];
         let env = std::env::vars_os().filter(|(var, _)| safe_vars.contains(&var.as_os_str()));
 


### PR DESCRIPTION
Re-implements https://github.com/bazelbuild/rules_rust/pull/3223 (special thanks to @tkr-sh!)

> No bazel command will work on NixOS when using crate_universe because `NIX_LD` is removed by `.env_clear()`.
See <https://github.com/nix-community/nix-ld>
This fix is fairly simple, and makes the command work on NixOS.

closes https://github.com/bazelbuild/rules_rust/issues/3224