### PR TITLE
RFC: support proc_macro_deps in deps

### DIFF
--- a/crate_universe/BUILD.bazel
+++ b/crate_universe/BUILD.bazel
@@ -66,7 +66,6 @@ rust_library(
     aliases = aliases(),
     compile_data = [":rust_data"],
     edition = "2021",
-    proc_macro_deps = all_crate_deps(proc_macro = True),
     # This target embeds additional, stamping related information (see
     # https://docs.bazel.build/versions/main/user-manual.html#workspace_status
     # for more information). Set stamp = -1 to indicate that it should respect
@@ -74,7 +73,10 @@ rust_library(
     stamp = -1,
     version = VERSION,
     visibility = ["//visibility:public"],
-    deps = all_crate_deps(normal = True),
+    deps = all_crate_deps(
+        normal = True,
+        proc_macro = True,
+    ),
 )
 
 rust_binary(

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -75,8 +75,6 @@ rust_library(
     aliases = aliases(),
     deps = all_crate_deps(
         normal = True,
-    ),
-    proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
 )
@@ -90,8 +88,6 @@ rust_test(
     ),
     deps = all_crate_deps(
         normal_dev = True,
-    ),
-    proc_macro_deps = all_crate_deps(
         proc_macro_dev = True,
     ),
 )
@@ -143,10 +139,8 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "lib",
     deps = [
-        "@crate_index//:tokio",
-    ],
-    proc_macro_deps = [
         "@crate_index//:async-trait",
+        "@crate_index//:tokio",
     ],
 )
 

--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -89,8 +89,6 @@ rust_library(
     aliases = aliases(),
     deps = all_crate_deps(
         normal = True,
-    ),
-    proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
 )
