### PR TITLE
Draft: Add new cargo creds feature

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -606,6 +606,7 @@ def _generate_hub_and_spokes(
             packages = packages,
             splicing_config = splicing_config,
             cargo_config = cfg.cargo_config,
+            cargo_creds = cfg.cargo_creds,
             manifests = manifests,
             manifest_to_path = module_ctx.path,
         ),
@@ -965,6 +966,8 @@ def _crate_impl(module_ctx):
                 module_ctx.watch(cfg.lockfile)
             if cfg.cargo_config:
                 module_ctx.watch(cfg.cargo_config)
+            if cfg.cargo_creds:
+                module_ctx.watch(cfg.cargo_creds)
             if hasattr(cfg, "manifests"):
                 for m in cfg.manifests:
                     module_ctx.watch(m)
@@ -1031,6 +1034,7 @@ def _crate_impl(module_ctx):
 
 _FROM_COMMON_ATTRS = {
     "cargo_config": CRATES_VENDOR_ATTRS["cargo_config"],
+    "cargo_creds": CRATES_VENDOR_ATTRS["cargo_creds"],
     "cargo_lockfile": CRATES_VENDOR_ATTRS["cargo_lockfile"],
     "generate_binaries": CRATES_VENDOR_ATTRS["generate_binaries"],
     "generate_build_scripts": CRATES_VENDOR_ATTRS["generate_build_scripts"],

--- a/crate_universe/private/common_utils.bzl
+++ b/crate_universe/private/common_utils.bzl
@@ -115,7 +115,7 @@ def get_rust_tools(repository_ctx, host_triple):
     Returns:
         struct: A struct containing the expected rust tools
     """
-
+    
     # This is a bit hidden but to ensure Cargo behaves consistently based
     # on the user provided config file, the config file is installed into
     # the `CARGO_HOME` path. This is done so here since fetching tools
@@ -125,6 +125,13 @@ def get_rust_tools(repository_ctx, host_triple):
         cargo_home_config = repository_ctx.path("{}/config.toml".format(cargo_home))
         cargo_config = repository_ctx.path(repository_ctx.attr.cargo_config)
         repository_ctx.symlink(cargo_config, cargo_home_config)
+    
+    # Workspace backwards compat for cargo credentia
+    if repository_ctx.attr.isolated and repository_ctx.attr.cargo_creds:
+        cargo_home = _cargo_home_path(repository_ctx)
+        cargo_home_config = repository_ctx.path("{}/credentials.toml".format(cargo_home))
+        cargo_creds = repository_ctx.path(repository_ctx.attr.cargo_creds)
+        repository_ctx.symlink(cargo_creds, cargo_home_config)
 
     if repository_ctx.attr.rust_version.startswith(("beta", "nightly")):
         channel, _, version = repository_ctx.attr.rust_version.partition("/")

--- a/crate_universe/private/crates_repository.bzl
+++ b/crate_universe/private/crates_repository.bzl
@@ -245,6 +245,10 @@ CARGO_BAZEL_REPIN=1 CARGO_BAZEL_REPIN_ONLY=crate_index bazel sync --only=crate_i
         "cargo_config": attr.label(
             doc = "A [Cargo configuration](https://doc.rust-lang.org/cargo/reference/config.html) file",
         ),
+        "cargo_creds": attr.label(
+            doc = "A [Cargo credentials](https://doc.rust-lang.org/cargo/reference/config.html#credentials) file.",
+            allow_single_file = True,
+        ),
         "cargo_lockfile": attr.label(
             doc = (
                 "The path used to store the `crates_repository` specific " +

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -223,6 +223,7 @@ def _write_splicing_manifest(ctx):
             packages = ctx.attr.packages,
             splicing_config = splicing_config,
             cargo_config = ctx.attr.cargo_config,
+            cargo_creds = ctx.attr.cargo_creds,
             manifests = manifests,
             manifest_to_path = _prepare_manifest_path,
         ),
@@ -232,10 +233,11 @@ def _write_splicing_manifest(ctx):
 
     env = [_sys_runfile_env(ctx, "SPLICING_MANIFEST", manifest, is_windows)]
     args = ["--splicing-manifest", _expand_env("SPLICING_MANIFEST", is_windows)]
-    runfiles = [manifest] + ctx.files.manifests + ([ctx.file.cargo_config] if ctx.attr.cargo_config else [])
+    runfiles = [manifest] + ctx.files.manifests + ([ctx.file.cargo_config] if ctx.attr.cargo_config else []) + ([ctx.file.cargo_creds] if ctx.attr.cargo_creds else [])
+
     return args, env, runfiles
 
-def generate_splicing_manifest(*, packages, splicing_config, cargo_config, manifests, manifest_to_path):
+def generate_splicing_manifest(*, packages, splicing_config, cargo_config, cargo_creds, manifests, manifest_to_path):
     # Deserialize information about direct packages
     direct_packages_info = {
         # Ensure the data is using kebab-case as that's what `cargo_toml::DependencyDetail` expects.
@@ -245,6 +247,7 @@ def generate_splicing_manifest(*, packages, splicing_config, cargo_config, manif
 
     splicing_manifest_content = {
         "cargo_config": str(manifest_to_path(cargo_config)) if cargo_config else None,
+        "cargo_creds": str(manifest_to_path(cargo_creds)) if cargo_creds else None,
         "direct_packages": direct_packages_info,
         "manifests": manifests,
     }
@@ -508,6 +511,10 @@ CRATES_VENDOR_ATTRS = {
     ),
     "cargo_config": attr.label(
         doc = "A [Cargo configuration](https://doc.rust-lang.org/cargo/reference/config.html) file.",
+        allow_single_file = True,
+    ),
+    "cargo_creds": attr.label(
+        doc = "A [Cargo credentials](https://doc.rust-lang.org/cargo/reference/config.html#credentials) file.",
         allow_single_file = True,
     ),
     "cargo_lockfile": attr.label(

--- a/crate_universe/private/splicing_utils.bzl
+++ b/crate_universe/private/splicing_utils.bzl
@@ -33,7 +33,7 @@ def kebab_case_keys(data):
         for (key, val) in data.items()
     }
 
-def compile_splicing_manifest(splicing_config, manifests, cargo_config_path, packages):
+def compile_splicing_manifest(splicing_config, manifests, cargo_config_path, cargo_creds_path, packages):
     """Produce a manifest containing required components for splicing a new Cargo workspace
 
     [cargo_config]: https://doc.rust-lang.org/cargo/reference/config.html
@@ -59,6 +59,7 @@ def compile_splicing_manifest(splicing_config, manifests, cargo_config_path, pac
     # Auto-generated splicer manifest values
     splicing_manifest_content = {
         "cargo_config": cargo_config_path,
+        "cargo_creds": cargo_creds_path,
         "direct_packages": direct_packages_info,
         "manifests": manifests,
     }
@@ -91,6 +92,11 @@ def create_splicing_manifest(repository_ctx):
     else:
         cargo_config = None
 
+    if repository_ctx.attr.cargo_creds:
+        cargo_creds = str(repository_ctx.path(repository_ctx.attr.cargo_creds))
+    else:
+        cargo_creds = None
+
     # Load user configurable splicing settings
     config = json.decode(repository_ctx.attr.splicing_config or splicing_config())
 
@@ -100,6 +106,7 @@ def create_splicing_manifest(repository_ctx):
         splicing_config = config,
         manifests = manifests,
         cargo_config_path = cargo_config,
+        cargo_creds = cargo_creds,
         packages = repository_ctx.attr.packages,
     )
 

--- a/crate_universe/src/splicing.rs
+++ b/crate_universe/src/splicing.rs
@@ -39,6 +39,9 @@ pub(crate) struct SplicingManifest {
     /// The path of a Cargo config file
     pub(crate) cargo_config: Option<Utf8PathBuf>,
 
+    /// The path of a Cargo cred file
+    pub(crate) cargo_creds: Option<Utf8PathBuf>,
+
     /// The Cargo resolver version to use for splicing
     pub(crate) resolver_version: cargo_toml::Resolver,
 }
@@ -61,6 +64,7 @@ impl SplicingManifest {
         let Self {
             manifests,
             cargo_config,
+            cargo_creds,
             ..
         } = self;
 
@@ -88,9 +92,18 @@ impl SplicingManifest {
             Utf8PathBuf::from(resolved_path)
         });
 
+        let cargo_creds = cargo_creds.map(|path| {
+            let resolved_path = path
+                .to_string()
+                .replace("${build_workspace_directory}", &workspace_dir_str)
+                .replace("${output_base}", &output_base_str);
+            Utf8PathBuf::from(resolved_path)
+        });
+
         Self {
             manifests,
             cargo_config,
+            cargo_creds,
             ..self
         }
     }


### PR DESCRIPTION
- Add Cargo Credentials to the Module.bazel `from_crates` and vendor calls.
- Currently private crates repositories cannot pull from repos by default.  You have to set `CARGO_BAZEL_ISOLATED=false` for it to work