### PR TITLE
util/collect_coverage: Allow overriding TARGET_FILE

### DIFF
--- a/util/collect_coverage/BUILD.bazel
+++ b/util/collect_coverage/BUILD.bazel
@@ -5,4 +5,5 @@ rust_binary(
     srcs = ["collect_coverage.rs"],
     edition = "2018",
     visibility = ["//visibility:public"],
+    deps = ["@rules_rust//tools/runfiles"],
 )


### PR DESCRIPTION
Currently, the instrumented binary is sourced from the `TARGET_FILE` environment variable. For wrappers around `rust_test`, this variable points to the wrapper rather than the actual binary, which breaks code coverage.

This change:

* Introduces the `RULES_RUST_TEST_BINARY_OVERRIDE` environment variable, which wrapper authors can use to supply the path to the original test binary.

* Uses the runfiles library to resolve `runfiles_dir` instead of relying solely on the `RUNFILES_DIR` variable.