### PR TITLE
Avoid quadratic deduping in location expansion

### DIFF
--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -28,7 +28,7 @@ load(
     "//rust/private:utils.bzl",
     "concat",
     "dedent",
-    "dedup_expand_location",
+    "deduplicate",
     "find_toolchain",
 )
 
@@ -270,9 +270,9 @@ def _create_single_crate(ctx, attrs, info):
 
     # TODO: The only imagined use case is an env var holding a filename in the workspace passed to a
     # macro like include_bytes!. Other use cases might exist that require more complex logic.
-    expand_targets = concat([getattr(attrs, attr, []) for attr in ["data", "compile_data"]])
+    expand_targets = deduplicate(concat([getattr(attrs, attr, []) for attr in ["data", "compile_data"]]))
 
-    crate["env"].update({k: dedup_expand_location(ctx, v, expand_targets) for k, v in info.env.items()})
+    crate["env"].update({k: ctx.expand_location(v, expand_targets) for k, v in info.env.items()})
 
     # Omit when a crate appears to depend on itself (e.g. foo_test crates).
     # It can happen a single source file is present in multiple crates - there can

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -18,7 +18,7 @@ load(
 load(
     "//rust/private:utils.bzl",
     "dedent",
-    "dedup_expand_location",
+    "deduplicate",
     "find_cc_toolchain",
     "is_exec_configuration",
     "is_std_dylib",
@@ -534,9 +534,10 @@ def _experimental_use_cc_common_link(ctx):
     return ctx.attr.experimental_use_cc_common_link[BuildSettingInfo].value
 
 def _expand_flags(ctx, flags, targets):
+    targets = deduplicate(targets)
     expanded_flags = []
     for flag in flags:
-        expanded_flags.append(dedup_expand_location(ctx, flag, targets))
+        expanded_flags.append(ctx.expand_location(flag, targets))
     return expanded_flags
 
 def _rust_toolchain_impl(ctx):


### PR DESCRIPTION
Does what it says on the tin. Usually the deduping was not necessary at all because the argument were already coming from a depset or an attribute (though kept for safety), but doing the same work for every arg was truly unnecessary

Before:
<img width="898" height="222" alt="image" src="https://github.com/user-attachments/assets/1ffce739-20eb-4c3b-8cc6-fed0ba702aa0" />


After:
<img width="898" height="150" alt="image" src="https://github.com/user-attachments/assets/2497e70f-3434-4e9d-9dc8-4c9535cd2feb" />
