### PR TITLE
Fixes behavior of rust_generated_srcs within the rust-analyzer aspect

### DIFF
--- a/test/rust_analyzer/generated_srcs_test/BUILD.bazel
+++ b/test/rust_analyzer/generated_srcs_test/BUILD.bazel
@@ -1,20 +1,17 @@
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load(":generated_srcs_test.bzl", "generated_srcs_analysis_test_suite", "rust_generated_src")
 
-write_file(
+rust_generated_src(
     name = "generated_rs",
     out = "generated.rs",
-    content = [
-        "pub fn forty_two() -> i32 { 42 }",
-        "",
-    ],
+    content = "pub fn forty_two() -> i32 { 42 }\n",
 )
 
 rust_library(
     name = "generated_srcs",
     srcs = [
         "lib.rs",
-        ":generated.rs",
+        ":generated_rs",
     ],
     edition = "2021",
 )
@@ -39,3 +36,6 @@ rust_test(
         "//test/rust_analyzer/3rdparty/crates:serde_json",
     ],
 )
+
+############################ UNIT TESTS #############################
+generated_srcs_analysis_test_suite(name = "generated_srcs_analysis_test_suite")

--- a/test/rust_analyzer/generated_srcs_test/generated_srcs_test.bzl
+++ b/test/rust_analyzer/generated_srcs_test/generated_srcs_test.bzl
@@ -1,0 +1,53 @@
+"""Analysis test for rust_analyzer_aspect rust_generated_srcs propagation."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_rust//rust:defs.bzl", "rust_analyzer_aspect")
+
+def _rust_generated_src_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.out)
+    ctx.actions.write(output = out, content = ctx.attr.content)
+    return [
+        DefaultInfo(files = depset([out])),
+        OutputGroupInfo(rust_generated_srcs = depset([out])),
+    ]
+
+rust_generated_src = rule(
+    implementation = _rust_generated_src_impl,
+    attrs = {
+        "content": attr.string(mandatory = True),
+        "out": attr.string(mandatory = True),
+    },
+    doc = "Test helper that generates a .rs file and provides rust_generated_srcs output group.",
+)
+
+def _rust_generated_srcs_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    rust_generated_srcs = target[OutputGroupInfo].rust_generated_srcs.to_list()
+    asserts.equals(env, ["generated.rs"], [f.basename for f in rust_generated_srcs])
+
+    return analysistest.end(env)
+
+rust_generated_srcs_test = analysistest.make(
+    _rust_generated_srcs_test_impl,
+    extra_target_under_test_aspects = [rust_analyzer_aspect],
+)
+
+def generated_srcs_analysis_test_suite(name):
+    """Test suite for rust_analyzer_aspect rust_generated_srcs propagation.
+
+    Args:
+        name: Name of the test suite.
+    """
+    rust_generated_srcs_test(
+        name = "rust_generated_srcs_propagation_test",
+        target_under_test = ":generated_srcs",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":rust_generated_srcs_propagation_test",
+        ],
+    )


### PR DESCRIPTION
The existing rust analyzer aspect does not handle generated files completely.

1. The aspect does not propagate through the `srcs` attribute, so on a top level target that uses a generated dependency, the aspect will not run.
2. For targets with transitive dependencies that contain generated rust sources, the aspect will visit those dependencies, but because `rust_generated_srcs` is not aggregated onto the top-level target, the files themselves will not be generated. This breaks things like e.g. jump-to-definition if you try to jump to a file that has not yet been generated by bazel.

This PR addresses both these issues.