### PR TITLE
Fix broken bindgen doc link

### DIFF
--- a/extensions/bindgen/defs.bzl
+++ b/extensions/bindgen/defs.bzl
@@ -29,7 +29,7 @@ register_toolchains("@rules_rust_bindgen//:default_bindgen_toolchain")
 ```
 
 The default toolchain builds libclang from source via the [llvm-project](https://registry.bazel.build/modules/llvm-project) bazel_dep.
-[examples/bindgen_toolchain/Readme.md](https://github.com/bazelbuild/rules_rust/blob/main/examples/bindgen_toolchain/Readme.md) shows how to use a prebuilt libclang.
+[examples/bindgen_toolchain](https://github.com/bazelbuild/rules_rust/tree/main/examples/bindgen_toolchain) shows how to use a prebuilt libclang.
 
 ### Workspace
 


### PR DESCRIPTION
It should've been /README.md but I now think linking to the "folder" is actually nicer.