### PR TITLE
RFC: rust_toolchains submodule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,10 +12,17 @@ module(
 bazel_dep(name = "bazel_features", version = "1.32.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rust_toolchains", version = "0.68.1")
 bazel_dep(name = "rules_cc", version = "0.2.4")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "apple_support", version = "1.24.1", repo_name = "build_bazel_apple_support")
+
+bazel_dep(name = "rust_toolchains", version = "0.0.1")
+local_path_override(
+    module_name = "rust_toolchains",
+    path = "rust_toolchains",
+)
 
 internal_deps = use_extension("//rust/private:internal_extensions.bzl", "i")
 use_repo(
@@ -45,10 +52,10 @@ use_repo(
 
 rust = use_extension("//rust:extensions.bzl", "rust")
 rust.toolchain(edition = "2021")
-use_repo(rust, "rust_toolchains")
+use_repo(rust, rules_rust_toolchains = "rust_toolchains")
 
 register_toolchains(
-    "@rust_toolchains//:all",
+    "@rules_rust_toolchains//:all",
 )
 
 rust_host_tools = use_extension("//rust:extensions.bzl", "rust_host_tools")

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -9,14 +9,17 @@ exports_files([
     "toolchain.bzl",
 ])
 
-toolchain_type(
+alias(
     name = "toolchain_type",
+    actual = "@rust_toolchains//rustc:toolchain_type",
+    deprecation = "instead use `@rust_toolchains//rustc:toolchain_type`",
+    tags = ["manual"],
 )
 
 alias(
     name = "toolchain",
     actual = "toolchain_type",
-    deprecation = "instead use `@rules_rust//rust:toolchain_type`",
+    deprecation = "instead use `@rust_toolchains//rustc:toolchain_type`",
     tags = ["manual"],
 )
 

--- a/rust/rust_analyzer/BUILD.bazel
+++ b/rust/rust_analyzer/BUILD.bazel
@@ -1,5 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-toolchain_type(
+alias(
     name = "toolchain_type",
+    actual = "@rust_toolchains//rust_analyzer:toolchain_type",
+    deprecation = "instead use `@rust_toolchains//rust_analyzer:toolchain_type`",
+    tags = ["manual"],
 )

--- a/rust/rustfmt/BUILD.bazel
+++ b/rust/rustfmt/BUILD.bazel
@@ -1,5 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-toolchain_type(
+alias(
     name = "toolchain_type",
+    actual = "@rust_toolchains//rustfmt:toolchain_type",
+    deprecation = "instead use `@rust_toolchains//rustfmt:toolchain_type`",
+    tags = ["manual"],
 )

--- a/rust_toolchains/BUILD.bazel
+++ b/rust_toolchains/BUILD.bazel
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/rust_toolchains/MODULE.bazel
+++ b/rust_toolchains/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "rust_toolchains",
+    version = "0.0.1",
+)

--- a/rust_toolchains/cargo/BUILD.bazel
+++ b/rust_toolchains/cargo/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+# The toolchain for the exec platform.
+toolchain_type(
+    name = "toolchain_type",
+)

--- a/rust_toolchains/clippy/BUILD.bazel
+++ b/rust_toolchains/clippy/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+# The toolchain for the exec platform.
+toolchain_type(
+    name = "toolchain_type",
+)

--- a/rust_toolchains/rust_analyzer/BUILD.bazel
+++ b/rust_toolchains/rust_analyzer/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+# The toolchain for the exec platform.
+toolchain_type(
+    name = "toolchain_type",
+)

--- a/rust_toolchains/rustc/BUILD.bazel
+++ b/rust_toolchains/rustc/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+# The toolchain for the exec platform.
+toolchain_type(
+    name = "toolchain_type",
+)

--- a/rust_toolchains/rustfmt/BUILD.bazel
+++ b/rust_toolchains/rustfmt/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+# The toolchain for the exec platform.
+toolchain_type(
+    name = "toolchain_type",
+)

--- a/rust_toolchains/toolchain/BUILD.bazel
+++ b/rust_toolchains/toolchain/BUILD.bazel
@@ -1,0 +1,74 @@
+load(
+    "@rules_rust//rust:toolchain.bzl",
+    "current_rust_analyzer_toolchain",
+    "current_rustfmt_toolchain",
+)
+load(
+    "@rules_rust//rust/private:toolchain_utils.bzl",
+    "current_rust_toolchain",
+    "toolchain_files",
+    "toolchain_files_for_target",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+toolchain_files(
+    name = "current_cargo_files",
+    tool = "cargo",
+)
+
+toolchain_files(
+    name = "current_clippy_files",
+    tool = "clippy",
+)
+
+toolchain_files(
+    name = "current_cargo_clippy_files",
+    tool = "cargo-clippy",
+)
+
+toolchain_files(
+    name = "current_rustc_files",
+    tool = "rustc",
+)
+
+toolchain_files(
+    name = "current_rustdoc_files",
+    tool = "rustdoc",
+)
+
+toolchain_files(
+    name = "current_rustc_lib_files",
+    tool = "rustc_lib",
+)
+
+toolchain_files(
+    name = "current_rust_stdlib_files",
+    tool = "rust_stdlib",
+)
+
+current_rust_toolchain(
+    name = "current_rust_toolchain",
+)
+
+current_rustfmt_toolchain(
+    name = "current_rustfmt_toolchain",
+)
+
+current_rust_analyzer_toolchain(
+    name = "current_rust_analyzer_toolchain",
+    tags = ["manual"],
+)
+
+toolchain_files_for_target(
+    name = "current_rustfmt_toolchain_for_target",
+    toolchain_files = ":current_rustfmt_toolchain",
+    visibility = ["//:__subpackages__"],
+)
+
+alias(
+    name = "current_rustfmt_files",
+    actual = ":current_rustfmt_toolchain",
+    deprecation = "instead use `@rules_rust//rust/toolchain:current_rustfmt_toolchain`",
+    tags = ["manual"],
+)


### PR DESCRIPTION
This unblocks alternative rulesets from providing their own toolchain definitions while reusing rules_rust for compilation. Also it lays groundwork for splitting cargo and clippy to their own toolchains, so we can slim down rustc toolchain and optimize fetches