### PR TITLE
Fixes rust-analyzer include_dirs for crates with generated sources

### DIFF
--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -263,7 +263,10 @@ def _create_single_crate(ctx, attrs, info):
         src_map = {src.short_path: src for src in srcs if src.is_source}
         if info.crate.root.short_path in src_map:
             crate["root_module"] = _WORKSPACE_TEMPLATE + src_map[info.crate.root.short_path].path
-            crate["source"]["include_dirs"].append(path_prefix + info.crate.root.dirname)
+            crate["source"]["include_dirs"].extend([
+                _WORKSPACE_TEMPLATE + src_map[info.crate.root.short_path].dirname,
+                path_prefix + info.crate.root.dirname,
+            ])
 
     if info.build_info != None and info.build_info.out_dir != None:
         out_dir_path = info.build_info.out_dir.path

--- a/test/rust_analyzer/generated_srcs_test/rust_project_json_test.rs
+++ b/test/rust_analyzer/generated_srcs_test/rust_project_json_test.rs
@@ -50,7 +50,12 @@ mod tests {
         assert!(with_gen.root_module.ends_with("/lib.rs"));
 
         let include_dirs = &with_gen.source.as_ref().unwrap().include_dirs;
-        assert!(include_dirs.len() == 1);
-        assert!(include_dirs[0].starts_with(output_base));
+        assert_eq!(include_dirs.len(), 2);
+
+        // The first entry is the workspace directory.
+        assert!(!include_dirs[0].starts_with(output_base));
+
+        // The second entry is the output base, where the generated files are located.
+        assert!(include_dirs[1].starts_with(output_base));
     }
 }


### PR DESCRIPTION
When a crate contains generated sources, `include_dirs` needs to include BOTH the root_module directory, and the generated sources directory.

When `include_dirs` is empty, the inclusion of the root_module directory is done automatically, but when setting `include_dirs`, this needs to be done manually.

See:
https://github.com/rust-lang/rust-analyzer/blob/a84d92ff213e30fb00d7b812e07c4f67e99dcd29/crates/project-model/src/project_json.rs#L123-L131