### PR TITLE
Improve proc_macro_deps ergonomics, take 3

### DIFF
--- a/crate_universe/BUILD.bazel
+++ b/crate_universe/BUILD.bazel
@@ -66,7 +66,6 @@ rust_library(
     aliases = aliases(),
     compile_data = [":rust_data"],
     edition = "2021",
-    proc_macro_deps = all_crate_deps(proc_macro = True),
     # This target embeds additional, stamping related information (see
     # https://docs.bazel.build/versions/main/user-manual.html#workspace_status
     # for more information). Set stamp = -1 to indicate that it should respect
@@ -74,7 +73,7 @@ rust_library(
     stamp = -1,
     version = VERSION,
     visibility = ["//visibility:public"],
-    deps = all_crate_deps(normal = True),
+    deps = all_crate_deps(normal = True, proc_macro = True),
 )
 
 rust_binary(

--- a/crate_universe/defs.bzl
+++ b/crate_universe/defs.bzl
@@ -75,8 +75,6 @@ rust_library(
     aliases = aliases(),
     deps = all_crate_deps(
         normal = True,
-    ),
-    proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
 )
@@ -90,8 +88,6 @@ rust_test(
     ),
     deps = all_crate_deps(
         normal_dev = True,
-    ),
-    proc_macro_deps = all_crate_deps(
         proc_macro_dev = True,
     ),
 )
@@ -143,10 +139,8 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 rust_library(
     name = "lib",
     deps = [
-        "@crate_index//:tokio",
-    ],
-    proc_macro_deps = [
         "@crate_index//:async-trait",
+        "@crate_index//:tokio",
     ],
 )
 

--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -89,8 +89,6 @@ rust_library(
     aliases = aliases(),
     deps = all_crate_deps(
         normal = True,
-    ),
-    proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
 )
@@ -104,8 +102,6 @@ rust_test(
     ),
     deps = all_crate_deps(
         normal_dev = True,
-    ),
-    proc_macro_deps = all_crate_deps(
         proc_macro_dev = True,
     ),
 )

--- a/crate_universe/src/utils/starlark.rs
+++ b/crate_universe/src/utils/starlark.rs
@@ -118,8 +118,6 @@ pub(crate) struct CargoBuildScript {
     pub(crate) links: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) pkg_name: Option<String>,
-    #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectScalar::is_empty")]
     pub(crate) rundir: SelectScalar<String>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
