### PR TITLE
Fix typos in rust tools and util

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,19 +12,17 @@ repos:
       - id: buildifier-lint
         args: [--version, "v8.2.0", --warnings=all]
   - repo: https://github.com/crate-ci/typos
-    rev: v1.35.3
+    rev: v1.35.5
     hooks:
       - id: typos
         exclude: |
           (?x)^(
             crate_universe/test_data|
             examples|
-            extensions|
-            ffi|
-            rust|
-            tools|
-            util
+            extensions
           )
+        exclude_types:
+          - diff
   - repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -282,7 +282,7 @@ _SYSTEM_TO_STDLIB_LINKFLAGS = {
 }
 
 def cpu_arch_to_constraints(cpu_arch, *, system = None):
-    """Returns a list of contraint values which represents a triple's CPU.
+    """Returns a list of constraint values which represents a triple's CPU.
 
     Args:
         cpu_arch (str): The architecture to match constraints for

--- a/rust/private/common.bzl
+++ b/rust/private/common.bzl
@@ -42,7 +42,7 @@ def _create_crate_info(**kwargs):
     provider to improve API stability.
 
     Args:
-        **kwargs: An inital set of keyword arguments.
+        **kwargs: An initial set of keyword arguments.
 
     Returns:
         CrateInfo: A provider

