### PR TITLE
Support crate_features in rust_doc() and rust_doc_test()

### DIFF
--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -321,6 +321,11 @@ rust_doc = rule(
             providers = [rust_common.crate_info],
             mandatory = True,
         ),
+        "crate_features": attr.string_list(
+            doc = dedent("""\
+                List of features to enable for the crate being documented.
+            """),
+        ),
         "html_after_content": attr.label(
             doc = "File to add in `<body>`, after content.",
             allow_single_file = [".html", ".md"],

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -200,6 +200,11 @@ rust_doc_test = rule(
             providers = [rust_common.crate_info],
             mandatory = True,
         ),
+        "crate_features": attr.string_list(
+            doc = dedent("""\
+                List of features to enable for the crate being documented.
+            """),
+        ),
         "deps": attr.label_list(
             doc = dedent("""\
                 List of other libraries to be linked to this library target.


### PR DESCRIPTION
These attributes are already handled by construct_arguments() in rustdoc_compile_action(), this just tells Bazel that they are valid parameters in the top-level rules.