### PR TITLE
fix link flags of suffix versioned libs

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2317,8 +2317,13 @@ def portable_link_flags(
                 "-Clink-arg=-l{}".format(get_lib_name(artifact)),
             ]
     elif _is_dylib(lib):
-        lib_file_name = artifact.basename
-        if lib_file_name.startswith("lib") and lib_file_name.endswith(".so"):
+        if for_windows or for_darwin:
+            use_lib_name = True
+        else:
+            lib_file_name = artifact.basename
+            use_lib_name = (lib_file_name.startswith("lib") and lib_file_name.endswith(".so"))
+
+        if use_lib_name:
             return [
                 "-ldylib=%s" % get_lib_name(artifact),
             ]

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2317,10 +2317,10 @@ def portable_link_flags(
                 "-Clink-arg=-l{}".format(get_lib_name(artifact)),
             ]
     elif _is_dylib(lib):
+        lib_file_name = artifact.basename
         if for_windows or for_darwin:
             use_lib_name = True
         else:
-            lib_file_name = artifact.basename
             use_lib_name = (lib_file_name.startswith("lib") and lib_file_name.endswith(".so"))
 
         if use_lib_name:

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2252,6 +2252,7 @@ def portable_link_flags(
         use_pic,
         ambiguous_libs,
         get_lib_name,
+        for_windows = False,
         for_darwin = False,
         flavor_msvc = False):
     """_summary_
@@ -2261,6 +2262,7 @@ def portable_link_flags(
         use_pic (_type_): _description_
         ambiguous_libs (_type_): _description_
         get_lib_name (_type_): _description_
+        for_windows (bool, optional): _description_. Defaults to False.
         for_darwin (bool, optional): _description_. Defaults to False.
         flavor_msvc (bool, optional): _description_. Defaults to False.
 
@@ -2353,7 +2355,7 @@ def _make_link_flags_windows(make_link_flags_args, flavor_msvc, use_direct_drive
                 ])
         elif include_link_flags:
             get_lib_name = get_lib_name_for_windows if flavor_msvc else get_lib_name_default
-            ret.extend(portable_link_flags(lib, use_pic, ambiguous_libs, get_lib_name, flavor_msvc = flavor_msvc))
+            ret.extend(portable_link_flags(lib, use_pic, ambiguous_libs, get_lib_name, for_windows = True, flavor_msvc = flavor_msvc))
 
     # Windows toolchains can inherit POSIX defaults like -pthread from C deps,
     # which fails to link with the MinGW/LLD toolchain. Drop them here.

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2317,9 +2317,15 @@ def portable_link_flags(
                 "-Clink-arg=-l{}".format(get_lib_name(artifact)),
             ]
     elif _is_dylib(lib):
-        return [
-            "-ldylib=%s" % get_lib_name(artifact),
-        ]
+        lib_file_name = artifact.basename
+        if lib_file_name.startswith("lib") and lib_file_name.endswith(".so"):
+            return [
+                "-ldylib=%s" % get_lib_name(artifact),
+            ]
+        else:
+            return [
+                "-Clink-arg=-l:{}".format(lib_file_name),
+            ]
 
     return []
 

--- a/test/unit/versioned_libs/versioned_libs_analysis_test.bzl
+++ b/test/unit/versioned_libs/versioned_libs_analysis_test.bzl
@@ -5,7 +5,7 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import")
 load("//rust:defs.bzl", "rust_shared_library")
 
-LIBNAMES = ["sterling", "cheryl", "lana", "pam", "malory", "cyril"]
+LIBNAMES = ["sterling", "lana", "pam", "malory", "cyril"]
 
 def _is_in_argv(argv, version = None):
     return any(["-ldylib={}{}".format(name, version or "") in argv for name in LIBNAMES])
@@ -33,7 +33,7 @@ def _suffix_version_test_impl(ctx):
     tut = analysistest.target_under_test(env)
     argv = tut.actions[0].argv
 
-    asserts.true(env, _is_in_argv(argv))
+    asserts.true(env, "-Clink-arg=-l:libcheryl.so.3.8" in argv)
 
     return analysistest.end(env)
 
@@ -68,7 +68,7 @@ def _test_linux():
         name = "linux_suffix_version",
         srcs = ["a.rs"],
         edition = "2018",
-        deps = [":import_libcheryl.so.3.8", ":import_libcheryl.so"],
+        deps = [":import_libcheryl.so.3.8"],
         target_compatible_with = ["@platforms//os:linux"],
     )
     cc_import(
@@ -79,15 +79,6 @@ def _test_linux():
         name = "libcheryl.so.3.8",
         srcs = ["b.c"],
         linkshared = True,
-    )
-    cc_import(
-        name = "import_libcheryl.so",
-        shared_library = "libcheryl.so",
-    )
-    copy_file(
-        name = "copy_unversioned",
-        src = ":libcheryl.so.3.8",
-        out = "libcheryl.so",
     )
     suffix_version_test(
         name = "linux_suffix_version_test",


### PR DESCRIPTION
### Problem

When a versioned shared library (e.g. `libcheryl.so.3.8`) is used, the current behavior generates linker flags such as:

* `rustc -dylib=cheryl`
* `gcc -lcheryl`

These flags assume the presence of an unversioned shared library (`libcheryl.so`). As a result, linking fails when only versioned libraries (e.g., `libcheryl.so.3.8`) are available:

```
ld: cannot find -lcheryl
```

The correct linker options in this case should explicitly reference the versioned `.so`:

* `rustc -Clink-arg=-l:libcheryl.so.3.8`
* `gcc -l:libcheryl.so.3.8`

### Solution

IMO, the current implementation assumes that users always provide unversioned shared libraries (`libxxx.so`). This assumption is too restrictive:

1. Some libraries do not provide an unversioned `.so` symlink (e.g., only `libxxx.so.X.Y` exists)
2. Library naming may not follow the `libxxx.so` convention (e.g., `xxx.so.1`)
3. Users may require fine-grained control over linker arguments, especially for ABI-specific or version-pinned dependencies

This PR updates the linking behavior as follows:

* If the library file name matches the conventional form `lib<name>.so`, generate `-ldylib=<name>`
* Otherwise, pass the exact file name to the linker via `-Clink-arg=-l:<filename>`