### PR TITLE
Fix stamping for rules that don't have a stamp attribute

### DIFF
--- a/rust/private/stamp.bzl
+++ b/rust/private/stamp.bzl
@@ -10,7 +10,7 @@ def is_stamping_enabled(ctx, attr):
     Returns:
         bool: The stamp value
     """
-    stamp_num = getattr(attr, "stamp", -1)
+    stamp_num = getattr(attr, "stamp", 0)
     if stamp_num == 1:
         return True
     elif stamp_num == 0:


### PR DESCRIPTION
Rules that don't have a `stamp` attribute, for example `rust_cc_proto_library_aspect`, should not be treated as stamped. This was broken by https://github.com/bazelbuild/rules_rust/pull/3816 - prior to that, we were returning false because they also don't have a `_stamp_flag ` attribute.

By returning true for `rust_cc_proto_library_aspect`, we're unnecessarily including the volatile stamp files as action inputs, which harms build caching.