### PR TITLE
rust allocator symbols: add new rustc_std_internal_symbol-s

### DIFF
--- a/ffi/rs/allocator_library/allocator_library.rs
+++ b/ffi/rs/allocator_library/allocator_library.rs
@@ -80,7 +80,7 @@ fn __rust_alloc_error_handler(size: usize, align: usize) {
 #[rustc_std_internal_symbol]
 static mut __rust_alloc_error_handler_should_panic: u8 = 1;
 
-// See https://github.com/rust-lang/rust/pull/143434.
+// See  https://github.com/rust-lang/rust/pull/143387.
 #[linkage = "weak"]
 #[rustc_std_internal_symbol]
 fn __rust_alloc_error_handler_should_panic_v2() -> u8 {

--- a/ffi/rs/allocator_library/allocator_library.rs
+++ b/ffi/rs/allocator_library/allocator_library.rs
@@ -80,7 +80,19 @@ fn __rust_alloc_error_handler(size: usize, align: usize) {
 #[rustc_std_internal_symbol]
 static mut __rust_alloc_error_handler_should_panic: u8 = 1;
 
+// See https://github.com/rust-lang/rust/pull/143434.
+#[linkage = "weak"]
+#[rustc_std_internal_symbol]
+fn __rust_alloc_error_handler_should_panic_v2() -> u8 {
+    return 1;
+}
+
 // See https://github.com/rust-lang/rust/issues/73632#issuecomment-1563462239
 #[linkage = "weak"]
 #[rustc_std_internal_symbol]
 static mut __rust_no_alloc_shim_is_unstable: u8 = 0;
+
+// See https://github.com/rust-lang/rust/pull/141061.
+#[linkage = "weak"]
+#[rustc_std_internal_symbol]
+fn __rust_no_alloc_shim_is_unstable_v2() {}

--- a/test/integration/cc_common_link/MODULE.bazel
+++ b/test/integration/cc_common_link/MODULE.bazel
@@ -24,7 +24,7 @@ rust.toolchain(
 # Generate a toolchain to be used for rust-based allocator symbols.
 
 # A recent enough version of rustc that mangles the internal allocator symbols.
-VERSION = "nightly/2025-04-08"
+VERSION = "nightly/2025-07-08"
 
 rust.repository_set(
     name = "rust_with_alloc_mangling_linux_x86_64",


### PR DESCRIPTION
Added a couple of new symbols that new versions of rustc are emitting (https://github.com/bazelbuild/rules_rust/issues/3459). For testing, bumped the test nightly version to a date that includes a compiler that uses them.