### PR TITLE
Update bazel run command for VSCode debug

### DIFF
--- a/tools/vscode/src/lib.rs
+++ b/tools/vscode/src/lib.rs
@@ -273,7 +273,7 @@ impl LaunchConfigGenerator {
             // 3. Creates the debug target
                 "script ".to_owned() + &[
                     "import subprocess, os, sys".to_owned(),
-                    format!("result = subprocess.run(['bazel', 'run', '--compilation_mode=dbg', '--strip=never', '--run_under=@rules_rust//tools/vscode_debug:get_binary_path', '{}'], stdout=subprocess.PIPE, text=True, cwd='${{workspaceFolder}}')", target_info.label),
+                    format!("result = subprocess.run(['bazel', 'run', '--compilation_mode=dbg', '--strip=never', '--run_under=@rules_rust//tools/vscode:get_binary_path', '{}'], stdout=subprocess.PIPE, text=True, cwd='${{workspaceFolder}}')", target_info.label),
                     "binary_path = result.stdout.strip().splitlines()[-1]".to_owned(),
                     format!("assert binary_path, 'No binary path output for {}'", target_info.label),
                     "abs_path = os.path.join('${workspaceFolder}', binary_path)".to_owned(),


### PR DESCRIPTION
The vscod_debug package does not exist.
This target does