### PR TITLE
Update crate universe to use musl binaries on Linux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Ensure release does not already exist
-        if: startsWith(github.ref, 'refs/heads/main') == false
+        if: startsWith(github.ref, 'refs/heads/main')
         run: |
           git fetch origin &> /dev/null
           version="$(grep 'VERSION =' ${{ github.workspace }}/version.bzl | sed 's/VERSION = "//' | sed 's/"//')"
@@ -46,12 +46,15 @@ jobs:
       matrix:
         # Create a job for each target triple
         include:
-          - os: macOS-13
+          - os: macOS-14
             env:
               TARGET: "aarch64-apple-darwin"
           - os: ubuntu-22.04
             env:
               TARGET: "aarch64-unknown-linux-gnu"
+          - os: ubuntu-22.04
+            env:
+              TARGET: "aarch64-unknown-linux-musl"
           - os: windows-2022
             env:
               TARGET: "aarch64-pc-windows-msvc"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,6 @@
 name: Release
 on:
   workflow_dispatch:
-  merge_group:
   pull_request:
     branches:
       - main

--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -779,19 +779,19 @@ def _package_to_json(p):
         if v or k == "default_features"
     })
 
-def _get_generator(module_ctx):
+def _get_generator(module_ctx, host_triple):
     """Query Network Resources to local a `cargo-bazel` binary.
 
     Based off get_generator in crates_universe/private/generate_utils.bzl
 
     Args:
-        module_ctx (module_ctx):  The rules context object
+        module_ctx (module_ctx): The rules context object
+        host_triple (struct): A triple struct that represents the host.
 
     Returns:
         tuple(path, dict) The path to a 'cargo-bazel' binary. The pairing (dict)
             may be `None` if there is not need to update the attribute
     """
-    host_triple = get_host_triple(module_ctx)
     use_environ = False
     for var in GENERATOR_ENV_VARS:
         if var in module_ctx.os.environ:
@@ -858,8 +858,11 @@ def _get_host_cargo_rustc(module_ctx, host_triple, host_tools_repo):
 
 def _crate_impl(module_ctx):
     reproducible = True
-    generator = _get_generator(module_ctx)
-    host_triple = get_host_triple(module_ctx)
+    host_triple = get_host_triple(module_ctx, abi = {
+        "aarch64-unknown-linux": "musl",
+        "x86_64-unknown-linux": "musl",
+    })
+    generator = _get_generator(module_ctx, host_triple)
 
     all_repos = []
 

--- a/rust/platform/triple.bzl
+++ b/rust/platform/triple.bzl
@@ -86,7 +86,7 @@ def _validate_cpu_architecture(arch, expected_archs):
             expected_archs,
         ))
 
-def get_host_triple(repository_ctx, abi = None):
+def get_host_triple(repository_ctx, abi = {}):
     """Query host information for the appropriate triple to use with load_arbitrary_tool or the crate_universe resolver
 
     Example:
@@ -110,8 +110,9 @@ def get_host_triple(repository_ctx, abi = None):
 
     Args:
         repository_ctx (repository_ctx): The repository_rule's context object
-        abi (str): Since there's no consistent way to check for ABI, this info
-            may be explicitly provided
+        abi (dict): A mapping of platform triple prefixes to desired abi. This
+            is useful since there's no consistent way to check for ABI, this info
+            may be explicitly provided.
 
     Returns:
         struct: A triple struct; see the `triple` function in this module
@@ -134,9 +135,10 @@ def get_host_triple(repository_ctx, abi = None):
 
     if "linux" in repository_ctx.os.name:
         _validate_cpu_architecture(arch, supported_architectures["linux"])
-        return triple("{}-unknown-linux-{}".format(
-            arch,
-            abi or "gnu",
+        prefix = "{}-unknown-linux".format(arch)
+        return triple("{}-{}".format(
+            prefix,
+            abi.get(prefix, "gnu"),
         ))
 
     if "mac" in repository_ctx.os.name:
@@ -145,9 +147,10 @@ def get_host_triple(repository_ctx, abi = None):
 
     if "win" in repository_ctx.os.name:
         _validate_cpu_architecture(arch, supported_architectures["windows"])
-        return triple("{}-pc-windows-{}".format(
-            arch,
-            abi or "msvc",
+        prefix = "{}-pc-windows".format(arch)
+        return triple("{}-{}".format(
+            prefix,
+            abi.get(prefix, "msvc"),
         ))
 
     fail("Unhandled host os: {}", repository_ctx.os.name)

--- a/rust/platform/triple.bzl
+++ b/rust/platform/triple.bzl
@@ -136,7 +136,7 @@ def get_host_triple(repository_ctx, abi = None):
         _validate_cpu_architecture(arch, supported_architectures["linux"])
         return triple("{}-unknown-linux-{}".format(
             arch,
-            abi or "musl",
+            abi or "gnu",
         ))
 
     if "mac" in repository_ctx.os.name:

--- a/rust/platform/triple.bzl
+++ b/rust/platform/triple.bzl
@@ -136,7 +136,7 @@ def get_host_triple(repository_ctx, abi = None):
         _validate_cpu_architecture(arch, supported_architectures["linux"])
         return triple("{}-unknown-linux-{}".format(
             arch,
-            abi or "gnu",
+            abi or "musl",
         ))
 
     if "mac" in repository_ctx.os.name:


### PR DESCRIPTION
This change makes `musl` binaries available for all supported linux platforms.