### PR TITLE
Use pre-commit github action

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -32,13 +32,4 @@ jobs:
           if [[ -n "$(git status --porcelain)" ]]; then
             exit 1
           fi
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.11
-      - name: Install dependencies
-        run: |
-          pip install pre-commit
-      - name: Run pre-commit
-        run: |
-          pre-commit run --all-files
+      - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
This simplifies the CI setup and applies the right options by default, e.g. running on all files or showing a nice failure diff to users