### PR TITLE
Tweak recommended script for rust analyzer project discovery

### DIFF
--- a/docs/rust_analyzer.vm
+++ b/docs/rust_analyzer.vm
@@ -139,7 +139,7 @@ is passed through `stderr`) and, additionally, for specifying rule arguments. E.
 bazel \
     run \
     @rules_rust//tools/rust_analyzer:discover_bazel_rust_project -- \
-    --bazel_startup_option=--output_base=~/ide_bazel \
+    --bazel_startup_option=--output_user_root=~/.cache/bazel_ra \
     --bazel_arg=--watchfs \
     ${1:+"$1"} 2>/dev/null
 ```


### PR DESCRIPTION
The previous script set the `output_base`, which is good for keeping the bazel instances isolated but this causes every bazel workspace to use the same directory. Using `output_user_root` instead causes bazel to create a separate directory for every workspace, keeping them isolated.

I have also updated this directory from `~/ide_bazel` to `~/.cache/bazel_ra`, since this puts it in a similar location to the default `output_user_root`, which is `~/.cache/bazel/_bazel_$USER`.