### PR TITLE
Avoid flattening cc toolchain depset when constructing rust toolchain

### DIFF
--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -194,9 +194,10 @@ def _make_libstd_and_allocator_ccinfo(
         )
 
         # Include C++ toolchain files as additional inputs for cross-compilation scenarios
-        additional_inputs = []
         if cc_toolchain and cc_toolchain.all_files:
-            additional_inputs = cc_toolchain.all_files.to_list()
+            additional_inputs = cc_toolchain.all_files
+        else:
+            additional_inputs = depset()
 
         linking_context, _linking_outputs = cc_common.create_linking_context_from_compilation_outputs(
             name = label.name,


### PR DESCRIPTION
These get converted to a depset anyway inside `cc_common`:

https://github.com/bazelbuild/bazel/blob/0cf8627d6f199979e6919a3e04b255268c547cdb/src/main/starlark/builtins_bzl/common/cc/link/create_linking_context_from_compilation_outputs.bzl#L85-L104