### PR TITLE
Make dep_variant_infos a list, not a depset

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -558,7 +558,7 @@ def _cargo_build_script_impl(ctx):
         else:
             dep_infos = [
                 dep_variant_info.dep_info
-                for dep_variant_info in dep[CrateGroupInfo].dep_variant_infos.to_list()
+                for dep_variant_info in dep[CrateGroupInfo].dep_variant_infos
                 if dep_variant_info.dep_info
             ]
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -267,7 +267,7 @@ def collect_deps(
     for dep in deps + proc_macro_deps:
         crate_group = getattr(dep, "crate_group_info", None)
         if crate_group:
-            crate_deps.extend(crate_group.dep_variant_infos.to_list())
+            crate_deps.extend(crate_group.dep_variant_infos)
         else:
             crate_deps.append(dep)
 

--- a/test/unit/cc_info/cc_info_test.bzl
+++ b/test/unit/cc_info/cc_info_test.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//rust:defs.bzl", "rust_binary", "rust_common", "rust_library", "rust_proc_macro", "rust_shared_library", "rust_static_library")
+load("//rust:rust_common.bzl", "CrateGroupInfo", "DepVariantInfo")
 
 def _is_dylib_on_windows(ctx):
     return ctx.target_platform_has_constraint(ctx.attr._windows[platform_common.ConstraintValueInfo])
@@ -178,16 +179,14 @@ def _build_test(ctx):
 build_test = analysistest.make(_build_test)
 
 def _rust_cc_injection_impl(ctx):
-    dep_variant_info = rust_common.dep_variant_info(
+    dep_variant_info = DepVariantInfo(
         cc_info = ctx.attr.cc_dep[CcInfo],
         crate_info = None,
         dep_info = None,
         build_info = None,
     )
     return [
-        rust_common.crate_group_info(
-            dep_variant_infos = depset([dep_variant_info]),
-        ),
+        CrateGroupInfo(dep_variant_infos = [dep_variant_info]),
     ]
 
 rust_cc_injection = rule(


### PR DESCRIPTION
For anyone using rust_library_group (or similar, like rules_rs) the current setup forces flattening in every rdep. We can just carry them as a list instead and iterate it directly in the consumers.

We are slightly less efficient now when nesting a library group in a library group (which is probably very rare?).

The prost rules do incur flattening now when `include_transitive_deps` is enabled (which it's not by default, and it seems like a bad practice to not declare your deps properly?). In exchange, I've improved the depset handling for constructing those transitive deps (and I think we could further improve it by not constructing the transitive depset when the toolchain isn't configured to use it...)

This is technically a breaking change for folks who have custom rules creating CrateGroupInfo, although the adjustment should be pretty trivial.