### PR TITLE
Add PWD prefixing for -internal-isystem

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -171,6 +171,14 @@ def _prefix_pwd_to_flag(args, flag_variations):
     res = []
     prefix_next_arg = False
     for arg in args:
+        # When expecting a path argument and we see -Xclang, skip over it and
+        # map the next argument instead.
+        # ex: -Xclang -internal-isystem -Xclang path
+        # to: -Xclang -internal-isystem -Xclang ${pwd}/path
+        if prefix_next_arg and arg == "-Xclang":
+            res.append(arg)
+            continue
+
         handled = False
         new_prefix_next_arg = False
 
@@ -240,8 +248,8 @@ def _pwd_flags_fsanitize_ignorelist(args):
     return _prefix_pwd_to_flag(args, ["-fsanitize-ignorelist="])
 
 def _pwd_flags_isystem(args):
-    """Prefix execroot-relative paths in -isystem arguments with ${pwd}."""
-    return _prefix_pwd_to_flag(args, ["-isystem"])
+    """Prefix execroot-relative paths in -isystem and -Xclang -internal-isystem arguments with ${pwd}."""
+    return _prefix_pwd_to_flag(args, ["-isystem", "-internal-isystem"])
 
 def _pwd_flags_L(args):
     """Prefix execroot-relative paths in -L arguments with ${pwd}."""

--- a/test/cargo_build_script/cc_args_and_env/BUILD.bazel
+++ b/test/cargo_build_script/cc_args_and_env/BUILD.bazel
@@ -17,6 +17,8 @@ load(
     "sysroot_absolute_test",
     "sysroot_next_absolute_test",
     "sysroot_relative_test",
+    "xclang_isystem_absolute_test",
+    "xclang_isystem_relative_test",
 )
 
 sysroot_relative_test(name = "sysroot_relative_test")
@@ -28,6 +30,10 @@ sysroot_next_absolute_test(name = "sysroot_next_absolute_test")
 isystem_relative_test(name = "isystem_relative_test")
 
 isystem_absolute_test(name = "isystem_absolute_test")
+
+xclang_isystem_relative_test(name = "xclang_isystem_relative_test")
+
+xclang_isystem_absolute_test(name = "xclang_isystem_absolute_test")
 
 bindir_relative_test(name = "bindir_relative_test")
 

--- a/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/test/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -372,6 +372,28 @@ def sysroot_next_absolute_test(name):
         expected_cflags = ["--sysroot=/test/absolute/sysroot", "test/relative/another"],
     )
 
+def xclang_isystem_relative_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = ["-Xclang", "-internal-isystem", "-Xclang", "test/relative/path"],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = ["-Xclang", "-internal-isystem", "-Xclang", "${pwd}/test/relative/path"],
+    )
+
+def xclang_isystem_absolute_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = ["-Xclang", "-internal-isystem", "-Xclang", "/test/absolute/path"],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = ["-Xclang", "-internal-isystem", "-Xclang", "/test/absolute/path"],
+    )
+
 def isystem_relative_test(name):
     cargo_build_script_with_extra_cc_compile_flags(
         name = "%s/cargo_build_script" % name,


### PR DESCRIPTION
This is a follow up to 0a4285119b21c943560c5aa9dbad3b5ca51f2b2d for
another flag. This one is slightly different since it is wrapped with
`-Xclang` as forwarding args.
