### PR TITLE
platform: add Mac Catalyst triple mappings for crate_universe

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -43,6 +43,7 @@ SUPPORTED_T1_PLATFORM_TRIPLES = {
 # See `@rules_rust//rust/platform:triple_mappings.bzl` for the complete list.
 SUPPORTED_T2_PLATFORM_TRIPLES = {
     "aarch64-apple-ios": _support(std = True, host_tools = False),
+    "aarch64-apple-ios-macabi": _support(std = True, host_tools = False),
     "aarch64-apple-ios-sim": _support(std = True, host_tools = False),
     "aarch64-linux-android": _support(std = True, host_tools = False),
     "aarch64-pc-windows-msvc": _support(std = True, host_tools = True),
@@ -67,6 +68,7 @@ SUPPORTED_T2_PLATFORM_TRIPLES = {
     "wasm32-wasip1-threads": _support(std = True, host_tools = False),
     "wasm32-wasip2": _support(std = True, host_tools = False),
     "x86_64-apple-ios": _support(std = True, host_tools = False),
+    "x86_64-apple-ios-macabi": _support(std = True, host_tools = False),
     "x86_64-linux-android": _support(std = True, host_tools = False),
     "x86_64-unknown-freebsd": _support(std = True, host_tools = True),
     "x86_64-unknown-fuchsia": _support(std = True, host_tools = False),
@@ -455,6 +457,18 @@ def triple_to_constraint_set(target_triple):
         return [
             "@platforms//cpu:wasm64",
             "@platforms//os:none",
+        ]
+    if target_triple == "aarch64-apple-ios-macabi":
+        return [
+            "@platforms//cpu:aarch64",
+            "@platforms//os:osx",
+            "@build_bazel_apple_support//constraints:catalyst",
+        ]
+    if target_triple == "x86_64-apple-ios-macabi":
+        return [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:osx",
+            "@build_bazel_apple_support//constraints:catalyst",
         ]
 
     triple_struct = triple(target_triple)

--- a/test/unit/platform_triple/BUILD.bazel
+++ b/test/unit/platform_triple/BUILD.bazel
@@ -1,5 +1,10 @@
+load(":apple_platform_test.bzl", "apple_platform_test_suite")
 load(":platform_triple_test.bzl", "platform_triple_test_suite")
 load(":wasi_platform_test.bzl", "wasi_platform_test_suite")
+
+apple_platform_test_suite(
+    name = "apple_platform_test_suite",
+)
 
 platform_triple_test_suite(
     name = "platform_triple_test_suite",

--- a/test/unit/platform_triple/apple_platform_test.bzl
+++ b/test/unit/platform_triple/apple_platform_test.bzl
@@ -1,0 +1,66 @@
+"""Tests for Apple platform constraint mappings."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//rust/platform:triple_mappings.bzl", "triple_to_constraint_set")
+
+def _apple_platform_constraints_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    aarch64_macabi_constraints = triple_to_constraint_set("aarch64-apple-ios-macabi")
+    asserts.equals(
+        env,
+        [
+            "@platforms//cpu:aarch64",
+            "@platforms//os:osx",
+            "@build_bazel_apple_support//constraints:catalyst",
+        ],
+        aarch64_macabi_constraints,
+        "aarch64-apple-ios-macabi should map to Mac Catalyst constraints",
+    )
+
+    x86_64_macabi_constraints = triple_to_constraint_set("x86_64-apple-ios-macabi")
+    asserts.equals(
+        env,
+        [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:osx",
+            "@build_bazel_apple_support//constraints:catalyst",
+        ],
+        x86_64_macabi_constraints,
+        "x86_64-apple-ios-macabi should map to Mac Catalyst constraints",
+    )
+
+    x86_64_ios_constraints = triple_to_constraint_set("x86_64-apple-ios")
+    asserts.equals(
+        env,
+        [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:ios",
+            "@build_bazel_apple_support//constraints:simulator",
+        ],
+        x86_64_ios_constraints,
+        "x86_64-apple-ios should remain mapped to iOS simulator constraints",
+    )
+
+    return unittest.end(env)
+
+apple_platform_constraints_test = unittest.make(_apple_platform_constraints_test_impl)
+
+def apple_platform_test_suite(name, **kwargs):
+    """Define a test suite for Apple platform constraint mappings.
+
+    Args:
+        name (str): The name of the test suite.
+        **kwargs (dict): Additional keyword arguments for the test_suite.
+    """
+    apple_platform_constraints_test(
+        name = "apple_platform_constraints_test",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":apple_platform_constraints_test",
+        ],
+        **kwargs
+    )

--- a/test/unit/platform_triple/platform_triple_test.bzl
+++ b/test/unit/platform_triple/platform_triple_test.bzl
@@ -120,6 +120,7 @@ def _construct_known_triples_test_impl(ctx):
     env = unittest.begin(ctx)
 
     _assert_parts(env, triple("aarch64-apple-darwin"), "aarch64", "apple", "macos", None)
+    _assert_parts(env, triple("aarch64-apple-ios-macabi"), "aarch64", "apple", "ios", "macabi")
     _assert_parts(env, triple("aarch64-fuchsia"), "aarch64", "unknown", "fuchsia", None)
     _assert_parts(env, triple("aarch64-unknown-linux-musl"), "aarch64", "unknown", "linux", "musl")
     _assert_parts(env, triple("thumbv7em-none-eabi"), "thumbv7em", None, "none", "eabi")
@@ -143,6 +144,7 @@ def _construct_known_triples_test_impl(ctx):
     _assert_parts(env, triple("wasm32v1-none"), "wasm32", "v1", "none", None)
 
     _assert_parts(env, triple("x86_64-fuchsia"), "x86_64", "unknown", "fuchsia", None)
+    _assert_parts(env, triple("x86_64-apple-ios-macabi"), "x86_64", "apple", "ios", "macabi")
 
     return unittest.end(env)
 


### PR DESCRIPTION
## Summary
- add `aarch64-apple-ios-macabi` and `x86_64-apple-ios-macabi` to `SUPPORTED_T2_PLATFORM_TRIPLES`
- map both `*-apple-ios-macabi` triples to Mac Catalyst constraints in `triple_to_constraint_set` (`@platforms//os:osx` + `@build_bazel_apple_support//constraints:catalyst`)
- add unit coverage for Catalyst triple parsing and constraint mapping to avoid regressions

## Testing
- `bazel test //test/unit/platform_triple:platform_triple_test_suite //test/unit/platform_triple:wasi_platform_test_suite //test/unit/platform_triple:apple_platform_test_suite`

This fixes missing platform labels such as `@rules_rust//rust/platform:aarch64-apple-ios-macabi`, which currently breaks crate_universe-generated selects when consumers include Catalyst in `supported_platform_triples`.