### PR TITLE
Fix typos in nix and test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: buildifier-lint
         args: [--version, "v8.2.0", --warnings=all]
   - repo: https://github.com/crate-ci/typos
-    rev: v1.34.0
+    rev: v1.35.3
     hooks:
       - id: typos
         exclude: |
@@ -21,9 +21,7 @@ repos:
             examples|
             extensions|
             ffi|
-            nix|
             rust|
-            test|
             tools|
             util
           )

--- a/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -53,7 +53,7 @@ test_cc_config = rule(
     provides = [CcToolchainConfigInfo],
 )
 
-def _with_extra_toolchains_transition_impl(_setings, attr):
+def _with_extra_toolchains_transition_impl(_settings, attr):
     return {"//command_line_option:extra_toolchains": attr.extra_toolchains}
 
 with_extra_toolchains_transition = transition(

--- a/test/cargo_build_script/foreign_toolchain_make_variables/toolchain.bzl
+++ b/test/cargo_build_script/foreign_toolchain_make_variables/toolchain.bzl
@@ -1,4 +1,4 @@
-"""Utilties for testing forwarding Make variables from toolchains."""
+"""Utilities for testing forwarding Make variables from toolchains."""
 
 def _dummy_env_var_toolchain_impl(_ctx):
     make_variables = platform_common.TemplateVariableInfo({

--- a/test/current_toolchain_files/BUILD.bazel
+++ b/test/current_toolchain_files/BUILD.bazel
@@ -23,7 +23,7 @@ _FILES = {
         name = tool + "_test",
         kind = kind,
         pattern = pattern,
-        # TOOO: Windows requires use of bash which is not guaranteed to be available.
+        # TODO: Windows requires use of bash which is not guaranteed to be available.
         # The test runner should ideally be rewritten in rust so that windows could
         # be tested.
         target_compatible_with = select({

--- a/test/process_wrapper/process_wrapper_tester.cc
+++ b/test/process_wrapper/process_wrapper_tester.cc
@@ -158,7 +158,7 @@ void test_stderr() { std::cerr << "This is the stderr output"; }
 
 int main(int argc, const char* argv[], const char* envp[]) {
     if (argc < 4) {
-        std::cerr << "error: Invalid number of args exected at least 4 got "
+        std::cerr << "error: Invalid number of args expected at least 4 got "
                   << argc << ".\n";
         return 1;
     }

--- a/test/process_wrapper_bootstrap/bootstrap_process_wrapper_test.rs
+++ b/test/process_wrapper_bootstrap/bootstrap_process_wrapper_test.rs
@@ -1,4 +1,4 @@
-//! Tests for the boostrap process wrapper
+//! Tests for the bootstrap process wrapper
 
 use std::fs::read_to_string;
 

--- a/test/rust_analyzer/generated_srcs_test/lib.rs
+++ b/test/rust_analyzer/generated_srcs_test/lib.rs
@@ -3,7 +3,7 @@ pub mod generated;
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_fourty_two() {
+    fn test_forty_two() {
         assert_eq!(super::generated::forty_two(), 42);
     }
 }

--- a/test/unit/exports/exports_test.bzl
+++ b/test/unit/exports/exports_test.bzl
@@ -11,7 +11,7 @@ def _exports_test_impl(ctx, dependencies, externs):
     asserts.equals(env, action.mnemonic, "Rustc")
 
     # Transitive symbols that get re-exported are expected to be located by a `-Ldependency` flag.
-    # The assert below ensures that each dependnecy flag is passed to the Rustc action. For details see
+    # The assert below ensures that each dependency flag is passed to the Rustc action. For details see
     # https://doc.rust-lang.org/rustc/command-line-arguments.html#-l-add-a-directory-to-the-library-search-path
     for dep in dependencies:
         assert_argv_contains_prefix_suffix(

--- a/test/unit/toolchain/toolchain_test.bzl
+++ b/test/unit/toolchain/toolchain_test.bzl
@@ -25,7 +25,7 @@ def _toolchain_specifies_target_json_test_impl(ctx):
     asserts.equals(env, None, toolchain_info.target_triple)
     asserts.equals(env, "x86_64", toolchain_info.target_arch)
 
-    # The specific name here is not as vaulable as identifying that `target_json` is a json file
+    # The specific name here is not as valuable as identifying that `target_json` is a json file
     expected_basename = "{}.target.json".format(target.label.name)
     asserts.equals(env, expected_basename, toolchain_info.target_json.basename)
 


### PR DESCRIPTION
Next cycle of typo fixes in test folder. Removing nix from the exclude as well since it did not had any typos