### PR TITLE
Add buildifier hook

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -14,14 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Buildifier
-        run: |
-          wget "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDIFIER_VERSION}/buildifier-linux-amd64" -O buildifier
-          chmod +x ./buildifier
-          ./buildifier -lint=warn -mode=check -warnings=all -r ${{ github.workspace }}
-          rm ./buildifier
-        env:
-          BUILDIFIER_VERSION: 8.2.0
       - uses: actionsx/prettier@v2
         with:
           args: --config "${{ github.workspace }}/.prettierrc.toml" --write "**/*.{js,mjs,cjs,jsx,ts,tsx}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,13 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  - repo: https://github.com/Warchant/pre-commit-buildifier
+    rev: 0.1.5
+    hooks:
+      - id: buildifier
+        args: [--version, "v8.2.0"]
+      - id: buildifier-lint
+        args: [--version, "v8.2.0", --warnings=all]
   - repo: https://github.com/crate-ci/typos
     rev: v1.33.1
     hooks:

--- a/examples/all_deps_vendor/WORKSPACE.bzlmod
+++ b/examples/all_deps_vendor/WORKSPACE.bzlmod
@@ -4,7 +4,7 @@
 # https://bazel.build/external/migration#hybrid-mode
 ###############################################################################
 # rule http_archive
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")  # buildifier: disable=load
 load("//:sys_deps.bzl", "sys_deps")
+
 sys_deps()

--- a/examples/ffi/WORKSPACE.bzlmod
+++ b/examples/ffi/WORKSPACE.bzlmod
@@ -10,6 +10,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # https://github.com/bazelbuild/rules_cc/releases
 http_archive(
     name = "rules_cc",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.10-rc1/rules_cc-0.0.10-rc1.tar.gz"],
     sha256 = "d75a040c32954da0d308d3f2ea2ba735490f49b3a7aa3e4b40259ca4b814f825",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.10-rc1/rules_cc-0.0.10-rc1.tar.gz"],
 )


### PR DESCRIPTION
Replace the buildifier CI call with the pre-commit hook. Now developers can run exactly the same formatting and linting as we use in CI