### PR TITLE
Update build_bazel_apple_support version and checksum

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -125,8 +125,8 @@ def rules_rust_dependencies():
     maybe(
         http_archive,
         name = "build_bazel_apple_support",
-        sha256 = "b53f6491e742549f13866628ddffcc75d1f3b2d6987dc4f14a16b242113c890b",
-        url = "https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz",
+        sha256 = "1ae6fcf983cff3edab717636f91ad0efff2e5ba75607fdddddfd6ad0dbdfaf10",
+        url = "https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz",
     )
 
     # process_wrapper needs a low-dependency way to process json.


### PR DESCRIPTION
This version contains https://github.com/bazelbuild/apple_support/commit/44c43c715aa58d16dc713ec0daa0a4373c39245a which fixes missing `LC_UUID` errors when trying to build this (and transitive dependencies) on OSX Tahoe (e.g. https://github.com/google-ai-edge/LiteRT/issues/4727).

Also, I notice this comment: 

```
    # Make the iOS simulator constraint available, which is referenced in abi_to_constraints()
    # rules_rust does not require this dependency; it is just imported as a convenience for users.
```

FWIW, this "convenience" has caused months of pain for many users. This old dependency was very difficult to track down.