### PR TITLE
Do not forward ARFLAGS

### DIFF
--- a/test/cargo_build_script/cc_args_and_env/BUILD.bazel
+++ b/test/cargo_build_script/cc_args_and_env/BUILD.bazel
@@ -1,6 +1,5 @@
 load(
     "cc_args_and_env_test.bzl",
-    "ar_flags_test",
     "bindir_absolute_test",
     "bindir_relative_test",
     "fsanitize_ignorelist_absolute_test",
@@ -30,7 +29,5 @@ bindir_absolute_test(name = "bindir_absolute_test")
 fsanitize_ignorelist_absolute_test(name = "fsanitize_ignorelist_absolute_test")
 
 fsanitize_ignorelist_relative_test(name = "fsanitize_ignorelist_relative_test")
-
-ar_flags_test(name = "ar_flags_test")
 
 legacy_cc_toolchain_test(name = "legacy_cc_toolchain_test")


### PR DESCRIPTION
This is a partial revert of #3704. It does NOT revert logic that properly finds the hermetic archiver (binary and associated tests).

cc-rs needs full ownership of flag handling for the archiver. This is in part due to `ar` having very specific positional flag behaviors, and partially due to some special logic in how cc-rs constructs static libraries.

The change to enable `ARFLAGS` was causing many toolchains that pass flags to the static archiver to error out due to conflicting expectations for flag handling. Example bad `ar` invocation, where `cq` is treated as the destination archive instead of the `ar` tool mode:
```
  ar rcsD cq dest.a src1.o src2.o
```
This drops forwarding of `ARFLAGS` to fix the common case.