### PR TITLE
Allow the customization of sysroot_src in the generated rust-project.…

### DIFF
--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -277,6 +277,7 @@ def _rust_analyzer_toolchain_impl(ctx):
         proc_macro_srv = ctx.executable.proc_macro_srv,
         rustc = ctx.executable.rustc,
         rustc_srcs = ctx.attr.rustc_srcs,
+        rustc_srcs_path = ctx.attr.rustc_srcs_path,
     )
 
     return [toolchain]
@@ -302,6 +303,10 @@ rust_analyzer_toolchain = rule(
             doc = "The source code of rustc.",
             mandatory = True,
         ),
+        "rustc_srcs_path": attr.string(
+            doc = "The direct path to rustc srcs relative to rustc_srcs package root.",
+            mandatory = False
+        )
     },
 )
 
@@ -315,8 +320,15 @@ def _rust_analyzer_detect_sysroot_impl(ctx):
         )
 
     rustc_srcs = rust_analyzer_toolchain.rustc_srcs
+    rustc_srcs_path = rust_analyzer_toolchain.rustc_srcs_path
 
-    sysroot_src = rustc_srcs.label.package + "/library"
+    sysroot_src = rustc_srcs.label.package
+
+    if not rust_analyzer_toolchain.rustc_srcs_path:
+        sysroot_src = sysroot_src + "/library"
+    else:
+        sysroot_src = sysroot_src + "/" + rust_analyzer_toolchain.rustc_srcs_path
+
     if rustc_srcs.label.workspace_root:
         sysroot_src = _OUTPUT_BASE_TEMPLATE + rustc_srcs.label.workspace_root + "/" + sysroot_src
     else:


### PR DESCRIPTION

When specifying a local rust toolchain with an unconventional rust-src location; this attribute will allow you to influence what the sysroot_src path in the resulting rust-project.json.

In my particular case I'm working in a conda environment which I configure as a new_local_repo in my project.

There I define a rust toolchain and my rustc sources live in `$CONDA_PREFIX/lib/rustlib/src/rust/library`. By default, if I'm unable to provide this path, the resulting sysroot_src in my project ends up resolving to the equivalent of `$CONDA_PREFIX/library`.