### PR TITLE
Rewrite relative paths in bin dirs (`-B`)

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -193,6 +193,27 @@ def _pwd_flags_isystem(args):
 
     return res
 
+def _pwd_flags_bindir(args):
+    """Prefix execroot-relative paths of known arguments with ${pwd}.
+
+    Args:
+        args (list): List of tool arguments.
+
+    Returns:
+        list: The modified argument list.
+    """
+    res = []
+    fix_next_arg = False
+    for arg in args:
+        if fix_next_arg and not paths.is_absolute(arg):
+            res.append("${{pwd}}/{}".format(arg))
+        else:
+            res.append(arg)
+
+        fix_next_arg = arg == "-B"
+
+    return res
+
 def _pwd_flags_fsanitize_ignorelist(args):
     """Prefix execroot-relative paths of known arguments with ${pwd}.
 
@@ -212,7 +233,7 @@ def _pwd_flags_fsanitize_ignorelist(args):
     return res
 
 def _pwd_flags(args):
-    return _pwd_flags_fsanitize_ignorelist(_pwd_flags_isystem(_pwd_flags_sysroot(args)))
+    return _pwd_flags_fsanitize_ignorelist(_pwd_flags_isystem(_pwd_flags_bindir(_pwd_flags_sysroot(args))))
 
 def _feature_enabled(ctx, feature_name, default = False):
     """Check if a feature is enabled.

--- a/test/cargo_build_script/cc_args_and_env/BUILD.bazel
+++ b/test/cargo_build_script/cc_args_and_env/BUILD.bazel
@@ -1,5 +1,7 @@
 load(
     "cc_args_and_env_test.bzl",
+    "bindir_absolute_test",
+    "bindir_relative_test",
     "fsanitize_ignorelist_absolute_test",
     "fsanitize_ignorelist_relative_test",
     "isystem_absolute_test",
@@ -18,6 +20,10 @@ sysroot_next_absolute_test(name = "sysroot_next_absolute_test")
 isystem_relative_test(name = "isystem_relative_test")
 
 isystem_absolute_test(name = "isystem_absolute_test")
+
+bindir_relative_test(name = "bindir_relative_test")
+
+bindir_absolute_test(name = "bindir_absolute_test")
 
 fsanitize_ignorelist_absolute_test(name = "fsanitize_ignorelist_absolute_test")
 

--- a/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -207,6 +207,28 @@ def isystem_absolute_test(name):
         expected_cflags = ["-isystem", "/test/absolute/path"],
     )
 
+def bindir_relative_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = ["-B", "test/relative/path"],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = ["-B", "${pwd}/test/relative/path"],
+    )
+
+def bindir_absolute_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = ["-B", "/test/absolute/path"],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = ["-B", "/test/absolute/path"],
+    )
+
 def fsanitize_ignorelist_relative_test(name):
     cargo_build_script_with_extra_cc_compile_flags(
         name = "%s/cargo_build_script" % name,


### PR DESCRIPTION
With a hermetic gcc toolchain binary dirs (`-B`) may be necessary to invoke the C pre-processor.

I ran into this issue when using the [mongo gcc toolchain](https://github.com/mongodb/mongo/blob/master/bazel/toolchains/cc/mongo_linux/mongo_toolchain.BUILD.tmpl) where the packaging of the toolchain and relative bindir paths cause failures when compiling certain crates (namely `ring`).