### PR TITLE
Fix 'NoneType has no attribute' error when building `rust_test` using `crate` attr with `settings:experimental_per_crate_rustc_flag` set

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -427,7 +427,7 @@ def _rust_test_impl(ctx):
             compile_data_targets = compile_data_targets,
             wrapped_crate_type = crate.type,
             owner = ctx.label,
-            cfgs = _collect_cfgs(ctx, toolchain, crate_root, crate_type, crate_is_test = True),
+            cfgs = _collect_cfgs(ctx, toolchain, crate.root, crate_type, crate_is_test = True),
         )
     else:
         crate_name = compute_crate_name(ctx.workspace_name, ctx.label, toolchain, ctx.attr.crate_name)


### PR DESCRIPTION
When `settings:experimental_per_crate_rustc_flag` is set, the`crate_root` parameter passed to `_collect_cfgs` is accessed. In the case of a `rust_test` using the `crate` attribute, we were previously passing the value of `ctx.file.crate_root` which could be `None`. This change uses `CrateInfo.root` (which should not be `None`) of the library target specified by the `crate` attr instead.

This raises a broader question of what it means for a `rust_test` with `crate` to have a `crate_root` attr also specified. It looks like for compilation purposes, this is ignored, and the `crate_root` of the corresponding `crate` attribute is inherited regardless. Given that, perhaps it makes sense to just `fail()` if a user specifies both `crate` and `crate_root` attrs simultaneously?