### PR TITLE
Fixed loss of data in gen_rust_project for duplicate crate ids

### DIFF
--- a/test/rust_analyzer/generated_srcs_test/rust_project_json_test.rs
+++ b/test/rust_analyzer/generated_srcs_test/rust_project_json_test.rs
@@ -27,7 +27,6 @@ mod tests {
         let rust_project_path = PathBuf::from(env::var("RUST_PROJECT_JSON").unwrap());
         let content = std::fs::read_to_string(&rust_project_path)
             .unwrap_or_else(|_| panic!("couldn't open {:?}", &rust_project_path));
-        println!("{}", content);
         let project: Project =
             serde_json::from_str(&content).expect("Failed to deserialize project JSON");
 
@@ -42,15 +41,15 @@ mod tests {
             .unwrap();
         println!("output_base: {output_base}");
 
-        let gen = project
+        let with_gen = project
             .crates
             .iter()
             .find(|c| &c.display_name == "generated_srcs")
             .unwrap();
-        assert!(gen.root_module.starts_with("/"));
-        assert!(gen.root_module.ends_with("/lib.rs"));
+        assert!(with_gen.root_module.starts_with("/"));
+        assert!(with_gen.root_module.ends_with("/lib.rs"));
 
-        let include_dirs = &gen.source.as_ref().unwrap().include_dirs;
+        let include_dirs = &with_gen.source.as_ref().unwrap().include_dirs;
         assert!(include_dirs.len() == 1);
         assert!(include_dirs[0].starts_with(output_base));
     }


### PR DESCRIPTION
Previously `aliases` and `source` were susceptible to being dropped from `rust-project.json` in the event a crate without either of these fields was processed before another crate with them. These are now aggregated and `gen_rust_project` should be more resilient to the ordering targets are listed in aquery outputs.