### PR TITLE
Fix CARGO_MANIFEST_DIR when transform_sources moves crate root to bazel-out

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -997,7 +997,21 @@ def construct_arguments(
 
     # Both ctx.label.workspace_root and ctx.label.package are relative paths
     # and either can be empty strings. Avoid trailing/double slashes in the path.
-    components = "${{pwd}}/{}/{}".format(ctx.label.workspace_root, ctx.label.package).split("/")
+    #
+    # When transform_sources moves source files into bazel-out (due to mixed
+    # generated/non-generated sources), the crate root ends up under a different
+    # directory than the original source package. We must derive CARGO_MANIFEST_DIR
+    # from the actual crate root path so proc-macros can find Cargo.toml in the
+    # sandbox.
+    _package_path = "/".join([c for c in [ctx.label.workspace_root, ctx.label.package] if c])
+    if crate_info.root.is_source:
+        components = "${{pwd}}/{}/{}".format(ctx.label.workspace_root, ctx.label.package).split("/")
+    else:
+        # Crate root was transformed (symlinked into bazel-out). The file is at
+        # <root.root.path>/<workspace_root>/<package>/<relative_path>, so the
+        # manifest directory is <root.root.path>/<workspace_root>/<package>.
+        _manifest_dir = "/".join([c for c in [crate_info.root.root.path, _package_path] if c])
+        components = "${{pwd}}/{}".format(_manifest_dir).split("/")
     env["CARGO_MANIFEST_DIR"] = "/".join([c for c in components if c])
 
     if out_dir != None:


### PR DESCRIPTION
Summary

When a rust_library (or similar rule) has a mix of generated and non-generated files in compile_data, `transform_sources` symlinks all source files into `bazel-out/`. However, CARGO_MANIFEST_DIR was still computed from `ctx.label.workspace_root` and `ctx.label.package`, pointing to the original source directory. This caused proc-macros that read `Cargo.toml` (e.g., Bevy's `#[derive(Component)]`) to fail with "Cargo manifest does not exist" errors in sandboxed builds on Linux / macOS.

  This change derives `CARGO_MANIFEST_DIR` from the actual crate root location when the crate root has been transformed, using `crate_info.root.root.path` combined with the package path.

Reproduction

  1. Create a rust_library with a generated file in compile_data and Cargo.toml also in compile_data
  2. Use a proc-macro that reads `Cargo.toml` via `CARGO_MANIFEST_DIR` (e.g., Bevy's derive macros)
  3. Build with sandboxing enabled (default on Linux)
  4. Observe: proc-macro panics because `Cargo.toml` is not found at the `CARGO_MANIFEST_DIR` path

  Fix

  - If `crate_info.root.is_source`, use the existing label-based path (no behavior change)
  - Otherwise, compute the manifest directory from `crate_info.root.root.path` + the workspace/package path, which reflects the actual bazel-out/ layout
  
  Disclosure
  
  This PR was created with assistance from Claude Code.