### PR TITLE
Add pre-commit in CI and move some check over

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -22,11 +22,6 @@ jobs:
           rm ./buildifier
         env:
           BUILDIFIER_VERSION: 8.2.0
-      - uses: DoozyX/clang-format-lint-action@v0.14
-        with:
-          source: '.'
-          extensions: 'h,c,cc,proto,java,m'
-          clangFormatVersion: 14
       - uses: actionsx/prettier@v2
         with:
           args: --config "${{ github.workspace }}/.prettierrc.toml" --write "**/*.{js,mjs,cjs,jsx,ts,tsx}"
@@ -43,10 +38,7 @@ jobs:
           python-version: 3.11
       - name: Install dependencies
         run: |
-          pip install 'black==24.10.0' 'isort==5.13.2'
-      - name: Run black
+          pip install pre-commit
+      - name: Run pre-commit
         run: |
-          python -m black --check --diff ./
-      - name: Run isort
-        run: |
-          python -m isort --profile=black --check-only ./
+          pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,20 @@ repos:
             tools|
             util
           )
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: [--profile, black]
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    # See supported types: https://github.com/pre-commit/mirrors-clang-format/blob/v14.0.6/.pre-commit-hooks.yaml#L6
+    rev: v14.0.6
+    hooks:
+      - id: clang-format
+        exclude_types:
+          - json
+          - javascript


### PR DESCRIPTION
As promised in #3484, I am adding pre-commit to CI. To better demonstrate what we can gain from this, I also move some formatting checks into pre-commit. This way, users can easily run exactly the same formatters as used in CI.