### PR TITLE
Allow `crate_universe` to use external `rust_host_tools`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,14 +56,9 @@ rust_host_tools = use_extension("//rust:extensions.bzl", "rust_host_tools")
 rust_host_tools.host_tools(
     name = "rust_host_tools",
 )
-rust_host_tools.host_tools(
-    name = "rust_host_tools_nightly",
-    version = "nightly",
-)
 use_repo(
     rust_host_tools,
     "rust_host_tools",
-    "rust_host_tools_nightly",
 )
 
 rust_test = use_extension("//test:test_extensions.bzl", "rust_test", dev_dependency = True)

--- a/examples/crate_universe/MODULE.bazel
+++ b/examples/crate_universe/MODULE.bazel
@@ -263,13 +263,23 @@ use_repo(
 # C A R G O   B I N D E P S
 ###############################################################################
 
+rust_host_tools = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
+rust_host_tools.host_tools(
+    name = "rust_host_tools_nightly",
+    version = "nightly",
+)
+use_repo(
+    rust_host_tools,
+    "rust_host_tools_nightly",
+)
+
 # https://bazelbuild.github.io/rules_rust/crate_universe_bzlmod.html
 crate_index_cargo_bindeps = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
 crate_index_cargo_bindeps.from_cargo(
     name = "crate_index_cargo_bindeps",
     cargo_lockfile = "//cargo_bindeps:Cargo.lock",
     generate_binaries = True,
-    host_tools_repo = "rust_host_tools_nightly",
+    host_tools = "@rust_host_tools_nightly",
     manifests = ["//cargo_bindeps:Cargo.toml"],
 )
 use_repo(

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -526,8 +526,13 @@ def _rust_toolchain_tools_repository_impl(ctx):
         )
         sha256s.update(rustc_dev_sha256)
 
-    ctx.file("WORKSPACE.bazel", "")
+    ctx.file("WORKSPACE.bazel", """workspace(name = "{}")""".format(
+        ctx.name,
+    ))
     ctx.file("BUILD.bazel", "\n".join(build_components))
+
+    # Used to locate `rust_host_tools` repositories.
+    ctx.file(ctx.name, "")
 
     repro = {"name": ctx.name}
     for key in _RUST_TOOLCHAIN_REPOSITORY_ATTRS:


### PR DESCRIPTION
This allows users of `rules_rust` to define their own `rust_host_tools` modules and use it with `crate_universe` to control the versions of rustc and cargo used by it.

For example:

```python
rust_host_tools = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
rust_host_tools.host_tools(
    name = "my_rust_host_tools",
    version = "1.86.0",
)
use_repo(
    rust_host_tools,
    "my_rust_host_tools",
)

crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")

crate.from_cargo(
    name = "crate_index",
    manifests = ["//:Cargo.toml"],
    cargo_lockfile = "//:Cargo.lock",
    lockfile = "//:cargo-bazel-lock.json",
    host_tools = "@my_rust_host_tools",
)

use_repo(
    crate,
    "crate_index",
)
```