### PR TITLE
use crate_name in progress message

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1401,7 +1401,7 @@ def rustc_compile_action(
             mnemonic = "Rustc",
             progress_message = "Compiling Rust {} {}{} ({} files)".format(
                 crate_info.type,
-                ctx.label.name,
+                crate_info.name,
                 formatted_version,
                 len(srcs),
             ),
@@ -1418,7 +1418,7 @@ def rustc_compile_action(
                 mnemonic = "RustcMetadata",
                 progress_message = "Compiling Rust metadata {} {}{} ({} files)".format(
                     crate_info.type,
-                    ctx.label.name,
+                    crate_info.name,
                     formatted_version,
                     len(srcs),
                 ),
@@ -1437,7 +1437,7 @@ def rustc_compile_action(
             mnemonic = "Rustc",
             progress_message = "Compiling Rust (without process_wrapper) {} {}{} ({} files)".format(
                 crate_info.type,
-                ctx.label.name,
+                crate_info.name,
                 formatted_version,
                 len(srcs),
             ),


### PR DESCRIPTION
This PR fixes issue #3461 by using crate_name instead of label.name in progress messages for better clarity.

The issue occurs when crate_name doesn't match the target label, making it difficult to distinguish between different crates during compilation. Using crate_name provides clearer identification of what's being compiled.

Fixes https://github.com/bazelbuild/rules_rust/issues/3461