### PR TITLE
feat: Allow process_wrapper to capture exit codes instead of forwarding them

### DIFF
--- a/util/process_wrapper/main.rs
+++ b/util/process_wrapper/main.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::fs::{copy, OpenOptions};
 use std::io;
+use std::io::Write;
 use std::process::{exit, Command, ExitStatus, Stdio};
 
 use tinyjson::JsonValue;
@@ -228,7 +229,24 @@ fn main() -> Result<(), ProcessWrapperError> {
         }
     }
 
-    exit(code)
+    if let Some(ecf) = opts.exit_code_file {
+        let exit_code_file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(ecf)
+            .map_err(|e| ProcessWrapperError(format!("failed to create exit code file: {}", e)))?;
+        let mut writer = io::LineWriter::new(exit_code_file);
+        writeln!(writer, "{}", code).map_err(|e| {
+            ProcessWrapperError(format!("failed to write exit code to file: {}", e))
+        })?;
+    }
+
+    if opts.forward_exit_code {
+        exit(code)
+    } else {
+        exit(0)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Draft implementation of #3771 
I'll add tests once the maintainers have confirmed that this behaviour is wanted.