### PR TITLE
crate_info: Fix for out_binary

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1728,7 +1728,7 @@ def rustc_compile_action(
             **crate_info_dict
         )
 
-    if crate_info.type in ["staticlib", "cdylib"]:
+    if crate_info.type in ["staticlib", "cdylib"] and not out_binary:
         # These rules are not supposed to be depended on by other rust targets, and
         # as such they shouldn't provide a CrateInfo. However, one may still want to
         # write a rust_test for them, so we provide the CrateInfo wrapped in a provider


### PR DESCRIPTION
this has been an issue for a long time

http://github.com/bazelbuild/rules_rust/pull/1315

and is still an issue