### PR TITLE
feat(bzlmod): Add rust_toolchain_file attribute for rust.toolchain()

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -72,6 +72,44 @@ rust.toolchain(
 )
 ```
 
+#### Using rust-toolchain.toml
+
+Alternatively, you can specify the Rust version using a `rust-toolchain.toml` file. This allows you to keep the Rust version in sync between Bazel and cargo/rustup:
+
+```python
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(
+    edition = "2021",
+    rust_toolchain_file = "//:rust-toolchain.toml",
+)
+```
+
+The parser supports both single-line and multi-line TOML arrays:
+
+```toml
+[toolchain]
+channel = "1.86.0"
+
+# Multi-line arrays are supported
+components = [
+  "rustfmt",
+  "clippy",
+]
+
+# Single-line arrays work too
+targets = ["wasm32-unknown-unknown"]
+```
+
+The following fields from `rust-toolchain.toml` are parsed and mapped to rules_rust attributes:
+
+| rust-toolchain.toml | rules_rust attribute | Notes |
+|---------------------|---------------------|-------|
+| `channel` | `versions` | Required. The Rust version to use. |
+| `targets` | `extra_target_triples` | Merged with any explicit `extra_target_triples`. |
+| `components` | `dev_components` | Set to `True` if `"rustc-dev"` is in components. |
+
+Explicit attributes in `rust.toolchain()` take precedence over values parsed from `rust-toolchain.toml`.
+
 By default, a `stable` and `nightly` toolchain will be registered if no `toolchain` method is called (and thus no specific versions are registered). However, if only 1 version is passed and it is from the `nightly` or `beta` release channels (i.e. __not__ `stable`), then the following build setting flag must be present, either on the command line or set in the project's `.bazelrc` file:
 
 ```text

--- a/rust/private/rust_toolchain_toml.bzl
+++ b/rust/private/rust_toolchain_toml.bzl
@@ -1,0 +1,139 @@
+"""Parser for rust-toolchain.toml files."""
+
+def normalize_toml_multiline_arrays(content):
+    """Normalize multi-line TOML arrays to single-line for simpler parsing.
+
+    Handles arrays like:
+        targets = [
+          "wasm32-unknown-unknown",
+          "x86_64-unknown-linux-gnu",
+        ]
+
+    Args:
+        content: The raw TOML file content.
+
+    Returns:
+        Content with multi-line arrays collapsed to single lines.
+    """
+    result = []
+    in_array = False
+    array_buffer = ""
+
+    for line in content.split("\n"):
+        stripped = line.strip()
+
+        # Preserve comments and empty lines outside arrays
+        if not stripped or stripped.startswith("#"):
+            if not in_array:
+                result.append(line)
+            continue
+
+        if in_array:
+            array_buffer += " " + stripped
+            if "]" in stripped:
+                in_array = False
+                result.append(array_buffer)
+                array_buffer = ""
+        elif "= [" in stripped and "]" not in stripped:
+            # Start of multi-line array
+            in_array = True
+            array_buffer = stripped
+        else:
+            result.append(line)
+
+    return "\n".join(result)
+
+def parse_toml_string(line):
+    """Parse a TOML string value: key = "value" -> value
+
+    Args:
+        line: A line containing a TOML key-value pair.
+
+    Returns:
+        The parsed string value, or None if parsing fails.
+    """
+    parts = line.split("=", 1)
+    if len(parts) == 2:
+        return parts[1].strip().strip("\"'")
+    return None
+
+def parse_toml_list(line):
+    """Parse a TOML list value: key = ["a", "b"] -> ["a", "b"]
+
+    Args:
+        line: A line containing a TOML key-value pair with a list value.
+
+    Returns:
+        The parsed list of strings, or an empty list if parsing fails.
+    """
+    parts = line.split("=", 1)
+    if len(parts) == 2:
+        list_str = parts[1].strip()
+        if list_str.startswith("[") and list_str.endswith("]"):
+            items = list_str[1:-1].split(",")
+            return [item.strip().strip("\"'") for item in items if item.strip().strip("\"'")]
+    return []
+
+def parse_rust_toolchain_file(content):
+    """Parse rust-toolchain.toml content and extract toolchain configuration.
+
+    Supports:
+    - channel: The toolchain version (e.g., "1.92.0", "nightly-2024-01-01")
+    - targets: Additional target triples to install
+    - components: Additional components (sets dev_components=True if "rustc-dev" present)
+
+    Both single-line and multi-line TOML arrays are supported.
+
+    Args:
+        content: The content of the rust-toolchain.toml file.
+
+    Returns:
+        A struct with versions, extra_target_triples, and dev_components fields,
+        or None if parsing fails completely.
+    """
+
+    # Normalize multi-line arrays first
+    content = normalize_toml_multiline_arrays(content)
+
+    versions = None
+    extra_target_triples = []
+    dev_components = False
+
+    for line in content.split("\n"):
+        line = line.strip()
+
+        # Skip empty lines, comments, and section headers
+        if not line or line.startswith("#") or line.startswith("["):
+            continue
+
+        if line.startswith("channel"):
+            version = parse_toml_string(line)
+            if version:
+                versions = [version]
+
+        elif line.startswith("targets"):
+            targets = parse_toml_list(line)
+            if targets:
+                extra_target_triples = targets
+
+        elif line.startswith("components"):
+            components = parse_toml_list(line)
+            if "rustc-dev" in components:
+                dev_components = True
+
+    # If no channel was found, try simple format (just version string)
+    if not versions:
+        for line in content.split("\n"):
+            line = line.strip()
+            if line and not line.startswith("#") and not line.startswith("[") and "=" not in line:
+                versions = [line]
+                break
+
+    if not versions:
+        return None
+
+    return struct(
+        versions = versions,
+        extra_target_triples = extra_target_triples,
+        dev_components = dev_components,
+    )

