### PR TITLE
"sandwich" dynamic libs in addition to static libs

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2008,6 +2008,7 @@ def _portable_link_flags(lib, use_pic, ambiguous_libs, get_lib_name, for_windows
     elif _is_dylib(lib):
         return [
             "-ldylib=%s" % get_lib_name(artifact),
+            "-Clink-arg=-l{}".format(get_lib_name(artifact)),
         ]
 
     return []


### PR DESCRIPTION
This changed was first introduced in https://github.com/bazelbuild/rules_rust/pull/1333

I am not sure why it was only done for static libs. This patch was necessary for some dynamic libs to work in my use case.