### PR TITLE
Fix prost dependencies in rust-project.json

### DIFF
--- a/extensions/prost/private/prost.bzl
+++ b/extensions/prost/private/prost.bzl
@@ -263,7 +263,7 @@ def _rust_prost_aspect_impl(target, ctx):
                 build_info = None,
             ))
         if RustAnalyzerInfo in prost_runtime:
-            rust_analyzer_deps.append(prost_runtime[RustAnalyzerInfo].deps)
+            rust_analyzer_deps.append(prost_runtime[RustAnalyzerInfo])
         if RustAnalyzerGroupInfo in prost_runtime:
             rust_analyzer_deps.extend(prost_runtime[RustAnalyzerGroupInfo].deps)
 


### PR DESCRIPTION
With this change `rust-project.json` files now correctly reference `prost` and `tonic` as dependencies.

This fixes https://github.com/bazelbuild/rules_rust/issues/3189.