### PR TITLE
Add platform triple arm-unknown-linux-musleabi

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -49,6 +49,7 @@ SUPPORTED_T2_PLATFORM_TRIPLES = {
     "aarch64-unknown-fuchsia": _support(std = True, host_tools = False),
     "aarch64-unknown-uefi": _support(std = True, host_tools = False),
     "arm-unknown-linux-gnueabi": _support(std = True, host_tools = True),
+    "arm-unknown-linux-musleabi": _support(std = True, host_tools = True),
     "armv7-linux-androideabi": _support(std = True, host_tools = False),
     "armv7-unknown-linux-gnueabi": _support(std = True, host_tools = True),
     "i686-linux-android": _support(std = True, host_tools = False),


### PR DESCRIPTION
Add `arm-unknown-linux-musleabi` to the list of supported platform triples in `SUPPORTED_T2_PLATFORM_TRIPLES`.

The `arm-unknown-linux-musleabi` triple is a valid Rust target supported by the official Rust toolchain and is required for building Rust projects targeting ARM devices with musl. This platform triple is also recognized by popular crates in the ecosystem, such as the https://crates.io/crates/nix/0.26.2, which explicitly supports this target as T2.