### PR TITLE
Optionally write the rendering lockfile when vendored

### DIFF
--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -449,6 +449,12 @@ def _crates_vendor_impl(ctx):
         args.extend(["--bazel", _expand_env("BAZEL_REAL", is_windows)])
         cargo_bazel_runfiles.append(ctx.executable.bazel)
 
+    # Optionally write the rendering lockfile.
+    if ctx.attr.lockfile:
+        environ.append(_sys_runfile_env(ctx, "BAZEL_LOCK", ctx.file.lockfile, is_windows))
+        args.extend(["--lockfile", _expand_env("BAZEL_LOCK", is_windows)])
+        cargo_bazel_runfiles.extend([ctx.file.lockfile])
+
     # Determine platform specific settings
     if is_windows:
         extension = ".bat"
@@ -535,6 +541,14 @@ CRATES_VENDOR_ATTRS = {
     "generate_target_compatible_with": attr.bool(
         doc = "DEPRECATED: Moved to `render_config`.",
         default = True,
+    ),
+    "lockfile": attr.label(
+        doc = (
+            "The path to a file to write rendering information. It contains the same information as the " +
+            "lockfile attribute of crates_repository. It is not used by crates_vendor but may be useful " +
+            "for code generators like gazelle."
+        ),
+        allow_single_file = True,
     ),
     "manifests": attr.label_list(
         doc = "A list of Cargo manifests (`Cargo.toml` files).",

--- a/crate_universe/src/cli/vendor.rs
+++ b/crate_universe/src/cli/vendor.rs
@@ -210,8 +210,8 @@ pub fn vendor(opt: VendorOptions) -> anyhow::Result<()> {
         .unwrap_or_else(|path| panic!("Temporary directory wasn't valid UTF-8: {:?}", path));
 
     // Generate a splicer for creating a Cargo workspace manifest
-    let splicer =
-        Splicer::new(temp_dir_path, splicing_manifest.clone()).context("Failed to create splicer")?;
+    let splicer = Splicer::new(temp_dir_path, splicing_manifest.clone())
+        .context("Failed to create splicer")?;
 
     let cargo = Cargo::new(opt.cargo, opt.rustc.clone());
 
@@ -318,8 +318,7 @@ pub fn vendor(opt: VendorOptions) -> anyhow::Result<()> {
 
     // Write the rendering lockfile if requested.
     if let Some(lockfile) = opt.lockfile {
-        let lock_content =
-            lock_context(context, &config, &splicing_manifest, &cargo, &opt.rustc)?;
+        let lock_content = lock_context(context, &config, &splicing_manifest, &cargo, &opt.rustc)?;
 
         write_lockfile(lock_content, &lockfile, opt.dry_run)?;
     }

--- a/crate_universe/src/cli/vendor.rs
+++ b/crate_universe/src/cli/vendor.rs
@@ -13,6 +13,7 @@ use clap::Parser;
 
 use crate::config::{Config, VendorMode};
 use crate::context::Context;
+use crate::lockfile::{lock_context, write_lockfile};
 use crate::metadata::CargoUpdateRequest;
 use crate::metadata::TreeResolver;
 use crate::metadata::{Annotations, Cargo, Generator, MetadataGenerator, VendorGenerator};
@@ -43,6 +44,10 @@ pub struct VendorOptions {
     /// A generated manifest of splicing inputs
     #[clap(long)]
     pub splicing_manifest: PathBuf,
+
+    /// The path to write a Bazel lockfile
+    #[clap(long)]
+    pub lockfile: Option<PathBuf>,
 
     /// The path to a [Cargo.lock](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html) file.
     #[clap(long)]
@@ -206,7 +211,7 @@ pub fn vendor(opt: VendorOptions) -> anyhow::Result<()> {
 
     // Generate a splicer for creating a Cargo workspace manifest
     let splicer =
-        Splicer::new(temp_dir_path, splicing_manifest).context("Failed to create splicer")?;
+        Splicer::new(temp_dir_path, splicing_manifest.clone()).context("Failed to create splicer")?;
 
     let cargo = Cargo::new(opt.cargo, opt.rustc.clone());
 
@@ -261,7 +266,7 @@ pub fn vendor(opt: VendorOptions) -> anyhow::Result<()> {
     // Render build files
     let outputs = Renderer::new(
         Arc::new(config.rendering.clone()),
-        Arc::new(config.supported_platform_triples),
+        Arc::new(config.supported_platform_triples.clone()),
     )
     .render(&context, None)?;
 
@@ -280,7 +285,7 @@ pub fn vendor(opt: VendorOptions) -> anyhow::Result<()> {
     }
 
     if matches!(config.rendering.vendor_mode, Some(VendorMode::Local)) {
-        VendorGenerator::new(cargo, opt.rustc.clone())
+        VendorGenerator::new(cargo.clone(), opt.rustc.clone())
             .generate(manifest_path.as_path_buf(), &vendor_dir)
             .context("Failed to vendor dependencies")?;
     }
@@ -309,6 +314,14 @@ pub fn vendor(opt: VendorOptions) -> anyhow::Result<()> {
         if module_bazel.exists() {
             bzlmod_tidy(&opt.bazel, &opt.workspace_dir)?;
         }
+    }
+
+    // Write the rendering lockfile if requested.
+    if let Some(lockfile) = opt.lockfile {
+        let lock_content =
+            lock_context(context, &config, &splicing_manifest, &cargo, &opt.rustc)?;
+
+        write_lockfile(lock_content, &lockfile, opt.dry_run)?;
     }
 
     Ok(())


### PR DESCRIPTION
This lockfile is useful for tools like gazelle because it contains all the information about resolved crates. The regular cargo lockfile does not have enough details about each crate to properly identify dependencies.