### PR TITLE
Provide RUSTDOC env var to build scripts

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -369,7 +369,7 @@ def _cargo_build_script_impl(ctx):
 
     cc_toolchain = find_cpp_toolchain(ctx)
 
-    env = dict({})
+    env = {}
 
     if ctx.attr.use_default_shell_env == -1:
         use_default_shell_env = ctx.attr._default_use_default_shell_env[BuildSettingInfo].value
@@ -384,9 +384,7 @@ def _cargo_build_script_impl(ctx):
         env.update(ctx.configuration.default_shell_env)
 
     if toolchain.cargo:
-        env.update({
-            "CARGO": "${{pwd}}/{}".format(toolchain.cargo.path),
-        })
+        env["CARGO"] = "${pwd}/%s" % toolchain.cargo.path
 
     env.update({
         "CARGO_CRATE_NAME": name_to_crate_name(pkg_name),
@@ -396,6 +394,7 @@ def _cargo_build_script_impl(ctx):
         "NUM_JOBS": "1",
         "OPT_LEVEL": compilation_mode_opt_level,
         "RUSTC": toolchain.rustc.path,
+        "RUSTDOC": toolchain.rust_doc.path,
         "TARGET": toolchain.target_flag_value,
         # OUT_DIR is set by the runner itself, rather than on the action.
     })

--- a/test/cargo_build_script/tools_exec/build.rs
+++ b/test/cargo_build_script/tools_exec/build.rs
@@ -48,11 +48,12 @@ fn main() {
     for env_var in &["CARGO", "CC", "CXX", "LD", "RUSTC"] {
         let path = std::env::var(env_var)
             .unwrap_or_else(|err| panic!("Error getting {}: {}", env_var, err));
-        std::process::Command::new(path).status().unwrap();
+        std::process::Command::new(&path).status()
+            .unwrap_or_else(|err| panic!("Error executing {}: {}", path, err));
     }
 
     // Assert that some env variables are set.
-    for env_var in &["CFLAGS", "CXXFLAGS", "LDFLAGS"] {
+    for env_var in &["CFLAGS", "CXXFLAGS", "LDFLAGS", "RUSTDOC"] {
         assert!(std::env::var(env_var).is_ok());
     }
 


### PR DESCRIPTION
`built`[expects this to be present at build script runtime](https://github.com/lukaslueg/built/blob/0d82cd1b959275dd5b05ee717634913a18192d1f/src/environment.rs#L379) 