### PR TITLE
Don't force DepInfo provider on link_deps

### DIFF
--- a/rust/private/providers.bzl
+++ b/rust/private/providers.bzl
@@ -18,6 +18,10 @@ CrateInfo = provider(
     doc = "A provider containing general Crate information.",
     fields = {
         "aliases": "Dict[Label, String]: Renamed and aliased crates",
+        "cfgs": (
+            "List[str]: The set of enabled cfgs for this crate. Note that this field is populated only " +
+            "when @rules_rust//rust/settings:collect_cfgs is set."
+        ),
         "compile_data": "depset[File]: Compile data required by this crate.",
         "compile_data_targets": "depset[Label]: Compile data targets required by this crate.",
         "data": "depset[File]: Compile data required by crates that use the current crate as a proc-macro.",
@@ -45,10 +49,6 @@ CrateInfo = provider(
         "wrapped_crate_type": (
             "str, optional: The original crate type for targets generated using a previously defined " +
             "crate (typically tests using the `rust_test::crate` attribute)"
-        ),
-        "cfgs": (
-            "List[str]: The set of enabled cfgs for this crate. Note that this field is populated only " +
-            "when @rules_rust//rust/settings:collect_cfgs is set."
         ),
     },
 )

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -799,13 +799,13 @@ _common_attrs = {
         doc = "A version to inject in the cargo environment variable.",
         default = "0.0.0",
     ),
-    "_stamp_flag": attr.label(
-        doc = "A setting used to determine whether or not the `--stamp` flag is enabled",
-        default = Label("//rust/private:stamp"),
-    ),
     "_collect_cfgs": attr.label(
         doc = "Enable collection of cfg flags with results stored in CrateInfo.cfgs.",
         default = Label("//rust/settings:collect_cfgs"),
+    ),
+    "_stamp_flag": attr.label(
+        doc = "A setting used to determine whether or not the `--stamp` flag is enabled",
+        default = Label("//rust/private:stamp"),
     ),
 } | RUSTC_ATTRS | _rustc_allocator_libraries_attrs
 
@@ -1719,7 +1719,7 @@ def _replace_illlegal_chars(name):
 def _collect_cfgs(ctx, toolchain, crate_root, crate_type, crate_is_test):
     """Collect all cfg flags for a crate but only when @rules_rust//rust/settings:collect_cfgs is set.
 
-    Cfgs are gathered from the target's own attributes (e.g., rustc_flags, crate_featues, etc.), as
+    Cfgs are gathered from the target's own attributes (e.g., rustc_flags, crate_features, etc.), as
     well as from the toolchain (e.g., toolchain.extra_rustc_flags).
 
     Args:

--- a/test/unit/collect_cfgs/collect_cfgs_test.bzl
+++ b/test/unit/collect_cfgs/collect_cfgs_test.bzl
@@ -1,3 +1,5 @@
+"""Collect cfg tests"""
+
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//rust:defs.bzl", "rust_library", "rust_proc_macro")
 load("//rust:rust_common.bzl", "CrateInfo")
@@ -114,6 +116,8 @@ collect_cfgs_extra_exec_rustc_flags_test = analysistest.make(
 )
 
 def collect_cfgs_test_suite(name):
+    """Collect cfg tests"""
+
     rust_library(
         name = "lib",
         srcs = ["lib.rs"],


### PR DESCRIPTION
I have a macro that simplifies using a crate + build_script, which passes the same labels to the crate's `deps` and the build_script's `link_deps`. This currently doesn't work for `cc_library` because we force the presence of the provider, so this PR relaxes that requirement. Note that we still check for the presence of the provider before attempting to use it, so the extra allowed deps won't affect the build. 

While I was here, I cleaned up the provider references a bit.