### PR TITLE
coverage binary override

### DIFF
--- a/util/collect_coverage/collect_coverage.rs
+++ b/util/collect_coverage/collect_coverage.rs
@@ -73,9 +73,7 @@ fn find_test_binary(execroot: &Path, runfiles_dir: &Path) -> PathBuf {
                 path
             });
 
-        let test_binary = execroot
-            .join(configuration)
-            .join(&bin);
+        let test_binary = execroot.join(configuration).join(&bin);
 
         debug_log!(
             "TEST_BINARY is not found in runfiles. Falling back to: {}",


### PR DESCRIPTION
Allow for the binary that the `//util/collect_coverage` to be overridden.

The usecase for this is because i have written a custom extension rule

```
nextest_test = rule(
    doc = """A test rule that runs tests using a custom test runner.

    Args:
        binary: The test binary to run
        crate_name: The name of the crate this test is for
        env: Additional environment variables
        data: Runtime dependencies for the test
        workspace_root: Optional workspace root setting
    """,
    implementation = _nextest_test_impl,
    parent = rust_test,
    attrs = {
        "workspace_root": attr.label(mandatory = False),
        "_profile": attr.label(mandatory = False, default = "//:test_profile"),
        "_test_runner": attr.label(
            default = "//dev-tools/test-runner",
            executable = True,
            cfg = "exec"
        ),
        "_nextest_config": attr.label(
            default = "//:.config/nextest.toml",
            allow_single_file = True
        ),
        "_windows_constraint": attr.label(
            default = "@platforms//os:windows"
        ),
    },
)
```

That extends the `rust_test` rule and then adds a wrapper script to invoke the test via a custom runner. Due to that the `TEST_BINARY` env variable points to the wrapper and not the `rust_test` binary.