### PR TITLE
fix(rust_library): honor the --stamp flag by default

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -732,7 +732,7 @@ _common_attrs = {
         flags = ["DIRECT_COMPILE_TIME_INPUT"],
     ),
     "stamp": _stamp_attribute(
-        default_value = 0,
+        default_value = -1,
     ),
     "version": attr.string(
         doc = "A version to inject in the cargo environment variable.",


### PR DESCRIPTION
Currently users must explicitly set `stamp = -1` on a `rust_library` that relies on a build env file.

https://github.com/bazelbuild/rules_rust/blob/906d1fa6232464b6c704b0d5c431ef8ba5c26010/test/unit/stamp/stamp_test.bzl illustrates this, but in a way that's hard to observe, since it's explicitly setting options everywhere.

I think we're also missing a documentation page explaining how to stamp your rust binaries. Whether or not this PR is accepted, I think we also need to write that (unless I missed it somewhere)