### PR TITLE
Enable pipelined_compilation tests for windows

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -68,7 +68,6 @@ default_macos_targets: &default_macos_targets
 default_windows_targets: &default_windows_targets
   - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
   - "//..."
-  - "-//test/unit/pipelined_compilation/..."
 default_windows_no_runfiles_targets: &default_windows_no_runfiles_targets
   - "--" # Allows negative patterns; hack for https://github.com/bazelbuild/continuous-integration/pull/245
   - "//..."
@@ -80,7 +79,6 @@ default_windows_no_runfiles_targets: &default_windows_no_runfiles_targets
   - "-//test/test_env_launcher:test"
   - "-//test/test_env:test_manifest_dir"
   - "-//test/test_env:test_run"
-  - "-//test/unit/pipelined_compilation/..."
   - "-//test/unit/rustdoc/..."
   - "-//rust/runfiles/..."
   # Runfiles used by the test only.

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -693,11 +693,9 @@ def can_build_metadata(toolchain, ctx, crate_type):
 
     # In order to enable pipelined compilation we require that:
     # 1) The _pipelined_compilation flag is enabled,
-    # 2) the OS running the rule is something other than windows as we require sandboxing (for now),
-    # 3) process_wrapper is enabled (this is disabled when compiling process_wrapper itself),
-    # 4) the crate_type is rlib or lib.
+    # 2) process_wrapper is enabled (this is disabled when compiling process_wrapper itself),
+    # 3) the crate_type is rlib or lib.
     return toolchain._pipelined_compilation and \
-           toolchain.exec_triple.system != "windows" and \
            ctx.attr._process_wrapper and \
            crate_type in ("rlib", "lib")
 

--- a/test/unit/pipelined_compilation/pipelined_compilation_test.bzl
+++ b/test/unit/pipelined_compilation/pipelined_compilation_test.bzl
@@ -5,12 +5,6 @@ load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_proc_macro")
 load("//test/unit:common.bzl", "assert_argv_contains", "assert_list_contains_adjacent_elements", "assert_list_contains_adjacent_elements_not")
 load(":wrap.bzl", "wrap")
 
-NOT_WINDOWS = select({
-    "@platforms//os:linux": [],
-    "@platforms//os:macos": [],
-    "//conditions:default": ["@platforms//:incompatible"],
-})
-
 ENABLE_PIPELINING = {
     str(Label("//rust/settings:pipelined_compilation")): True,
 }
@@ -109,8 +103,8 @@ def _pipelined_compilation_test():
         deps = [":second"],
     )
 
-    second_lib_test(name = "second_lib_test", target_under_test = ":second", target_compatible_with = NOT_WINDOWS)
-    bin_test(name = "bin_test", target_under_test = ":bin", target_compatible_with = NOT_WINDOWS)
+    second_lib_test(name = "second_lib_test", target_under_test = ":second")
+    bin_test(name = "bin_test", target_under_test = ":bin")
 
 def _rmeta_is_propagated_through_custom_rule_test_impl(ctx):
     env = analysistest.begin(ctx)
@@ -195,7 +189,6 @@ def _disable_pipelining_test():
     )
     rmeta_not_produced_if_pipelining_disabled_test(
         name = "rmeta_not_produced_if_pipelining_disabled_test",
-        target_compatible_with = NOT_WINDOWS,
         target_under_test = ":lib",
     )
 
@@ -222,13 +215,11 @@ def _custom_rule_test(generate_metadata, suffix):
     rmeta_is_propagated_through_custom_rule_test(
         name = "rmeta_is_propagated_through_custom_rule_test" + suffix,
         generate_metadata = generate_metadata,
-        target_compatible_with = NOT_WINDOWS,
         target_under_test = ":uses_wrapper" + suffix,
     )
 
     rmeta_is_used_when_building_custom_rule_test(
         name = "rmeta_is_used_when_building_custom_rule_test" + suffix,
-        target_compatible_with = NOT_WINDOWS,
         target_under_test = ":wrapper" + suffix,
     )
 


### PR DESCRIPTION
It's not clear why windows is disabled from this. Gonna enable it so developers can give it a try.