### PR TITLE
cargo_build_script: normalize CARGO_MANIFEST_DIR in cargo_build_script

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -349,18 +349,19 @@ def _cargo_build_script_impl(ctx):
     incompatible_runfiles_cargo_manifest_dir = ctx.attr._incompatible_runfiles_cargo_manifest_dir[BuildSettingInfo].value
     if not incompatible_runfiles_cargo_manifest_dir:
         script_data.append(ctx.attr.script[DefaultInfo].default_runfiles.files)
-        manifest_dir = "{}.runfiles/{}/{}".format(script.path, workspace_name, ctx.label.package)
+        manifest_dir_components = "{}.runfiles/{}/{}".format(script.path, workspace_name, ctx.label.package).split("/")
     else:
         runfiles_dir, runfiles_inputs, runfiles_args = _create_runfiles_dir(
             ctx = ctx,
             script = ctx.attr.script,
             retain_list = ctx.attr._cargo_manifest_dir_filename_suffixes_to_retain[BuildSettingInfo].value,
         )
-        manifest_dir = "{}/{}/{}".format(runfiles_dir.path, workspace_name, ctx.label.package)
+        manifest_dir_components = "{}/{}/{}".format(runfiles_dir.path, workspace_name, ctx.label.package).split("/")
         extra_args.append(runfiles_args)
         extra_inputs.append(runfiles_inputs)
         extra_output = [runfiles_dir]
 
+    manifest_dir = "/".join([c for c in manifest_dir_components if c])
     pkg_name = ctx.attr.pkg_name
     if pkg_name == "":
         pkg_name = name_to_pkg_name(ctx.label.name)


### PR DESCRIPTION
This PR fixes issue #3247 by normalizing the CARGO_MANIFEST_DIR path in cargo_build_script to ensure it doesn't end with trailing slashes.

The issue occurs because CARGO_MANIFEST_DIR in cargo_build_script doesn't clean the path like in rust.bzl and rustc.bzl, leading to inconsistent paths that can cause problems for build scripts.

Fixes https://github.com/bazelbuild/rules_rust/issues/3247