### PR TITLE
Resolve mismatched_lifetime_syntaxes warning in cargo-bazel

### DIFF
--- a/crate_universe/src/splicing/splicer.rs
+++ b/crate_universe/src/splicing/splicer.rs
@@ -480,7 +480,7 @@ impl Splicer {
         SplicerKind::new(&self.manifests, &self.splicing_manifest)?.splice(&self.workspace_dir)
     }
 
-    pub(crate) fn prepare(&self) -> Result<SplicerKind> {
+    pub(crate) fn prepare(&self) -> Result<SplicerKind<'_>> {
         SplicerKind::new(&self.manifests, &self.splicing_manifest)
     }
 }


### PR DESCRIPTION
This fixes a warning when using `crates_vendor` from `@rules_rust//crate_universe:defs.bzl` inside a workspace that uses a Rust toolchain 1.89.0 or newer. Specifically I hit this in https://github.com/dtolnay/cxx/tree/ebb3d0954eee94ce9a8189cbcc508b37108a2aee.

```console
dtolnay:cxx$  bazel run //third-party:vendor
INFO: Analyzed target //third-party:vendor (390 packages loaded, 14191 targets configured).
INFO: From Compiling Rust rlib cargo_bazel v0.17.0 (40 files) [for tool]:
warning: hiding a lifetime that's elided elsewhere is confusing
   --> external/rules_rust+/crate_universe/src/splicing/splicer.rs:483:27
    |
483 |     pub(crate) fn prepare(&self) -> Result<SplicerKind> {
    |                           ^^^^^            ----------- the same lifetime is hidden here
    |                           |
    |                           the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
483 |     pub(crate) fn prepare(&self) -> Result<SplicerKind<'_>> {
    |                                                       ++++

warning: 1 warning emitted

INFO: Found 1 target...
Target //third-party:vendor up-to-date:
  bazel-bin/third-party/vendor.sh
INFO: Elapsed time: 84.754s, Critical Path: 82.69s
INFO: 799 processes: 218 internal, 581 processwrapper-sandbox.
INFO: Build completed successfully, 799 total actions
INFO: Running command line: bazel-bin/third-party/vendor.sh
```