### PR TITLE
Fix rust-analyzer for core libraries

### DIFF
--- a/rust/private/repositories.bzl
+++ b/rust/private/repositories.bzl
@@ -759,6 +759,24 @@ def _rust_analyzer_toolchain_tools_repository_impl(repository_ctx):
         build_contents.append(BUILD_for_rust_analyzer_proc_macro_srv(host_triple))
         proc_macro_srv = "//:rust_analyzer_proc_macro_srv"
 
+    rust_stdlib_content, rust_stdlib_sha256 = load_rust_stdlib(
+        ctx = repository_ctx,
+        target_triple = host_triple,
+        version = version,
+        iso_date = iso_date,
+    )
+    build_contents.append(rust_stdlib_content)
+    sha256s.update(rust_stdlib_sha256)
+
+    cargo_content, cargo_sha256 = load_cargo(
+        ctx = repository_ctx,
+        iso_date = iso_date,
+        target_triple = host_triple,
+        version = version,
+    )
+    build_contents.append(cargo_content)
+    sha256s.update(cargo_sha256)
+
     # Load rust-analyzer binary from official Rust distribution
     rust_analyzer = None
     rust_analyzer_content, rust_analyzer_sha256 = load_rust_analyzer(
@@ -775,6 +793,7 @@ def _rust_analyzer_toolchain_tools_repository_impl(repository_ctx):
     build_contents.append(BUILD_for_rust_analyzer_toolchain(
         name = "rust_analyzer_toolchain",
         rustc = "//:rustc",
+        target_triple = host_triple,
         proc_macro_srv = proc_macro_srv,
         rust_analyzer = rust_analyzer,
         version = version,

--- a/rust/private/repository_utils.bzl
+++ b/rust/private/repository_utils.bzl
@@ -716,16 +716,19 @@ rust_analyzer_toolchain(
     name = "{name}",
     proc_macro_srv = {proc_macro_srv},
     rust_analyzer = {rust_analyzer},
+    rust_std = "//:rust_std-{target_triple}",
     rustc = "{rustc}",
     rustc_srcs = "//lib/rustlib/src:rustc_srcs",
+    cargo = "//:cargo",
     version = "{version}",
     visibility = ["//visibility:public"],
 )
 """
 
-def BUILD_for_rust_analyzer_toolchain(name, rustc, proc_macro_srv, version, rust_analyzer = None):
+def BUILD_for_rust_analyzer_toolchain(name, target_triple, rustc, proc_macro_srv, version, rust_analyzer = None):
     return _build_file_for_rust_analyzer_toolchain_template.format(
         name = name,
+        target_triple = target_triple.str,
         rustc = rustc,
         proc_macro_srv = repr(proc_macro_srv),
         rust_analyzer = repr(rust_analyzer) if rust_analyzer else "None",

--- a/rust/private/rust_analyzer.bzl
+++ b/rust/private/rust_analyzer.bzl
@@ -372,6 +372,12 @@ rust_analyzer_toolchain = rule(
             executable = True,
             allow_single_file = True,
         ),
+        "cargo": attr.label(
+            doc = "The path to a `cargo` binary.",
+            cfg = "exec",
+            executable = True,
+            allow_single_file = True,
+        ),
         "rustc": attr.label(
             doc = "The path to a `rustc` binary.",
             cfg = "exec",
@@ -386,6 +392,10 @@ rust_analyzer_toolchain = rule(
         "rustc_srcs_path": attr.string(
             doc = "The direct path to rustc srcs relative to rustc_srcs package root.",
             default = "library",
+        ),
+        "rust_std": attr.label(
+            doc = "The core library of rust.",
+            mandatory = True,
         ),
         "version": attr.string(
             doc = (


### PR DESCRIPTION
For a description of the problem see: #3985

This fixes the dependency problem for the core libraries for me, but I am not sure if this is the best solution. It might be better to add proper BUILD files describing the core dependencies instead. 

(As an aside: It might be nice with some clippy support in rust-analyzer too now that I am adding cargo anyways.)