### PR TITLE
bindgen: Pass `-resource-dir` Clang flag to bindgen-cli.

### DIFF
--- a/extensions/bindgen/test/bindgen_test.bzl
+++ b/extensions/bindgen/test/bindgen_test.bzl
@@ -1,9 +1,64 @@
 """Analysis test for for rust_bindgen_library rule."""
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("@rules_rust_bindgen//:defs.bzl", "rust_bindgen_library")
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("@rules_testing//lib:truth.bzl", "matching")
+
+def _fake_cc_toolchain_config_impl(ctx):
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        toolchain_identifier = "fake-toolchain",
+        host_system_name = "unknown",
+        target_system_name = "unknown",
+        target_cpu = "unknown",
+        target_libc = "unknown",
+        compiler = "unknown",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+    )
+
+_fake_cc_toolchain_config = rule(
+    implementation = _fake_cc_toolchain_config_impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)
+
+def _fake_cc_toolchain(name):
+    _fake_cc_toolchain_config(name = name + "_toolchain_config")
+
+    empty_filegroup = name + "_empty_filegroup"
+    native.filegroup(name = empty_filegroup)
+
+    stdbool_file = name + "_stdbool"
+    write_file(
+        name = stdbool_file,
+        content = [],
+        out = "my/resource/dir/include/stdbool.h",
+    )
+
+    all_files = name + "_all_files"
+    native.filegroup(name = all_files, srcs = [stdbool_file])
+
+    cc_toolchain(
+        name = name + "_cc_toolchain",
+        toolchain_config = name + "_toolchain_config",
+        all_files = all_files,
+        dwp_files = empty_filegroup,
+        compiler_files = empty_filegroup,
+        linker_files = empty_filegroup,
+        objcopy_files = empty_filegroup,
+        strip_files = empty_filegroup,
+    )
+
+    native.toolchain(
+        name = name,
+        toolchain = name + "_cc_toolchain",
+        toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    )
 
 def _test_cc_linkopt_impl(env, target):
     # Assert
@@ -100,6 +155,42 @@ def _test_cc_lib_object_merging_disabled(name):
         impl = _test_cc_lib_object_merging_disabled_impl,
     )
 
+def _test_resource_dir_impl(env, target):
+    env.expect.that_int(len(target.actions)).is_greater_than(0)
+    env.expect.that_action(target.actions[0]).mnemonic().contains("RustBindgen")
+    env.expect.that_action(target.actions[0]).argv().contains_predicate(
+        matching.all(
+            matching.str_startswith("-resource-dir="),
+            matching.str_endswith("my/resource/dir"),
+        ),
+    )
+
+def _test_resource_dir(name):
+    _fake_cc_toolchain(name + "_toolchain")
+
+    cc_library(
+        name = name + "_cc",
+        hdrs = ["simple.h"],
+        srcs = ["simple.cc"],
+    )
+
+    rust_bindgen_library(
+        name = name + "_rust_bindgen",
+        cc_lib = name + "_cc",
+        header = "simple.h",
+        tags = ["manual"],
+        edition = "2021",
+    )
+
+    analysis_test(
+        name = name,
+        target = name + "_rust_bindgen__bindgen",
+        impl = _test_resource_dir_impl,
+        config_settings = {
+            "//command_line_option:extra_toolchains": [str(native.package_relative_label(name + "_toolchain"))],
+        },
+    )
+
 def bindgen_test_suite(name):
     test_suite(
         name = name,
@@ -107,5 +198,6 @@ def bindgen_test_suite(name):
             _test_cc_linkopt,
             _test_cc_lib_object_merging,
             _test_cc_lib_object_merging_disabled,
+            _test_resource_dir,
         ],
     )


### PR DESCRIPTION
For some cc_toolchain configurations, this is required to find the builtin
headers.

So far, the bindgen rules had assumed that the builtin headers can be
found through `cc_toolchain.built_in_include_directories`. This is,
however, not guaranteed to be the case; indeed,
`built_in_include_directories` is not really intended for finding
builtin headers but merely for filtering out diagnostics in builtin
headers.

Clang itself finds the resource directory relative to its own binary,
and then finds the builtin headers in the "include" subdirectory of the
resource directory. bindgen-cli may, however, be located in a different
directory than Clang, so we pass a `-resource-dir` flag on the command
line.
