### PR TITLE
fix: Return repo_metadata from repository rules in rust/repositories.bzl

### DIFF
--- a/rust/repositories.bzl
+++ b/rust/repositories.bzl
@@ -564,7 +564,15 @@ def _rust_toolchain_tools_repository_impl(ctx):
         repro[key] = getattr(ctx.attr, key)
     repro["sha256s"] = sha256s
 
-    return repro
+    # Bazel <8.3.0 lacks ctx.repo_metadata
+    if not hasattr(ctx, "repo_metadata"):
+        return repro
+
+    reproducible = sha256s == dict(ctx.attr.sha256s)
+    return ctx.repo_metadata(
+        reproducible = reproducible,
+        attrs_for_reproducibility = {} if reproducible else repro,
+    )
 
 rust_toolchain_tools_repository = repository_rule(
     doc = (
@@ -834,7 +842,15 @@ def _rust_analyzer_toolchain_tools_repository_impl(repository_ctx):
         repro[key] = getattr(repository_ctx.attr, key)
     repro["sha256s"] = sha256s
 
-    return repro
+    # Bazel <8.3.0 lacks ctx.repo_metadata
+    if not hasattr(repository_ctx, "repo_metadata"):
+        return repro
+
+    reproducible = sha256s == dict(repository_ctx.attr.sha256s)
+    return repository_ctx.repo_metadata(
+        reproducible = reproducible,
+        attrs_for_reproducibility = {} if reproducible else repro,
+    )
 
 rust_analyzer_toolchain_tools_repository = repository_rule(
     doc = "A repository rule for defining a rust_analyzer_toolchain with a `rust-src` artifact.",
@@ -979,7 +995,15 @@ def _rustfmt_toolchain_tools_repository_impl(repository_ctx):
         repro[key] = getattr(repository_ctx.attr, key)
     repro["sha256s"] = sha256s
 
-    return repro
+    # Bazel <8.3.0 lacks ctx.repo_metadata
+    if not hasattr(repository_ctx, "repo_metadata"):
+        return repro
+
+    reproducible = sha256s == dict(repository_ctx.attr.sha256s)
+    return repository_ctx.repo_metadata(
+        reproducible = reproducible,
+        attrs_for_reproducibility = {} if reproducible else repro,
+    )
 
 rustfmt_toolchain_tools_repository = repository_rule(
     doc = "A repository rule for defining a rustfmt_toolchain.",


### PR DESCRIPTION
This allows repos produced by `rust_toolchain_tools_repository` to use the remote repo content cache.

Using Bazel 9.0.0 and the remote repo content cache, the external directory in the output base is much smaller when using this patch. Downloading the toolchain, which comes in at almost 800 MB, can be entirely skipped when using remote execution.

Before:
```shell
external # du -h -d1 | sort -h | grep rules_rust
<SNIP>
4.0K    ./rules_rust++i+rules_rust_tinyjson
32K     ./rules_rust++rust+rust_toolchains
196K    ./rules_rust_prost+
6.1M    ./rules_rust+
787M    ./rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools
```

After:
```shell
external # du -h -d1 | sort -h | grep rules_rust
<SNIP>
4.0K    ./rules_rust++i+rules_rust_tinyjson
4.0K    ./rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools
32K     ./rules_rust++rust+rust_toolchains
196K    ./rules_rust_prost+
6.1M    ./rules_rust+
```