### PR TITLE
Fix self-contained (bundled) linker in hermetic sandbox

### DIFF
--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -78,11 +78,9 @@ filegroup(
     srcs = ["lib/rustlib/{target_triple}/bin/rust-lld{binary_ext}"],
     data = glob(
         include = [
+            "lib/rustlib/{target_triple}/bin/rust-lld{binary_ext}",
             "lib/rustlib/{target_triple}/bin/*-ld{binary_ext}",
             "lib/rustlib/{target_triple}/bin/gcc-ld/*",
-        ],
-        exclude = [
-            "lib/rustlib/{target_triple}/bin/rust-lld{binary_ext}",
         ],
         allow_empty = True,
     ),


### PR DESCRIPTION
rustc looks for its bundled linker in target-specific path, e.g.

`lib/rustlib/x86_64-unknown-linux-gnu/bin/rust-lld`

But it is installed into `bin/rust-lld` in the generated sysroot instead. This resulted in rustc errors durning linking such as

```
error: the self-contained linker was requested, but it wasn't found in the target's sysroot, or in rustc's sysroot
```

This patch makes rust-lld to be installed in both bin and its original path.