--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -76,7 +76,7 @@ BuildInfo = provider(
     doc = "A provider containing `rustc` build settings for a given Crate.",
     fields = {
         "compile_data": "Depset[File]: Compile data provided by the build script that was not copied into `out_dir`.",
-        "dep_env": "Optinal[File]: extra build script environment varibles to be set to direct dependencies.",
+        "dep_env": "Optional[File]: extra build script environment variables to be set to direct dependencies.",
         "flags": "Optional[File]: file containing additional flags to pass to rustc",
         "link_search_paths": "Optional[File]: file containing search paths to pass to rustc and linker",
         "linker_flags": "Optional[File]: file containing flags to pass to the linker invoked by rustc or cc_common.link",

--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -303,7 +303,7 @@ def BUILD_for_rust_toolchain(
         default_edition (str): Default Rust edition.
         include_rustfmt (bool): Whether rustfmt is present in the toolchain.
         include_llvm_tools (bool): Whether llvm-tools are present in the toolchain.
-        stdlib_linkflags (list, optional): Overriden flags needed for linking to rust
+        stdlib_linkflags (list, optional): Overridden flags needed for linking to rust
                                            stdlib, akin to BAZEL_LINKLIBS. Defaults to
                                            None.
         extra_rustc_flags (list, optional): Extra flags to pass to rustc in non-exec configuration.
@@ -812,7 +812,7 @@ def load_arbitrary_tool(
         is_reproducible = bool(ctx_sha256)
 
     for subdirectory in tool_subdirectories:
-        # As long as the sha256 value is consistent accross calls here the
+        # As long as the sha256 value is consistent across calls here the
         # cost of downloading an artifact is negated as by Bazel's caching.
         result = ctx.download_and_extract(
             urls,
@@ -882,7 +882,7 @@ def _get_tool_extension(urls = None):
         return ""
 
 def select_rust_version(versions):
-    """Select the highest priorty version for a list of Rust versions
+    """Select the highest priority version for a list of Rust versions
 
     Priority order: `stable > nightly > beta`
 

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -84,7 +84,7 @@ def _rust_library_impl(ctx):
 
     This rule provides CcInfo, so it can be used everywhere Bazel
     expects rules_cc, but care must be taken to have the correct
-    dependencies on an allocator and std implemetation as needed.
+    dependencies on an allocator and std implementation as needed.
 
     Args:
         ctx (ctx): The rule's context object
@@ -1563,7 +1563,7 @@ def rust_test_suite(name, srcs, shared_srcs = [], **kwargs):
         name (str): The name of the `test_suite`.
         srcs (list): All test sources, typically `glob(["tests/**/*.rs"])`.
         shared_srcs (list): Optional argument for sources shared among tests, typically helper functions.
-        **kwargs (dict): Additional keyword arguments for the underyling [rust_test](#rust_test) targets. The
+        **kwargs (dict): Additional keyword arguments for the underlying [rust_test](#rust_test) targets. The
             `tags` argument is also passed to the generated `test_suite` target.
     """
     tests = []

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1718,7 +1718,7 @@ def _add_lto_flags(ctx, toolchain, args, crate):
     args.add_all(lto_args)
 
 def _add_codegen_units_flags(toolchain, emit, args):
-    """Adds flags to an Args object to configure codgen_units for 'rustc'.
+    """Adds flags to an Args object to configure codegen_units for 'rustc'.
 
     https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
 
@@ -1983,7 +1983,7 @@ def add_crate_link_flags(args, dep_info, force_all_deps_direct = False, use_meta
         dep_info (DepInfo): The current target's dependency info
         force_all_deps_direct (bool, optional): Whether to pass the transitive rlibs with --extern
             to the commandline as opposed to -L.
-        use_metadata (bool, optional): Build command line arugments using metadata for crates that provide it.
+        use_metadata (bool, optional): Build command line arguments using metadata for crates that provide it.
     """
 
     direct_crates = depset(
@@ -2083,7 +2083,7 @@ def _portable_link_flags(lib, use_pic, ambiguous_libs, get_lib_name, for_windows
         # On linux, Rustc adds a -Bdynamic to the linker command line before the libraries specified
         # with `-Clink-arg`, which leads to us linking against the `.so`s but not putting the
         # corresponding value to the runtime library search paths, which results in a
-        # "cannot open shared object file: No such file or directory" error at exectuion time.
+        # "cannot open shared object file: No such file or directory" error at execution time.
         # We can fix this by adding a `-Clink-arg=-Bstatic` on linux, but we don't have that option for
         # macos. The proper solution for this issue would be to remove `libtest-{hash}.so` and `libstd-{hash}.so`
         # from the toolchain. However, it is not enough to change the toolchain's `rust_std_{...}` filegroups

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -152,7 +152,7 @@ def rustdoc_compile_action(
     )
 
     # Because rustdoc tests compile tests outside of the sandbox, the sysroot
-    # must be updated to the `short_path` equivilant as it will now be
+    # must be updated to the `short_path` equivalent as it will now be
     # a part of runfiles.
     if is_test:
         if "SYSROOT" in env:

--- a/rust/private/rustdoc/rustdoc_test_writer.rs
+++ b/rust/private/rustdoc/rustdoc_test_writer.rs
@@ -175,7 +175,7 @@ fn write_test_runner_unix(
         "#!/usr/bin/env bash".to_owned(),
         "".to_owned(),
         // TODO: Instead of creating a symlink to mimic the behavior of
-        // --legacy_external_runfiles, this rule should be able to correcrtly
+        // --legacy_external_runfiles, this rule should be able to correctly
         // sanitize the action args to run in a runfiles without this link.
         "if [[ ! -e 'external' ]]; then ln -s ../ external ; fi".to_owned(),
         "".to_owned(),
@@ -234,7 +234,7 @@ fn write_test_runner_windows(
         "@ECHO OFF".to_owned(),
         "".to_owned(),
         // TODO: Instead of creating a symlink to mimic the behavior of
-        // --legacy_external_runfiles, this rule should be able to correcrtly
+        // --legacy_external_runfiles, this rule should be able to correctly
         // sanitize the action args to run in a runfiles without this link.
         "powershell.exe -c \"if (!(Test-Path .\\external)) { New-Item -Path .\\external -ItemType SymbolicLink -Value ..\\ }\""
             .to_owned(),

--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -468,7 +468,7 @@ def _rust_toolchain_tools_repository_impl(ctx):
             if iso_date:
                 rustfmt_iso_date = iso_date
             else:
-                fail("`rustfmt_version` does not include an iso_date. The following reposiotry should either set `iso_date` or update `rustfmt_version` to include an iso_date suffix: {}".format(
+                fail("`rustfmt_version` does not include an iso_date. The following repository should either set `iso_date` or update `rustfmt_version` to include an iso_date suffix: {}".format(
                     ctx.name,
                 ))
         elif rustfmt_version.startswith(("nightly", "beta")):
@@ -819,7 +819,7 @@ def rust_analyzer_toolchain_repository(
     """Assemble a remote rust_analyzer_toolchain target based on the given params.
 
     Args:
-        name (str): The name of the toolchain proxy repository contianing the registerable toolchain.
+        name (str): The name of the toolchain proxy repository containing the registerable toolchain.
         version (str): The version of the tool among "nightly", "beta', or an exact version.
         exec_compatible_with (list, optional): A list of constraints for the execution platform for this toolchain.
         target_compatible_with (list, optional): A list of constraints for the target platform for this toolchain.
@@ -963,7 +963,7 @@ def rustfmt_toolchain_repository(
     """Assemble a remote rustfmt_toolchain target based on the given params.
 
     Args:
-        name (str): The name of the toolchain proxy repository contianing the registerable toolchain.
+        name (str): The name of the toolchain proxy repository containing the registerable toolchain.
         version (str): The version of the tool among "nightly", "beta', or an exact version.
         exec_triple (str): The platform triple Rustfmt is expected to run on.
         exec_compatible_with (list, optional): A list of constraints for the execution platform for this toolchain.
@@ -1058,7 +1058,7 @@ def _get_toolchain_repositories(
             - name: The name of the toolchain repository.
             - target_triple: The target triple of the toolchain.
             - channel: The toolchain channel (nightly/stable).
-            - target_constraints: Bazel constrants assicated with the toolchain.
+            - target_constraints: Bazel constraints associated with the toolchain.
     """
     extra_target_triples_list = extra_target_triples.keys() if type(extra_target_triples) == "dict" else extra_target_triples
 
@@ -1146,7 +1146,7 @@ def rust_repository_set(
 
     Args:
         name (str): The name of the generated repository
-        versions (list, optional): A list of toolchain versions to download. This paramter only accepts one versions
+        versions (list, optional): A list of toolchain versions to download. This parameter only accepts one versions
             per channel. E.g. `["1.65.0", "nightly/2022-11-02", "beta/2020-12-30"]`.
         exec_triple (str): The Rust-style target that this compiler runs on
         target_settings (list of labels as strings, optional): A list of config_settings that must be satisfied by the target configuration in order for this set of toolchains to be selected during toolchain resolution.
@@ -1163,7 +1163,7 @@ def rust_repository_set(
             Requires version to be "nightly".
         extra_rustc_flags (dict, list, optional): Dictionary of target triples to list of extra flags to pass to rustc in non-exec configuration.
         extra_exec_rustc_flags (list, optional): Extra flags to pass to rustc in exec configuration.
-        opt_level (dict, dict, optional): Dictionary of target triples to optimiztion config.
+        opt_level (dict, dict, optional): Dictionary of target triples to optimization config.
         strip_level (dict, dict, optional): Dictionary of target triples to strip config.
         sha256s (str, optional): A dict associating tool subdirectories to sha256 hashes. See
             [rust_register_toolchains](#rust_register_toolchains) for more details.
@@ -1182,7 +1182,7 @@ def rust_repository_set(
             toolchains. This is to avoid MAX_PATH issues.
 
     Returns:
-        dict[str, dict]: A dict of informations about all generated toolchains.
+        dict[str, dict]: A dict of information about all generated toolchains.
     """
 
     all_toolchain_details = {}

--- a/rust/runfiles/runfiles.rs
+++ b/rust/runfiles/runfiles.rs
@@ -352,7 +352,7 @@ mod test {
     /// A mutex used to guard
     static GLOBAL_MUTEX: OnceLock<Mutex<i32>> = OnceLock::new();
 
-    /// Mock out environment variables for a given body fo work. Very similar to
+    /// Mock out environment variables for a given body to work. Very similar to
     /// [temp-env](https://crates.io/crates/temp-env).
     fn with_mock_env<K, V, F, R>(kvs: impl AsRef<[(K, Option<V>)]>, closure: F) -> R
     where

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -984,7 +984,7 @@ rust_toolchain = rule(
         "_toolchain_generated_sysroot": attr.label(
             default = Label("//rust/settings:toolchain_generated_sysroot"),
             doc = (
-                "Label to a boolean build setting that lets the rule knows wheter to set --sysroot to rustc. " +
+                "Label to a boolean build setting that lets the rule knows whether to set --sysroot to rustc. " +
                 "This flag is only relevant when used together with --@rules_rust//rust/settings:toolchain_generated_sysroot."
             ),
         ),

--- a/tools/rustfmt/src/bin/test_main.rs
+++ b/tools/rustfmt/src/bin/test_main.rs
@@ -12,7 +12,7 @@ fn main() {
 /// Run rustfmt on a set of Bazel targets
 fn run_rustfmt(options: &Config) {
     // In order to ensure the test parses all sources, we separately
-    // track whether or not a failure has occured when checking formatting.
+    // track whether or not a failure has occurred when checking formatting.
     let mut is_failure: bool = false;
 
     for manifest in options.manifests.iter() {

--- a/util/fetch_shas/fetch_shas.py
+++ b/util/fetch_shas/fetch_shas.py
@@ -107,7 +107,7 @@ def download_direct_sha256s(
 
     This function is mostly here for backward compatibility. There are artifacts
     referenced by the `channel-rust-*.toml` files which are marked as `available: false`
-    and probably intented to not be downloaded. But for now this is ignored and instead
+    and probably intended to not be downloaded. But for now this is ignored and instead
     a collection of artifacts whose hash data could not be found is explicitly checked
     by trying to download the `.sha256` files directly. A 404 indicates the artifact
     genuinely does not exist and anything else we find is extra data we can retain

--- a/util/process_wrapper/rustc.rs
+++ b/util/process_wrapper/rustc.rs
@@ -65,7 +65,7 @@ impl TryFrom<JsonValue> for RustcMessage {
 /// --error-format=json, parses the json and returns the appropriate output
 /// according to the original --error-format supplied.
 /// Only messages are returned, emits are ignored.
-/// Retuns an errors if parsing json fails.
+/// Returns an errors if parsing json fails.
 pub(crate) fn process_json(line: String, error_format: ErrorFormat) -> LineResult {
     let parsed: JsonValue = line
         .parse()
@@ -83,7 +83,7 @@ pub(crate) fn process_json(line: String, error_format: ErrorFormat) -> LineResul
 /// is emitted so the compiler can be terminated.
 /// This is used to implement pipelining in rules_rust, please see
 /// https://internals.rust-lang.org/t/evaluating-pipelined-rustc-compilation/10199
-/// Retuns an error if parsing json fails.
+/// Returns an error if parsing json fails.
 /// TODO: pass a function to handle the emit event and merge with process_json
 pub(crate) fn stop_on_rmeta_completion(
     line: String,


### PR DESCRIPTION
Fix more typos, bump the typos hook to the latest version available, and exclude `diff` types (we don't want to change patches).