### PR TITLE
Use default env on rustc compile actions to allow bash scripts for linker

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1383,6 +1383,7 @@ def rustc_compile_action(
             inputs = compile_inputs,
             outputs = action_outputs,
             env = env,
+            use_default_shell_env = True,
             arguments = args.all,
             mnemonic = "Rustc",
             progress_message = "Compiling Rust {} {}{} ({} files)".format(
@@ -1400,6 +1401,7 @@ def rustc_compile_action(
                 inputs = compile_inputs,
                 outputs = [build_metadata] + [x for x in [rustc_rmeta_output] if x],
                 env = env,
+                use_default_shell_env = True,
                 arguments = args_metadata.all,
                 mnemonic = "RustcMetadata",
                 progress_message = "Compiling Rust metadata {} {}{} ({} files)".format(
@@ -1419,6 +1421,7 @@ def rustc_compile_action(
             inputs = compile_inputs,
             outputs = action_outputs,
             env = env,
+            use_default_shell_env = True,
             arguments = [args.rustc_path, args.rustc_flags],
             mnemonic = "Rustc",
             progress_message = "Compiling Rust (without process_wrapper) {} {}{} ({} files)".format(


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_rust/issues/3482 for context.

I accept that this may not be merged as-is, as using `use_default_shell_env` opens the sandbox to other env vars affecting caching etc. However, getting `PATH` into the sandbox another way requires a bit more discussion, which I hope we can have here and I can amend PR.

Possible alternatives:
- The default env coming from `ctx.configuration.default_shell_env` is empty, so that's no use
- The upstream rules_cc could set the appropriate env var on the toolchain, which is then inherited by `cc_common.get_environment_variables()` for the linker
- Revert https://github.com/bazelbuild/rules_cc/commit/d74915024017250e46d95e91a3defc34174effe0 and address the path search in the 'Bazel' way that doesn't require PATH i.e use `repository_ctx.which(bash)` to embed the correct absolute path to bash into cc_wrapper.sh, then no changes are required here potentially