### PR TITLE
Bump ctve's autocfg from 1.4.0 -> 1.5.0 to pick up determinism fix.

### DIFF
--- a/cargo/cargo_toml_variable_extractor/3rdparty/Cargo.Bazel.lock
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/Cargo.Bazel.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "cargo-util-schemas"

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.autocfg-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.autocfg-1.5.0.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],
@@ -82,5 +83,5 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-uefi": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "1.4.0",
+    version = "1.5.0",
 )

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.cargo-util-schemas-0.3.1.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.cargo-util-schemas-0.3.1.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.displaydoc-0.2.5.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.displaydoc-0.2.5.bazel
@@ -61,6 +61,7 @@ rust_proc_macro(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.equivalent-1.0.1.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.equivalent-1.0.1.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.erased-serde-0.4.5.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.erased-serde-0.4.5.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.form_urlencoded-1.2.1.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.form_urlencoded-1.2.1.bazel
@@ -65,6 +65,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.hashbrown-0.15.2.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.hashbrown-0.15.2.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_collections-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_collections-1.5.0.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_locid-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_locid-1.5.0.bazel
@@ -67,6 +67,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_locid_transform-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_locid_transform-1.5.0.bazel
@@ -67,6 +67,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_locid_transform_data-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_locid_transform_data-1.5.0.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_normalizer-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_normalizer-1.5.0.bazel
@@ -68,6 +68,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_normalizer_data-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_normalizer_data-1.5.0.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_properties-1.5.1.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_properties-1.5.1.bazel
@@ -68,6 +68,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_properties_data-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_properties_data-1.5.0.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_provider-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_provider-1.5.0.bazel
@@ -68,6 +68,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_provider_macros-1.5.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.icu_provider_macros-1.5.0.bazel
@@ -61,6 +61,7 @@ rust_proc_macro(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.idna-1.0.3.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.idna-1.0.3.bazel
@@ -66,6 +66,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.idna_adapter-1.2.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.idna_adapter-1.2.0.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.indexmap-2.7.1.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.indexmap-2.7.1.bazel
@@ -65,6 +65,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.litemap-0.7.4.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.litemap-0.7.4.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.memchr-2.7.4.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.memchr-2.7.4.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.num-traits-0.2.19.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.num-traits-0.2.19.bazel
@@ -65,6 +65,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],
@@ -143,7 +144,7 @@ cargo_build_script(
     version = "0.2.19",
     visibility = ["//visibility:private"],
     deps = [
-        "@rules_rust_ctve__autocfg-1.4.0//:autocfg",
+        "@rules_rust_ctve__autocfg-1.5.0//:autocfg",
     ],
 )
 

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.ordered-float-2.10.1.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.ordered-float-2.10.1.bazel
@@ -65,6 +65,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.pathdiff-0.1.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.pathdiff-0.1.0.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.percent-encoding-2.3.1.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.percent-encoding-2.3.1.bazel
@@ -65,6 +65,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.proc-macro2-1.0.93.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.proc-macro2-1.0.93.bazel
@@ -66,6 +66,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.quote-1.0.38.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.quote-1.0.38.bazel
@@ -65,6 +65,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.semver-1.0.25.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.semver-1.0.25.bazel
@@ -67,6 +67,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde-1.0.217.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde-1.0.217.bazel
@@ -72,6 +72,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde-untagged-0.1.6.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde-untagged-0.1.6.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde-value-0.7.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde-value-0.7.0.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde_derive-1.0.217.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde_derive-1.0.217.bazel
@@ -64,6 +64,7 @@ rust_proc_macro(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde_spanned-0.6.8.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.serde_spanned-0.6.8.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.smallvec-1.13.2.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.smallvec-1.13.2.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.stable_deref_trait-1.2.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.stable_deref_trait-1.2.0.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.syn-2.0.98.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.syn-2.0.98.bazel
@@ -72,6 +72,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.synstructure-0.13.1.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.synstructure-0.13.1.bazel
@@ -65,6 +65,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.thiserror-1.0.69.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.thiserror-1.0.69.bazel
@@ -65,6 +65,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.thiserror-impl-1.0.69.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.thiserror-impl-1.0.69.bazel
@@ -61,6 +61,7 @@ rust_proc_macro(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.tinystr-0.7.6.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.tinystr-0.7.6.bazel
@@ -68,6 +68,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.toml-0.8.20.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.toml-0.8.20.bazel
@@ -66,6 +66,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.toml_datetime-0.6.8.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.toml_datetime-0.6.8.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.toml_edit-0.22.24.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.toml_edit-0.22.24.bazel
@@ -66,6 +66,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.typeid-1.0.2.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.typeid-1.0.2.bazel
@@ -62,6 +62,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.unicode-ident-1.0.16.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.unicode-ident-1.0.16.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.unicode-xid-0.2.6.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.unicode-xid-0.2.6.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.url-2.5.4.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.url-2.5.4.bazel
@@ -65,6 +65,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.utf16_iter-1.0.5.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.utf16_iter-1.0.5.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.utf8_iter-1.0.4.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.utf8_iter-1.0.4.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.winnow-0.7.2.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.winnow-0.7.2.bazel
@@ -66,6 +66,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.write16-1.0.0.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.write16-1.0.0.bazel
@@ -64,6 +64,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.writeable-0.5.5.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.writeable-0.5.5.bazel
@@ -61,6 +61,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.yoke-0.7.5.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.yoke-0.7.5.bazel
@@ -70,6 +70,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.yoke-derive-0.7.5.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.yoke-derive-0.7.5.bazel
@@ -61,6 +61,7 @@ rust_proc_macro(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.zerofrom-0.1.5.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.zerofrom-0.1.5.bazel
@@ -68,6 +68,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.zerofrom-derive-0.1.5.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.zerofrom-derive-0.1.5.bazel
@@ -61,6 +61,7 @@ rust_proc_macro(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.zerovec-0.10.4.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.zerovec-0.10.4.bazel
@@ -68,6 +68,7 @@ rust_library(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.zerovec-derive-0.10.3.bazel
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/BUILD.zerovec-derive-0.10.3.bazel
@@ -61,6 +61,7 @@ rust_proc_macro(
         "@rules_rust//rust/platform:i686-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:powerpc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv32imc-unknown-none-elf": [],
+        "@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:riscv64gc-unknown-none-elf": [],
         "@rules_rust//rust/platform:s390x-unknown-linux-gnu": [],
         "@rules_rust//rust/platform:thumbv7em-none-eabi": [],

--- a/cargo/cargo_toml_variable_extractor/3rdparty/crates/defs.bzl
+++ b/cargo/cargo_toml_variable_extractor/3rdparty/crates/defs.bzl
@@ -381,6 +381,7 @@ _CONDITIONS = {
     "i686-unknown-linux-gnu": ["@rules_rust//rust/platform:i686-unknown-linux-gnu"],
     "powerpc-unknown-linux-gnu": ["@rules_rust//rust/platform:powerpc-unknown-linux-gnu"],
     "riscv32imc-unknown-none-elf": ["@rules_rust//rust/platform:riscv32imc-unknown-none-elf"],
+    "riscv64gc-unknown-linux-gnu": ["@rules_rust//rust/platform:riscv64gc-unknown-linux-gnu"],
     "riscv64gc-unknown-none-elf": ["@rules_rust//rust/platform:riscv64gc-unknown-none-elf"],
     "s390x-unknown-linux-gnu": ["@rules_rust//rust/platform:s390x-unknown-linux-gnu"],
     "thumbv7em-none-eabi": ["@rules_rust//rust/platform:thumbv7em-none-eabi"],
@@ -412,12 +413,12 @@ def crate_repositories():
     """
     maybe(
         http_archive,
-        name = "rules_rust_ctve__autocfg-1.4.0",
-        sha256 = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26",
+        name = "rules_rust_ctve__autocfg-1.5.0",
+        sha256 = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/autocfg/1.4.0/download"],
-        strip_prefix = "autocfg-1.4.0",
-        build_file = Label("//cargo/cargo_toml_variable_extractor/3rdparty/crates:BUILD.autocfg-1.4.0.bazel"),
+        urls = ["https://static.crates.io/crates/autocfg/1.5.0/download"],
+        strip_prefix = "autocfg-1.5.0",
+        build_file = Label("//cargo/cargo_toml_variable_extractor/3rdparty/crates:BUILD.autocfg-1.5.0.bazel"),
     )
 
     maybe(


### PR DESCRIPTION
I was doing some action determinism analysis and found that rules_rust's ctve's autocfg (version 1.4.0) showed up in a lot of sha differences....  looks like it leaves behind files with random filenames. This was fixed upstream in https://github.com/cuviper/autocfg/pull/75, which is included in autocfg 1.5.0.

Posted about this in slack at https://bazelbuild.slack.com/archives/CSV56UT0F/p1760515874096159.

