### PR TITLE
Update runfiles to work with directory embedded manifests

### DIFF
--- a/rust/runfiles/runfiles.rs
+++ b/rust/runfiles/runfiles.rs
@@ -158,7 +158,12 @@ impl Runfiles {
         let mode = if let Some(manifest_file) = std::env::var_os(MANIFEST_FILE_ENV_VAR) {
             Self::create_manifest_based(Path::new(&manifest_file))?
         } else {
-            Mode::DirectoryBased(find_runfiles_dir()?)
+            let dir = find_runfiles_dir()?;
+            let manifest_path = dir.join("MANIFEST");
+            match manifest_path.exists() {
+                true => Self::create_manifest_based(&manifest_path)?,
+                false => Mode::DirectoryBased(dir),
+            }
         };
 
         let repo_mapping = raw_rlocation(&mode, "_repo_mapping")


### PR DESCRIPTION
This fixes the ability to use runfiles in scenarios where a runfiles directory is created but all it contains is a `MANIFEST` file.

This matches the behavior of:
- rules_cc: https://github.com/bazelbuild/bazel/blob/c8217fdd2f20e4a061122c0af0417380d09e9480/tools/cpp/runfiles/runfiles_test.cc#L180-L196
- rules_shell: https://github.com/bazelbuild/bazel/blob/c8217fdd2f20e4a061122c0af0417380d09e9480/tools/bash/runfiles/runfiles.bash#L88-L96