### PR TITLE
bindgen: Strip out `-Xclang` flags that upstream Clang doesn't understand.

### DIFF
--- a/extensions/bindgen/test/bindgen_test.bzl
+++ b/extensions/bindgen/test/bindgen_test.bzl
@@ -1,6 +1,8 @@
 """Analysis test for for rust_bindgen_library rule."""
 
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:action_names.bzl", "ALL_CPP_COMPILE_ACTION_NAMES")
+load("@rules_cc//cc:cc_toolchain_config_lib.bzl", "feature", "flag_group", "flag_set")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
@@ -9,6 +11,24 @@ load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 load("@rules_testing//lib:truth.bzl", "matching")
 
 def _fake_cc_toolchain_config_impl(ctx):
+    xclang_flags_feature = feature(
+        name = "xclang_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = ALL_CPP_COMPILE_ACTION_NAMES,
+                flag_groups = [
+                    flag_group(flags = [
+                        "-Xclang",
+                        "-fexperimental-optimized-noescape",
+                        "-Xclang",
+                        "-fcolor-diagnostics",
+                    ]),
+                ],
+            ),
+        ],
+    )
+
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         toolchain_identifier = "fake-toolchain",
@@ -19,6 +39,7 @@ def _fake_cc_toolchain_config_impl(ctx):
         compiler = "unknown",
         abi_version = "unknown",
         abi_libc_version = "unknown",
+        features = [xclang_flags_feature],
     )
 
 _fake_cc_toolchain_config = rule(
@@ -37,7 +58,7 @@ def _fake_cc_toolchain(name):
     write_file(
         name = stdbool_file,
         content = [],
-        out = "my/resource/dir/include/stdbool.h",
+        out = name + "/resource/dir/include/stdbool.h",
     )
 
     all_files = name + "_all_files"
@@ -58,6 +79,21 @@ def _fake_cc_toolchain(name):
         name = name,
         toolchain = name + "_cc_toolchain",
         toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    )
+
+def _create_simple_rust_bindgen_library(test_name):
+    cc_library(
+        name = test_name + "_cc",
+        hdrs = ["simple.h"],
+        srcs = ["simple.cc"],
+    )
+
+    rust_bindgen_library(
+        name = test_name + "_rust_bindgen",
+        cc_lib = test_name + "_cc",
+        header = "simple.h",
+        tags = ["manual"],
+        edition = "2021",
     )
 
 def _test_cc_linkopt_impl(env, target):
@@ -161,31 +197,47 @@ def _test_resource_dir_impl(env, target):
     env.expect.that_action(target.actions[0]).argv().contains_predicate(
         matching.all(
             matching.str_startswith("-resource-dir="),
-            matching.str_endswith("my/resource/dir"),
+            matching.str_endswith("/resource/dir"),
         ),
     )
 
 def _test_resource_dir(name):
     _fake_cc_toolchain(name + "_toolchain")
 
-    cc_library(
-        name = name + "_cc",
-        hdrs = ["simple.h"],
-        srcs = ["simple.cc"],
-    )
-
-    rust_bindgen_library(
-        name = name + "_rust_bindgen",
-        cc_lib = name + "_cc",
-        header = "simple.h",
-        tags = ["manual"],
-        edition = "2021",
-    )
+    _create_simple_rust_bindgen_library(name)
 
     analysis_test(
         name = name,
         target = name + "_rust_bindgen__bindgen",
         impl = _test_resource_dir_impl,
+        config_settings = {
+            "//command_line_option:extra_toolchains": [str(native.package_relative_label(name + "_toolchain"))],
+        },
+    )
+
+def _test_strip_xclang_impl(env, target):
+    env.expect.that_int(len(target.actions)).is_greater_than(0)
+    env.expect.that_action(target.actions[0]).mnemonic().contains("RustBindgen")
+    env.expect.that_action(target.actions[0]).not_contains_arg(
+        "-fexperimental-optimized-noescape",
+    )
+    env.expect.that_action(target.actions[0]).contains_at_least_args(
+        ["-Xclang", "-fcolor-diagnostics"],
+    )
+
+def _test_strip_xclang(name):
+    # Test that we strip certain `-Xclang` flags defined by forks of Clang
+    # that upstream Clang doesn't know about, such as
+    # `-fexperimental-optimized-noescape`. (This is added by the toolchain.)
+
+    _fake_cc_toolchain(name + "_toolchain")
+
+    _create_simple_rust_bindgen_library(name)
+
+    analysis_test(
+        name = name,
+        target = name + "_rust_bindgen__bindgen",
+        impl = _test_strip_xclang_impl,
         config_settings = {
             "//command_line_option:extra_toolchains": [str(native.package_relative_label(name + "_toolchain"))],
         },
@@ -199,5 +251,6 @@ def bindgen_test_suite(name):
             _test_cc_lib_object_merging,
             _test_cc_lib_object_merging_disabled,
             _test_resource_dir,
+            _test_strip_xclang,
         ],
     )


### PR DESCRIPTION
Some forks of Clang, such as Apple's, define additional `-Xclang` flags
that upstream Clang (as used by bindgen) does not understand. This PR
adds code for stripping these out so that bindgen does not error out on
them.
