### PR TITLE
Include transitive out_dirs in linking action

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1891,6 +1891,7 @@ def _create_extra_input_args(build_info, dep_info, include_link_flags = True):
     build_env_file = None
     build_flags_files = []
 
+    # We include the direct dep build_info because crates which use cargo build scripts may need to e.g. include_str! a generated file.
     if build_info:
         if build_info.out_dir:
             out_dir = build_info.out_dir.path
@@ -1903,6 +1904,11 @@ def _create_extra_input_args(build_info, dep_info, include_link_flags = True):
             input_files.append(build_info.linker_flags)
 
         input_depsets.append(build_info.compile_data)
+
+    # We include transitive dep build_infos because cargo build scripts may generate files which get linked into the final binary.
+    # This should probably only actually be exposed to actions which link.
+    for dep_build_info in dep_info.transitive_build_infos.to_list():
+        input_files.append(dep_build_info.out_dir)
 
     out_dir_compile_inputs = depset(
         input_files,

--- a/test/unit/common.bzl
+++ b/test/unit/common.bzl
@@ -70,6 +70,24 @@ def _startswith(list, prefix):
             return False
     return True
 
+def assert_list_contains(env, list, expected_element):
+    """Assert that list contains the expected element.
+
+    Args:
+          env: env from analysistest.begin(ctx).
+          list: list supposed to contain expected_element.
+          expected_element: element to be found inside list.
+    """
+    if expected_element in list:
+        return
+    unittest.fail(
+        env,
+        "Expected the to find '{expected_element}' within '{list}'".format(
+            expected_element = expected_element,
+            list = list,
+        ),
+    )
+
 def assert_list_contains_adjacent_elements(env, list_under_test, adjacent_elements):
     """Assert that list_under_test contains given adjacent flags.
 

--- a/test/unit/transitive_link_search_paths/bin.rs
+++ b/test/unit/transitive_link_search_paths/bin.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("dummy file");
+}


### PR DESCRIPTION
If a build script compiles a file which is needed at linking time, and adds a linker flag to add it to the search path, we need the out_dir to be present in the link action in order for the search path flag to actually take effect.

This was the original behaviour way back in
3a569b8590aed8a2166aec269aaf83c195bdd373 but got removed in 9426a3820093e75ea07d14f875e42f789632507f which was intending to only restrict where flags were propagated but also stopped propagating out_dir files.

This is required because cargo uses the path to the out_dir as a well-known-path that doesn't move between builds, so link flags from a build script which get transitively propagated up to a link action happen to point at the right location on disk. We need to propagate this out_dir because the known location on disk is probably in a sandbox, so we need to explicitly materialise the files into the sandbox.