### PR TITLE
Build and upload s390x-unknown-linux-gnu crate_universe binary to releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,9 @@ jobs:
           - os: windows-2022
             env:
               TARGET: "aarch64-pc-windows-msvc"
+          - os: ubuntu-22.04
+            env:
+              TARGET: "s390x-unknown-linux-gnu"
           - os: macOS-13
             env:
               TARGET: "x86_64-apple-darwin"
@@ -216,6 +219,15 @@ jobs:
           upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
           asset_name: cargo-bazel-aarch64-unknown-linux-gnu
           asset_path: ${{ github.workspace }}/crate_universe/target/artifacts/aarch64-unknown-linux-gnu/cargo-bazel
+          asset_content_type: application/octet-stream
+      - name: "Upload s390x-unknown-linux-gnu"
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.rules_rust_release.outputs.upload_url }}
+          asset_name: cargo-bazel-s390x-unknown-linux-gnu
+          asset_path: ${{ github.workspace }}/crate_universe/target/artifacts/s390x-unknown-linux-gnu/cargo-bazel
           asset_content_type: application/octet-stream
       - name: "Upload x86_64-apple-darwin"
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
When building envoy on s390x, I get an error when trying to download the cargo-bazel binary because it is not published to github releases (see example message below).

This PR adds s390x-unknown-linux-gnu to the list of targets to release.

Error message:

```bash
ERROR: /home/jalbrecht/.cache/bazel/_bazel_jalbrecht/6fade89f6c57252e6093cc46d35caeb2/external/rules_rust/crate_universe/private/generate_utils.bzl:60:13: An error occurred during the fetch of repository 'dynamic_modules_rust_sdk_crate_index':
   Traceback (most recent call last):
        File "/home/jalbrecht/.cache/bazel/_bazel_jalbrecht/6fade89f6c57252e6093cc46d35caeb2/external/rules_rust/crate_universe/private/crates_repository.bzl", line 28, column 48, in _crates_repository_impl
                generator, generator_sha256 = get_generator(repository_ctx, host_triple.str)
        File "/home/jalbrecht/.cache/bazel/_bazel_jalbrecht/6fade89f6c57252e6093cc46d35caeb2/external/rules_rust/crate_universe/private/generate_utils.bzl", line 60, column 13, in get_generator
                fail((
Error in fail: No generator URL was found either in the `CARGO_BAZEL_GENERATOR_URL` environment variable or for the `s390x-unknown-linux-gnu` triple in the `generator_urls` attribute
ERROR: Error computing the main repository mapping: no such package '@@dynamic_modules_rust_sdk_crate_index//': No generator URL was found either in the `CARGO_BAZEL_GENERATOR_URL` environment variable or for the `s390x-unknown-linux-gnu` triple in the `generator_urls` attribute
```