--- a/test/unit/rust_toolchain_toml/BUILD.bazel
+++ b/test/unit/rust_toolchain_toml/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":rust_toolchain_toml_test.bzl", "rust_toolchain_toml_test_suite")
+
+rust_toolchain_toml_test_suite(name = "rust_toolchain_toml_tests")

--- a/test/unit/rust_toolchain_toml/rust_toolchain_toml_test.bzl
+++ b/test/unit/rust_toolchain_toml/rust_toolchain_toml_test.bzl
@@ -1,0 +1,190 @@
+"""Unit tests for rust_toolchain_toml.bzl parser functions."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load(
+    "//rust/private:rust_toolchain_toml.bzl",
+    "normalize_toml_multiline_arrays",
+    "parse_rust_toolchain_file",
+    "parse_toml_list",
+    "parse_toml_string",
+)
+
+def _parse_toml_string_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Basic string parsing
+    asserts.equals(env, "1.86.0", parse_toml_string('channel = "1.86.0"'))
+    asserts.equals(env, "nightly-2024-01-01", parse_toml_string('channel = "nightly-2024-01-01"'))
+
+    # With extra whitespace
+    asserts.equals(env, "1.86.0", parse_toml_string('channel   =   "1.86.0"'))
+
+    # Single quotes
+    asserts.equals(env, "1.86.0", parse_toml_string("channel = '1.86.0'"))
+
+    # No equals sign
+    asserts.equals(env, None, parse_toml_string("just a string"))
+
+    return unittest.end(env)
+
+def _parse_toml_list_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Basic list parsing
+    asserts.equals(
+        env,
+        ["rustfmt", "clippy"],
+        parse_toml_list('components = ["rustfmt", "clippy"]'),
+    )
+
+    # Single item
+    asserts.equals(
+        env,
+        ["wasm32-unknown-unknown"],
+        parse_toml_list('targets = ["wasm32-unknown-unknown"]'),
+    )
+
+    # Empty list
+    asserts.equals(env, [], parse_toml_list("targets = []"))
+
+    # With extra whitespace
+    asserts.equals(
+        env,
+        ["a", "b", "c"],
+        parse_toml_list('items = [ "a" , "b" , "c" ]'),
+    )
+
+    # No equals sign
+    asserts.equals(env, [], parse_toml_list("not a list"))
+
+    # Not a list value
+    asserts.equals(env, [], parse_toml_list('key = "value"'))
+
+    return unittest.end(env)
+
+def _normalize_multiline_arrays_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Single-line array should be unchanged
+    single_line = 'targets = ["a", "b"]'
+    asserts.equals(env, single_line, normalize_toml_multiline_arrays(single_line))
+
+    # Multi-line array should be collapsed
+    multi_line = """components = [
+  "rustfmt",
+  "clippy",
+]"""
+    normalized = normalize_toml_multiline_arrays(multi_line)
+    asserts.true(env, "components = [" in normalized)
+    asserts.true(env, "]" in normalized)
+    asserts.true(env, "\n" not in normalized or normalized.count("\n") == 0)
+
+    # Verify the list can be parsed after normalization
+    parsed = parse_toml_list(normalized)
+    asserts.equals(env, ["rustfmt", "clippy"], parsed)
+
+    # Mixed content
+    mixed = """[toolchain]
+channel = "1.86.0"
+components = [
+  "rustfmt",
+  "clippy",
+]
+targets = ["wasm32-unknown-unknown"]"""
+    normalized_mixed = normalize_toml_multiline_arrays(mixed)
+    asserts.true(env, 'channel = "1.86.0"' in normalized_mixed)
+    asserts.true(env, 'targets = ["wasm32-unknown-unknown"]' in normalized_mixed)
+
+    return unittest.end(env)
+
+def _parse_rust_toolchain_file_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Basic TOML format
+    basic = """[toolchain]
+channel = "1.86.0"
+"""
+    parsed = parse_rust_toolchain_file(basic)
+    asserts.true(env, parsed != None, "Should parse basic TOML")
+    asserts.equals(env, ["1.86.0"], parsed.versions)
+    asserts.equals(env, [], parsed.extra_target_triples)
+    asserts.equals(env, False, parsed.dev_components)
+
+    # Full TOML with all fields
+    full = """[toolchain]
+channel = "1.92.0"
+components = ["rustfmt", "clippy", "rustc-dev"]
+targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"]
+"""
+    parsed_full = parse_rust_toolchain_file(full)
+    asserts.true(env, parsed_full != None, "Should parse full TOML")
+    asserts.equals(env, ["1.92.0"], parsed_full.versions)
+    asserts.equals(
+        env,
+        ["wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"],
+        parsed_full.extra_target_triples,
+    )
+    asserts.equals(env, True, parsed_full.dev_components)
+
+    # Multi-line arrays
+    multiline = """[toolchain]
+channel = "1.86.0"
+components = [
+  "rustfmt",
+  "clippy",
+]
+targets = ["wasm32-unknown-unknown"]
+"""
+    parsed_multiline = parse_rust_toolchain_file(multiline)
+    asserts.true(env, parsed_multiline != None, "Should parse multi-line arrays")
+    asserts.equals(env, ["1.86.0"], parsed_multiline.versions)
+    asserts.equals(env, ["wasm32-unknown-unknown"], parsed_multiline.extra_target_triples)
+
+    # Simple format (just version string)
+    simple = "1.86.0"
+    parsed_simple = parse_rust_toolchain_file(simple)
+    asserts.true(env, parsed_simple != None, "Should parse simple format")
+    asserts.equals(env, ["1.86.0"], parsed_simple.versions)
+
+    # With comments
+    with_comments = """# This is a comment
+[toolchain]
+# Another comment
+channel = "1.86.0"
+"""
+    parsed_comments = parse_rust_toolchain_file(with_comments)
+    asserts.true(env, parsed_comments != None, "Should handle comments")
+    asserts.equals(env, ["1.86.0"], parsed_comments.versions)
+
+    # Invalid content (no version)
+    invalid = """[toolchain]
+components = ["rustfmt"]
+"""
+    parsed_invalid = parse_rust_toolchain_file(invalid)
+    asserts.equals(env, None, parsed_invalid, "Should return None for invalid content")
+
+    # Nightly channel
+    nightly = """[toolchain]
+channel = "nightly-2024-06-01"
+"""
+    parsed_nightly = parse_rust_toolchain_file(nightly)
+    asserts.true(env, parsed_nightly != None)
+    asserts.equals(env, ["nightly-2024-06-01"], parsed_nightly.versions)
+
+    return unittest.end(env)
+
+parse_toml_string_test = unittest.make(_parse_toml_string_test_impl)
+parse_toml_list_test = unittest.make(_parse_toml_list_test_impl)
+normalize_multiline_arrays_test = unittest.make(_normalize_multiline_arrays_test_impl)
+parse_rust_toolchain_file_test = unittest.make(_parse_rust_toolchain_file_test_impl)
+
+def rust_toolchain_toml_test_suite(name):
+    unittest.suite(
+        name,
+        parse_toml_string_test,
+        parse_toml_list_test,
+        normalize_multiline_arrays_test,
+        parse_rust_toolchain_file_test,
+    )


### PR DESCRIPTION
Adds support for reading Rust toolchain configuration from a rust-toolchain.toml file, allowing Bazel and cargo/rustup to share the same version specification.

Supported fields:
- channel: Maps to versions attribute
- targets: Merged with extra_target_triples
- components: Sets dev_components=True if "rustc-dev" present

Supports both single-line and multi-line TOML arrays.

Fixes #2753
