### PR TITLE
Fix: Handle package.workspace key in child Cargo.toml

### DIFF
--- a/crate_universe/src/metadata/workspace_discoverer.rs
+++ b/crate_universe/src/metadata/workspace_discoverer.rs
@@ -135,8 +135,13 @@ fn discover_workspaces_with_cache(
                                 explicit_workspace_path.display()
                             )
                         })?;
-                    actual_workspace_path =
-                        child_path.parent().unwrap().join(explicit_workspace_path);
+                    actual_workspace_path = child_path
+                        .parent()
+                        .unwrap()
+                        .join(explicit_workspace_path)
+                        .canonicalize_utf8()
+                        .unwrap()
+                        .join("Cargo.toml");
                 }
             }
             if !discovered_workspaces

--- a/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b78c987f5327687e670e9a453e7cbf40fa4179255243800d0d359a140e2647af",
+  "checksum": "5803dfc7b0b2d5413b5418fefb64cd9090b7d8ecea37158ea73af58b700924ce",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",

--- a/examples/crate_universe/cargo_workspace/num_printer/Cargo.toml
+++ b/examples/crate_universe/cargo_workspace/num_printer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "num_printer"
 version = "0.1.0"
 edition = "2018"
+workspace = ".."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/examples/crate_universe/cargo_workspace/printer/Cargo.toml
+++ b/examples/crate_universe/cargo_workspace/printer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "printer"
 version = "0.1.0"
 edition = "2018"
+workspace = ".."
 
 [dependencies]
 rng = { path = "../rng" }

--- a/examples/crate_universe/cargo_workspace/rng/Cargo.toml
+++ b/examples/crate_universe/cargo_workspace/rng/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rng"
 version = "0.1.0"
 edition = "2018"
+workspace = ".."
 
 [dependencies]
 rand = "0.7.3"


### PR DESCRIPTION
Setting the `package.workspace` key in child workspace fails splicing with an error similar to

```
Found manifest at /home/mlaurin/src/check_mk.git/packages/site/check-http/Cargo.toml which is a member of the workspace at
/home/mlaurin/src/check_mk.git/packages/site/check-http/.. which isn't included in the crates_universe
```

Now, the key is valid in Cargo.toml when the code is organized in workspaces.  It is even required for out-of-tree workspaces.  See https://github.com/nox/rust-rfcs/blob/master/text/1525-cargo-workspace.md

Before December, the key was ignored but would not fail splicing.  The regression is most likely due to changes related to https://github.com/bazelbuild/rules_rust/issues/3090