### PR TITLE
Replace `new_git_repository` with `git_repository`

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -373,7 +373,7 @@ There are some more examples of using crate_universe with bzlmod in the [example
 
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:structs.bzl", "structs")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "//crate_universe/private:common_utils.bzl",
@@ -758,7 +758,7 @@ def _generate_hub_and_spokes(
                     kwargs["commit"] = v
                 else:
                     kwargs[k.lower()] = v
-            new_git_repository(
+            git_repository(
                 name = crate_repo_name,
                 init_submodules = True,
                 patch_args = repo.get("patch_args", None),

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -345,7 +345,7 @@ pub(crate) struct CrateAnnotations {
     pub(crate) additive_build_file_content: Option<String>,
 
     /// For git sourced crates, this is a the
-    /// [git_repository::shallow_since](https://docs.bazel.build/versions/main/repo/git.html#new_git_repository-shallow_since) attribute.
+    /// [git_repository::shallow_since](https://docs.bazel.build/versions/main/repo/git.html#git_repository-shallow_since) attribute.
     pub(crate) shallow_since: Option<String>,
 
     /// The `patch_args` attribute of a Bazel repository rule. See

--- a/crate_universe/src/rendering/templates/module_bzl.j2
+++ b/crate_universe/src/rendering/templates/module_bzl.j2
@@ -14,7 +14,7 @@ Expected length = 6 lines
 
 """
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_skylib//lib:selects.bzl", "selects")

--- a/crate_universe/src/rendering/templates/partials/module/repo_git.j2
+++ b/crate_universe/src/rendering/templates/partials/module/repo_git.j2
@@ -1,5 +1,5 @@
     maybe(
-        new_git_repository,
+        git_repository,
         name = "{{ crate_repository(name = crate.name, version = crate.version) }}",
     {%- for type, commitish in attrs.commitish %}
     {%- if type in ["Rev"] %}


### PR DESCRIPTION
The repository rule `new_git_repository` has been an alias of `git_repository` since Bazel 6.0.0:

https://github.com/bazelbuild/bazel/blob/6.0.0/tools/build_defs/repo/git.bzl#L190

Recently, a change was made to make use of `new_git_repository` fail - https://github.com/bazelbuild/bazel/commit/71160cb619b5bfeb89c91fee53bb044438ee9b3f

Users should use `git_repository` instead, which this change does. The change should be a no-op for Bazel >= 6.0.0