### PR TITLE
Cargo Bazel: Expose `path` on `crate.spec()` and split off LocalPath from Path

### DIFF
--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -27,7 +27,8 @@ def _spec(
         git = None,
         branch = None,
         tag = None,
-        rev = None):
+        rev = None,
+        path = None):
     """A constructor for a crate dependency.
 
     See [specifying dependencies][sd] in the Cargo book for more details.
@@ -36,15 +37,16 @@ def _spec(
 
     Args:
         package (str, optional): The explicit name of the package (used when attempting to alias a crate).
-        version (str, optional): The exact version of the crate. Cannot be used with `git`.
+        version (str, optional): The exact version of the crate. Cannot be used with `git` or `path`.
         artifact (str, optional): Set to "bin" to pull in a binary crate as an artifact dependency. Requires a nightly Cargo.
         lib (bool, optional): If using `artifact = "bin"`, additionally setting `lib = True` declares a dependency on both the package's library and binary, as opposed to just the binary.
         default_features (bool, optional): Maps to the `default-features` flag.
         features (list, optional): A list of features to use for the crate
-        git (str, optional): The Git url to use for the crate. Cannot be used with `version`.
+        git (str, optional): The Git url to use for the crate. Cannot be used with `version` or `path`.
         branch (str, optional): The git branch of the remote crate. Tied with the `git` param. Only one of branch, tag or rev may be specified. Specifying `rev` is recommended for fully-reproducible builds.
         tag (str, optional): The git tag of the remote crate. Tied with the `git` param. Only one of branch, tag or rev may be specified. Specifying `rev` is recommended for fully-reproducible builds.
         rev (str, optional): The git revision of the remote crate. Tied with the `git` param. Only one of branch, tag or rev may be specified.
+        path (str, optional): The local path of the remote crate. Cannot be used with `version` or `git`.
 
     Returns:
         string: A json encoded string of all inputs
@@ -59,6 +61,7 @@ def _spec(
             "git": git,
             "lib": lib,
             "package": package,
+            "path": path,
             "rev": rev,
             "tag": tag,
             "version": version,

--- a/crate_universe/src/cli/generate.rs
+++ b/crate_universe/src/cli/generate.rs
@@ -246,12 +246,11 @@ fn write_paths_to_track<
     unused_patches: UnusedPatches,
 ) -> Result<()> {
     let source_annotation_manifests: BTreeSet<_> = source_annotations
-        .filter_map(|v| {
-            if let SourceAnnotation::Path { path } = v {
-                Some(path.join("Cargo.toml"))
-            } else {
-                None
-            }
+        .filter_map(|source_annotation| match source_annotation {
+            SourceAnnotation::Git { .. } => None,
+            SourceAnnotation::Http { .. } => None,
+            SourceAnnotation::Path { path } => Some(path.join("Cargo.toml")),
+            SourceAnnotation::LocalPath { path } => Some(path.join("Cargo.toml")),
         })
         .collect();
     let paths_to_track: BTreeSet<_> = source_annotation_manifests

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -393,7 +393,7 @@ impl CrateContext {
                 target,
                 alias: dep.alias,
                 local_path: match source_annotations.get(&dep.package_id) {
-                    Some(SourceAnnotation::Path { path }) => Some(path.clone()),
+                    Some(SourceAnnotation::LocalPath { path }) => Some(path.clone()),
                     _ => None,
                 },
             }
@@ -494,7 +494,7 @@ impl CrateContext {
                     target: target.crate_name.clone(),
                     alias: None,
                     local_path: match source_annotations.get(&annotation.node.id) {
-                        Some(SourceAnnotation::Path { path }) => Some(path.clone()),
+                        Some(SourceAnnotation::LocalPath { path }) => Some(path.clone()),
                         _ => None,
                     },
                 },
@@ -753,6 +753,9 @@ impl CrateContext {
                         patches.clone_from(&crate_extra.patches);
                     }
                     SourceAnnotation::Path { .. } => {
+                        // We don't support applying patches to local path deps.
+                    }
+                    SourceAnnotation::LocalPath { .. } => {
                         // We don't support applying patches to local path deps.
                     }
                 }

--- a/crate_universe/src/metadata/metadata_annotation.rs
+++ b/crate_universe/src/metadata/metadata_annotation.rs
@@ -164,6 +164,10 @@ pub(crate) enum SourceAnnotation {
         patches: Option<BTreeSet<String>>,
     },
     Path {
+        /// Path to crate's source.
+        path: Utf8PathBuf,
+    },
+    LocalPath {
         /// Local path to crate's source, relative to Bazel workspace root.
         path: Utf8PathBuf,
     },
@@ -265,7 +269,7 @@ impl LockfileAnnotation {
                     if let Some(path_with_suffix) = node.id.repr.strip_prefix("path+file://") {
                         if let Some((path_in_lockfile, _suffix)) = path_with_suffix.rsplit_once('#')
                         {
-                            let path = match Utf8Path::new(path_in_lockfile)
+                            match Utf8Path::new(path_in_lockfile)
                                 .strip_prefix(&metadata.workspace_root)
                             {
                                 Ok(suffix) => {
@@ -301,11 +305,14 @@ impl LockfileAnnotation {
                                         }
                                     }
                                     new_path.push(suffix);
-                                    new_path
+                                    return Ok(SourceAnnotation::LocalPath { path: new_path });
                                 }
-                                Err(_) => Utf8PathBuf::from(path_in_lockfile),
-                            };
-                            return Ok(SourceAnnotation::Path { path });
+                                Err(_) => {
+                                    return Ok(SourceAnnotation::Path {
+                                        path: Utf8PathBuf::from(path_in_lockfile),
+                                    })
+                                }
+                            }
                         }
                     }
                     bail!(

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -361,6 +361,7 @@ impl Renderer {
 
                 let filename = match &context.crates[id].repository {
                     Some(SourceAnnotation::Path { path }) => path.join("BUILD.bazel").into(),
+                    Some(SourceAnnotation::LocalPath { path }) => path.join("BUILD.bazel").into(),
                     _ => Renderer::label_to_path(&label),
                 };
                 let content = self.render_one_build_file(engine, platforms, &context.crates[id])?;

--- a/crate_universe/src/rendering/templates/module_bzl.j2
+++ b/crate_universe/src/rendering/templates/module_bzl.j2
@@ -338,7 +338,7 @@ def crate_repositories():
 {% include "partials/module/repo_http.j2" %}
 {%- elif repository_type in ["Git"] %}
 {% include "partials/module/repo_git.j2" %}
-{%- elif repository_type in ["Path"] %}
+{%- elif repository_type in ["Path", "LocalPath"] %}
 
     local_crate_mirror(
         name = "{{ crate_repository(name = crate.name, version = crate.version) }}",


### PR DESCRIPTION
Exposes `path` on `crate.spec()` (which just works with `cargo metadata` 🎉).

However if the `path` is outside of the Bazel workspace, it attempts to generate dependency paths in the form `//<absolute path>` (which don't exist), so this splits `SourceAnnotation::Path` into `SourceAnnotation::Path` (located somewhere on the file system) and `SourceAnnotation::LocalPath` (located relative to the Bazel workspace).