### PR TITLE
feat: Add BPF triple constraint mapping

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
 
 bazel_dep(name = "bazel_features", version = "1.32.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
-bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.4")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")

--- a/rust/platform/BUILD.bazel
+++ b/rust/platform/BUILD.bazel
@@ -6,6 +6,8 @@ package(default_visibility = ["//visibility:public"])
 declare_config_settings()
 
 # WASI Preview version constraint settings
+#
+# TODO(https://github.com/bazelbuild/platforms/pull/123): Replace with upstream.
 constraint_setting(
     name = "wasi_version",
     default_constraint_value = ":wasi_preview_1",

--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -80,6 +80,8 @@ SUPPORTED_T2_PLATFORM_TRIPLES = {
 
 _T3_PLATFORM_TRIPLES = {
     "aarch64-unknown-nto-qnx710": _support(std = True, host_tools = False),
+    "bpfeb-unknown-none": _support(std = False, host_tools = False),
+    "bpfel-unknown-none": _support(std = False, host_tools = False),
     "wasm64-unknown-unknown": _support(std = False, host_tools = False),
 }
 
@@ -115,6 +117,8 @@ _CPU_ARCH_TO_BUILTIN_PLAT_SUFFIX = {
     "armv7": "armv7",
     "armv7s": None,
     "asmjs": None,
+    "bpfeb": "bpfeb",
+    "bpfel": "bpfel",
     "i386": "i386",
     "i586": None,
     "i686": "x86_32",

--- a/test/unit/platform_triple/platform_triple_test.bzl
+++ b/test/unit/platform_triple/platform_triple_test.bzl
@@ -127,6 +127,10 @@ def _construct_known_triples_test_impl(ctx):
     _assert_parts(env, triple("thumbv7em-none-eabihf"), "thumbv7em", None, "none", "eabihf")
     _assert_parts(env, triple("thumbv8m.main-none-eabi"), "thumbv8m.main", None, "none", "eabi")
 
+    # BPF targets
+    _assert_parts(env, triple("bpfeb-unknown-none"), "bpfeb", "unknown", "none", None)
+    _assert_parts(env, triple("bpfel-unknown-none"), "bpfel", "unknown", "none", None)
+
     # Test all WASM32 targets
     _assert_parts(env, triple("wasm32-unknown-unknown"), "wasm32", "unknown", "unknown", None)
     _assert_parts(env, triple("wasm32-unknown-emscripten"), "wasm32", "unknown", "emscripten", None)


### PR DESCRIPTION
Add support for tier 3 targets bpfeb-unknown-none and bpfel-unknown-none
(see
https://github.com/rust-lang/rust/blob/f5e2df7/src/doc/rustc/src/platform-support.md?plain=1#L311-L312).

This is modeled after https://github.com/bazelbuild/rules_rust/pull/3507 and
should probably be updated if/when
https://github.com/bazelbuild/platforms/pull/131 is merged.

(please use rebase merge when landing this as the proper commit message is in the commit, rather than the PR description)

/cc @avrabe