@@ -104,8 +102,6 @@ rust_test(
     ),
     deps = all_crate_deps(
         normal_dev = True,
-    ),
-    proc_macro_deps = all_crate_deps(
         proc_macro_dev = True,
     ),
 )

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -582,11 +582,21 @@ impl Renderer {
                 attrs.map(|attrs| attrs.data.clone()).unwrap_or_default(),
             ),
             deps: SelectSet::new(
-                self.make_deps(
-                    attrs.map(|attrs| attrs.deps.clone()).unwrap_or_default(),
-                    attrs
-                        .map(|attrs| attrs.extra_deps.clone())
-                        .unwrap_or_default(),
+                Select::merge(
+                    self.make_deps(
+                        attrs.map(|attrs| attrs.deps.clone()).unwrap_or_default(),
+                        attrs
+                            .map(|attrs| attrs.extra_deps.clone())
+                            .unwrap_or_default(),
+                    ),
+                    self.make_deps(
+                        attrs
+                            .map(|attrs| attrs.proc_macro_deps.clone())
+                            .unwrap_or_default(),
+                        attrs
+                            .map(|attrs| attrs.extra_proc_macro_deps.clone())
+                            .unwrap_or_default(),
+                    ),
                 ),
                 platforms,
             ),
@@ -605,17 +615,6 @@ impl Renderer {
             linker_script: krate.common_attrs.linker_script.clone(),
             links: attrs.and_then(|attrs| attrs.links.clone()),
             pkg_name: Some(krate.name.clone()),
-            proc_macro_deps: SelectSet::new(
-                self.make_deps(
-                    attrs
-                        .map(|attrs| attrs.proc_macro_deps.clone())
-                        .unwrap_or_default(),
-                    attrs
-                        .map(|attrs| attrs.extra_proc_macro_deps.clone())
-                        .unwrap_or_default(),
-                ),
-                platforms,
-            ),
             rundir: SelectScalar::new(
                 attrs.map(|attrs| attrs.rundir.clone()).unwrap_or_default(),
                 platforms,
@@ -674,16 +673,15 @@ impl Renderer {
         Ok(RustProcMacro {
             name: target.crate_name.clone(),
             deps: SelectSet::new(
-                self.make_deps(
-                    krate.common_attrs.deps.clone(),
-                    krate.common_attrs.extra_deps.clone(),
-                ),
-                platforms,
-            ),
-            proc_macro_deps: SelectSet::new(
-                self.make_deps(
-                    krate.common_attrs.proc_macro_deps.clone(),
-                    krate.common_attrs.extra_proc_macro_deps.clone(),
+                Select::merge(
+                    self.make_deps(
+                        krate.common_attrs.deps.clone(),
+                        krate.common_attrs.extra_deps.clone(),
+                    ),
+                    self.make_deps(
+                        krate.common_attrs.proc_macro_deps.clone(),
+                        krate.common_attrs.extra_proc_macro_deps.clone(),
+                    ),
                 ),
                 platforms,
             ),
@@ -701,16 +699,15 @@ impl Renderer {
         Ok(RustLibrary {
             name: target.crate_name.clone(),
             deps: SelectSet::new(
-                self.make_deps(
-                    krate.common_attrs.deps.clone(),
-                    krate.common_attrs.extra_deps.clone(),
-                ),
-                platforms,
-            ),
-            proc_macro_deps: SelectSet::new(
-                self.make_deps(
-                    krate.common_attrs.proc_macro_deps.clone(),
-                    krate.common_attrs.extra_proc_macro_deps.clone(),
+                Select::merge(
+                    self.make_deps(
+                        krate.common_attrs.deps.clone(),
+                        krate.common_attrs.extra_deps.clone(),
+                    ),
+                    self.make_deps(
+                        krate.common_attrs.proc_macro_deps.clone(),
+                        krate.common_attrs.extra_proc_macro_deps.clone(),
+                    ),
                 ),
                 platforms,
             ),
@@ -729,9 +726,15 @@ impl Renderer {
         Ok(RustBinary {
             name: format!("{}__bin", target.crate_name),
             deps: {
-                let mut deps = self.make_deps(
-                    krate.common_attrs.deps.clone(),
-                    krate.common_attrs.extra_deps.clone(),
+                let mut deps = Select::merge(
+                    self.make_deps(
+                        krate.common_attrs.deps.clone(),
+                        krate.common_attrs.extra_deps.clone(),
+                    ),
+                    self.make_deps(
+                        krate.common_attrs.proc_macro_deps.clone(),
+                        krate.common_attrs.extra_proc_macro_deps.clone(),
+                    ),
                 );
                 if let Some(library_target_name) = &krate.library_target_name {
                     deps.insert(
@@ -741,13 +744,6 @@ impl Renderer {
                 }
                 SelectSet::new(deps, platforms)
             },
-            proc_macro_deps: SelectSet::new(
-                self.make_deps(
-                    krate.common_attrs.proc_macro_deps.clone(),
-                    krate.common_attrs.extra_proc_macro_deps.clone(),
-                ),
-                platforms,
-            ),
             aliases: SelectDict::new(self.make_aliases(krate, false, false), platforms),
             common: self.make_common_attrs(platforms, krate, target)?,
         })

--- a/crate_universe/src/utils/starlark.rs
+++ b/crate_universe/src/utils/starlark.rs
@@ -118,8 +118,6 @@ pub(crate) struct CargoBuildScript {
     pub(crate) links: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) pkg_name: Option<String>,
-    #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectScalar::is_empty")]
     pub(crate) rundir: SelectScalar<String>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
@@ -153,8 +151,6 @@ pub(crate) struct RustProcMacro {
     pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
     pub(crate) deps: SelectSet<Label>,
-    #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]
@@ -166,8 +162,6 @@ pub(crate) struct RustLibrary {
     pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
     pub(crate) deps: SelectSet<Label>,
-    #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]
@@ -181,8 +175,6 @@ pub(crate) struct RustBinary {
     pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
     pub(crate) deps: SelectSet<Label>,
-    #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]

--- a/crate_universe/tools/cross_installer/BUILD.bazel
+++ b/crate_universe/tools/cross_installer/BUILD.bazel
@@ -21,13 +21,15 @@ rust_binary(
         "@rules_rust//rust/toolchain:current_cargo_files",
     ],
     edition = "2021",
-    proc_macro_deps = all_crate_deps(proc_macro = True),
     rustc_env = {
         "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
         "CROSS_BIN": "$(rlocationpath :cross)",
         "CROSS_CONFIG_RLOCATION": "$(rlocationpath :Cross.toml)",
     },
-    deps = all_crate_deps(normal = True) + ["@rules_rust//rust/runfiles"],
+    deps = all_crate_deps(
+        normal = True,
+        proc_macro = True,
+    ) + ["@rules_rust//rust/runfiles"],
 )
 
 filegroup(

--- a/crate_universe/tools/urls_generator/BUILD.bazel
+++ b/crate_universe/tools/urls_generator/BUILD.bazel
@@ -14,9 +14,11 @@ rust_binary(
         "//crate_universe/private:urls.bzl",
     ],
     edition = "2021",
-    proc_macro_deps = all_crate_deps(proc_macro = True),
     rustc_env = {
         "MODULE_ROOT_PATH": "$(rootpath //crate_universe/private:urls.bzl)",
     },
-    deps = all_crate_deps(normal = True),
+    deps = all_crate_deps(
+        normal = True,
+        proc_macro = True,
+    ),
 )

--- a/examples/crate_universe/cargo_aliases/BUILD.bazel
+++ b/examples/crate_universe/cargo_aliases/BUILD.bazel
@@ -7,16 +7,20 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     aliases = aliases(),
     edition = "2018",
-    proc_macro_deps = all_crate_deps(proc_macro = True),
-    deps = all_crate_deps(normal = True),
+    deps = all_crate_deps(
+        normal = True,
+        proc_macro = True,
+    ),
 )
 
 rust_test(
     name = "unit_test",
     aliases = aliases(),
     crate = ":aliases",
-    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
-    deps = all_crate_deps(normal_dev = True),
+    deps = all_crate_deps(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
 )
 
 # Ensures that Bazel aliases from the crates_repository are actually usable.

--- a/extensions/wasm_bindgen/private/wasm_bindgen_test.bzl
+++ b/extensions/wasm_bindgen/private/wasm_bindgen_test.bzl
@@ -19,6 +19,7 @@ load(
     "find_toolchain",
     "generate_output_diagnostics",
     "get_import_macro_deps",
+    "partition_deps",
     "transform_deps",
     "transform_sources",
 )
@@ -67,8 +68,9 @@ def _rust_wasm_bindgen_test_impl(ctx):
     toolchain = find_toolchain(ctx)
 
     crate_type = "bin"
-    deps = transform_deps(ctx.attr.deps + [wb_toolchain.wasm_bindgen_test])
-    proc_macro_deps = transform_deps(ctx.attr.proc_macro_deps + get_import_macro_deps(ctx))
+    deps, proc_macro_deps = partition_deps(ctx)
+    deps = transform_deps(deps + [wb_toolchain.wasm_bindgen_test])
+    proc_macro_deps = transform_deps(proc_macro_deps + get_import_macro_deps(ctx))
 
     # Target is building the crate in `test` config
     if WasmBindgenTestCrateInfo in ctx.attr.wasm:

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -36,7 +36,6 @@ load(
     _rust_binary = "rust_binary",
     _rust_library = "rust_library",
     _rust_library_group = "rust_library_group",
-    _rust_proc_macro = "rust_proc_macro",
     _rust_shared_library = "rust_shared_library",
     _rust_static_library = "rust_static_library",
     _rust_test = "rust_test",
@@ -45,6 +44,10 @@ load(
 load(
     "//rust/private:rust_analyzer.bzl",
     _rust_analyzer_aspect = "rust_analyzer_aspect",
+)
+load(
+    "//rust/private:rust_proc_macro.bzl",
+    _rust_proc_macro = "rust_proc_macro_macro",
 )
 load(
     "//rust/private:rustc.bzl",

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -177,7 +177,7 @@ def _clippy_aspect_impl(target, ctx):
         out_dir = out_dir,
         build_env_files = build_env_files,
         build_flags_files = build_flags_files,
-        emit = ["dep-info", "metadata"],
+        emit = ["metadata"],
         skip_expanding_rustc_env = True,
         use_json_output = bool(clippy_diagnostics),
         error_format = error_format,

--- a/rust/private/rust_proc_macro.bzl
+++ b/rust/private/rust_proc_macro.bzl
@@ -1,0 +1,71 @@
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""rust_proc_macro implementation"""
+
+load("//rust/private:common.bzl", "COMMON_PROVIDERS")
+load(
+    "//rust/private:rust_proc_macro_inner.bzl",
+    "rust_proc_macro_inner_attrs",
+    _rust_proc_macro_inner = "rust_proc_macro",
+)
+
+def _rust_proc_macro_impl(ctx):
+    """The implementation of the `rust_proc_macro` rule.
+
+    Args:
+        ctx (ctx): The rule's context object
+
+    Returns:
+        list: A list of providers.
+    """
+    return [
+        ctx.attr.inner[provider]
+        for provider in COMMON_PROVIDERS + [OutputGroupInfo]
+    ]
+
+rust_proc_macro = rule(
+    implementation = _rust_proc_macro_impl,
+    provides = COMMON_PROVIDERS,
+    # Take all the same attrs in case there are any aspects examining them.
+    # `inner` is the only load-bearing one - providers are forwarded.
+    attrs = dict(
+        rust_proc_macro_inner_attrs.items(),
+        inner = attr.label(
+            doc = "The wrapped proc_macro crate that will be transitioned to the exec configuration.",
+            cfg = "exec",
+            providers = COMMON_PROVIDERS,
+        ),
+    ),
+    fragments = ["cpp"],
+    toolchains = [
+        str(Label("//rust:toolchain_type")),
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
+    doc = "Builds a Rust proc-macro crate.",
+)
+
+def rust_proc_macro_macro(name, **kwargs):
+    kwargs["crate_name"] = kwargs.get("crate_name", name)
+
+    _rust_proc_macro_inner(
+        name = name + "_inner",
+        **kwargs
+    )
+
+    rust_proc_macro(
+        name = name,
+        inner = name + "_inner",
+        **kwargs
+    )

--- a/rust/private/rust_proc_macro_inner.bzl
+++ b/rust/private/rust_proc_macro_inner.bzl
@@ -1,0 +1,74 @@
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""rust_proc_macro implementation"""
+
+load("//rust/private:common.bzl", "COMMON_PROVIDERS")
+load("//rust/private:rust.bzl", "common_attrs", "rust_library_common")
+load("//rust/private:utils.bzl", "dedent")
+
+def _rust_proc_macro_inner_impl(ctx):
+    """The implementation of the `rust_proc_macro` rule.
+
+    Args:
+        ctx (ctx): The rule's context object
+
+    Returns:
+        list: A list of providers.
+    """
+    return rust_library_common(ctx, "proc-macro")
+
+def _proc_macro_dep_transition_impl(settings, _attr):
+    if settings["//rust/private:is_proc_macro_dep_enabled"]:
+        return {"//rust/private:is_proc_macro_dep": True}
+    else:
+        return []
+
+_proc_macro_dep_transition = transition(
+    inputs = ["//rust/private:is_proc_macro_dep_enabled"],
+    outputs = ["//rust/private:is_proc_macro_dep"],
+    implementation = _proc_macro_dep_transition_impl,
+)
+
+# Start by copying the common attributes, then override the `deps` attribute
+# to apply `_proc_macro_dep_transition`. To add this transition we additionally
+# need to declare `_allowlist_function_transition`, see
+# https://docs.bazel.build/versions/main/skylark/config.html#user-defined-transitions.
+rust_proc_macro_inner_attrs = dict(
+    common_attrs.items(),
+    _allowlist_function_transition = attr.label(
+        default = Label("//tools/allowlists/function_transition_allowlist"),
+    ),
+    deps = attr.label_list(
+        doc = dedent("""\
+            List of other libraries to be linked to this library target.
+
+            These can be either other `rust_library` targets or `cc_library` targets if
+            linking a native library.
+        """),
+        cfg = _proc_macro_dep_transition,
+    ),
+)
+
+rust_proc_macro = rule(
+    implementation = _rust_proc_macro_inner_impl,
+    provides = COMMON_PROVIDERS,
+    attrs = rust_proc_macro_inner_attrs,
+    fragments = ["cpp"],
+    toolchains = [
+        str(Label("//rust:toolchain_type")),
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
+    doc = "Builds a Rust proc-macro crate.",
+)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -228,8 +228,8 @@ def collect_deps(
     """Walks through dependencies and collects the transitive dependencies.
 
     Args:
-        deps (list): The deps from ctx.attr.deps.
-        proc_macro_deps (list): The proc_macro deps from ctx.attr.proc_macro_deps.
+        deps (list): The deps from partition_deps(ctx)
+        proc_macro_deps (list): The proc_macro_deps from partition_deps(ctx).
         aliases (dict): A dict mapping aliased targets to their actual Crate information.
 
     Returns:

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -18,7 +18,7 @@ load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//rust/private:common.bzl", "rust_common")
 load("//rust/private:providers.bzl", "CrateInfo")
 load("//rust/private:rustdoc.bzl", "rustdoc_compile_action")
-load("//rust/private:utils.bzl", "dedent", "find_toolchain", "transform_deps")
+load("//rust/private:utils.bzl", "dedent", "find_toolchain", "partition_deps", "transform_deps")
 
 def _construct_writer_arguments(ctx, test_runner, opt_test_params, action, crate_info):
     """Construct arguments and environment variables specific to `rustdoc_test_writer`.
@@ -110,8 +110,9 @@ def _rust_doc_test_impl(ctx):
     toolchain = find_toolchain(ctx)
 
     crate = ctx.attr.crate[rust_common.crate_info]
-    deps = transform_deps(ctx.attr.deps)
-    proc_macro_deps = transform_deps(ctx.attr.proc_macro_deps)
+    deps, proc_macro_deps = partition_deps(ctx)
+    deps = transform_deps(deps)
+    proc_macro_deps = transform_deps(proc_macro_deps)
 
     crate_info = rust_common.create_crate_info(
         name = crate.name,

--- a/rust/private/unpretty.bzl
+++ b/rust/private/unpretty.bzl
@@ -202,7 +202,7 @@ def _rust_unpretty_aspect_impl(target, ctx):
             out_dir = out_dir,
             build_env_files = build_env_files,
             build_flags_files = build_flags_files,
-            emit = ["dep-info", "metadata"],
+            emit = ["metadata"],
             skip_expanding_rustc_env = True,
         )
 

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -18,6 +18,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:find_cc_toolchain.bzl", find_rules_cc_toolchain = "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load(":common.bzl", "rust_common")
 load(":compat.bzl", "abs")
 load(
     ":providers.bzl",
@@ -497,6 +498,28 @@ def is_exec_configuration(ctx):
 
     # TODO(djmarcin): Is there any better way to determine cfg=exec?
     return ctx.genfiles_dir.path.find("-exec") != -1
+
+def partition_deps(ctx):
+    """Split deps into normal deps and proc_macro_deps.
+
+    Args:
+        ctx (ctx): The current rule's context object
+
+    Returns:
+        deps and proc_macro_deps
+    """
+    if ctx.attr.proc_macro_deps:
+        print("`proc_macro_deps` attribute is deprecated; all deps can go in `deps`")  # buildifier: disable=print
+
+    deps = []
+    proc_macro_deps = []
+    for dep in ctx.attr.deps + ctx.attr.proc_macro_deps:
+        if rust_common.crate_info in dep and dep[rust_common.crate_info].type == "proc-macro":
+            proc_macro_deps.append(dep)
+        else:
+            deps.append(dep)
+
+    return deps, proc_macro_deps
 
 def transform_deps(deps):
     """Transforms a [Target] into [DepVariantInfo].

--- a/rust/rust_proc_macro.bzl
+++ b/rust/rust_proc_macro.bzl
@@ -1,8 +1,8 @@
 """rust_proc_macro"""
 
 load(
-    "//rust/private:rust.bzl",
-    _rust_proc_macro = "rust_proc_macro",
+    "//rust/private:rust_proc_macro.bzl",
+    _rust_proc_macro = "rust_proc_macro_macro",
 )
 
 rust_proc_macro = _rust_proc_macro

--- a/test/unit/ambiguous_libs/ambiguous_libs_test.bzl
+++ b/test/unit/ambiguous_libs/ambiguous_libs_test.bzl
@@ -101,7 +101,7 @@ def _create_test_targets():
     )
     ambiguous_deps_test(
         name = "proc_macro_with_ambiguous_deps_test",
-        target_under_test = ":proc_macro",
+        target_under_test = ":proc_macro_inner",
     )
     ambiguous_deps_test(
         name = "cdylib_with_ambiguous_deps_test",

--- a/test/unit/is_proc_macro_dep/is_proc_macro_dep_test.bzl
+++ b/test/unit/is_proc_macro_dep/is_proc_macro_dep_test.bzl
@@ -1,7 +1,10 @@
 """Unittests for the is_proc_macro_dep setting."""
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("//rust:defs.bzl", "rust_library", "rust_proc_macro")
+load("//rust:defs.bzl", "rust_library")
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:rust_proc_macro_inner.bzl", "rust_proc_macro")
 
 DepActionsInfo = provider(
     "Contains information about dependencies actions.",

--- a/test/unit/lto/lto_test_suite.bzl
+++ b/test/unit/lto/lto_test_suite.bzl
@@ -141,7 +141,7 @@ def lto_test_suite(name):
 
     _lto_proc_macro_test(
         name = "lto_proc_macro_test",
-        target_under_test = ":proc_macro",
+        target_under_test = ":proc_macro_inner",
     )
 
     native.test_suite(

--- a/test/unit/native_deps/native_action_inputs_test.bzl
+++ b/test/unit/native_deps/native_action_inputs_test.bzl
@@ -152,7 +152,7 @@ def _native_action_inputs_test():
 
     native_action_inputs_present_test(
         name = "native_action_inputs_proc_macro_test",
-        target_under_test = ":foo_proc_macro",
+        target_under_test = ":foo_proc_macro_inner",
     )
 
 def native_action_inputs_test_suite(name):

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -337,7 +337,7 @@ def _native_dep_test():
     )
     proc_macro_has_native_libs_test(
         name = "proc_macro_has_native_libs_test",
-        target_under_test = ":proc_macro_has_native_dep",
+        target_under_test = ":proc_macro_has_native_dep_inner",
     )
     bin_has_native_libs_test(
         name = "bin_has_native_libs_test",

--- a/test/unit/proc_macro/proc_macro_test.bzl
+++ b/test/unit/proc_macro/proc_macro_test.bzl
@@ -76,11 +76,11 @@ def _proc_macro_test():
 
     extern_flag_not_passed_when_compiling_macro_2015_test(
         name = "extern_flag_not_passed_when_compiling_macro_2015",
-        target_under_test = ":proc_macro_2015",
+        target_under_test = ":proc_macro_2015_inner",
     )
     extern_flag_passed_when_compiling_macro_2018_test(
         name = "extern_flag_passed_when_compiling_macro_2018",
-        target_under_test = ":proc_macro_2018",
+        target_under_test = ":proc_macro_2018_inner",
     )
     extern_flag_not_passed_when_compiling_macro_wrapper_rule_2015_test(
         name = "extern_flag_not_passed_when_compiling_macro_wrapper_rule_2015",

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -169,7 +169,7 @@ rustdoc_with_json_error_format_test = analysistest.make(_rustdoc_with_json_error
     str(Label("//rust/settings:error_format")): "json",
 })
 
-def _target_maker(rule_fn, name, rustdoc_deps = [], rustdoc_proc_macro_deps = [], **kwargs):
+def _target_maker(rule_fn, name, rustdoc_deps = [], rustdoc_proc_macro_deps = [], rustdoc_crate = None, **kwargs):
     rule_fn(
         name = name,
         edition = "2018",
@@ -189,7 +189,7 @@ def _target_maker(rule_fn, name, rustdoc_deps = [], rustdoc_proc_macro_deps = []
 
     rust_doc_test(
         name = "{}_doctest".format(name),
-        crate = ":{}".format(name),
+        crate = rustdoc_crate or name,
         deps = rustdoc_deps,
         proc_macro_deps = rustdoc_proc_macro_deps,
         target_compatible_with = NOT_WINDOWS,
@@ -241,6 +241,7 @@ def _define_targets():
         rust_proc_macro,
         name = "rustdoc_proc_macro",
         srcs = ["rustdoc_proc_macro.rs"],
+        rustdoc_crate = "rustdoc_proc_macro_inner",
     )
 
     _target_maker(


### PR DESCRIPTION
This is accomplished via a `rust_proc_macro` macro that instantiates a `rust_proc_macro` proxy rule which forwards relevant providers from an (inner) `rust_proc_macro` rule. The wrapper rule takes all the same attributes (even though they are ignored) and the rules are named the same to try to avoid any churn for aspects.