### PR TITLE
feat: add support to specify the `package_name` attribute for generation

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -604,6 +604,7 @@ def _generate_hub_and_spokes(
             workspace_name = cfg.name,
             generate_binaries = cfg.generate_binaries,
             render_config = render_config,
+            package_name = cfg.package_name,
             repository_ctx = module_ctx,
         ),
     )
@@ -1190,6 +1191,10 @@ _FROM_COMMON_ATTRS = {
     "cargo_lockfile": CRATES_VENDOR_ATTRS["cargo_lockfile"],
     "generate_binaries": CRATES_VENDOR_ATTRS["generate_binaries"],
     "generate_build_scripts": CRATES_VENDOR_ATTRS["generate_build_scripts"],
+    "package_name": attr.string(
+        doc = "The name of the package being generated",
+        mandatory = False,            
+    ),
     "host_tools": attr.label(
         doc = "The `rust_host_tools` repository to use.",
         default = "@rust_host_tools",

--- a/crate_universe/private/crates_repository.bzl
+++ b/crate_universe/private/crates_repository.bzl
@@ -284,6 +284,10 @@ CARGO_BAZEL_REPIN=1 CARGO_BAZEL_REPIN_ONLY=crate_index bazel sync --only=crate_i
             ),
             default = True,
         ),
+        "package_name": attr.string(
+            doc = "The name of the package being generated",
+            mandatory = False,            
+        ),
         "generate_target_compatible_with": attr.bool(
             doc = "DEPRECATED: Moved to `render_config`.",
             default = True,

--- a/crate_universe/private/crates_vendor.bzl
+++ b/crate_universe/private/crates_vendor.bzl
@@ -276,6 +276,7 @@ def _write_config_file(ctx):
             repository_name = ctx.attr.repository_name,
             output_pkg = _get_output_package(ctx),
             workspace_name = workspace_name,
+            package_name = ctx.attr.package_name,
             render_config = dict(json.decode(ctx.attr.render_config)) if ctx.attr.render_config else None,
         ),
     )
@@ -297,6 +298,7 @@ def generate_config_file(
         repository_name,
         output_pkg,
         workspace_name,
+        package_name,
         render_config,
         repository_ctx = None):
     """Writes the rendering config to cargo-bazel-config.json.
@@ -313,6 +315,7 @@ def generate_config_file(
         repository_name (str): The name of the repository to generate.
         output_pkg: The path to the package containing the build files.
         workspace_name (str): The name of the workspace.
+        package_name (str): The name of the package.
         render_config: The render config to use.
         repository_ctx (repository_ctx, optional): A repository context object
             used for enabling certain functionality.
@@ -389,6 +392,7 @@ def generate_config_file(
         render_config = render_config,
         supported_platform_triples = supported_platform_triples,
         repository_name = repository_name or ctx.label.name,
+        package_name = package_name,
         repository_ctx = repository_ctx,
     )
 
@@ -568,6 +572,9 @@ CRATES_VENDOR_ATTRS = {
             "remote",
         ],
         default = "remote",
+    ),
+    "package_name": attr.string(
+        doc = "The name of the package being generated",
     ),
     "packages": attr.string_dict(
         doc = "A set of crates (packages) specifications to depend on. See [crate.spec](#crate.spec).",

--- a/crate_universe/private/generate_utils.bzl
+++ b/crate_universe/private/generate_utils.bzl
@@ -249,6 +249,7 @@ def compile_config(
         render_config,
         supported_platform_triples,
         repository_name,
+        package_name = None,
         repository_ctx = None):
     """Create a config file for generating crate targets
 
@@ -264,6 +265,7 @@ def compile_config(
         render_config (dict): The deserialized dict of the `render_config` function.
         supported_platform_triples (list): A list of platform triples
         repository_name (str): The name of the repository being generated
+        package_name (str, optional): The name of the package being generated.
         repository_ctx (repository_ctx, optional): A repository context object used for enabling
             certain functionality.
 
@@ -305,6 +307,7 @@ def compile_config(
             repository_name = repository_name,
         ),
         supported_platform_triples = supported_platform_triples,
+        package_name = package_name,
     )
 
     return config
@@ -328,6 +331,7 @@ def generate_config(repository_ctx):
         render_config = _get_render_config(repository_ctx),
         supported_platform_triples = repository_ctx.attr.supported_platform_triples,
         repository_name = repository_ctx.name,
+        package_name = repository_ctx.attr.package_name,
         repository_ctx = repository_ctx,
     )
 

--- a/crate_universe/src/cli/splice.rs
+++ b/crate_universe/src/cli/splice.rs
@@ -130,6 +130,7 @@ pub fn splice(opt: SpliceOptions) -> Result<()> {
         .generate(
             manifest_path.as_path_buf(),
             &config.supported_platform_triples,
+            &config.package_name,
         )
         .context("Failed to generate features")?;
 

--- a/crate_universe/src/cli/vendor.rs
+++ b/crate_universe/src/cli/vendor.rs
@@ -234,6 +234,7 @@ pub fn vendor(opt: VendorOptions) -> anyhow::Result<()> {
     let resolver_data = TreeResolver::new(cargo.clone()).generate(
         manifest_path.as_path_buf(),
         &config.supported_platform_triples,
+        &config.package_name,
     )?;
 
     // Write the registry url info to the manifest now that a lockfile has been generated

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -692,6 +692,11 @@ impl<'de> Visitor<'de> for GenBinariesVisitor {
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
+    /// The name of a package to be the root of the crate graph.
+    /// If not specified, the workspace members will be used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) package_name: Option<String>,
+
     /// Whether to generate `rust_binary` targets for all bins by default
     pub(crate) generate_binaries: bool,
 


### PR DESCRIPTION
## What problem needs solving?

Enable support to generate from Cargo for a specific package, allowing Bazel to resolve dependencies solely for this package.

```bazel
crate = use_extension("//:Bazel/crate_universe.bzl", "crate")

crate.from_cargo(
     ...
     package_name = "specified_package",
)
```