### PR TITLE
Dry run release workflow for release pull requests.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,12 @@
 name: Release
 on:
   workflow_dispatch:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - version.bzl
   push:
     branches:
       - main
@@ -20,18 +26,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      # TODO: Unfortunately it's not obvious how to restrict `workflow_dispatch` to a particular branch
-      # so this step ensures releases are always done off of `main`.
-      - name: Ensure branch is 'main'
-        run: |
-          git fetch origin &> /dev/null
-          branch="$(git rev-parse --abbrev-ref HEAD)"
-          if [[ "${branch}" != "main" ]]; then
-            echo "The release branch must be main. Got '${branch}'' instead." >&2
-            exit 1
-          else
-            echo "Branch is '${branch}'"
-          fi
       - name: Ensure release does not already exist
         run: |
           git fetch origin &> /dev/null
@@ -117,6 +111,7 @@ jobs:
           path: ${{ github.workspace }}/crate_universe/target/artifacts/${{ matrix.env.TARGET }}
           if-no-files-found: error
   release:
+    if: startsWith(github.ref, 'refs/heads/main')
     needs: builds
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Avoid failures of the release process by running everything except for the release creation and artifact upload when making or merging a PR that bumps the release version.