### PR TITLE
Fixed missing cargo_toml_variable_extractor deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,10 +28,6 @@ use_repo(
     "rrra__log-0.4.19",
     "rrra__serde-1.0.171",
     "rrra__serde_json-1.0.102",
-    "rules_rust_ctve__cargo-util-schemas-0.3.1",
-    "rules_rust_ctve__pathdiff-0.1.0",
-    "rules_rust_ctve__semver-1.0.25",
-    "rules_rust_ctve__toml-0.8.20",
     "rules_rust_tinyjson",
 )
 
@@ -40,6 +36,11 @@ use_repo(
     cargo_internal_deps,
     "rrcti",
     "rrcti__cargo_toml-0.20.5",
+    "rules_rust_ctve",
+    "rules_rust_ctve__cargo-util-schemas-0.3.1",
+    "rules_rust_ctve__pathdiff-0.1.0",
+    "rules_rust_ctve__semver-1.0.25",
+    "rules_rust_ctve__toml-0.8.20",
 )
 
 rust = use_extension("//rust:extensions.bzl", "rust")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -14,10 +14,6 @@ load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencie
 
 crate_universe_dependencies(bootstrap = True)
 
-load("//cargo/cargo_toml_variable_extractor/3rdparty/crates:defs.bzl", ctve_crate_repositories = "crate_repositories")
-
-ctve_crate_repositories()
-
 load("//crate_universe/tools/cross_installer:cross_installer_deps.bzl", "cross_installer_deps")
 
 cross_installer_deps()

--- a/cargo/deps.bzl
+++ b/cargo/deps.bzl
@@ -2,8 +2,23 @@
 The dependencies for running the cargo_toml_info binary.
 """
 
-load("//cargo/private/cargo_toml_info/3rdparty/crates:crates.bzl", "crate_repositories")
+load(
+    "//cargo/cargo_toml_variable_extractor/3rdparty/crates:crates.bzl",
+    cargo_toml_variable_extractor_repositories = "crate_repositories",
+)
+load(
+    "//cargo/private/cargo_toml_info/3rdparty/crates:crates.bzl",
+    cargo_toml_info_repositories = "crate_repositories",
+)
 
 def cargo_dependencies():
-    """Define dependencies of the `cargo` Bazel tools"""
-    return crate_repositories()
+    """Define dependencies of the `cargo` Bazel tools
+
+    Returns:
+        list: A list of all defined repositories.
+    """
+    direct_deps = []
+    direct_deps.extend(cargo_toml_variable_extractor_repositories())
+    direct_deps.extend(cargo_toml_info_repositories())
+
+    return direct_deps

--- a/crate_universe/repositories.bzl
+++ b/crate_universe/repositories.bzl
@@ -1,7 +1,7 @@
 """A module defining dependencies of the `cargo-bazel` Rust target"""
 
 load("@rules_rust//rust:defs.bzl", "rust_common")
-load("//cargo/cargo_toml_variable_extractor/3rdparty/crates:defs.bzl", ctve_crate_repositories = "crate_repositories")
+load("//cargo/cargo_toml_variable_extractor/3rdparty/crates:crates.bzl", ctve_crate_repositories = "crate_repositories")
 load("//crate_universe:deps_bootstrap.bzl", "cargo_bazel_bootstrap")
 load("//crate_universe/3rdparty:third_party_deps.bzl", "third_party_deps")
 load("//crate_universe/3rdparty/crates:crates.bzl", _vendor_crate_repositories = "crate_repositories")

--- a/rust/private/internal_extensions.bzl
+++ b/rust/private/internal_extensions.bzl
@@ -2,7 +2,6 @@
 
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//cargo/cargo_toml_variable_extractor/3rdparty/crates:defs.bzl", ctve_crate_repositories = "crate_repositories")
 load("//rust/private:repository_utils.bzl", "TINYJSON_KWARGS")
 load("//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
 
@@ -16,8 +15,6 @@ def _internal_deps_impl(module_ctx):
     http_archive(**TINYJSON_KWARGS)
 
     direct_deps.extend(rust_analyzer_dependencies())
-
-    direct_deps.extend(ctve_crate_repositories())
 
     # is_dev_dep is ignored here. It's not relevant for internal_deps, as dev
     # dependencies are only relevant for module extensions that can be used


### PR DESCRIPTION
This fixes issues specifically for missing a `rules_rust_ctve` repository but others I wouldn't have expected to be missing unless users forgot to add the following to their `WORKSPACE.bazel` files
```starlark
load("@rules_rust//cargo:deps.bzl", "cargo_dependencies")

cargo_dependencies()
```

Users just using `crate_universe` and not `cargo_toml_env_vars` directly should be fine using the standard `crate_universe` setup macros
```starlark
load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")

crate_universe_dependencies()
```