@@ -153,8 +151,6 @@ pub(crate) struct RustProcMacro {
     pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
     pub(crate) deps: SelectSet<Label>,
-    #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]
@@ -166,8 +162,6 @@ pub(crate) struct RustLibrary {
     pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
     pub(crate) deps: SelectSet<Label>,
-    #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]
@@ -181,8 +175,6 @@ pub(crate) struct RustBinary {
     pub(crate) name: String,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
     pub(crate) deps: SelectSet<Label>,
-    #[serde(skip_serializing_if = "SelectSet::is_empty")]
-    pub(crate) proc_macro_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]

--- a/crate_universe/tools/cross_installer/BUILD.bazel
+++ b/crate_universe/tools/cross_installer/BUILD.bazel
@@ -21,13 +21,15 @@ rust_binary(
         "@rules_rust//rust/toolchain:current_cargo_files",
     ],
     edition = "2021",
-    proc_macro_deps = all_crate_deps(proc_macro = True),
     rustc_env = {
         "CARGO": "$(rlocationpath @rules_rust//rust/toolchain:current_cargo_files)",
         "CROSS_BIN": "$(rlocationpath :cross)",
         "CROSS_CONFIG_RLOCATION": "$(rlocationpath :Cross.toml)",
     },
-    deps = all_crate_deps(normal = True) + ["@rules_rust//rust/runfiles"],
+    deps = all_crate_deps(
+        normal = True,
+        proc_macro = True,
+    ) + ["@rules_rust//rust/runfiles"],
 )
 
 filegroup(

--- a/crate_universe/tools/urls_generator/BUILD.bazel
+++ b/crate_universe/tools/urls_generator/BUILD.bazel
@@ -14,9 +14,8 @@ rust_binary(
         "//crate_universe/private:urls.bzl",
     ],
     edition = "2021",
-    proc_macro_deps = all_crate_deps(proc_macro = True),
     rustc_env = {
         "MODULE_ROOT_PATH": "$(rootpath //crate_universe/private:urls.bzl)",
     },
-    deps = all_crate_deps(normal = True),
+    deps = all_crate_deps(normal = True, proc_macro = True),
 )

--- a/extensions/wasm_bindgen/private/wasm_bindgen_test.bzl
+++ b/extensions/wasm_bindgen/private/wasm_bindgen_test.bzl
@@ -16,6 +16,7 @@ load(
     "@rules_rust//rust/private:utils.bzl",
     "determine_output_hash",
     "expand_dict_value_locations",
+    "filter_deps",
     "find_toolchain",
     "generate_output_diagnostics",
     "get_import_macro_deps",
@@ -67,8 +68,10 @@ def _rust_wasm_bindgen_test_impl(ctx):
     toolchain = find_toolchain(ctx)
 
     crate_type = "bin"
-    deps = transform_deps(ctx.attr.deps + [wb_toolchain.wasm_bindgen_test])
-    proc_macro_deps = transform_deps(ctx.attr.proc_macro_deps + get_import_macro_deps(ctx))
+
+    deps, proc_macro_deps = filter_deps(ctx)
+    deps = transform_deps(deps + [wb_toolchain.wasm_bindgen_test])
+    proc_macro_deps = transform_deps(proc_macro_deps + get_import_macro_deps(ctx))
 
     # Target is building the crate in `test` config
     if WasmBindgenTestCrateInfo in ctx.attr.wasm:

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -76,25 +76,40 @@ load(
     _rust_unpretty_aspect = "rust_unpretty_aspect",
 )
 
-rust_library = _rust_library
+def _rule_wrapper(rule):
+    def _wrapped(name, deps = [], proc_macro_deps = [], **kwargs):
+        if proc_macro_deps:
+            print("proc_macros can now be passed directly to `deps`, no need to use `proc_macro_deps` in " + native.package_relative_label(name))
+
+        rule(
+            name = name,
+            deps = deps + proc_macro_deps,
+            # TODO(zbarsky): This attribute would ideally be called `exec_configured_deps` or similar.
+            proc_macro_deps = deps + proc_macro_deps,
+            **kwargs
+        )
+
+    return _wrapped
+
+rust_library = _rule_wrapper(_rust_library)
 # See @rules_rust//rust/private:rust.bzl for a complete description.
 
-rust_static_library = _rust_static_library
+rust_static_library = _rule_wrapper(_rust_static_library)
 # See @rules_rust//rust/private:rust.bzl for a complete description.
 
-rust_shared_library = _rust_shared_library
+rust_shared_library = _rule_wrapper(_rust_shared_library)
 # See @rules_rust//rust/private:rust.bzl for a complete description.
 
-rust_proc_macro = _rust_proc_macro
+rust_proc_macro = _rule_wrapper(_rust_proc_macro)
 # See @rules_rust//rust/private:rust.bzl for a complete description.
 
-rust_binary = _rust_binary
+rust_binary = _rule_wrapper(_rust_binary)
 # See @rules_rust//rust/private:rust.bzl for a complete description.
 
 rust_library_group = _rust_library_group
 # See @rules_rust//rust/private:rust.bzl for a complete description.
 
-rust_test = _rust_test
+rust_test = _rule_wrapper(_rust_test)
 # See @rules_rust//rust/private:rust.bzl for a complete description.
 
 rust_test_suite = _rust_test_suite
@@ -103,7 +118,7 @@ rust_test_suite = _rust_test_suite
 rust_doc = _rust_doc
 # See @rules_rust//rust/private:rustdoc.bzl for a complete description.
 
-rust_doc_test = _rust_doc_test
+rust_doc_test = _rule_wrapper(_rust_doc_test)
 # See @rules_rust//rust/private:rustdoc_test.bzl for a complete description.
 
 clippy_flag = _clippy_flag

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -22,6 +22,9 @@ load(
     "AllocatorLibrariesImplInfo",
     "AllocatorLibrariesInfo",
     "BuildInfo",
+    "CrateInfo",
+    "CrateGroupInfo",
+    "DepInfo",
     "LintsInfo",
 )
 load("//rust/private:rustc.bzl", "rustc_compile_action")
@@ -35,6 +38,7 @@ load(
     "determine_lib_name",
     "determine_output_hash",
     "expand_dict_value_locations",
+    "filter_deps",
     "find_toolchain",
     "generate_output_diagnostics",
     "get_edition",
@@ -52,32 +56,6 @@ def _assert_no_deprecated_attributes(_ctx):
         _ctx (ctx): The current rule's context object
     """
     pass
-
-def _assert_correct_dep_mapping(ctx):
-    """Forces a failure if proc_macro_deps and deps are mixed inappropriately
-
-    Args:
-        ctx (ctx): The current rule's context object
-    """
-    for dep in ctx.attr.deps:
-        if rust_common.crate_info in dep:
-            if dep[rust_common.crate_info].type == "proc-macro":
-                fail(
-                    "{} listed {} in its deps, but it is a proc-macro. It should instead be in the bazel property proc_macro_deps.".format(
-                        ctx.label,
-                        dep.label,
-                    ),
-                )
-    for dep in ctx.attr.proc_macro_deps:
-        type = dep[rust_common.crate_info].type
-        if type != "proc-macro":
-            fail(
-                "{} listed {} in its proc_macro_deps, but it is not proc-macro, it is a {}. It should probably instead be listed in deps.".format(
-                    ctx.label,
-                    dep.label,
-                    type,
-                ),
-            )
 
 def _rust_library_impl(ctx):
     """The implementation of the `rust_library` rule.
@@ -148,7 +126,7 @@ def _rust_library_common(ctx, crate_type):
         list: A list of providers. See `rustc_compile_action`
     """
     _assert_no_deprecated_attributes(ctx)
-    _assert_correct_dep_mapping(ctx)
+    deps, proc_macro_deps = filter_deps(ctx)
 
     toolchain = find_toolchain(ctx)
 
@@ -195,8 +173,8 @@ def _rust_library_common(ctx, crate_type):
             not ctx.attr.disable_pipelining
         )
 
-    deps = transform_deps(ctx.attr.deps)
-    proc_macro_deps = transform_deps(ctx.attr.proc_macro_deps + get_import_macro_deps(ctx))
+    deps = transform_deps(deps)
+    proc_macro_deps = transform_deps(proc_macro_deps + get_import_macro_deps(ctx))
 
     return rustc_compile_action(
         ctx = ctx,
@@ -238,7 +216,7 @@ def _rust_binary_impl(ctx):
     """
     toolchain = find_toolchain(ctx)
     crate_name = compute_crate_name(ctx.workspace_name, ctx.label, toolchain, ctx.attr.crate_name)
-    _assert_correct_dep_mapping(ctx)
+    deps, proc_macro_deps = filter_deps(ctx)
 
     if ctx.attr.binary_name:
         output_filename = ctx.attr.binary_name
@@ -246,8 +224,8 @@ def _rust_binary_impl(ctx):
         output_filename = ctx.label.name
     output = ctx.actions.declare_file(output_filename + toolchain.binary_ext)
 
-    deps = transform_deps(ctx.attr.deps)
-    proc_macro_deps = transform_deps(ctx.attr.proc_macro_deps + get_import_macro_deps(ctx))
+    deps = transform_deps(deps)
+    proc_macro_deps = transform_deps(proc_macro_deps + get_import_macro_deps(ctx))
 
     crate_root = getattr(ctx.file, "crate_root", None)
     if not crate_root:
@@ -327,13 +305,13 @@ def _rust_test_impl(ctx):
         list: The list of providers. See `rustc_compile_action`
     """
     _assert_no_deprecated_attributes(ctx)
-    _assert_correct_dep_mapping(ctx)
+    deps, proc_macro_deps = filter_deps(ctx)
 
     toolchain = find_toolchain(ctx)
 
     crate_type = "bin"
-    deps = transform_deps(ctx.attr.deps)
-    proc_macro_deps = transform_deps(ctx.attr.proc_macro_deps + get_import_macro_deps(ctx))
+    deps = transform_deps(deps)
+    proc_macro_deps = transform_deps(proc_macro_deps + get_import_macro_deps(ctx))
 
     if ctx.attr.crate and ctx.attr.srcs:
         fail("rust_test.crate and rust_test.srcs are mutually exclusive. Update {} to use only one of these attributes".format(
@@ -526,16 +504,16 @@ def _rust_library_group_impl(ctx):
     runfiles = []
 
     for dep in ctx.attr.deps:
-        if rust_common.crate_info in dep:
+        if CrateInfo in dep:
             dep_variant_infos.append(rust_common.dep_variant_info(
-                crate_info = dep[rust_common.crate_info] if rust_common.crate_info in dep else None,
-                dep_info = dep[rust_common.dep_info] if rust_common.crate_info in dep else None,
+                crate_info = dep[CrateInfo] if CrateInfo in dep else None,
+                dep_info = dep[DepInfo] if DepInfo in dep else None,
                 build_info = dep[BuildInfo] if BuildInfo in dep else None,
                 cc_info = dep[CcInfo] if CcInfo in dep else None,
                 crate_group_info = None,
             ))
-        elif rust_common.crate_group_info in dep:
-            dep_variant_transitive_infos.append(dep[rust_common.crate_group_info].dep_variant_infos)
+        elif CrateGroupInfo in dep:
+            dep_variant_transitive_infos.append(dep[CrateGroupInfo].dep_variant_infos)
         else:
             fail("crate_group_info targets can only depend on rust_library or rust_library_group targets.")
 
@@ -724,10 +702,12 @@ _common_attrs = {
     # `@local_config_platform//:exec` exposed.
     "proc_macro_deps": attr.label_list(
         doc = dedent("""\
-            List of `rust_proc_macro` targets used to help build this library target.
+            Copy of deps in exec configuration. This should really be called `exec_configured_deps`.
+
+            Rule implementations use this to select exec-configured `rust_proc_macro` targets.
+            User code should pass all deps to `deps` for the macros loaded from `defs.bzl`.
         """),
         cfg = "exec",
-        providers = [rust_common.crate_info],
     ),
     "rustc_env": attr.string_dict(
         doc = dedent("""\
@@ -1330,6 +1310,7 @@ rust_binary_without_process_wrapper = rule(
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
+        "_skip_deps_verification": attr.bool(default = True),
     }),
     executable = True,
     fragments = ["cpp"],
@@ -1510,7 +1491,7 @@ rust_test = rule(
 """),
 )
 
-def rust_test_suite(name, srcs, shared_srcs = [], **kwargs):
+def rust_test_suite(name, srcs, shared_srcs = [], deps = [], proc_macro_deps = [], **kwargs):
     """A rule for creating a test suite for a set of `rust_test` targets.
 
     This rule can be used for setting up typical rust [integration tests][it]. Given the following
@@ -1593,6 +1574,8 @@ def rust_test_suite(name, srcs, shared_srcs = [], **kwargs):
             srcs = [src] + shared_srcs,
             tags = tags,
             crate_name = crate_name,
+            deps = deps + proc_macro_deps,
+            proc_macro_deps = deps + proc_macro_deps,
             **kwargs
         )
         tests.append(test_name)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -229,7 +229,7 @@ def collect_deps(
 
     Args:
         deps (list): The deps from ctx.attr.deps.
-        proc_macro_deps (list): The proc_macro deps from ctx.attr.proc_macro_deps.
+        proc_macro_deps (list): The proc_macro deps from `filter_deps(ctx)`.
         aliases (dict): A dict mapping aliased targets to their actual Crate information.
 
     Returns:

--- a/rust/private/rustdoc/BUILD.bazel
+++ b/rust/private/rustdoc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//rust/private:rust.bzl", "rust_binary")
+load("//rust:defs.bzl", "rust_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -18,7 +18,7 @@ load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//rust/private:common.bzl", "rust_common")
 load("//rust/private:providers.bzl", "CrateInfo")
 load("//rust/private:rustdoc.bzl", "rustdoc_compile_action")
-load("//rust/private:utils.bzl", "dedent", "find_toolchain", "transform_deps")
+load("//rust/private:utils.bzl", "dedent", "filter_deps", "find_toolchain", "transform_deps")
 
 def _construct_writer_arguments(ctx, test_runner, opt_test_params, action, crate_info):
     """Construct arguments and environment variables specific to `rustdoc_test_writer`.
@@ -110,8 +110,10 @@ def _rust_doc_test_impl(ctx):
     toolchain = find_toolchain(ctx)
 
     crate = ctx.attr.crate[rust_common.crate_info]
-    deps = transform_deps(ctx.attr.deps)
-    proc_macro_deps = transform_deps(ctx.attr.proc_macro_deps)
+
+    deps, proc_macro_deps = filter_deps(ctx)
+    deps = transform_deps(deps)
+    proc_macro_deps = transform_deps(proc_macro_deps)
 
     crate_info = rust_common.create_crate_info(
         name = crate.name,

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -498,14 +498,39 @@ def is_exec_configuration(ctx):
     # TODO(djmarcin): Is there any better way to determine cfg=exec?
     return ctx.genfiles_dir.path.find("-exec") != -1
 
+
+def filter_deps(ctx):
+    """Filters the provided (combined) deps into normal deps and proc_macro deps.
+
+    Args:
+        ctx (ctx): The current rule's context object
+
+    Returns:
+        deps and proc_macro_deps
+    """
+    if len(ctx.attr.deps) != len(ctx.attr.proc_macro_deps) and not getattr(ctx.attr, "_skip_deps_verification", False):
+        fail("All deps should be passed to both `deps` and `proc_macro_deps`; please use the macros in //rust:defs.bzl")
+
+    deps = []
+    for dep in ctx.attr.deps:
+        if CrateInfo not in dep or dep[CrateInfo].type != "proc-macro":
+            deps.append(dep)
+
+    proc_macro_deps = []
+    for dep in ctx.attr.proc_macro_deps:
+        if CrateInfo in dep and dep[CrateInfo].type == "proc-macro":
+            proc_macro_deps.append(dep)
+
+    return deps, proc_macro_deps
+
 def transform_deps(deps):
     """Transforms a [Target] into [DepVariantInfo].
 
-    This helper function is used to transform ctx.attr.deps and ctx.attr.proc_macro_deps into
+    This helper function is used to transform deps and .proc_macro_deps coming from `filter_deps` into
     [DepVariantInfo].
 
     Args:
-        deps (list of Targets): Dependencies coming from ctx.attr.deps or ctx.attr.proc_macro_deps
+        deps (list of Targets): Dependencies coming from `filter_deps`
 
     Returns:
         list of DepVariantInfos.

--- a/test/proc_macro/BUILD.bazel
+++ b/test/proc_macro/BUILD.bazel
@@ -5,7 +5,7 @@ load("//rust:defs.bzl", "rust_test")
         name = "proc_macro_{}_integration_test".format(edition),
         srcs = ["proc_macro_{}_test.rs".format(edition)],
         edition = edition,
-        proc_macro_deps = ["//test/unit/proc_macro:proc_macro_{}".format(edition)],
+        deps = ["//test/unit/proc_macro:proc_macro_{}".format(edition)],
     )
     for edition in [
         "2015",

--- a/test/proc_macro/data/BUILD.bazel
+++ b/test/proc_macro/data/BUILD.bazel
@@ -6,11 +6,9 @@ rust_test(
     name = "proc_macro_data_test",
     srcs = ["rust_test.rs"],
     edition = "2021",
-    proc_macro_deps = [
-        ":rust_proc_macro",
-    ],
     deps = [
         ":nonmacro_library",
+        ":rust_proc_macro",
     ],
 )
 
@@ -19,7 +17,7 @@ rust_library(
     name = "nonmacro_library",
     srcs = ["nonmacro_library.rs"],
     edition = "2021",
-    proc_macro_deps = [
+    deps = [
         ":rust_proc_macro",
     ],
 )

--- a/test/rust_analyzer/aspect_traversal_test/BUILD.bazel
+++ b/test/rust_analyzer/aspect_traversal_test/BUILD.bazel
@@ -8,14 +8,12 @@ rust_library(
         ":renamed_proc_macro_dep": "shorter_name",
     },
     edition = "2018",
-    proc_macro_deps = [
-        ":proc_macro_dep",
-        ":renamed_proc_macro_dep",
-    ],
     deps = [
         ":alias_dep",
         ":custom_alias_dep",
         ":lib_dep",
+        ":proc_macro_dep",
+        ":renamed_proc_macro_dep",
     ],
 )
 
@@ -71,8 +69,10 @@ rust_test(
     name = "mylib_test",
     crate = ":mylib",
     edition = "2018",
-    proc_macro_deps = [":extra_proc_macro_dep"],
-    deps = [":extra_test_dep"],
+    deps = [
+        ":extra_test_dep",
+        ":extra_proc_macro_dep"
+    ],
 )
 
 rust_library(

--- a/test/unit/pipelined_compilation/pipelined_compilation_test.bzl
+++ b/test/unit/pipelined_compilation/pipelined_compilation_test.bzl
@@ -99,8 +99,10 @@ def _pipelined_compilation_test():
         name = "second",
         edition = "2021",
         srcs = ["second.rs"],
-        deps = [":first"],
-        proc_macro_deps = [":my_macro"],
+        deps = [
+            ":first",
+            ":my_macro",
+        ],
     )
 
     rust_binary(

--- a/test/unit/proc_macro/leaks_deps/proc_macro_does_not_leak_deps.bzl
+++ b/test/unit/proc_macro/leaks_deps/proc_macro_does_not_leak_deps.bzl
@@ -63,11 +63,9 @@ def _proc_macro_does_not_leak_deps_test():
         srcs = ["leaks_deps/proc_macro_user.rs"],
         edition = "2018",
         deps = [
-            "//test/unit/proc_macro/leaks_deps/native",
-        ],
-        proc_macro_deps = [
             ":proc_macro_definition",
             ":proc_macro_with_native_dep",
+            "//test/unit/proc_macro/leaks_deps/native",
         ],
     )
 
@@ -123,7 +121,7 @@ def _proc_macro_does_not_leak_lib_deps_test():
         name = "a",
         srcs = ["leaks_deps/lib/a.rs"],
         edition = "2018",
-        proc_macro_deps = [
+        deps = [
             ":my_macro",
         ],
     )

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -248,7 +248,7 @@ def _define_targets():
         name = "lib_with_proc_macro",
         srcs = ["rustdoc_lib.rs"],
         rustdoc_deps = [":adder"],
-        proc_macro_deps = [":rustdoc_proc_macro"],
+        deps = [":rustdoc_proc_macro"],
         crate_features = ["with_proc_macro"],
     )
 
@@ -256,7 +256,7 @@ def _define_targets():
         rust_library,
         name = "lib_with_proc_macro_in_docs",
         srcs = ["procmacro_in_rustdoc.rs"],
-        proc_macro_deps = [":rustdoc_proc_macro"],
+        deps = [":rustdoc_proc_macro"],
     )
 
     _target_maker(
@@ -270,7 +270,7 @@ def _define_targets():
         rust_library,
         name = "lib_nodep_with_proc_macro",
         srcs = ["rustdoc_nodep_lib.rs"],
-        proc_macro_deps = [":rustdoc_proc_macro"],
+        deps = [":rustdoc_proc_macro"],
         crate_features = ["with_proc_macro"],
     )
 
@@ -278,8 +278,10 @@ def _define_targets():
         rust_binary,
         name = "bin_with_transitive_proc_macro",
         srcs = ["rustdoc_bin.rs"],
-        deps = [":lib_with_proc_macro"],
-        proc_macro_deps = [":rustdoc_proc_macro"],
+        deps = [
+            ":lib_with_proc_macro",
+            ":rustdoc_proc_macro",
+        ],
         crate_features = ["with_proc_macro"],
     )
 

