### PR TITLE
Fix typos in examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,7 @@ repos:
       - id: typos
         exclude: |
           (?x)^(
-            crate_universe/test_data|
-            examples
+            crate_universe/test_data
           )
         exclude_types:
           - diff

--- a/examples/all_crate_deps/.bazelrc
+++ b/examples/all_crate_deps/.bazelrc
@@ -1,4 +1,4 @@
-# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+# This isn't currently the default in Bazel, but we enable it to test we'll be ready if/when it flips.
 build --incompatible_disallow_empty_glob
 
 # Required for cargo_build_script support before Bazel 7

--- a/examples/all_deps_vendor/README.md
+++ b/examples/all_deps_vendor/README.md
@@ -12,7 +12,7 @@ And the build target:
 ## Setup
 
 For the setup,
-you need to add the skylib in addition to the rust rules to your MODUE.bazel.
+you need to add the skylib in addition to the rust rules to your MODULE.bazel.
 
 ```starlark
 module(
@@ -120,7 +120,7 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 rust_binary(
     name = "hello_sys",
     srcs = ["src/main.rs"],
-    # Note the `crate_unvierse` dependencies here need to have been loaded
+    # Note the `crate_universe` dependencies here need to have been loaded
     # in the WORKSPACE file. See `//:sys_deps.bzl` for more details.
     deps = ["//basic/3rdparty/crates:bzip2"],
     visibility = ["//visibility:public"],

--- a/examples/all_deps_vendor/basic/BUILD.bazel
+++ b/examples/all_deps_vendor/basic/BUILD.bazel
@@ -4,7 +4,7 @@ rust_binary(
     name = "hello_sys",
     srcs = ["src/main.rs"],
     visibility = ["//visibility:public"],
-    # Note the `crate_unvierse` dependencies here need to have been loaded
+    # Note the `crate_universe` dependencies here need to have been loaded
     # in the WORKSPACE file. See `//:sys_deps.bzl` for more details.
     deps = ["//basic/3rdparty/crates:bzip2"],
 )

--- a/examples/compile_opt/.bazelrc
+++ b/examples/compile_opt/.bazelrc
@@ -1,4 +1,4 @@
-# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+# This isn't currently the default in Bazel, but we enable it to test we'll be ready if/when it flips.
 build --incompatible_disallow_empty_glob
 
 # Required for cargo_build_script support before Bazel 7

--- a/examples/crate_universe_local_path/WORKSPACE.bazel
+++ b/examples/crate_universe_local_path/WORKSPACE.bazel
@@ -21,7 +21,7 @@ crates_repository(
     name = "crates_from_cargo_workspace",
     cargo_lockfile = "//crates_from_workspace:Cargo.lock",
     # `generator` is not necessary in official releases.
-    # See load satement for `cargo_bazel_bootstrap`.
+    # See load statement for `cargo_bazel_bootstrap`.
     generator = "@cargo_bazel_bootstrap//:cargo-bazel",
     manifests = ["//crates_from_workspace:Cargo.toml"],
 )

--- a/examples/nix_cross_compiling/.bazelrc
+++ b/examples/nix_cross_compiling/.bazelrc
@@ -27,7 +27,7 @@ build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build --incompatible_enable_cc_toolchain_resolution=true
 
 # Require Platform Transitions
-## This works by setting the targte platform to an invalid platform
+## This works by setting the target platform to an invalid platform
 ## and each `x_binary()` and `x_library()` rule unfortunately needs
 ## to tag itself with `platform_missing` to get excluded from glob
 ## builds like `build //...` but still have a way to include them

--- a/examples/override_target/.bazelrc
+++ b/examples/override_target/.bazelrc
@@ -1,4 +1,4 @@
-# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+# This isn't currently the default in Bazel, but we enable it to test we'll be ready if/when it flips.
 build --incompatible_disallow_empty_glob
 
 # Required for cargo_build_script support before Bazel 7

--- a/examples/sys/basic/BUILD.bazel
+++ b/examples/sys/basic/BUILD.bazel
@@ -20,7 +20,7 @@ rust_binary(
     name = "hello_sys",
     srcs = ["src/main.rs"],
     edition = "2018",
-    # Note the `crate_unvierse` dependencies here need to have been loaded
+    # Note the `crate_universe` dependencies here need to have been loaded
     # in the `MODULE.bazel` file.
     deps = ["//basic/3rdparty/crates:bzip2"],
 )

--- a/examples/zig_cross_compiling/.bazelrc
+++ b/examples/zig_cross_compiling/.bazelrc
@@ -1,4 +1,4 @@
 build --incompatible_enable_cc_toolchain_resolution
 
-# This isn't currently the defaut in Bazel, but we enable it to test we'll be ready if/when it flips.
+# This isn't currently the default in Bazel, but we enable it to test we'll be ready if/when it flips.
 build --incompatible_disallow_empty_glob

--- a/examples/zig_cross_compiling/WORKSPACE.bazel
+++ b/examples/zig_cross_compiling/WORKSPACE.bazel
@@ -60,7 +60,7 @@ crates_repository(
     name = "crate_index",
     cargo_lockfile = "//:Cargo.lock",
     # `generator` is not necessary in official releases.
-    # See load satement for `cargo_bazel_bootstrap`.
+    # See load statement for `cargo_bazel_bootstrap`.
     generator = "@cargo_bazel_bootstrap//:cargo-bazel",
     lockfile = "//:cargo-bazel-lock.json",
     packages = {


### PR DESCRIPTION
Last PR to fix all typos (know to the tool) in rules_rust