### PR TITLE
Fix documentation for `experimental_per_crate_rustc_flag`.

### DIFF
--- a/rust/settings/settings.bzl
+++ b/rust/settings/settings.bzl
@@ -322,7 +322,7 @@ def experimental_per_crate_rustc_flag():
     The expected flag format is prefix_filter@flag, where any crate with a label or execution path starting
     with the prefix filter will be built with the given flag. The label matching uses the canonical form of
     the label (i.e `//package:label_name`). The execution path is the relative path to your workspace directory
-    including the base name (including extension) of the crate root. This flag is only applied to the exec
+    including the base name (including extension) of the crate root. This flag is not applied to the exec
     configuration (proc-macros, cargo_build_script, etc). Multiple uses are accumulated.
     """
     _per_crate_rustc_flag(


### PR DESCRIPTION
This setting was introduced in [this commit](https://github.com/bazelbuild/rules_rust/commit/6571cde64cbd72542ea012fe91d678031eb15fbf), and from the context there ([docs](https://github.com/bazelbuild/rules_rust/commit/6571cde64cbd72542ea012fe91d678031eb15fbf#diff-2a806da393e47c07ffe67c78ace69eb488b4ac44b029a46d8237b8e2a05637be), [tests](https://github.com/bazelbuild/rules_rust/commit/6571cde64cbd72542ea012fe91d678031eb15fbf#diff-7cfe86db91ef77d2663a7f891492547fcae21fc081ae947532f031585eb86f1d)), it seems clear that the intent is that the flag should apply to non-exec configurations.

When [this commit](https://github.com/bazelbuild/rules_rust/commit/eb1fe7da8c6cd95ce92c77dcbe00e643dd7c83e8#diff-d516c822cec75e56bb5c193fbd7c7dfd28d8f982224175324da28b61bf6a1fe3) later introduced the documentation being changed here, it seems that it inadvertently misunderstood the flag as applying _only_ to exec configurations, rather than _not_ to exec configurations.
