### PR TITLE
Switch pipelining metadata action to hollow rlib (-Zno-codegen)

### DIFF
--- a/extensions/prost/private/prost.bzl
+++ b/extensions/prost/private/prost.bzl
@@ -23,6 +23,7 @@ load(
     "can_build_metadata",
     "can_use_metadata_for_pipelining",
     "generate_output_diagnostics",
+    "metadata_output_path",
 )
 load("//:providers.bzl", "ProstProtoInfo")
 load(":prost_transform.bzl", "ProstTransformInfo")
@@ -176,26 +177,14 @@ def _compile_rust(
         extension = ".rlib",
     )
 
-    rmeta_name = "{prefix}{name}-{lib_hash}{extension}".format(
-        prefix = "lib",
-        name = crate_name,
-        lib_hash = output_hash,
-        extension = ".rmeta",
-    )
-
     lib = ctx.actions.declare_file(lib_name)
     rmeta = None
     rustc_rmeta_output = None
     metadata_supports_pipelining = False
 
     if can_build_metadata(toolchain, ctx, "rlib"):
-        rmeta_name = "{prefix}{name}-{lib_hash}{extension}".format(
-            prefix = "lib",
-            name = crate_name,
-            lib_hash = output_hash,
-            extension = ".rmeta",
-        )
-        rmeta = ctx.actions.declare_file(rmeta_name)
+        rmeta_rel_path = metadata_output_path(toolchain, lib_name)
+        rmeta = ctx.actions.declare_file(rmeta_rel_path, sibling = lib)
         rustc_rmeta_output = generate_output_diagnostics(ctx, rmeta)
         metadata_supports_pipelining = can_use_metadata_for_pipelining(toolchain, "rlib")
 

--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -177,7 +177,7 @@ def rust_clippy_action(ctx, clippy_executable, process_wrapper, crate_info, conf
         out_dir = out_dir,
         build_env_files = build_env_files,
         build_flags_files = build_flags_files,
-        emit = ["dep-info", "metadata"],
+        emit = ["metadata"],
         skip_expanding_rustc_env = True,
         use_json_output = bool(clippy_diagnostics_file),
         error_format = error_format,

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -50,6 +50,7 @@ load(
     "generate_output_diagnostics",
     "get_edition",
     "get_import_macro_deps",
+    "metadata_output_path",
     "transform_deps",
     "transform_sources",
 )
@@ -206,7 +207,7 @@ def _rust_library_common(ctx, crate_type):
         disable_pipelining = getattr(ctx.attr, "disable_pipelining", False),
     ):
         rust_metadata = ctx.actions.declare_file(
-            paths.replace_extension(rust_lib_name, ".rmeta"),
+            metadata_output_path(toolchain, rust_lib_name),
             sibling = rust_lib,
         )
         rustc_rmeta_output = generate_output_diagnostics(ctx, rust_metadata)
@@ -279,7 +280,7 @@ def _rust_binary_impl(ctx):
     rustc_rmeta_output = None
     if can_build_metadata(toolchain, ctx, ctx.attr.crate_type):
         rust_metadata = ctx.actions.declare_file(
-            paths.replace_extension("lib" + crate_name, ".rmeta"),
+            metadata_output_path(toolchain, "lib" + crate_name),
             sibling = output,
         )
         rustc_rmeta_output = generate_output_diagnostics(ctx, rust_metadata)
@@ -381,7 +382,7 @@ def _rust_test_impl(ctx):
         rustc_rmeta_output = None
         if can_build_metadata(toolchain, ctx, crate_type):
             rust_metadata = ctx.actions.declare_file(
-                paths.replace_extension("lib" + crate_name, ".rmeta"),
+                metadata_output_path(toolchain, "lib" + crate_name),
                 sibling = output,
             )
             rustc_rmeta_output = generate_output_diagnostics(ctx, rust_metadata)
