### PR TITLE
Updated crates index

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -106,7 +106,7 @@ use_repo(
     "cui__cargo_toml-0.21.0",
     "cui__cfg-expr-0.17.2",
     "cui__clap-4.5.26",
-    "cui__crates-index-3.6.0",
+    "cui__crates-index-3.7.0",
     "cui__glob-0.3.2",
     "cui__hex-0.4.3",
     "cui__indoc-2.0.5",

--- a/crate_universe/3rdparty/crates/BUILD.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.bazel
@@ -128,14 +128,14 @@ alias(
 )
 
 alias(
-    name = "crates-index-3.6.0",
-    actual = "@cui__crates-index-3.6.0//:crates_index",
+    name = "crates-index-3.7.0",
+    actual = "@cui__crates-index-3.7.0//:crates_index",
     tags = ["manual"],
 )
 
 alias(
     name = "crates-index",
-    actual = "@cui__crates-index-3.6.0//:crates_index",
+    actual = "@cui__crates-index-3.7.0//:crates_index",
     tags = ["manual"],
 )
 

--- a/crate_universe/3rdparty/crates/BUILD.crates-index-3.7.0.bazel
+++ b/crate_universe/3rdparty/crates/BUILD.crates-index-3.7.0.bazel
@@ -94,7 +94,7 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-uefi": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "3.6.0",
+    version = "3.7.0",
     deps = [
         "@cui__gix-0.70.0//:gix",
         "@cui__hex-0.4.3//:hex",

--- a/crate_universe/3rdparty/crates/defs.bzl
+++ b/crate_universe/3rdparty/crates/defs.bzl
@@ -16,7 +16,6 @@
 """
 
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
@@ -304,7 +303,7 @@ _NORMAL_DEPENDENCIES = {
             "cargo_toml": Label("@cui//:cargo_toml-0.21.0"),
             "cfg-expr": Label("@cui//:cfg-expr-0.17.2"),
             "clap": Label("@cui//:clap-4.5.26"),
-            "crates-index": Label("@cui//:crates-index-3.6.0"),
+            "crates-index": Label("@cui//:crates-index-3.7.0"),
             "glob": Label("@cui//:glob-0.3.2"),
             "hex": Label("@cui//:hex-0.4.3"),
             "itertools": Label("@cui//:itertools-0.14.0"),
@@ -865,12 +864,13 @@ def crate_repositories():
     )
 
     maybe(
-        new_git_repository,
-        name = "cui__crates-index-3.6.0",
-        commit = "ccaed89e15a2dfc469f06ee4ce858f5a65b66d66",
-        init_submodules = True,
-        remote = "https://github.com/frewsxcv/rust-crates-index.git",
-        build_file = Label("//crate_universe/3rdparty/crates:BUILD.crates-index-3.6.0.bazel"),
+        http_archive,
+        name = "cui__crates-index-3.7.0",
+        sha256 = "7c5dc2f0ba9eaac8a56b9544e7ec604ac259dd5d7f8d1d10db81448dbbbc4d43",
+        type = "tar.gz",
+        urls = ["https://static.crates.io/crates/crates-index/3.7.0/download"],
+        strip_prefix = "crates-index-3.7.0",
+        build_file = Label("//crate_universe/3rdparty/crates:BUILD.crates-index-3.7.0.bazel"),
     )
 
     maybe(
@@ -3202,7 +3202,7 @@ def crate_repositories():
         struct(repo = "cui__cargo_toml-0.21.0", is_dev_dep = False),
         struct(repo = "cui__cfg-expr-0.17.2", is_dev_dep = False),
         struct(repo = "cui__clap-4.5.26", is_dev_dep = False),
-        struct(repo = "cui__crates-index-3.6.0", is_dev_dep = False),
+        struct(repo = "cui__crates-index-3.7.0", is_dev_dep = False),
         struct(repo = "cui__glob-0.3.2", is_dev_dep = False),
         struct(repo = "cui__hex-0.4.3", is_dev_dep = False),
         struct(repo = "cui__indoc-2.0.5", is_dev_dep = False),

--- a/crate_universe/Cargo.lock
+++ b/crate_universe/Cargo.lock
@@ -325,8 +325,9 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "3.6.0"
-source = "git+https://github.com/frewsxcv/rust-crates-index.git?rev=ccaed89e15a2dfc469f06ee4ce858f5a65b66d66#ccaed89e15a2dfc469f06ee4ce858f5a65b66d66"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5dc2f0ba9eaac8a56b9544e7ec604ac259dd5d7f8d1d10db81448dbbbc4d43"
 dependencies = [
  "gix",
  "hex",

--- a/crate_universe/Cargo.toml
+++ b/crate_universe/Cargo.toml
@@ -71,7 +71,7 @@ cargo-lock = "10.1.0"
 cargo-platform = "0.1.9"
 cfg-expr = "0.17.2"
 clap = { version = "4.5.26", features = ["derive", "env"] }
-crates-index = { git = "https://github.com/frewsxcv/rust-crates-index.git", rev = "ccaed89e15a2dfc469f06ee4ce858f5a65b66d66", default-features = false, features = [
+crates-index = { version = "3.7.0", default-features = false, features = [
     "git",
 ] }
 hex = "0.4.3"


### PR DESCRIPTION
@UebelAndre my last MR (https://github.com/bazelbuild/rules_rust/pull/3318) got in a funky state due to the github rev pin of crates-index.  I opted to just redo the MR instead of fighting the rebase.

closes https://github.com/bazelbuild/rules_rust/issues/3310