### PR TITLE
extensions/prost/private/protoc_wrapper: codegen for enums was broken

### DIFF
--- a/extensions/prost/private/protoc_wrapper.rs
+++ b/extensions/prost/private/protoc_wrapper.rs
@@ -393,7 +393,7 @@ fn enum_type_to_extern_paths(
         .expect("Failed to get enum type name");
     extern_paths.insert(
         proto_path.join(enum_type_name),
-        rust_path.join(enum_type_name),
+        rust_path.join(&enum_type_name.to_upper_camel_case()),
     );
 }
 
@@ -1013,6 +1013,30 @@ mod test {
             assert_eq!(
                 extern_paths.get(&ProtoPath::from("bar.baz.Foo")),
                 Some(&RustModulePath::from("bar::baz::Foo"))
+            );
+        }
+    }
+
+    #[test]
+    fn enum_type_to_extern_paths_upper_camel_case_test() {
+        let enum_descriptor = EnumDescriptorProto {
+            name: Some("SomethingID".to_string()),
+            ..EnumDescriptorProto::default()
+        };
+
+        {
+            let mut extern_paths = BTreeMap::new();
+            enum_type_to_extern_paths(
+                &mut extern_paths,
+                &ProtoPath::from("bar"),
+                &RustModulePath::from("bar"),
+                &enum_descriptor,
+            );
+
+            assert_eq!(extern_paths.len(), 1);
+            assert_eq!(
+                extern_paths.get(&ProtoPath::from("bar.SomethingID")),
+                Some(&RustModulePath::from("bar::SomethingId"))
             );
         }
     }

--- a/extensions/prost/private/tests/camel_case/another.proto
+++ b/extensions/prost/private/tests/camel_case/another.proto
@@ -6,4 +6,5 @@ import "camel_case.proto";
 
 message Another {
     camel_case.NameWithCAPS inner = 1;
+    camel_case.SomethingID something = 2;
 }

--- a/extensions/prost/private/tests/camel_case/camel_case.proto
+++ b/extensions/prost/private/tests/camel_case/camel_case.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package camel_case;
 
+enum SomethingID {
+    UNKNOWN = 0;
+    SOMETHING = 1;
+}
+
 message NameWithCAPS {
     string name = 1;
 }


### PR DESCRIPTION
When generating a message that contains a field that is an enum, the generated code was not following the proper upper camel case convention, making it fail to build.
Example:
```
message Test {
    some.pkg.SomethingID test = 1;
}
```
```
    #[prost(enumeration="super::some::pkg::SomethingID", tag="1")]
    pub test: i32,
```
When we actually expects `SomethingId` because prost generates it like that.