### PR TITLE
bindgen: also support -target

### DIFF
--- a/extensions/bindgen/private/bindgen.bzl
+++ b/extensions/bindgen/private/bindgen.bzl
@@ -303,13 +303,14 @@ def _rust_bindgen_impl(ctx):
     # Ideally we could depend on a more specific toolchain, requesting one which is specifically clang via some constraint.
     # Unfortunately, we can't currently rely on this, so instead we filter only to flags we know clang supports.
     # We can add extra flags here as needed.
-    # Flags in this tuple accept a parameter in the same argument (`-Ipath`, `--target=T`) or separately (`-I path`).
+    # Flags in this tuple accept a parameter in the same argument (`-Ipath`, `--target=T`) or separately (`-I path`, `-target T`).
     param_flags_known_to_clang = (
         "-I",
         "-iquote",
         "-isystem",
         "--sysroot",
         "--gcc-toolchain",
+        "-target",
         "--target",
         "-W",
         "--system-header-prefix",

--- a/extensions/bindgen/test/bindgen_test.bzl
+++ b/extensions/bindgen/test/bindgen_test.bzl
@@ -24,6 +24,11 @@ def _fake_cc_toolchain_config_impl(ctx):
                         "-fexperimental-optimized-noescape",
                         "-Xclang",
                         "-fcolor-diagnostics",
+                        "--target=here",
+                        "-target",
+                        "there",
+                        "-notarget",
+                        "idbeholdi",
                     ]),
                 ],
             ),
@@ -222,8 +227,14 @@ def _test_strip_xclang_impl(env, target):
     env.expect.that_action(target.actions[0]).not_contains_arg(
         "-fexperimental-optimized-noescape",
     )
+    env.expect.that_action(target.actions[0]).not_contains_arg(
+        "-notarget",
+    )
+    env.expect.that_action(target.actions[0]).not_contains_arg(
+        "idbeholdi",
+    )
     env.expect.that_action(target.actions[0]).contains_at_least_args(
-        ["-Xclang", "-fcolor-diagnostics"],
+        ["-Xclang", "-fcolor-diagnostics", "--target=here", "-target", "there"],
     )
 
 def _test_strip_xclang(name):


### PR DESCRIPTION
https://clang.llvm.org/docs/ClangCommandLineReference.html:

    --target=<arg>, -target <arg>
    Generate code for the given target

Both syntaxes are documented for Clang, so let's support both.