### PR TITLE
Handle all `-isystem` variant flags in cargo build script path rewriting

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -248,8 +248,8 @@ def _pwd_flags_fsanitize_ignorelist(args):
     return _prefix_pwd_to_flag(args, ["-fsanitize-ignorelist="])
 
 def _pwd_flags_isystem(args):
-    """Prefix execroot-relative paths in -isystem and -Xclang -internal-isystem arguments with ${pwd}."""
-    return _prefix_pwd_to_flag(args, ["-isystem", "-internal-isystem"])
+    """Prefix execroot-relative paths in -isystem-like arguments with ${pwd}."""
+    return _prefix_pwd_to_flag(args, ["-isystem", "-isystem-after", "-internal-isystem", "-cxx-isystem", "-stdlib++-isystem"])
 
 def _pwd_flags_L(args):
     """Prefix execroot-relative paths in -L arguments with ${pwd}."""


### PR DESCRIPTION
## Summary

Handle all `-isystem` variant flags in cargo build script path rewriting.

## Problem

When Bazel passes CC toolchain flags to cargo build scripts, paths following `-isystem` are prefixed with `${pwd}` so they resolve correctly inside the sandbox. However, several other Clang flags that take system include paths were not handled:

- `-stdlib++-isystem` — C++ standard library headers
- `-isystem-after` — appended to SYSTEM include search path
- `-cxx-isystem` — C++ SYSTEM include search path

See the [Clang command line reference](https://clang.llvm.org/docs/ClangCommandLineReference.html) for the full set.

This caused cargo build scripts to fail when the CC toolchain used any of these flags, because paths weren't rewritten for the sandbox.

## Fix

Add `-stdlib++-isystem`, `-isystem-after`, and `-cxx-isystem` to the flag list in `_pwd_flags_isystem`.

---

> **Note:** This PR was largely AI-generated using Claude Code, with human review and guidance throughout.