### PR TITLE
Add gcc-ld to rustc_lib target

### DIFF
--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -44,6 +44,7 @@ filegroup(
             "bin/*{dylib_ext}",
             "lib/*{dylib_ext}*",
             "lib/rustlib/{target_triple}/codegen-backends/*{dylib_ext}",
+            "lib/rustlib/{target_triple}/bin/gcc-ld/*",
             "lib/rustlib/{target_triple}/bin/rust-lld{binary_ext}",
             "lib/rustlib/{target_triple}/lib/*{dylib_ext}*",
             "lib/rustlib/{target_triple}/lib/*.rmeta",


### PR DESCRIPTION
This makes it possible to use the self-contained `rust-lld` linker through the gcc driver, which will be the default setup in [Rust 1.90.0](https://blog.rust-lang.org/2024/05/17/enabling-rust-lld-on-linux/).