### PR TITLE
Allow opting-out of the 0.0.0 crate version fallback

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -11,6 +11,7 @@ load("//rust:rust_common.bzl", "BuildInfo", "CrateGroupInfo", "DepInfo")
 # buildifier: disable=bzl-visibility
 load(
     "//rust/private:rustc.bzl",
+    "env_vars_from_version",
     "get_compilation_mode_opts",
     "get_linker_and_args",
 )
@@ -407,13 +408,7 @@ def _cargo_build_script_impl(ctx):
     })
 
     if ctx.attr.version:
-        version = ctx.attr.version.split("+")[0].split(".")
-        patch = version[2].split("-") if len(version) > 2 else [""]
-        env["CARGO_PKG_VERSION_MAJOR"] = version[0]
-        env["CARGO_PKG_VERSION_MINOR"] = version[1] if len(version) > 1 else ""
-        env["CARGO_PKG_VERSION_PATCH"] = patch[0]
-        env["CARGO_PKG_VERSION_PRE"] = patch[1] if len(patch) > 1 else ""
-        env["CARGO_PKG_VERSION"] = ctx.attr.version
+        env.update(env_vars_from_version(ctx.attr.version))
 
     # Pull in env vars which may be required for the cc_toolchain to work (e.g. on OSX, the SDK version).
     # We hope that the linker env is sufficient for the whole cc_toolchain.

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -27,6 +27,7 @@ load(
     "incompatible_change_clippy_error_format",
     "incompatible_change_rust_test_compilation_output_directory",
     "incompatible_do_not_include_data_in_compile_data",
+    "incompatible_do_not_inject_degenerate_version_to_rustc_env",
     "lto",
     "no_std",
     "pipelined_compilation",
@@ -110,6 +111,8 @@ incompatible_change_clippy_error_format()
 incompatible_change_rust_test_compilation_output_directory()
 
 incompatible_do_not_include_data_in_compile_data()
+
+incompatible_do_not_inject_degenerate_version_to_rustc_env()
 
 lto()
 

--- a/rust/settings/settings.bzl
+++ b/rust/settings/settings.bzl
@@ -478,6 +478,16 @@ def incompatible_do_not_include_data_in_compile_data():
         issue = "https://github.com/bazelbuild/rules_rust/issues/2977",
     )
 
+# buildifier: disable=unnamed-macro
+def incompatible_do_not_inject_degenerate_version_to_rustc_env():
+    """A flag to control whether we inject env vars corresponding to version 0.0.0 if version is omitted.
+    """
+    incompatible_flag(
+        name = "incompatible_do_not_inject_degenerate_version_to_rustc_env",
+        build_setting_default = False,
+        issue = "https://github.com/bazelbuild/rules_rust/issues/3674",
+    )
+
 def codegen_units():
     """The default value for `--codegen-units` which also affects resource allocation for rustc actions.
 

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -760,6 +760,7 @@ def _rust_toolchain_impl(ctx):
         _incompatible_change_rust_test_compilation_output_directory = ctx.attr._incompatible_change_rust_test_compilation_output_directory[IncompatibleFlagInfo].enabled,
         _toolchain_generated_sysroot = ctx.attr._toolchain_generated_sysroot[BuildSettingInfo].value,
         _incompatible_do_not_include_data_in_compile_data = ctx.attr._incompatible_do_not_include_data_in_compile_data[IncompatibleFlagInfo].enabled,
+        _incompatible_do_not_inject_degenerate_version_to_rustc_env = ctx.attr._incompatible_do_not_inject_degenerate_version_to_rustc_env[IncompatibleFlagInfo].enabled,
         _no_std = no_std,
         _codegen_units = ctx.attr._codegen_units[BuildSettingInfo].value,
         _experimental_use_allocator_libraries_with_mangled_symbols = ctx.attr.experimental_use_allocator_libraries_with_mangled_symbols,
@@ -985,6 +986,10 @@ rust_toolchain = rule(
         "_incompatible_do_not_include_data_in_compile_data": attr.label(
             default = Label("//rust/settings:incompatible_do_not_include_data_in_compile_data"),
             doc = "Label to a boolean build setting that controls whether to include data files in compile_data.",
+        ),
+        "_incompatible_do_not_inject_degenerate_version_to_rustc_env": attr.label(
+            default = Label("//rust/settings:incompatible_do_not_inject_degenerate_version_to_rustc_env"),
+            doc = "Label to a boolean build setting that controls whether to set rustc env vars based on a crate version of '0.0.0' if one is not explicitly provided. ",
         ),
         "_no_std": attr.label(
             default = Label("//rust/settings:no_std"),


### PR DESCRIPTION
Most users are configuring these (indirectly) via .env files anyway, so for them this is a source of duplicative or conflicting env vars.

This also unifies the 2 inconsistent implementations of the version parsing.