### PR TITLE
Use setdefault in case no other annotations exist

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -1051,7 +1051,7 @@ def _crate_impl(module_ctx):
             if repositories:
                 for repo in repositories:
                     _update_annotations(
-                        repo_specific_annotations.get(repo, {}),
+                        repo_specific_annotations.setdefault(repo, {}),
                         crate,
                         version,
                         triples,


### PR DESCRIPTION
If the only annotation used is annotation_select, it will be silently dropped because no repository annotation exists yet.