### PR TITLE
Add extra_exec_rustc_flags_triples to toolchain attributes

### DIFF
--- a/rust/extensions.bzl
+++ b/rust/extensions.bzl
@@ -115,6 +115,8 @@ def _rust_impl(module_ctx):
     for toolchain in toolchains:
         if toolchain.extra_rustc_flags and toolchain.extra_rustc_flags_triples:
             fail("Cannot define both extra_rustc_flags and extra_rustc_flags_triples")
+        if toolchain.extra_exec_rustc_flags and toolchain.extra_exec_rustc_flags_triples:
+            fail("Cannot define both extra_exec_rustc_flags and extra_exec_rustc_flags_triples")
         if len(toolchain.versions) == 0:
             # If the root module has asked for rules_rust to not register default
             # toolchains, an empty repository named `rust_toolchains` is created
@@ -123,13 +125,14 @@ def _rust_impl(module_ctx):
             _empty_repository(name = "rust_toolchains")
         else:
             extra_rustc_flags = toolchain.extra_rustc_flags if toolchain.extra_rustc_flags else toolchain.extra_rustc_flags_triples
+            extra_exec_rustc_flags = toolchain.extra_exec_rustc_flags if toolchain.extra_rustc_flags else toolchain.extra_exec_rustc_flags_triples
 
             rust_register_toolchains(
                 hub_name = "rust_toolchains",
                 dev_components = toolchain.dev_components,
                 edition = toolchain.edition,
                 extra_rustc_flags = extra_rustc_flags,
-                extra_exec_rustc_flags = toolchain.extra_exec_rustc_flags,
+                extra_exec_rustc_flags = extra_exec_rustc_flags,
                 allocator_library = str(toolchain.allocator_library) if toolchain.allocator_library else None,
                 global_allocator_library = str(toolchain.global_allocator_library) if toolchain.global_allocator_library else None,
                 rustfmt_version = toolchain.rustfmt_version,
@@ -254,6 +257,9 @@ _RUST_TOOLCHAIN_TAG = tag_class(
         ),
         "extra_exec_rustc_flags": attr.string_list(
             doc = "Extra flags to pass to rustc in exec configuration",
+        ),
+        "extra_exec_rustc_flags_triples": attr.string_list_dict(
+            doc = "Extra flags to pass to rustc in exec configuration. Key is the triple, value is the flag.",
         ),
         "extra_rustc_flags": attr.string_list(
             doc = "Extra flags to pass to rustc in non-exec configuration",

--- a/rust/private/repositories.bzl
+++ b/rust/private/repositories.bzl
@@ -99,7 +99,7 @@ def rust_register_toolchains(
         sha256s (str, optional): A dict associating tool subdirectories to sha256 hashes.
         extra_target_triples (list, optional): Additional rust-style targets that rust toolchains should support.
         extra_rustc_flags (dict, list, optional): Dictionary of target triples to list of extra flags to pass to rustc in non-exec configuration.
-        extra_exec_rustc_flags (list, optional): Extra flags to pass to rustc in exec configuration.
+        extra_exec_rustc_flags (dict, list, optional): Dictionary of target triples to list of extra flags to pass to rustc in exec configuration.
         strip_level (dict, dict, optional): Dictionary of target triples to strip config.
         urls (list, optional): A list of mirror urls containing the tools from the Rust-lang static file server. These must contain the '{}' used to substitute the tool being fetched (using .format).
         versions (list, optional): A list of toolchain versions to download. This parameter only accepts one versions


### PR DESCRIPTION
We have:
extra_rustc_flags
extra_rustc_flags_triples
extra_exec_rustc_flags
, so rounding out the set. Hit this when passing `-Clink-self-contained=no` to the toolchain, and this is only available on x86_64 rust toolchains.