### PR TITLE
cargo_build_script: remap sandbox path to create reproducible outputs

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -444,11 +444,16 @@ def _cargo_build_script_impl(ctx):
             action_name = ACTION_NAMES.cpp_link_static_library,
         )
 
+        remap_flags = [
+            "-ffile-prefix-map=${pwd}=BAZEL_EXEC_ROOT",
+            "-ffile-prefix-map=${{pwd}}/{}=CARGO_MANIFEST_DIR".format(manifest_dir),
+        ]
+
         # Populate CFLAGS and CXXFLAGS that cc-rs relies on when building from source, in particular
         # to determine the deployment target when building for apple platforms (`macosx-version-min`
         # for example, itself derived from the `macos_minimum_os` Bazel argument).
-        env["CFLAGS"] = " ".join(_pwd_flags(cc_c_args))
-        env["CXXFLAGS"] = " ".join(_pwd_flags(cc_cxx_args))
+        env["CFLAGS"] = " ".join(_pwd_flags(cc_c_args + remap_flags))
+        env["CXXFLAGS"] = " ".join(_pwd_flags(cc_cxx_args + remap_flags))
 
     # Inform build scripts of rustc flags
     # https://github.com/rust-lang/cargo/issues/9600


### PR DESCRIPTION
This PR fixes issue #3246 by remapping sandbox paths to create reproducible outputs in cargo build scripts.

The issue occurs when cargo build script invokes CC, causing sandbox paths to leak into the output. The fix adds extra flags to CFLAGS and CXXFLAGS to remap paths similar to how cc_library works.

Fixes https://github.com/bazelbuild/rules_rust/issues/3246