### PR TITLE
Fix document for crate_univere

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -81,7 +81,7 @@ they return will automatically update BUILD targets. In your BUILD files,
 you use these macros for a Rust library as shown below:
 
 ```python
-load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
+load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 rust_library(


### PR DESCRIPTION
It's `use_repo(crate, "crates")` for `bzlmod`
There's no `crate_index`

