### PR TITLE
Streamline deps handling in collect_deps

### DIFF
--- a/test/unit/cc_info/cc_info_test.bzl
+++ b/test/unit/cc_info/cc_info_test.bzl
@@ -182,6 +182,7 @@ def _rust_cc_injection_impl(ctx):
         cc_info = ctx.attr.cc_dep[CcInfo],
         crate_info = None,
         dep_info = None,
+        build_info = None,
     )
     return [
         rust_common.crate_group_info(


### PR DESCRIPTION
We already call `transform_deps` in all cases upstream, so we can't end up with Targets here anymore.

Before:
<img width="1673" height="117" alt="image" src="https://github.com/user-attachments/assets/22fb4eab-9159-48df-8e2c-f873bdbae4a4" />

After:
<img width="1680" height="122" alt="image" src="https://github.com/user-attachments/assets/6e95d767-c4aa-45e2-bfc4-9423fefd41e1" />