--- a/test/unit/transitive_link_search_paths/transitive_link_search_paths_test.bzl
+++ b/test/unit/transitive_link_search_paths/transitive_link_search_paths_test.bzl
@@ -56,8 +56,10 @@ def _transitive_link_search_paths_test():
         name = "dep",
         srcs = ["dep.rs"],
         edition = "2018",
-        proc_macro_deps = [":proc_macro"],
-        deps = [":dep_build_script"],
+        deps = [
+            ":dep_build_script",
+            ":proc_macro",
+        ],
     )
 
     rust_binary(

--- a/test/unpretty/BUILD.bazel
+++ b/test/unpretty/BUILD.bazel
@@ -32,7 +32,7 @@ rust_test(
     name = "proc_macro_test",
     srcs = ["proc_macro_consumer.rs"],
     edition = "2021",
-    proc_macro_deps = [":proc_macro"],
+    deps = [":proc_macro"],
 )
 
 rust_unpretty(
@@ -59,7 +59,7 @@ rust_library(
     name = "proc_macro_lib",
     srcs = ["proc_macro_consumer.rs"],
     edition = "2021",
-    proc_macro_deps = [":proc_macro"],
+    deps = [":proc_macro"],
 )
 
 rust_unpretty(
@@ -86,7 +86,7 @@ rust_shared_library(
     name = "proc_macro_shared_lib",
     srcs = ["proc_macro_consumer.rs"],
     edition = "2021",
-    proc_macro_deps = [":proc_macro"],
+    deps = [":proc_macro"],
 )
 
 rust_unpretty(


### PR DESCRIPTION
I kept the `proc_macro_deps` attribute named the same just in case, but it would be nice to rename to `exec_configured_deps` at some point to reflect reality.