### PR TITLE
Tell which workspace to clean up

### DIFF
--- a/crate_universe/src/splicing/splicer.rs
+++ b/crate_universe/src/splicing/splicer.rs
@@ -71,7 +71,16 @@ impl<'a> SplicerKind<'a> {
             .and_then(|path| manifests.get_key_value(path))
         {
             if manifests.len() > 1 {
-                eprintln!("Only the workspace's Cargo.toml is required in the `manifests` attribute; the rest can be removed");
+                let workspace_name = manifest
+                    .package
+                    .as_ref()
+                    .map(|p| p.name.as_str())
+                    .unwrap_or_else(|| {
+                        path.parent()
+                            .and_then(|p| p.file_name())
+                            .unwrap_or_else(|| path.file_name().unwrap_or("unknown"))
+                    });
+                eprintln!("INFO: Only the workspace's Cargo.toml is required in the `manifests` attribute of workspace `{workspace_name}`; the rest can be removed");
             }
             Ok(Self::Workspace {
                 path,

--- a/examples/crate_universe/MODULE.bazel
+++ b/examples/crate_universe/MODULE.bazel
@@ -338,12 +338,7 @@ crate_index_cargo_workspace.from_cargo(
     cargo_config = "//cargo_workspace:.cargo/config.toml",
     cargo_lockfile = "//cargo_workspace:Cargo.Bazel.lock",
     lockfile = "//cargo_workspace:cargo-bazel-lock.json",
-    manifests = [
-        "//cargo_workspace:Cargo.toml",
-        "//cargo_workspace/num_printer:Cargo.toml",
-        "//cargo_workspace/printer:Cargo.toml",
-        "//cargo_workspace/rng:Cargo.toml",
-    ],
+    manifests = ["//cargo_workspace:Cargo.toml"],
 )
 use_repo(
     crate_index_cargo_workspace,

--- a/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
+++ b/examples/crate_universe/cargo_workspace/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b78c987f5327687e670e9a453e7cbf40fa4179255243800d0d359a140e2647af",
+  "checksum": "a0fc59bd2c83a5d9e7dadb29fbe1474272b1d62fa4e833385aba9fcfa12e8940",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",


### PR DESCRIPTION
Now the user will see `INFO: Only the workspace's Cargo.toml is required in the `manifests` attribute of workspace `cargo_workspace`; the rest can be removed`

Before it was not clear in which workspace this happened. Might not have been a problem for most users but it helped to cleanup the examples in this repo.