### PR TITLE
Wire rust_objcopy into the generated sysroot action inputs

### DIFF
--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -213,7 +213,8 @@ def _generate_sysroot(
         llvm_tools = None,
         rust_std = None,
         rustfmt = None,
-        linker = None):
+        linker = None,
+        rust_objcopy = None):
     """Generate a rust sysroot from collection of toolchain components
 
     Args:
@@ -228,6 +229,7 @@ def _generate_sysroot(
         rust_std (Target, optional): A collection of Files containing Rust standard library components.
         rustfmt (File, optional): The path to a `rustfmt` executable.
         linker (Target, optional): The linker target (e.g. `rust-lld`).
+        rust_objcopy (File, optional): The path to a `rust-objcopy` executable.
 
     Returns:
         struct: A struct of generated files representing the new sysroot
@@ -299,6 +301,18 @@ def _generate_sysroot(
         sysroot_linker_files = _symlink_sysroot_tree(ctx, name, linker, linker[DefaultInfo].default_runfiles.files)
         direct_files.append(sysroot_linker)
         transitive_file_sets.append(sysroot_linker_files)
+
+    # rust-objcopy. rustc invokes this when `-Cstrip=debuginfo` is set and
+    # looks for it inside the sysroot at lib/rustlib/{triple}/bin, so it
+    # needs to land at the same relative path under the generated sysroot
+    # and be declared as an action input.
+    if rust_objcopy:
+        dest = "bin"
+        if "/lib/rustlib/" in rust_objcopy.dirname:
+            idx = rust_objcopy.dirname.find("/lib/rustlib/")
+            dest = rust_objcopy.dirname[idx + 1:]
+        sysroot_rust_objcopy = _symlink_sysroot_bin(ctx, name, dest, rust_objcopy)
+        direct_files.append(sysroot_rust_objcopy)
 
     # Llvm tools
     sysroot_llvm_tools = None
@@ -425,6 +439,7 @@ def _rust_toolchain_impl(ctx):
         cargo_clippy = ctx.file.cargo_clippy,
         llvm_tools = ctx.attr.llvm_tools,
         linker = ctx.attr.linker,
+        rust_objcopy = ctx.file.rust_objcopy,
     )
 
     # Determine the path and short_path of the sysroot


### PR DESCRIPTION
## Summary

#3727 added a `rust_objcopy` attribute to `rust_toolchain`, a separate `rust-objcopy` filegroup, and automatic opt-in for Rust 1.84+/recent nightlies. But the glue to turn that attribute into a real action input is missing: `ctx.file.rust_objcopy` is stashed on `ToolchainInfo` and never used again. It never flows through `_generate_sysroot` into `direct_files`, so it doesn't join `toolchain.all_files` and isn't declared as an input to the Rustc action.

On Linux/macOS with symlink-based sandboxing this is masked — rustc happens to see the neighboring file in the unsandboxed `rules_rust` external repo. Under remote execution, Windows (file-copy sandbox), or stricter local sandboxes, rustc invokes `rust-objcopy` and fails:

```
error: unable to run `rust-objcopy`: No such file or directory (os error 2)
```

Tracking: #3307.

## Fix

Mirror the `linker` handling in `_generate_sysroot`: symlink `rust_objcopy` into the sysroot at `lib/rustlib/<triple>/bin/rust-objcopy` (where rustc looks) and append it to `direct_files` so it becomes a declared Rustc action input.

## Verification

Patched `rules_rust` via `local_path_override` in a minimal smoke workspace using rustc 1.93.0 on aarch64-apple-darwin:

- `bazel build -c opt //:hello` succeeds (opt-mode `process_wrapper` uses `-Cstrip=debuginfo`, which invokes rust-objcopy).
- `bazel aquery 'mnemonic("Rustc", //:hello)'` now lists the sysroot `rust-objcopy` symlink as a declared input — it was absent before.

Before: no `rust-objcopy` entry in the Rustc action inputs.
After: `bazel-out/.../rust_toolchain/lib/rustlib/aarch64-apple-darwin/bin/rust-objcopy`.
