### PR TITLE
Fix wasm staticlib extensions

### DIFF
--- a/rust/platform/triple_mappings.bzl
+++ b/rust/platform/triple_mappings.bzl
@@ -210,12 +210,12 @@ _SYSTEM_TO_STATICLIB_EXT = {
     "nixos": ".a",
     "none": ".a",
     "nto": ".a",
-    "threads": "",
+    "threads": ".a",
     "uefi": ".lib",
-    "unknown": "",
-    "wasi": "",
-    "wasip1": "",
-    "wasip2": "",
+    "unknown": ".a",
+    "wasi": ".a",
+    "wasip1": ".a",
+    "wasip2": ".a",
     "windows": ".lib",
 }
 

--- a/test/unit/platform_triple/platform_triple_test.bzl
+++ b/test/unit/platform_triple/platform_triple_test.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//rust/platform:triple.bzl", "triple")
-load("//rust/platform:triple_mappings.bzl", "SUPPORTED_PLATFORM_TRIPLES")
+load("//rust/platform:triple_mappings.bzl", "SUPPORTED_PLATFORM_TRIPLES", "system_to_staticlib_ext")
 
 def _construct_platform_triple_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -152,10 +152,24 @@ def _construct_known_triples_test_impl(ctx):
 
     return unittest.end(env)
 
+def _wasm_staticlib_ext_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    for system in ["threads", "unknown", "wasi", "wasip1", "wasip2"]:
+        asserts.equals(
+            env,
+            ".a",
+            system_to_staticlib_ext(system),
+            "{} should use a static archive extension".format(system),
+        )
+
+    return unittest.end(env)
+
 construct_platform_triple_test = unittest.make(_construct_platform_triple_test_impl)
 construct_minimal_platform_triple_test = unittest.make(_construct_minimal_platform_triple_test_impl)
 supported_platform_triples_test = unittest.make(_supported_platform_triples_test_impl)
 construct_known_triples_test = unittest.make(_construct_known_triples_test_impl)
+wasm_staticlib_ext_test = unittest.make(_wasm_staticlib_ext_test_impl)
 
 def platform_triple_test_suite(name, **kwargs):
     """Define a test suite for testing the `triple` constructor
@@ -176,6 +190,9 @@ def platform_triple_test_suite(name, **kwargs):
     construct_known_triples_test(
         name = "construct_known_triples_test",
     )
+    wasm_staticlib_ext_test(
+        name = "wasm_staticlib_ext_test",
+    )
 
     native.test_suite(
         name = name,
@@ -184,6 +201,7 @@ def platform_triple_test_suite(name, **kwargs):
             ":construct_minimal_platform_triple_test",
             ":supported_platform_triples_test",
             ":construct_known_triples_test",
+            ":wasm_staticlib_ext_test",
         ],
         **kwargs
     )


### PR DESCRIPTION
`rust_static_library` targets fail for wasm-style platform mappings whose `staticlib_ext` is empty.
 This became visible after https://github.com/bazelbuild/rules_rust/pull/3864 changed the allocator shim target to use `rust_static_library`. When building that target for the wasm platform, rules_rust computes:

```
  crate_type = "staticlib"
  staticlib_ext = ""
```

`determine_lib_name` treats the empty extension as invalid and fails with:

```
Unknown crate_type: staticlib
```

Static library outputs for these wasm/WASI-style targets should use archive output names, e.g. libfoo.a. Binary and dylib outputs can continue using .wasm.

This updates the wasm-style staticlib mappings to .a for:

- threads
- unknown
- wasi
- wasip1
- wasip2

This is easily reproducible from the rules_rust repository, before this change:

```
bazel build --platforms=//rust/platform:wasm32 //ffi/rs/allocator_library:allocator_library
```

fails during analysis with:

```
  Unknown crate_type: staticlib
```

closes https://github.com/bazelbuild/rules_rust/issues/3894