### PR TITLE
Flip default for `incompatible_change_clippy_error_format` to true.

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -398,14 +398,14 @@ _RUST_TOOLCHAIN_REPOSITORY_ATTRS = {
     "opt_level": attr.string_dict(
         doc = "Rustc optimization levels. For more details see the documentation for `rust_toolchain.opt_level`.",
     ),
-    "strip_level": attr.string_dict(
-        doc = "Rustc strip levels. For more details see the documentation for `rust_toolchain.strip_level`.",
-    ),
     "rustfmt_version": attr.string(
         doc = "The version of the tool among \"nightly\", \"beta\", or an exact version.",
     ),
     "sha256s": attr.string_dict(
         doc = "A dict associating tool subdirectories to sha256 hashes. See [rust_register_toolchains](#rust_register_toolchains) for more details.",
+    ),
+    "strip_level": attr.string_dict(
+        doc = "Rustc strip levels. For more details see the documentation for `rust_toolchain.strip_level`.",
     ),
     "target_triple": attr.string(
         doc = "The Rust-style target that this compiler builds for.",

--- a/rust/settings/settings.bzl
+++ b/rust/settings/settings.bzl
@@ -321,7 +321,7 @@ def incompatible_change_clippy_error_format():
     """
     incompatible_flag(
         name = "incompatible_change_clippy_error_format",
-        build_setting_default = False,
+        build_setting_default = True,
         issue = "https://github.com/bazelbuild/rules_rust/issues/3494",
     )
 


### PR DESCRIPTION
In accordance with the process described [here](https://github.com/bazelbuild/rules_rust/blob/main/COMPATIBILITY.md#compatibility-before-10), I will let at least another two weeks pass before removing the setting
entirely.