@@ -451,7 +452,7 @@ def _rust_test_impl(ctx):
         rustc_rmeta_output = None
         if can_build_metadata(toolchain, ctx, crate_type):
             rust_metadata = ctx.actions.declare_file(
-                paths.replace_extension("lib" + crate_name, ".rmeta"),
+                metadata_output_path(toolchain, "lib" + crate_name),
                 sibling = output,
             )
             rustc_rmeta_output = generate_output_diagnostics(ctx, rust_metadata)

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -922,7 +922,7 @@ def construct_arguments(
         out_dir,
         build_env_files,
         build_flags_files,
-        emit = ["dep-info", "link"],
+        emit = ["link"],
         force_all_deps_direct = False,
         add_flags_for_binary = False,
         include_link_flags = True,
@@ -933,6 +933,7 @@ def construct_arguments(
         force_depend_on_objects = False,
         skip_expanding_rustc_env = False,
         require_explicit_unstable_features = False,
+        inject_allow_features_guardrail = False,
         error_format = None):
     """Builds an Args object containing common rustc flags
 
@@ -968,6 +969,7 @@ def construct_arguments(
         force_depend_on_objects (bool): Force using `.rlib` object files instead of metadata (`.rmeta`) files even if they are available.
         skip_expanding_rustc_env (bool): Whether to skip expanding CrateInfo.rustc_env_attr
         require_explicit_unstable_features (bool): Whether to require all unstable features to be explicitly opted in to using `-Zallow-features=...`.
+        inject_allow_features_guardrail (bool): When True, inject `-Zallow-features=` alongside `-Zno-codegen` to prevent silent unstable-feature enablement via RUSTC_BOOTSTRAP=1. Disabled on nightly toolchains (where unstable features are already allowed by default) and when the user manages bootstrap/allow-features themselves; gated in rustc_compile_action.
         error_format (str, optional): Error format to pass to the `--error-format` command line argument. If set to None, uses the "_error_format" entry in `attr`.
 
     Returns:
@@ -1070,12 +1072,31 @@ def construct_arguments(
         error_format = "json"
 
     if build_metadata:
-        # Configure process_wrapper to terminate rustc when metadata are emitted
-        process_wrapper_flags.add("--rustc-quit-on-rmeta", "true")
+        if toolchain._incompatible_use_unstable_no_codegen_for_pipelining:
+            # RUSTC_BOOTSTRAP=1 is set on the action env in rustc_compile_action,
+            # required for -Zno-codegen on stable/beta rustc. -Zallow-features=
+            # (empty list) blocks all #![feature(...)] attributes to prevent the
+            # bootstrap env from silently enabling unstable language features in
+            # user code. Both are gated on inject_allow_features_guardrail, which
+            # is False on nightly (unstable features already allowed) and when
+            # the user manages bootstrap/allow-features themselves.
+            rustc_flags.add("-Zno-codegen")
+            if inject_allow_features_guardrail:
+                rustc_flags.add("-Zallow-features=")
+        else:
+            process_wrapper_flags.add("--rustc-quit-on-rmeta", "true")
         if crate_info.rustc_rmeta_output:
             process_wrapper_flags.add("--output-file", crate_info.rustc_rmeta_output.path)
     elif crate_info.rustc_output:
         process_wrapper_flags.add("--output-file", crate_info.rustc_output.path)
+
+    if not build_metadata and toolchain._incompatible_use_unstable_no_codegen_for_pipelining and bool(crate_info.metadata):
+        # Mirror the metadata action's -Zallow-features= so the bootstrap env
+        # does not silently enable unstable language features on the full
+        # compile. Gated on inject_allow_features_guardrail (computed in
+        # rustc_compile_action via _user_manages_bootstrap).
+        if inject_allow_features_guardrail:
+            rustc_flags.add("-Zallow-features=")
 
     rustc_flags.add(error_format, format = "--error-format=%s")
 
@@ -1105,8 +1126,17 @@ def construct_arguments(
         rustc_flags.add("--remap-path-prefix=${{output_base}}={}".format(remap_path_prefix))
 
     emit_without_paths = []
+    redirect_link_to_metadata = (
+        build_metadata and
+        crate_info.metadata != None and
+        toolchain._incompatible_use_unstable_no_codegen_for_pipelining
+    )
     for kind in emit:
-        if kind == "link" and crate_info.type == "bin" and crate_info.output != None:
+        if kind == "link" and redirect_link_to_metadata:
+            # -Zno-codegen --emit=link writes lib<name>.rlib by default, which would
+            # collide with the full action's output; redirect to the hollow path.
+            rustc_flags.add(crate_info.metadata, format = "--emit=link=%s")
+        elif kind == "link" and crate_info.type == "bin" and crate_info.output != None:
             rustc_flags.add(crate_info.output, format = "--emit=link=%s")
         else:
             emit_without_paths.append(kind)
@@ -1193,7 +1223,13 @@ def construct_arguments(
     use_metadata = _depend_on_metadata(crate_info, force_depend_on_objects)
 
     # These always need to be added, even if not linking this crate.
-    add_crate_link_flags(rustc_flags, dep_info, force_all_deps_direct, use_metadata)
+    add_crate_link_flags(
+        rustc_flags,
+        dep_info,
+        force_all_deps_direct,
+        use_metadata,
+        metadata_in_separate_dir = toolchain._incompatible_use_unstable_no_codegen_for_pipelining,
+    )
 
     needs_extern_proc_macro_flag = _is_proc_macro(crate_info) and crate_info.edition != "2015"
     if needs_extern_proc_macro_flag:
@@ -1273,6 +1309,44 @@ def construct_arguments(
     )
 
     return args, env
+
+def _flag_is_allow_features(argv, index):
+    """Returns True if the flag at argv[index] is a -Zallow-features flag.
+
+    Handles three forms rustc accepts:
+    - "-Zallow-features=..."
+    - "-Zallow-features" followed by the value in the next token
+    - "-Z" followed by "allow-features[=...]" in the next token
+    """
+    flag = argv[index]
+    if flag == "-Zallow-features" or flag.startswith("-Zallow-features="):
+        return True
+    if flag == "-Z" and index + 1 < len(argv):
+        next_tok = argv[index + 1]
+        if next_tok == "allow-features" or next_tok.startswith("allow-features="):
+            return True
+    return False
+
+def _user_manages_bootstrap(ctx, attr, env_before_inject, collected_extra_flags):
+    """Return True if the user has set RUSTC_BOOTSTRAP or -Zallow-features themselves.
+
+    When True, rules_rust skips auto-injecting both RUSTC_BOOTSTRAP=1 and
+    -Zallow-features= for this target, treating the user's configuration as
+    authoritative.
+    """
+    if "RUSTC_BOOTSTRAP" in env_before_inject:
+        return True
+
+    attr_flags = getattr(attr, "rustc_flags", []) or []
+    for i in range(len(attr_flags)):
+        if _flag_is_allow_features(attr_flags, i):
+            return True
+
+    for i in range(len(collected_extra_flags)):
+        if _flag_is_allow_features(collected_extra_flags, i):
+            return True
+
+    return False
 
 def collect_extra_rustc_flags(ctx, toolchain, crate_root, crate_type):
     """Gather all 'extra' rustc flags from the target's attributes and toolchain.
@@ -1413,18 +1487,21 @@ def rustc_compile_action(
         experimental_use_cc_common_link = experimental_use_cc_common_link,
     )
 
+    use_no_codegen_pipelining = toolchain._incompatible_use_unstable_no_codegen_for_pipelining
+
     # The types of rustc outputs to emit.
-    # If we build metadata, we need to keep the command line of the two invocations
-    # (rlib and rmeta) as similar as possible, otherwise rustc rejects the rmeta as
-    # a candidate.
-    # Because of that we need to add emit=metadata to both the rlib and rmeta invocation.
-    #
-    # When cc_common linking is enabled, emit a `.o` file, which is later
-    # passed to the cc_common.link action.
-    emit = ["dep-info", "link"]
-    if build_metadata:
-        emit.append("metadata")
+    if use_no_codegen_pipelining:
+        # Metadata is emitted by a separate -Zno-codegen action; the full action
+        # only produces the linked rlib.
+        emit = ["link"]
+    else:
+        # Legacy pipelining: rustc matches metadata against full-compile command
+        # lines, so both actions must request `--emit=...,metadata`.
+        emit = ["dep-info", "link"]
+        if build_metadata:
+            emit.append("metadata")
     if experimental_use_cc_common_link:
+        # Pass a `.o` to the cc_common.link action.
         emit = ["obj"]
 
     # Determine whether to pass `--require-explicit-unstable-features true` to the process wrapper:
@@ -1436,6 +1513,35 @@ def rustc_compile_action(
             require_explicit_unstable_features = True
         elif ctx.attr.require_explicit_unstable_features == -1:
             require_explicit_unstable_features = toolchain.require_explicit_unstable_features
+
+    # Build the env snapshot used to detect a user-managed RUSTC_BOOTSTRAP before
+    # any rules_rust-injected values are added. Matches the merge order in the
+    # main env assembly below.
+    env_before_inject = dict(ctx.configuration.default_shell_env)
+    env_before_inject.update(crate_info.rustc_env)
+    if hasattr(ctx.attr, "_extra_rustc_env") and not is_exec_configuration(ctx):
+        env_before_inject.update(
+            ctx.attr._extra_rustc_env[ExtraRustcEnvInfo].extra_rustc_env,
+        )
+
+    collected_extra_flags = collect_extra_rustc_flags(
+        ctx,
+        toolchain,
+        crate_info.root,
+        crate_info.type,
+    )
+
+    user_manages_bootstrap = _user_manages_bootstrap(
+        ctx,
+        attr,
+        env_before_inject,
+        collected_extra_flags,
+    )
+    inject_allow_features_guardrail = (
+        use_no_codegen_pipelining and
+        not user_manages_bootstrap and
+        toolchain.channel != "nightly"
+    )
 
     args, env_from_args = construct_arguments(
         ctx = ctx,
@@ -1460,10 +1566,12 @@ def rustc_compile_action(
         use_json_output = bool(build_metadata) or bool(rustc_output) or bool(rustc_rmeta_output),
         skip_expanding_rustc_env = skip_expanding_rustc_env,
         require_explicit_unstable_features = require_explicit_unstable_features,
+        inject_allow_features_guardrail = inject_allow_features_guardrail,
     )
 
     args_metadata = None
     if build_metadata:
+        metadata_emit = ["link"] if use_no_codegen_pipelining else emit
         args_metadata, _ = construct_arguments(
             ctx = ctx,
             attr = attr,
@@ -1471,7 +1579,7 @@ def rustc_compile_action(
             toolchain = toolchain,
             tool_path = toolchain.rustc.path,
             cc_toolchain = cc_toolchain,
-            emit = emit,
+            emit = metadata_emit,
             feature_configuration = feature_configuration,
             crate_info = crate_info,
             dep_info = dep_info,
@@ -1487,12 +1595,21 @@ def rustc_compile_action(
             use_json_output = True,
             build_metadata = True,
             require_explicit_unstable_features = require_explicit_unstable_features,
+            inject_allow_features_guardrail = inject_allow_features_guardrail,
         )
 
     env = dict(ctx.configuration.default_shell_env)
 
     # this is the final list of env vars
     env.update(env_from_args)
+
+    if build_metadata and use_no_codegen_pipelining and inject_allow_features_guardrail:
+        # RUSTC_BOOTSTRAP=1 is required for -Zno-codegen on stable/beta rustc, and
+        # must be set on both the metadata and full actions for SVH compatibility
+        # (since RUSTC_BOOTSTRAP affects the crate hash). Skipped on nightly
+        # toolchains (where -Zno-codegen works without bootstrap) and when the user
+        # manages RUSTC_BOOTSTRAP or -Zallow-features themselves (escape hatch).
+        env["RUSTC_BOOTSTRAP"] = "1"
 
     if hasattr(attr, "version") and attr.version != "0.0.0":
         formatted_version = " v{}".format(attr.version)
@@ -2166,7 +2283,7 @@ def _get_dir_names(files):
         dirs[f.dirname] = None
     return dirs.keys()
 
-def add_crate_link_flags(args, dep_info, force_all_deps_direct = False, use_metadata = False):
+def add_crate_link_flags(args, dep_info, force_all_deps_direct = False, use_metadata = False, metadata_in_separate_dir = False):
     """Adds link flags to an Args object reference
 
     Args:
@@ -2175,6 +2292,9 @@ def add_crate_link_flags(args, dep_info, force_all_deps_direct = False, use_meta
         force_all_deps_direct (bool, optional): Whether to pass the transitive rlibs with --extern
             to the commandline as opposed to -L.
         use_metadata (bool, optional): Build command line arguments using metadata for crates that provide it.
+        metadata_in_separate_dir (bool, optional): If True, add an extra `-Ldependency` pointing at
+            the `_meta/` subdir where hollow rlibs live under `-Zno-codegen` pipelining. Under legacy
+            pipelining the `.rmeta` is a sibling of the full rlib, so no extra flag is needed.
     """
 
     direct_crates = depset(
@@ -2193,6 +2313,14 @@ def add_crate_link_flags(args, dep_info, force_all_deps_direct = False, use_meta
         uniquify = True,
         format_each = "-Ldependency=%s",
     )
+
+    if use_metadata and metadata_in_separate_dir:
+        args.add_all(
+            dep_info.transitive_crates,
+            map_each = _get_crate_metadata_dirname,
+            uniquify = True,
+            format_each = "-Ldependency=%s",
+        )
 
 def _crate_to_link_flag_metadata(crate):
     """A helper macro used by `add_crate_link_flags` for adding crate link flags to a Arg object
@@ -2246,6 +2374,15 @@ def _get_crate_dirname(crate):
         str: The directory name of the the output File that will be produced.
     """
     return crate.output.dirname
+
+def _get_crate_metadata_dirname(crate):
+    """Returns the `_meta/` subdir containing `crate`'s hollow `_meta.rlib`, or None.
+
+    Only meaningful under `-Zno-codegen` pipelining; callers gate on that flag.
+    """
+    if crate.metadata and crate.metadata_supports_pipelining and crate.metadata.dirname != crate.output.dirname:
+        return crate.metadata.dirname
+    return None
 
 def portable_link_flags(
         lib,

--- a/rust/private/unpretty.bzl
+++ b/rust/private/unpretty.bzl
@@ -202,7 +202,7 @@ def _rust_unpretty_aspect_impl(target, ctx):
             out_dir = out_dir,
             build_env_files = build_env_files,
             build_flags_files = build_flags_files,
-            emit = ["dep-info", "metadata"],
+            emit = ["metadata"],
             skip_expanding_rustc_env = True,
         )
 

--- a/rust/private/utils.bzl
+++ b/rust/private/utils.bzl
@@ -718,6 +718,17 @@ def _replace_all(string, substitutions):
 
     return string
 
+def metadata_output_path(toolchain, base_name):
+    """Path for the pipelined metadata artifact, relative to the full rlib's dir.
+
+    New path (`incompatible_use_unstable_no_codegen_for_pipelining`=true) writes a
+    hollow rlib into a `_meta/` subdir to avoid colliding with the full rlib under
+    `-Ldependency=`. Legacy path writes `<base>.rmeta` as a sibling.
+    """
+    if toolchain._incompatible_use_unstable_no_codegen_for_pipelining:
+        return "_meta/" + paths.replace_extension(base_name, "_meta.rlib")
+    return paths.replace_extension(base_name, ".rmeta")
+
 def can_build_metadata(toolchain, ctx, crate_type, *, disable_pipelining = False):
     """Can we build metadata for the target built using this context?
 

--- a/rust/settings/BUILD.bazel
+++ b/rust/settings/BUILD.bazel
@@ -28,6 +28,7 @@ load(
     "incompatible_change_clippy_error_format",
     "incompatible_do_not_include_data_in_compile_data",
     "incompatible_do_not_include_transitive_data_in_compile_inputs",
+    "incompatible_use_unstable_no_codegen_for_pipelining",
     "lto",
     "no_std",
     "pipelined_compilation",
@@ -113,6 +114,8 @@ incompatible_change_clippy_error_format()
 incompatible_do_not_include_data_in_compile_data()
 
 incompatible_do_not_include_transitive_data_in_compile_inputs()
+
+incompatible_use_unstable_no_codegen_for_pipelining()
 
 lto()
 

--- a/rust/settings/settings.bzl
+++ b/rust/settings/settings.bzl
@@ -112,10 +112,12 @@ def use_real_import_macro():
     )
 
 def pipelined_compilation():
-    """When set, this flag causes rustc to emit `*.rmeta` files and use them for `rlib -> rlib` dependencies.
+    """When set, this flag enables pipelined compilation for `rlib -> rlib` dependencies.
 
-    While this involves one extra (short) rustc invocation to build the rmeta file,
-    it allows library dependencies to be unlocked much sooner, increasing parallelism during compilation.
+    rules_rust creates a second RustcMetadata action so downstream libraries can start
+    compiling from metadata before the full upstream rlib finishes. See
+    `incompatible_use_unstable_no_codegen_for_pipelining` for the alternate metadata
+    production mode.
     """
     bool_flag(
         name = "pipelined_compilation",
@@ -542,6 +544,21 @@ def incompatible_do_not_include_transitive_data_in_compile_inputs():
         name = "incompatible_do_not_include_transitive_data_in_compile_inputs",
         build_setting_default = True,
         issue = "https://github.com/bazelbuild/rules_rust/issues/3915",
+    )
+
+# buildifier: disable=unnamed-macro
+def incompatible_use_unstable_no_codegen_for_pipelining():
+    """Switch pipelined compilation to `-Zno-codegen` hollow rlibs.
+
+    When enabled with `pipelined_compilation`, the metadata action runs to
+    completion with `rustc -Zno-codegen --emit=link=<path>`. rules_rust also
+    injects `RUSTC_BOOTSTRAP=1` and `-Zallow-features=` on the metadata and
+    full compile actions unless the user already manages either setting.
+    """
+    incompatible_flag(
+        name = "incompatible_use_unstable_no_codegen_for_pipelining",
+        build_setting_default = False,
+        issue = "https://github.com/bazelbuild/rules_rust/issues/3977",
     )
 
 def codegen_units():

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -645,6 +645,7 @@ def _rust_toolchain_impl(ctx):
         _toolchain_generated_sysroot = ctx.attr._toolchain_generated_sysroot[BuildSettingInfo].value,
         _incompatible_do_not_include_data_in_compile_data = ctx.attr._incompatible_do_not_include_data_in_compile_data[IncompatibleFlagInfo].enabled,
         _incompatible_do_not_include_transitive_data_in_compile_inputs = ctx.attr._incompatible_do_not_include_transitive_data_in_compile_inputs[IncompatibleFlagInfo].enabled,
+        _incompatible_use_unstable_no_codegen_for_pipelining = ctx.attr._incompatible_use_unstable_no_codegen_for_pipelining[IncompatibleFlagInfo].enabled,
         _no_std = no_std,
         _codegen_units = ctx.attr._codegen_units[BuildSettingInfo].value,
         _experimental_use_allocator_libraries_with_mangled_symbols = ctx.attr.experimental_use_allocator_libraries_with_mangled_symbols,
@@ -903,6 +904,10 @@ rust_toolchain = rule(
         "_incompatible_do_not_include_transitive_data_in_compile_inputs": attr.label(
             default = Label("//rust/settings:incompatible_do_not_include_transitive_data_in_compile_inputs"),
             doc = "Label to a boolean build setting that controls whether to include transitive data dependencies in compile inputs.",
+        ),
+        "_incompatible_use_unstable_no_codegen_for_pipelining": attr.label(
+            default = Label("//rust/settings:incompatible_use_unstable_no_codegen_for_pipelining"),
+            doc = "Label to a boolean build setting that switches pipelined compilation to `-Zno-codegen` hollow rlibs (see #3977).",
         ),
         "_linker_preference": attr.label(
             default = Label("//rust/settings:toolchain_linker_preference"),

--- a/test/pipelining_bootstrap_gate/BUILD.bazel
+++ b/test/pipelining_bootstrap_gate/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+# Local-only validation target for the -Zallow-features= guardrail that
+# rules_rust auto-injects when `incompatible_use_unstable_no_codegen_for_pipelining`
+# is enabled. The source uses an unstable feature gate (`#![feature(trait_alias)]`),
+# which rustc must reject with error E0725 ("the feature ... is not in the list of
+# allowed features") when the guardrail is in effect.
+#
+# Tagged "manual" so it is skipped by `:all` / `...` wildcards. Build it explicitly
+# to verify the guardrail:
+#
+#     bazel build --@rules_rust//rust/settings:pipelined_compilation \
+#                 --@rules_rust//rust/settings:incompatible_use_unstable_no_codegen_for_pipelining \
+#                 //test/pipelining_bootstrap_gate:unstable
+#
+# Expected: the build fails with rustc error E0725 referencing `trait_alias`.
+#
+# To verify the escape hatch works, supply your own bootstrap + allow-list:
+#
+#     bazel build --@rules_rust//rust/settings:pipelined_compilation \
+#                 --@rules_rust//rust/settings:incompatible_use_unstable_no_codegen_for_pipelining \
+#                 --@rules_rust//rust/settings:extra_rustc_env=RUSTC_BOOTSTRAP=1 \
+#                 --@rules_rust//rust/settings:extra_rustc_flag=-Zallow-features=trait_alias \
+#                 //test/pipelining_bootstrap_gate:unstable
+#
+# Expected: the build succeeds.
+rust_library(
+    name = "unstable",
+    srcs = ["unstable.rs"],
+    edition = "2021",
+    tags = ["manual"],
+)

--- a/test/pipelining_bootstrap_gate/unstable.rs
+++ b/test/pipelining_bootstrap_gate/unstable.rs
@@ -1,0 +1,3 @@
+#![feature(trait_alias)]
+
+pub trait Alias = Clone + Send;

--- a/test/process_wrapper/BUILD.bazel
+++ b/test/process_wrapper/BUILD.bazel
@@ -157,8 +157,29 @@ rust_binary(
 )
 
 rust_test(
+    name = "rustc_output_format",
+    srcs = [
+        "rustc_output_format.rs",
+        "rustc_test_util.rs",
+    ],
+    data = [
+        ":fake_rustc",
+        "//util/process_wrapper",
+    ],
+    edition = "2018",
+    rustc_env = {
+        "FAKE_RUSTC_RLOCATIONPATH": "$(rlocationpath :fake_rustc)",
+        "PROCESS_WRAPPER_RLOCATIONPATH": "$(rlocationpath //util/process_wrapper)",
+    },
+    deps = ["//rust/runfiles"],
+)
+
+rust_test(
     name = "rustc_quit_on_rmeta",
-    srcs = ["rustc_quit_on_rmeta.rs"],
+    srcs = [
+        "rustc_quit_on_rmeta.rs",
+        "rustc_test_util.rs",
+    ],
     data = [
         ":fake_rustc",
         "//util/process_wrapper",

--- a/test/process_wrapper/rustc_output_format.rs
+++ b/test/process_wrapper/rustc_output_format.rs
@@ -1,0 +1,52 @@
+#[path = "rustc_test_util.rs"]
+mod rustc_test_util;
+
+#[cfg(test)]
+mod test {
+    use super::rustc_test_util::fake_rustc;
+
+    #[test]
+    fn test_rustc_output_format_rendered() {
+        let out_content = fake_rustc(&["--rustc-output-format", "rendered"], &[], true);
+        assert!(
+            out_content.contains("should be\nin output"),
+            "output should contain the first rendered message",
+        );
+        assert!(
+            out_content.contains("should not be in output"),
+            "output should contain the second rendered message",
+        );
+        assert!(
+            !out_content.contains(r#""rendered""#),
+            "rendered mode should not print raw json",
+        );
+    }
+
+    #[test]
+    fn test_rustc_output_format_json() {
+        let json_content = fake_rustc(&["--rustc-output-format", "json"], &[], true);
+        assert_eq!(
+            json_content,
+            concat!(
+                r#"{"rendered": "should be\nin output"}"#,
+                "\n",
+                r#"{"rendered": "should not be in output"}"#,
+                "\n"
+            )
+        );
+    }
+
+    #[test]
+    fn test_rustc_panic() {
+        let rendered_content = fake_rustc(&["--rustc-output-format", "json"], &["error"], false);
+        assert_eq!(
+            rendered_content,
+            r#"{"rendered": "should be\nin output"}
+ERROR!
+this should all
+appear in output.
+Error: ProcessWrapperError("failed to process stderr: error parsing rustc output as json")
+"#
+        );
+    }
+}

--- a/test/process_wrapper/rustc_quit_on_rmeta.rs
+++ b/test/process_wrapper/rustc_quit_on_rmeta.rs
@@ -1,61 +1,9 @@
+#[path = "rustc_test_util.rs"]
+mod rustc_test_util;
+
 #[cfg(test)]
 mod test {
-    use std::process::Command;
-    use std::str;
-
-    use runfiles::Runfiles;
-
-    /// fake_rustc runs the fake_rustc binary under process_wrapper with the specified
-    /// process wrapper arguments. No arguments are passed to fake_rustc itself.
-    ///
-    fn fake_rustc(
-        process_wrapper_args: &[&'static str],
-        fake_rustc_args: &[&'static str],
-        should_succeed: bool,
-    ) -> String {
-        let r = Runfiles::create().unwrap();
-        let fake_rustc = runfiles::rlocation!(r, env!("FAKE_RUSTC_RLOCATIONPATH")).unwrap();
-
-        let process_wrapper =
-            runfiles::rlocation!(r, env!("PROCESS_WRAPPER_RLOCATIONPATH")).unwrap();
-
-        let output = Command::new(process_wrapper)
-            .args(process_wrapper_args)
-            .arg("--")
-            .arg(fake_rustc)
-            .args(fake_rustc_args)
-            .output()
-            .unwrap();
-
-        if should_succeed {
-            assert!(
-                output.status.success(),
-                "unable to run process_wrapper: {} {}",
-                str::from_utf8(&output.stdout).unwrap(),
-                str::from_utf8(&output.stderr).unwrap(),
-            );
-        }
-
-        String::from_utf8(output.stderr).unwrap()
-    }
-
-    #[test]
-    fn test_rustc_quit_on_rmeta_quits() {
-        let out_content = fake_rustc(
-            &[
-                "--rustc-quit-on-rmeta",
-                "true",
-                "--rustc-output-format",
-                "rendered",
-            ],
-            &[],
-            true,
-        );
-        assert!(
-            !out_content.contains("should not be in output"),
-            "output should not contain 'should not be in output' but did",
-        );
-    }
+    use super::rustc_test_util::fake_rustc;
 
     #[test]
     fn test_rustc_quit_on_rmeta_output_json() {
@@ -88,19 +36,5 @@ mod test {
             true,
         );
         assert_eq!(rendered_content, "should be\nin output");
-    }
-
-    #[test]
-    fn test_rustc_panic() {
-        let rendered_content = fake_rustc(&["--rustc-output-format", "json"], &["error"], false);
-        assert_eq!(
-            rendered_content,
-            r#"{"rendered": "should be\nin output"}
-ERROR!
-this should all
-appear in output.
-Error: ProcessWrapperError("failed to process stderr: error parsing rustc output as json")
-"#
-        );
     }
 }

--- a/test/process_wrapper/rustc_test_util.rs
+++ b/test/process_wrapper/rustc_test_util.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+use std::str;
+
+use runfiles::Runfiles;
+
+/// Runs fake_rustc under process_wrapper with the specified wrapper arguments.
+pub(crate) fn fake_rustc(
+    process_wrapper_args: &[&'static str],
+    fake_rustc_args: &[&'static str],
+    should_succeed: bool,
+) -> String {
+    let r = Runfiles::create().unwrap();
+    let fake_rustc = runfiles::rlocation!(r, env!("FAKE_RUSTC_RLOCATIONPATH")).unwrap();
+    let process_wrapper = runfiles::rlocation!(r, env!("PROCESS_WRAPPER_RLOCATIONPATH")).unwrap();
+
+    let output = Command::new(process_wrapper)
+        .args(process_wrapper_args)
+        .arg("--")
+        .arg(fake_rustc)
+        .args(fake_rustc_args)
+        .output()
+        .unwrap();
+
+    if should_succeed {
+        assert!(
+            output.status.success(),
+            "unable to run process_wrapper: {} {}",
+            str::from_utf8(&output.stdout).unwrap(),
+            str::from_utf8(&output.stderr).unwrap(),
+        );
+    }
+
+    String::from_utf8(output.stderr).unwrap()
+}

--- a/test/unit/metadata_output_groups/metadata_output_groups.bzl
+++ b/test/unit/metadata_output_groups/metadata_output_groups.bzl
@@ -3,6 +3,13 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_proc_macro", "rust_test")
 
+_TARGETS = [
+    struct(name = "bin", rule = rust_binary, srcs = ["bin.rs"]),
+    struct(name = "lib", rule = rust_library, srcs = ["lib.rs"]),
+    struct(name = "macro", rule = rust_proc_macro, srcs = ["macro.rs"]),
+    struct(name = "unit", rule = rust_test, srcs = ["unit.rs"]),
+]
+
 def _metadata_output_groups_present_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
@@ -12,13 +19,17 @@ def _metadata_output_groups_present_test_impl(ctx):
     rustc_rmeta_output = output_groups.rustc_rmeta_output.to_list()
 
     asserts.equals(env, 1, len(build_metadata), "Expected 1 build_metadata file")
+    basename = build_metadata[0].basename
+    expected_suffix = "_meta.rlib" if ctx.attr.expect_new_path else ".rmeta"
     asserts.true(
-        build_metadata[0].basename.endswith(".rmeta"),
-        "Expected %s to end with .rmeta" % build_metadata[0],
+        env,
+        basename.endswith(expected_suffix),
+        "Expected %s to end with %s" % (build_metadata[0], expected_suffix),
     )
 
     asserts.equals(env, 1, len(rustc_rmeta_output), "Expected 1 rustc_rmeta_output file")
     asserts.true(
+        env,
         rustc_rmeta_output[0].basename.endswith(".rustc-output"),
         "Expected %s to end with .rustc-output" % rustc_rmeta_output[0],
     )
@@ -35,11 +46,23 @@ def _metadata_output_groups_missing_test_impl(ctx):
 
     return analysistest.end(env)
 
-metadata_output_groups_present_test = analysistest.make(
+metadata_output_groups_present_legacy_test = analysistest.make(
     _metadata_output_groups_present_test_impl,
+    attrs = {"expect_new_path": attr.bool(default = False)},
     config_settings = {
         str(Label("//rust/settings:always_enable_metadata_output_groups")): True,
         str(Label("//rust/settings:rustc_output_diagnostics")): True,
+        str(Label("//rust/settings:incompatible_use_unstable_no_codegen_for_pipelining")): False,
+    },
+)
+
+metadata_output_groups_present_new_test = analysistest.make(
+    _metadata_output_groups_present_test_impl,
+    attrs = {"expect_new_path": attr.bool(default = True)},
+    config_settings = {
+        str(Label("//rust/settings:always_enable_metadata_output_groups")): True,
+        str(Label("//rust/settings:rustc_output_diagnostics")): True,
+        str(Label("//rust/settings:incompatible_use_unstable_no_codegen_for_pipelining")): True,
     },
 )
 
@@ -47,63 +70,24 @@ metadata_output_groups_missing_test = analysistest.make(
     _metadata_output_groups_missing_test_impl,
 )
 
-def _output_groups_test(*, always_enable):
-    suffix = "_with_metadata" if always_enable else "_without_metadata"
+def _output_groups_test(*, always_enable, suffix, present_test = None):
+    test = present_test if always_enable else metadata_output_groups_missing_test
 
-    rust_binary(
-        name = "bin" + suffix,
-        srcs = ["bin.rs"],
-        edition = "2021",
-    )
+    for target in _TARGETS:
+        target.rule(
+            name = target.name + suffix,
+            srcs = target.srcs,
+            edition = "2021",
+        )
 
-    rust_library(
-        name = "lib" + suffix,
-        srcs = ["lib.rs"],
-        edition = "2021",
-    )
-
-    rust_proc_macro(
-        name = "macro" + suffix,
-        srcs = ["macro.rs"],
-        edition = "2021",
-    )
-
-    rust_test(
-        name = "unit" + suffix,
-        srcs = ["unit.rs"],
-        edition = "2021",
-    )
-
-    if always_enable:
-        test = metadata_output_groups_present_test
-    else:
-        test = metadata_output_groups_missing_test
-
-    test(
-        name = "bin_test" + suffix,
-        target_under_test = ":bin" + suffix,
-    )
-
-    test(
-        name = "lib_test" + suffix,
-        target_under_test = ":lib" + suffix,
-    )
-
-    test(
-        name = "macro_test" + suffix,
-        target_under_test = ":macro" + suffix,
-    )
-
-    test(
-        name = "unit_test" + suffix,
-        target_under_test = ":unit" + suffix,
-    )
+        test(
+            name = target.name + "_test" + suffix,
+            target_under_test = ":" + target.name + suffix,
+        )
 
     return [
-        ":bin_test" + suffix,
-        ":lib_test" + suffix,
-        ":macro_test" + suffix,
-        ":unit_test" + suffix,
+        ":" + target.name + "_test" + suffix
+        for target in _TARGETS
     ]
 
 def metadata_output_groups_test_suite(name):
@@ -113,8 +97,20 @@ def metadata_output_groups_test_suite(name):
         name: Name of the macro.
     """
     tests = []
-    tests.extend(_output_groups_test(always_enable = True))
-    tests.extend(_output_groups_test(always_enable = False))
+    tests.extend(_output_groups_test(
+        always_enable = True,
+        suffix = "_with_metadata_legacy",
+        present_test = metadata_output_groups_present_legacy_test,
+    ))
+    tests.extend(_output_groups_test(
+        always_enable = True,
+        suffix = "_with_metadata_new",
+        present_test = metadata_output_groups_present_new_test,
+    ))
+    tests.extend(_output_groups_test(
+        always_enable = False,
+        suffix = "_without_metadata",
+    ))
 
     native.test_suite(
         name = name,

--- a/test/unit/pipelined_compilation/pipelined_compilation_test.bzl
+++ b/test/unit/pipelined_compilation/pipelined_compilation_test.bzl
@@ -2,11 +2,43 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_proc_macro")
-load("//test/unit:common.bzl", "assert_argv_contains", "assert_list_contains_adjacent_elements", "assert_list_contains_adjacent_elements_not")
+load(
+    "//test/unit:common.bzl",
+    "assert_argv_contains",
+    "assert_list_contains_adjacent_elements",
+    "assert_list_contains_adjacent_elements_not",
+)
 load(":wrap.bzl", "wrap")
 
-ENABLE_PIPELINING = {
-    str(Label("//rust/settings:pipelined_compilation")): True,
+def _config(use_no_codegen):
+    return {
+        str(Label("//rust/settings:pipelined_compilation")): True,
+        str(Label("//rust/settings:incompatible_use_unstable_no_codegen_for_pipelining")): use_no_codegen,
+    }
+
+_VARIANTS = {
+    "new": struct(
+        suffix = "_new",
+        metadata_suffix = "_meta.rlib",
+        use_no_codegen = True,
+    ),
+    "legacy": struct(
+        suffix = "_legacy",
+        metadata_suffix = ".rmeta",
+        use_no_codegen = False,
+    ),
+}
+
+_VARIANT_ATTRS = {"variant": attr.string()}
+_CUSTOM_RULE_ATTRS = {
+    "generate_metadata": attr.bool(),
+    "variant": attr.string(),
+}
+_GUARDRAIL_ATTRS = {
+    "expected_bootstrap": attr.string(default = ""),
+    "expected_user_allow_features": attr.string(default = ""),
+    "expect_injected_allow_features": attr.bool(default = False),
+    "variant": attr.string(),
 }
 
 # TODO: Fix pipeline compilation on windows
@@ -16,146 +48,157 @@ _NO_WINDOWS = select({
     "//conditions:default": [],
 })
 
+def _variant(ctx):
+    return _VARIANTS[ctx.attr.variant]
+
+def _action(tut, mnemonic):
+    return [act for act in tut.actions if act.mnemonic == mnemonic][0]
+
+def _is_metadata_file(variant, path):
+    return path.endswith(variant.metadata_suffix)
+
+def _is_full_rlib(variant, path):
+    return path.endswith(".rlib") and not _is_metadata_file(variant, path)
+
+def _crate_inputs(action, crate_basename_prefix):
+    return [f for f in action.inputs.to_list() if f.basename.startswith(crate_basename_prefix)]
+
+def _crate_externs(action, crate_name):
+    return [arg for arg in action.argv if arg.startswith("--extern=%s=" % crate_name)]
+
+def _has_input(action, crate_name, variant, metadata):
+    for file in action.inputs.to_list():
+        if crate_name not in file.path:
+            continue
+        if metadata and _is_metadata_file(variant, file.path):
+            return True
+        if not metadata and _is_full_rlib(variant, file.path):
+            return True
+    return False
+
+def _has_metadata_input(action, crate_name, variant):
+    return _has_input(action, crate_name, variant, True)
+
+def _has_full_rlib_input(action, crate_name, variant):
+    return _has_input(action, crate_name, variant, False)
+
 def _second_lib_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    rlib_action = [act for act in tut.actions if act.mnemonic == "Rustc"][0]
-    metadata_action = [act for act in tut.actions if act.mnemonic == "RustcMetadata"][0]
+    variant = _variant(ctx)
+    rlib_action = _action(tut, "Rustc")
+    metadata_action = _action(tut, "RustcMetadata")
 
-    # Both actions should use the same --emit=
-    assert_argv_contains(env, rlib_action, "--emit=dep-info,link,metadata")
-    assert_argv_contains(env, metadata_action, "--emit=dep-info,link,metadata")
+    if variant.use_no_codegen:
+        assert_argv_contains(env, rlib_action, "--emit=link")
+        metadata_emit = [arg for arg in metadata_action.argv if arg.startswith("--emit=link=")]
+        asserts.true(
+            env,
+            len(metadata_emit) == 1,
+            "expected RustcMetadata to have --emit=link=<path>, got " + str(metadata_emit),
+        )
+        assert_argv_contains(env, metadata_action, "-Zno-codegen")
+    else:
+        assert_argv_contains(env, rlib_action, "--emit=dep-info,link,metadata")
+        assert_argv_contains(env, metadata_action, "--emit=dep-info,link,metadata")
+        assert_list_contains_adjacent_elements_not(env, rlib_action.argv, ["--rustc-quit-on-rmeta", "true"])
+        assert_list_contains_adjacent_elements(env, metadata_action.argv, ["--rustc-quit-on-rmeta", "true"])
 
-    # The metadata action should have a .rmeta as output and the rlib action a .rlib
-    path = rlib_action.outputs.to_list()[0].path
     asserts.true(
         env,
-        path.endswith(".rlib"),
-        "expected Rustc to output .rlib, got " + path,
+        _is_full_rlib(variant, rlib_action.outputs.to_list()[0].path),
+        "expected Rustc to output a full .rlib, got " + rlib_action.outputs.to_list()[0].path,
     )
-    path = metadata_action.outputs.to_list()[0].path
     asserts.true(
         env,
-        path.endswith(".rmeta"),
-        "expected RustcMetadata to output .rmeta, got " + path,
+        _is_metadata_file(variant, metadata_action.outputs.to_list()[0].path),
+        "expected RustcMetadata to output " + variant.metadata_suffix + ", got " + metadata_action.outputs.to_list()[0].path,
     )
 
-    # Only the action building metadata should contain --rustc-quit-on-rmeta
-    assert_list_contains_adjacent_elements_not(env, rlib_action.argv, ["--rustc-quit-on-rmeta", "true"])
-    assert_list_contains_adjacent_elements(env, metadata_action.argv, ["--rustc-quit-on-rmeta", "true"])
+    for action in [metadata_action, rlib_action]:
+        externs = _crate_externs(action, "first")
+        asserts.equals(env, 1, len(externs), "expected one --extern=first=... in " + action.mnemonic)
+        asserts.true(
+            env,
+            externs[0].endswith(variant.metadata_suffix),
+            "expected --extern=first to use " + variant.metadata_suffix + ", got " + externs[0],
+        )
 
-    # Check that both actions refer to the metadata of :first, not the rlib
-    extern_metadata = [arg for arg in metadata_action.argv if arg.startswith("--extern=first=") and "libfirst" in arg and arg.endswith(".rmeta")]
-    asserts.true(
-        env,
-        len(extern_metadata) == 1,
-        "did not find a --extern=first=*.rmeta but expected one",
-    )
-    extern_rlib = [arg for arg in rlib_action.argv if arg.startswith("--extern=first=") and "libfirst" in arg and arg.endswith(".rmeta")]
-    asserts.true(
-        env,
-        len(extern_rlib) == 1,
-        "did not find a --extern=first=*.rlib but expected one",
-    )
-
-    # Check that the input to both actions is the metadata of :first
-    input_metadata = [i for i in metadata_action.inputs.to_list() if i.basename.startswith("libfirst")]
-    asserts.true(env, len(input_metadata) == 1, "expected only one libfirst input, found " + str([i.path for i in input_metadata]))
-    asserts.true(env, input_metadata[0].extension == "rmeta", "expected libfirst dependency to be rmeta, found " + input_metadata[0].path)
-    input_rlib = [i for i in rlib_action.inputs.to_list() if i.basename.startswith("libfirst")]
-    asserts.true(env, len(input_rlib) == 1, "expected only one libfirst input, found " + str([i.path for i in input_rlib]))
-    asserts.true(env, input_rlib[0].extension == "rmeta", "expected libfirst dependency to be rmeta, found " + input_rlib[0].path)
+        crate_inputs = _crate_inputs(action, "libfirst")
+        asserts.equals(env, 1, len(crate_inputs), "expected one libfirst input in " + action.mnemonic)
+        asserts.true(
+            env,
+            _is_metadata_file(variant, crate_inputs[0].path),
+            "expected libfirst input to use " + variant.metadata_suffix + ", got " + crate_inputs[0].path,
+        )
 
     return analysistest.end(env)
 
 def _bin_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    bin_action = [act for act in tut.actions if act.mnemonic == "Rustc"][0]
+    variant = _variant(ctx)
+    bin_action = _action(tut, "Rustc")
 
-    # Check that no inputs to this binary are .rmeta files.
-    metadata_inputs = [i.path for i in bin_action.inputs.to_list() if i.path.endswith(".rmeta")]
-
-    # Filter out toolchain targets. This test intends to only check for rmeta files of `deps`.
-    metadata_inputs = [i for i in metadata_inputs if "/lib/rustlib" not in i]
-
-    asserts.false(env, metadata_inputs, "expected no metadata inputs, found " + json.encode_indent(metadata_inputs, indent = " " * 4))
+    metadata_inputs = [
+        i.path
+        for i in bin_action.inputs.to_list()
+        if _is_metadata_file(variant, i.path) and "/lib/rustlib" not in i.path
+    ]
+    asserts.false(
+        env,
+        metadata_inputs,
+        "expected no metadata inputs, found " + json.encode_indent(metadata_inputs, indent = " " * 4),
+    )
 
     return analysistest.end(env)
 
-bin_test = analysistest.make(_bin_test_impl, config_settings = ENABLE_PIPELINING)
-second_lib_test = analysistest.make(_second_lib_test_impl, config_settings = ENABLE_PIPELINING)
+def _guardrail_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+    rlib_action = _action(tut, "Rustc")
+    metadata_action = _action(tut, "RustcMetadata")
+    expected_bootstrap = ctx.attr.expected_bootstrap or None
 
-def _pipelined_compilation_test():
-    rust_proc_macro(
-        name = "my_macro",
-        edition = "2021",
-        srcs = ["my_macro.rs"],
-    )
+    for action in (metadata_action, rlib_action):
+        asserts.equals(
+            env,
+            expected_bootstrap,
+            action.env.get("RUSTC_BOOTSTRAP"),
+            "expected RUSTC_BOOTSTRAP=" + repr(expected_bootstrap) + " in " + action.mnemonic + ", got " + repr(action.env.get("RUSTC_BOOTSTRAP")),
+        )
+        has_our_flag = "-Zallow-features=" in action.argv
+        if ctx.attr.expect_injected_allow_features:
+            asserts.true(
+                env,
+                has_our_flag,
+                "expected injected -Zallow-features= in " + action.mnemonic,
+            )
+        else:
+            asserts.false(
+                env,
+                has_our_flag,
+                "expected no injected -Zallow-features= in " + action.mnemonic,
+            )
+        if ctx.attr.expected_user_allow_features:
+            asserts.true(
+                env,
+                ctx.attr.expected_user_allow_features in action.argv,
+                "expected user's " + ctx.attr.expected_user_allow_features + " in " + action.mnemonic,
+            )
 
-    rust_library(
-        name = "first",
-        edition = "2021",
-        srcs = ["first.rs"],
-    )
-
-    rust_library(
-        name = "second",
-        edition = "2021",
-        srcs = ["second.rs"],
-        deps = [":first"],
-        proc_macro_deps = [":my_macro"],
-    )
-
-    rust_binary(
-        name = "bin",
-        edition = "2021",
-        srcs = ["bin.rs"],
-        deps = [":second"],
-    )
-
-    second_lib_test(
-        name = "second_lib_test",
-        target_under_test = ":second",
-        target_compatible_with = _NO_WINDOWS,
-    )
-    bin_test(
-        name = "bin_test",
-        target_under_test = ":bin",
-        target_compatible_with = _NO_WINDOWS,
-    )
-
-    return [
-        ":second_lib_test",
-        ":bin_test",
-    ]
+    return analysistest.end(env)
 
 def _rmeta_is_propagated_through_custom_rule_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
+    variant = _variant(ctx)
+    rust_action = _action(tut, "RustcMetadata")
 
-    # This is the metadata-generating action. It should depend on metadata for the library and, if generate_metadata is set
-    # also depend on metadata for 'wrapper'.
-    rust_action = [act for act in tut.actions if act.mnemonic == "RustcMetadata"][0]
-
-    metadata_inputs = [i for i in rust_action.inputs.to_list() if i.path.endswith(".rmeta")]
-    rlib_inputs = [i for i in rust_action.inputs.to_list() if i.path.endswith(".rlib")]
-
-    seen_wrapper_metadata = False
-    seen_to_wrap_metadata = False
-    for mi in metadata_inputs:
-        if "libwrapper" in mi.path:
-            seen_wrapper_metadata = True
-        if "libto_wrap" in mi.path:
-            seen_to_wrap_metadata = True
-
-    seen_wrapper_rlib = False
-    seen_to_wrap_rlib = False
-    for ri in rlib_inputs:
-        if "libwrapper" in ri.path:
-            seen_wrapper_rlib = True
-        if "libto_wrap" in ri.path:
-            seen_to_wrap_rlib = True
+    seen_wrapper_metadata = _has_metadata_input(rust_action, "libwrapper", variant)
+    seen_wrapper_rlib = _has_full_rlib_input(rust_action, "libwrapper", variant)
+    seen_to_wrap_metadata = _has_metadata_input(rust_action, "libto_wrap", variant)
+    seen_to_wrap_rlib = _has_full_rlib_input(rust_action, "libto_wrap", variant)
 
     if ctx.attr.generate_metadata:
         asserts.true(env, seen_wrapper_metadata, "expected dependency on metadata for 'wrapper' but not found")
@@ -172,26 +215,16 @@ def _rmeta_is_propagated_through_custom_rule_test_impl(ctx):
 def _rmeta_is_used_when_building_custom_rule_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
+    variant = _variant(ctx)
+    rust_action = _action(tut, "Rustc")
 
-    # This is the custom rule invocation of rustc.
-    rust_action = [act for act in tut.actions if act.mnemonic == "Rustc"][0]
+    seen_to_wrap_metadata = _has_metadata_input(rust_action, "libto_wrap", variant)
+    seen_to_wrap_rlib = _has_full_rlib_input(rust_action, "libto_wrap", variant)
 
-    # We want to check that the action depends on metadata, regardless of ctx.attr.generate_metadata
-    seen_to_wrap_rlib = False
-    seen_to_wrap_rmeta = False
-    for act in rust_action.inputs.to_list():
-        if "libto_wrap" in act.path and act.path.endswith(".rlib"):
-            seen_to_wrap_rlib = True
-        elif "libto_wrap" in act.path and act.path.endswith(".rmeta"):
-            seen_to_wrap_rmeta = True
-
-    asserts.true(env, seen_to_wrap_rmeta, "expected dependency on metadata for 'to_wrap' but not found")
+    asserts.true(env, seen_to_wrap_metadata, "expected dependency on metadata for 'to_wrap' but not found")
     asserts.false(env, seen_to_wrap_rlib, "expected no dependency on object for 'to_wrap' but it was found")
 
     return analysistest.end(env)
-
-rmeta_is_propagated_through_custom_rule_test = analysistest.make(_rmeta_is_propagated_through_custom_rule_test_impl, attrs = {"generate_metadata": attr.bool()}, config_settings = ENABLE_PIPELINING)
-rmeta_is_used_when_building_custom_rule_test = analysistest.make(_rmeta_is_used_when_building_custom_rule_test_impl, config_settings = ENABLE_PIPELINING)
 
 def _rmeta_not_produced_if_pipelining_disabled_test_impl(ctx):
     env = analysistest.begin(ctx)
@@ -202,25 +235,258 @@ def _rmeta_not_produced_if_pipelining_disabled_test_impl(ctx):
 
     return analysistest.end(env)
 
-rmeta_not_produced_if_pipelining_disabled_test = analysistest.make(_rmeta_not_produced_if_pipelining_disabled_test_impl, config_settings = ENABLE_PIPELINING)
+second_lib_new_test = analysistest.make(
+    _second_lib_test_impl,
+    attrs = _VARIANT_ATTRS,
+    config_settings = _config(True),
+)
+second_lib_legacy_test = analysistest.make(
+    _second_lib_test_impl,
+    attrs = _VARIANT_ATTRS,
+    config_settings = _config(False),
+)
+
+bin_new_test = analysistest.make(
+    _bin_test_impl,
+    attrs = _VARIANT_ATTRS,
+    config_settings = _config(True),
+)
+bin_legacy_test = analysistest.make(
+    _bin_test_impl,
+    attrs = _VARIANT_ATTRS,
+    config_settings = _config(False),
+)
+
+def _make_guardrail_test(config_settings):
+    return analysistest.make(
+        _guardrail_test_impl,
+        attrs = _GUARDRAIL_ATTRS,
+        config_settings = config_settings,
+    )
+
+guardrail_test = _make_guardrail_test(_config(True))
+
+_GLOBAL_ENV_CONFIG = dict(_config(True))
+_GLOBAL_ENV_CONFIG[str(Label("//rust/settings:extra_rustc_env"))] = ["RUSTC_BOOTSTRAP=global-value"]
+
+guardrail_global_env_optout_test = _make_guardrail_test(_GLOBAL_ENV_CONFIG)
+
+_GLOBAL_FLAG_CONFIG = dict(_config(True))
+_GLOBAL_FLAG_CONFIG[str(Label("//rust/settings:extra_rustc_flag"))] = ["-Zallow-features=let_chains"]
+
+guardrail_global_flag_optout_test = _make_guardrail_test(_GLOBAL_FLAG_CONFIG)
+
+rmeta_is_propagated_through_custom_rule_new_test = analysistest.make(
+    _rmeta_is_propagated_through_custom_rule_test_impl,
+    attrs = _CUSTOM_RULE_ATTRS,
+    config_settings = _config(True),
+)
+rmeta_is_propagated_through_custom_rule_legacy_test = analysistest.make(
+    _rmeta_is_propagated_through_custom_rule_test_impl,
+    attrs = _CUSTOM_RULE_ATTRS,
+    config_settings = _config(False),
+)
+
+rmeta_is_used_when_building_custom_rule_new_test = analysistest.make(
+    _rmeta_is_used_when_building_custom_rule_test_impl,
+    attrs = _CUSTOM_RULE_ATTRS,
+    config_settings = _config(True),
+)
+rmeta_is_used_when_building_custom_rule_legacy_test = analysistest.make(
+    _rmeta_is_used_when_building_custom_rule_test_impl,
+    attrs = _CUSTOM_RULE_ATTRS,
+    config_settings = _config(False),
+)
+
+rmeta_not_produced_if_pipelining_disabled_test = analysistest.make(
+    _rmeta_not_produced_if_pipelining_disabled_test_impl,
+    config_settings = {
+        str(Label("//rust/settings:pipelined_compilation")): True,
+    },
+)
+
+_TESTS = {
+    "new": struct(
+        second_lib = second_lib_new_test,
+        bin = bin_new_test,
+        rmeta_propagated = rmeta_is_propagated_through_custom_rule_new_test,
+        rmeta_used = rmeta_is_used_when_building_custom_rule_new_test,
+    ),
+    "legacy": struct(
+        second_lib = second_lib_legacy_test,
+        bin = bin_legacy_test,
+        rmeta_propagated = rmeta_is_propagated_through_custom_rule_legacy_test,
+        rmeta_used = rmeta_is_used_when_building_custom_rule_legacy_test,
+    ),
+}
+
+def _pipelined_compilation_test(variant_name):
+    variant = _VARIANTS[variant_name]
+    tests = _TESTS[variant_name]
+
+    rust_proc_macro(
+        name = "my_macro" + variant.suffix,
+        crate_name = "my_macro",
+        edition = "2021",
+        srcs = ["my_macro.rs"],
+    )
+
+    rust_library(
+        name = "first" + variant.suffix,
+        crate_name = "first",
+        edition = "2021",
+        srcs = ["first.rs"],
+    )
+
+    rust_library(
+        name = "second" + variant.suffix,
+        crate_name = "second",
+        edition = "2021",
+        srcs = ["second.rs"],
+        deps = [":first" + variant.suffix],
+        proc_macro_deps = [":my_macro" + variant.suffix],
+    )
+
+    rust_binary(
+        name = "bin" + variant.suffix,
+        edition = "2021",
+        srcs = ["bin.rs"],
+        deps = [":second" + variant.suffix],
+    )
+
+    tests.second_lib(
+        name = "second_lib_test" + variant.suffix,
+        target_under_test = ":second" + variant.suffix,
+        target_compatible_with = _NO_WINDOWS,
+        variant = variant_name,
+    )
+    tests.bin(
+        name = "bin_test" + variant.suffix,
+        target_under_test = ":bin" + variant.suffix,
+        target_compatible_with = _NO_WINDOWS,
+        variant = variant_name,
+    )
+
+    if variant_name == "new":
+        # On nightly toolchains, rustc.bzl skips the RUSTC_BOOTSTRAP/-Zallow-features
+        # injection (unstable features are already allowed), so the baseline assertions
+        # flip per-channel. See `inject_allow_features_guardrail` in rust/private/rustc.bzl.
+        guardrail_test(
+            name = "guardrail_baseline_test" + variant.suffix,
+            target_under_test = ":second" + variant.suffix,
+            target_compatible_with = _NO_WINDOWS,
+            expect_injected_allow_features = select({
+                "@rules_rust//rust/toolchain/channel:nightly": False,
+                "//conditions:default": True,
+            }),
+            expected_bootstrap = select({
+                "@rules_rust//rust/toolchain/channel:nightly": "",
+                "//conditions:default": "1",
+            }),
+            variant = variant_name,
+        )
+
+        rust_library(
+            name = "user_env_optout" + variant.suffix,
+            crate_name = "user_env_optout",
+            edition = "2021",
+            srcs = ["first.rs"],
+            rustc_env = {"RUSTC_BOOTSTRAP": "user-value"},
+        )
+        guardrail_test(
+            name = "guardrail_user_env_optout_test" + variant.suffix,
+            target_under_test = ":user_env_optout" + variant.suffix,
+            target_compatible_with = _NO_WINDOWS,
+            expected_bootstrap = "user-value",
+            variant = variant_name,
+        )
+
+        # tags=["manual"] prevents `:all` from trying to compile this target
+        # end-to-end: the `-Z` flag would make rustc fail on stable without
+        # RUSTC_BOOTSTRAP=1, but the analysistest only needs the analysis
+        # phase (declared actions), which succeeds regardless.
+        rust_library(
+            name = "user_flag_optout" + variant.suffix,
+            crate_name = "user_flag_optout",
+            edition = "2021",
+            srcs = ["first.rs"],
+            rustc_flags = ["-Zallow-features=let_chains"],
+            tags = ["manual"],
+        )
+        guardrail_test(
+            name = "guardrail_user_flag_optout_test" + variant.suffix,
+            target_under_test = ":user_flag_optout" + variant.suffix,
+            target_compatible_with = _NO_WINDOWS,
+            expected_user_allow_features = "-Zallow-features=let_chains",
+            variant = variant_name,
+        )
+
+        # See note above on user_flag_optout for why tags=["manual"] is used.
+        rust_library(
+            name = "space_form_optout" + variant.suffix,
+            crate_name = "space_form_optout",
+            edition = "2021",
+            srcs = ["first.rs"],
+            rustc_flags = ["-Z", "allow-features=let_chains"],
+            tags = ["manual"],
+        )
+        guardrail_test(
+            name = "guardrail_space_form_optout_test" + variant.suffix,
+            target_under_test = ":space_form_optout" + variant.suffix,
+            target_compatible_with = _NO_WINDOWS,
+            variant = variant_name,
+        )
+
+        # Global env/flag escape hatches reuse the baseline target but run with
+        # a different config_settings dict (set inside the analysistest factory).
+        guardrail_global_env_optout_test(
+            name = "guardrail_global_env_optout_test" + variant.suffix,
+            target_under_test = ":second" + variant.suffix,
+            target_compatible_with = _NO_WINDOWS,
+            expected_bootstrap = "global-value",
+            variant = variant_name,
+        )
+
+        guardrail_global_flag_optout_test(
+            name = "guardrail_global_flag_optout_test" + variant.suffix,
+            target_under_test = ":second" + variant.suffix,
+            target_compatible_with = _NO_WINDOWS,
+            variant = variant_name,
+        )
+
+    labels = [
+        ":second_lib_test" + variant.suffix,
+        ":bin_test" + variant.suffix,
+    ]
+    if variant_name == "new":
+        labels.append(":guardrail_baseline_test" + variant.suffix)
+        labels.append(":guardrail_user_env_optout_test" + variant.suffix)
+        labels.append(":guardrail_user_flag_optout_test" + variant.suffix)
+        labels.append(":guardrail_space_form_optout_test" + variant.suffix)
+        labels.append(":guardrail_global_env_optout_test" + variant.suffix)
+        labels.append(":guardrail_global_flag_optout_test" + variant.suffix)
+    return labels
 
 def _disable_pipelining_test():
     rust_library(
-        name = "lib",
+        name = "lib_disable_pipelining",
+        crate_name = "lib",
         srcs = ["custom_rule_test/to_wrap.rs"],
         edition = "2021",
         disable_pipelining = True,
     )
     rmeta_not_produced_if_pipelining_disabled_test(
         name = "rmeta_not_produced_if_pipelining_disabled_test",
-        target_under_test = ":lib",
+        target_under_test = ":lib_disable_pipelining",
     )
 
-    return [
-        ":rmeta_not_produced_if_pipelining_disabled_test",
-    ]
+    return [":rmeta_not_produced_if_pipelining_disabled_test"]
 
-def _custom_rule_test(generate_metadata, suffix):
+def _custom_rule_test(generate_metadata, variant_name):
+    variant = _VARIANTS[variant_name]
+    tests = _TESTS[variant_name]
+    suffix = ("_with_metadata" if generate_metadata else "_without_metadata") + variant.suffix
+
     rust_library(
         name = "to_wrap" + suffix,
         crate_name = "to_wrap",
@@ -240,17 +506,19 @@ def _custom_rule_test(generate_metadata, suffix):
         edition = "2021",
     )
 
-    rmeta_is_propagated_through_custom_rule_test(
+    tests.rmeta_propagated(
         name = "rmeta_is_propagated_through_custom_rule_test" + suffix,
         generate_metadata = generate_metadata,
         target_under_test = ":uses_wrapper" + suffix,
         target_compatible_with = _NO_WINDOWS,
+        variant = variant_name,
     )
-
-    rmeta_is_used_when_building_custom_rule_test(
+    tests.rmeta_used(
         name = "rmeta_is_used_when_building_custom_rule_test" + suffix,
+        generate_metadata = generate_metadata,
         target_under_test = ":wrapper" + suffix,
         target_compatible_with = _NO_WINDOWS,
+        variant = variant_name,
     )
 
     return [
@@ -265,10 +533,13 @@ def pipelined_compilation_test_suite(name):
         name: Name of the macro.
     """
     tests = []
-    tests.extend(_pipelined_compilation_test())
+
+    for variant_name in _VARIANTS:
+        tests.extend(_pipelined_compilation_test(variant_name))
+        tests.extend(_custom_rule_test(True, variant_name))
+        tests.extend(_custom_rule_test(False, variant_name))
+
     tests.extend(_disable_pipelining_test())
-    tests.extend(_custom_rule_test(generate_metadata = True, suffix = "_with_metadata"))
-    tests.extend(_custom_rule_test(generate_metadata = False, suffix = "_without_metadata"))
 
     native.test_suite(
         name = name,

--- a/test/unit/pipelined_compilation/wrap.bzl
+++ b/test/unit/pipelined_compilation/wrap.bzl
@@ -9,7 +9,7 @@ load("//rust/private:providers.bzl", "BuildInfo", "CrateInfo", "DepInfo", "DepVa
 load("//rust/private:rustc.bzl", "rustc_compile_action")
 
 # buildifier: disable=bzl-visibility
-load("//rust/private:utils.bzl", "can_use_metadata_for_pipelining")
+load("//rust/private:utils.bzl", "can_use_metadata_for_pipelining", "metadata_output_path")
 
 _CONTENT = """\
 // crate_name: {}
@@ -40,12 +40,7 @@ def _wrap_impl(ctx):
         lib_hash = output_hash,
         extension = ".rlib",
     )
-    rust_metadata_name = "{prefix}{name}-{lib_hash}{extension}".format(
-        prefix = "lib",
-        name = crate_name,
-        lib_hash = output_hash,
-        extension = ".rmeta",
-    )
+    rust_metadata_name = metadata_output_path(toolchain, rust_lib_name)
 
     tgt = ctx.attr.target
     deps = [DepVariantInfo(

--- a/test/unit/rust_test_codegen_disambiguation/codegen_disambiguation_test.bzl
+++ b/test/unit/rust_test_codegen_disambiguation/codegen_disambiguation_test.bzl
@@ -1,7 +1,7 @@
 """Tests that rust_test targets receive codegen disambiguation flags.
 
 rust_test targets pass --codegen=metadata and --codegen=extra-filename to rustc
-so that intermediate compilation artifacts (.o, .d files) get unique names. This
+so that intermediate compilation artifacts (such as .o files) get unique names. This
 prevents collisions with rust_binary or rust_library targets that share the same
 crate name, which would otherwise cause link failures on non-sandboxed builds
 (e.g. Windows or --spawn_strategy=standalone). See

--- a/util/process_wrapper/main.rs
+++ b/util/process_wrapper/main.rs
@@ -186,8 +186,8 @@ fn main() -> Result<(), ProcessWrapperError> {
             move |line| process_line(line, quit_on_rmeta, format, metadata_emitted),
         );
         if me {
-            // If recv returns Ok(), a signal was sent in this channel so we should terminate the child process.
-            // We can safely ignore the Result from kill() as we don't care if the process already terminated.
+            // Metadata was emitted and we asked process_output to terminate early.
+            // We can safely ignore kill() failures -- the process may already be gone.
             let _ = child.kill();
             was_killed = true;
         }

--- a/util/process_wrapper/options.rs
+++ b/util/process_wrapper/options.rs
@@ -45,7 +45,7 @@ pub(crate) struct Options {
     // Meant to be used to get json output out of rustc for tooling usage.
     pub(crate) output_file: Option<String>,
     // If set, it configures rustc to emit an rmeta file and then
-    // quit.
+    // quit (legacy pipelining path).
     pub(crate) rustc_quit_on_rmeta: bool,
     // This controls the output format of rustc messages.
     pub(crate) rustc_output_format: Option<rustc::ErrorFormat>,
@@ -109,8 +109,8 @@ pub(crate) fn options() -> Result<Options, OptionError> {
     );
     flags.define_flag(
         "--rustc-output-format",
-        "Controls the rustc output format if --rustc-quit-on-rmeta is set.\n\
-        'json' will cause the json output to be output, \
+        "Controls how rustc JSON messages are forwarded.\n\
+        'json' will pass through JSON messages, \
         'rendered' will extract the rendered message and print that.\n\
         Default: `rendered`",
         &mut rustc_output_format_raw,

--- a/util/process_wrapper/output.rs
+++ b/util/process_wrapper/output.rs
@@ -21,7 +21,7 @@ use std::io::{self, prelude::*};
 /// Skip is returned nothing will be printed and execution continues,
 /// if Terminate is returned, process_output returns immediately.
 /// Terminate is used to stop processing when we see an emit metadata
-/// message.
+/// message under the --rustc-quit-on-rmeta code path.
 #[derive(Debug)]
 pub(crate) enum LineOutput {
     Message(String),

--- a/util/process_wrapper/rustc.rs
+++ b/util/process_wrapper/rustc.rs
@@ -56,7 +56,7 @@ impl TryFrom<JsonValue> for RustcMessage {
     }
 }
 
-/// process_rustc_json takes an output line from rustc configured with
+/// process_json takes an output line from rustc configured with
 /// --error-format=json, parses the json and returns the appropriate output
 /// according to the original --error-format supplied.
 /// Only messages are returned, emits are ignored.
@@ -74,12 +74,12 @@ pub(crate) fn process_json(line: String, error_format: ErrorFormat) -> LineResul
 }
 
 /// stop_on_rmeta_completion parses the json output of rustc in the same way
-/// process_rustc_json does. In addition, it will signal to stop when metadata
+/// process_json does. In addition, it will signal to stop when metadata
 /// is emitted so the compiler can be terminated.
-/// This is used to implement pipelining in rules_rust, please see
-/// https://internals.rust-lang.org/t/evaluating-pipelined-rustc-compilation/10199
+/// This is used to implement pipelining in rules_rust under the legacy
+/// `--rustc-quit-on-rmeta` path; see
+/// https://internals.rust-lang.org/t/evaluating-pipelined-rustc-compilation/10199.
 /// Returns an error if parsing json fails.
-/// TODO: pass a function to handle the emit event and merge with process_json
 pub(crate) fn stop_on_rmeta_completion(
     line: String,
     error_format: ErrorFormat,


### PR DESCRIPTION
Replace the --rustc-quit-on-rmeta / .rmeta approach with Buck2-style hollow rlibs: the RustcMetadata action runs rustc to completion with -Zno-codegen, emitting a .rlib archive. This approach mirrors the one used by buck2 and avoids needing to kill rustc mid-output in order to produce metadata.

While not fixing problems with SVH mismatches when non-determinism, this does simplify the codepath and uses a production tested technique that doesn't have any of the dangers associated with killing the rustc process while it's still active.

Previous work on this branch & the claimed prevention of SVH mismatches proved to be from changes which effectively removed all the actual benefits of the pipelined compilation