### PR TITLE
Remove rust_binary(out_binary=True) hack.

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1176,14 +1176,6 @@ _rust_binary_attrs = {
         """),
         allow_single_file = True,
     ),
-    "out_binary": attr.bool(
-        doc = (
-            "Force a target, regardless of it's `crate_type`, to always mark the " +
-            "file as executable. This attribute is only used to support wasm targets but is " +
-            "expected to be removed following a resolution to https://github.com/bazelbuild/rules_rust/issues/771."
-        ),
-        default = False,
-    ),
     "stamp": _stamp_attribute(default_value = -1),
 } | _experimental_use_cc_common_link_attrs
 

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -1679,11 +1679,7 @@ def rustc_compile_action(
         transitive_runfiles.append(dynamic_libraries)
     runfiles = runfiles.merge_all(transitive_runfiles)
 
-    # TODO: Remove after some resolution to
-    # https://github.com/bazelbuild/rules_rust/issues/771
-    out_binary = getattr(attr, "out_binary", False)
-
-    executable = crate_info.output if crate_info.type == "bin" or crate_info.is_test or out_binary else None
+    executable = crate_info.output if crate_info.type == "bin" or crate_info.is_test else None
 
     instrumented_files_kwargs = {
         "dependency_attributes": ["deps", "crate"],
@@ -1893,11 +1889,6 @@ def establish_cc_info(ctx, attr, crate_info, toolchain, cc_toolchain, feature_co
 
     # Only generate CcInfo for particular crate types
     if crate_info.type not in ("staticlib", "cdylib", "rlib", "lib"):
-        return []
-
-    # TODO: Remove after some resolution to
-    # https://github.com/bazelbuild/rules_rust/issues/771
-    if getattr(attr, "out_binary", False):
         return []
 
     dot_a = None


### PR DESCRIPTION
rust_shared_library() should be used instead.

closes https://github.com/bazelbuild/rules_rust/pull/3814