### PR TITLE
Add riscv64gc-unknown-linux-gnu to tier 2 targets.

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -55,6 +55,7 @@ SUPPORTED_T2_PLATFORM_TRIPLES = {
     "i686-unknown-freebsd": _support(std = True, host_tools = False),
     "powerpc-unknown-linux-gnu": _support(std = True, host_tools = True),
     "riscv32imc-unknown-none-elf": _support(std = True, host_tools = False),
+    "riscv64gc-unknown-linux-gnu": _support(std = True, host_tools = False),
     "riscv64gc-unknown-none-elf": _support(std = True, host_tools = False),
     "s390x-unknown-linux-gnu": _support(std = True, host_tools = True),
     "thumbv7em-none-eabi": _support(std = True, host_tools = False),


### PR DESCRIPTION
Per https://doc.rust-lang.org/rustc/platform-support/riscv64gc-unknown-linux-gnu.html this is now tier 2.

I've verified locally that with this patch I can run a rust test in qemu-riscv64 and have it pass.