### PR TITLE
Fix monitoring input manifest/lockfile/srcs changes

### DIFF
--- a/cargo/private/cargo_bootstrap.bzl
+++ b/cargo/private/cargo_bootstrap.bzl
@@ -173,13 +173,13 @@ def _detect_changes(repository_ctx):
     # 'consumed' which means changes to it will trigger rebuilds
 
     for src in repository_ctx.attr.srcs:
-        repository_ctx.path(src)
+        repository_ctx.watch(src)
 
-    repository_ctx.path(repository_ctx.attr.cargo_lockfile)
-    repository_ctx.path(repository_ctx.attr.cargo_toml)
+    repository_ctx.watch(repository_ctx.attr.cargo_lockfile)
+    repository_ctx.watch(repository_ctx.attr.cargo_toml)
 
     if repository_ctx.attr.cargo_config:
-        repository_ctx.path(repository_ctx.attr.cargo_config)
+        repository_ctx.watch(repository_ctx.attr.cargo_config)
 
 def _cargo_bootstrap_repository_impl(repository_ctx):
     # Pretend to Bazel that this rule's input files have been used, so that it will re-run the rule if they change.

--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -943,16 +943,17 @@ def _crate_impl(module_ctx):
                 fail("Spec specified for repo {}, but the module defined repositories {}".format(repo, local_repos))
 
         for cfg in mod.tags.from_cargo + mod.tags.from_specs:
-            # Preload all external repositories. Calling `module_ctx.path` will cause restarts of the implementation
-            # function of the module extension, so we want to trigger all restarts before we start the actual work.
-            # Once https://github.com/bazelbuild/bazel/issues/22729 has been fixed, this code can be removed.
+            # Preload all external repositories. Calling `module_ctx.watch` will cause restarts of the implementation
+            # function of the module extension when the file has changed.
             if cfg.cargo_lockfile:
-                module_ctx.path(cfg.cargo_lockfile)
+                module_ctx.watch(cfg.cargo_lockfile)
             if cfg.lockfile:
-                module_ctx.path(cfg.lockfile)
+                module_ctx.watch(cfg.lockfile)
+            if cfg.cargo_config:
+                module_ctx.watch(cfg.cargo_config)
             if hasattr(cfg, "manifests"):
                 for m in cfg.manifests:
-                    module_ctx.path(m)
+                    module_ctx.watch(m)
 
             cargo_path, rustc_path = _get_host_cargo_rustc(module_ctx, host_triple, cfg.host_tools_repo)
             cargo_bazel_fn = new_cargo_bazel_fn(


### PR DESCRIPTION
From a comment of @UebelAndre replacing the previous trick of calling `repository_ctx.path()` by the newly introduced `repository_ctx.watch` solves two issues:
- `rules_rust` correctly re-splices crates when the workspace `Cargo.toml` manifest changes, but also when any of the projects' `Cargo.toml` change
- `rules_rust` correctly re-bootstraps `cargo-bazel` when the source changes (if you're developing for `rules_rust` and using `local_path_override`)

Closes #3216