### PR TITLE
[cargo-bazel] Avoid regenerating cargo lockfile when splicing is not needed

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -645,6 +645,7 @@ def _generate_hub_and_spokes(
             config_path = config_file,
             output_dir = tag_path.get_child("splicing-output"),
             debug_workspace_dir = tag_path.get_child("splicing-workspace"),
+            skip_cargo_lockfile_overwrite = cfg.skip_cargo_lockfile_overwrite,
             repository_name = cfg.name,
         )
 

--- a/crate_universe/private/crates_repository.bzl
+++ b/crate_universe/private/crates_repository.bzl
@@ -91,6 +91,7 @@ def _crates_repository_impl(repository_ctx):
             splicing_manifest = splicing_manifest,
             config_path = config_path,
             output_dir = repository_ctx.path("splicing-output"),
+            skip_cargo_lockfile_overwrite = repository_ctx.attr.skip_cargo_lockfile_overwrite,
             repository_name = repository_ctx.name,
         )
 

--- a/crate_universe/private/generate_utils.bzl
+++ b/crate_universe/private/generate_utils.bzl
@@ -497,9 +497,7 @@ def execute_generator(
         ])
 
     if skip_cargo_lockfile_overwrite:
-        args.extend([
-            "--skip-cargo-lockfile-overwrite",
-        ])
+        args.append("--skip-cargo-lockfile-overwrite")
 
     # Some components are not required unless re-pinning is enabled
     if metadata:

--- a/crate_universe/private/splicing_utils.bzl
+++ b/crate_universe/private/splicing_utils.bzl
@@ -123,6 +123,7 @@ def splice_workspace_manifest(
         config_path,
         output_dir,
         repository_name,
+        skip_cargo_lockfile_overwrite,
         debug_workspace_dir = None):
     """Splice together a Cargo workspace from various other manifests and package definitions
 
@@ -134,6 +135,9 @@ def splice_workspace_manifest(
         config_path (path): The path to the config file (containing `cargo_bazel::config::Config`.)
         output_dir (path): THe location in which to write splicing outputs.
         repository_name (str): Name of the repository being generated.
+        skip_cargo_lockfile_overwrite (bool): Whether to skip writing the cargo lockfile back after resolving.
+            You may want to set this if your dependency versions are maintained externally through a non-trivial set-up.
+            But you probably don't want to set this.
         debug_workspace_dir (path): The location in which to save splicing outputs for future review.
 
     Returns:
@@ -158,6 +162,9 @@ def splice_workspace_manifest(
             "--cargo-lockfile",
             cargo_lockfile,
         ])
+
+    if skip_cargo_lockfile_overwrite:
+        arguments.append("--skip-cargo-lockfile-overwrite")
 
     # Optionally set the splicing workspace directory to somewhere within the repository directory
     # to improve the debugging experience.

--- a/crate_universe/tests/cargo_integration_test.rs
+++ b/crate_universe/tests/cargo_integration_test.rs
@@ -117,6 +117,7 @@ fn run(repository_name: &str, manifests: HashMap<String, String>, lockfile: &str
         cargo,
         rustc,
         repository_name: String::from("crates_index"),
+        skip_cargo_lockfile_overwrite: false,
     })
     .unwrap();
 


### PR DESCRIPTION
If we already have a Cargo.lock and don't intend to let cargo-bazel update it, we can just use it for splicing directly.