### PR TITLE
Fix platform label context in rule transitions

### DIFF
--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1013,7 +1013,7 @@ def _resolve_platform(settings, attr):
     main-repo labels omits the leading @, producing "//foo:bar" instead of
     "@//foo:bar". The platform setting requires the canonical form with @.
     See https://github.com/bazelbuild/bazel/issues/15916.
-    
+
     Note that this function will no longer be needed if
     `--noincompatible_unambiguous_label_stringification` is dropped but
     it's currently required internally by Google.

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1006,9 +1006,23 @@ rust_library = rule(
         """),
 )
 
+def _resolve_platform(settings, attr):
+    """Resolve the platform label for a transition, adding @ prefix if needed.
+
+    When a label has no repo name (e.g. from the main repo), str(label) omits
+    the leading @, producing "//platforms:foo" instead of "@//platforms:foo".
+    Bazel's platform setting requires the canonical form with @.
+    """
+    if not attr.platform:
+        return settings["//command_line_option:platforms"]
+    platform = str(attr.platform)
+    if not attr.platform.repo_name:
+        platform = "@" + platform
+    return platform
+
 def _rust_static_library_transition_impl(settings, attr):
     return {
-        "//command_line_option:platforms": str(attr.platform) if attr.platform else settings["//command_line_option:platforms"],
+        "//command_line_option:platforms": _resolve_platform(settings, attr),
     }
 
 _rust_static_library_transition = transition(
@@ -1049,7 +1063,7 @@ rust_static_library = rule(
 
 def _rust_shared_library_transition_impl(settings, attr):
     return {
-        "//command_line_option:platforms": str(attr.platform) if attr.platform else settings["//command_line_option:platforms"],
+        "//command_line_option:platforms": _resolve_platform(settings, attr),
     }
 
 _rust_shared_library_transition = transition(
@@ -1171,7 +1185,7 @@ _RUST_BINARY_ATTRS = {
 
 def _rust_binary_transition_impl(settings, attr):
     return {
-        "//command_line_option:platforms": str(attr.platform) if attr.platform else settings["//command_line_option:platforms"],
+        "//command_line_option:platforms": _resolve_platform(settings, attr),
     }
 
 _rust_binary_transition = transition(
@@ -1418,7 +1432,7 @@ rust_test_without_process_wrapper_test = rule(
 
 def _rust_test_transition_impl(settings, attr):
     return {
-        "//command_line_option:platforms": str(attr.platform) if attr.platform else settings["//command_line_option:platforms"],
+        "//command_line_option:platforms": _resolve_platform(settings, attr),
     }
 
 _rust_test_transition = transition(

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1009,14 +1009,15 @@ rust_library = rule(
 def _resolve_platform(settings, attr):
     """Resolve the platform label for a transition, adding @ prefix if needed.
 
-    When a label has no repo name (e.g. from the main repo), str(label) omits
-    the leading @, producing "//platforms:foo" instead of "@//platforms:foo".
-    Bazel's platform setting requires the canonical form with @.
+    With --noincompatible_unambiguous_label_stringification, str(label) for
+    main-repo labels omits the leading @, producing "//foo:bar" instead of
+    "@//foo:bar". The platform setting requires the canonical form with @.
+    See https://github.com/bazelbuild/bazel/issues/15916.
     """
     if not attr.platform:
         return settings["//command_line_option:platforms"]
     platform = str(attr.platform)
-    if not attr.platform.repo_name:
+    if not platform.startswith("@"):
         platform = "@" + platform
     return platform
 

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -1013,6 +1013,11 @@ def _resolve_platform(settings, attr):
     main-repo labels omits the leading @, producing "//foo:bar" instead of
     "@//foo:bar". The platform setting requires the canonical form with @.
     See https://github.com/bazelbuild/bazel/issues/15916.
+    
+    Note that this function will no longer be needed if
+    `--noincompatible_unambiguous_label_stringification` is dropped but
+    it's currently required internally by Google.
+    See https://github.com/bazelbuild/bazel/issues/16196
     """
     if not attr.platform:
         return settings["//command_line_option:platforms"]


### PR DESCRIPTION
## Summary

Fix platform label resolution in rule transitions for `rust_binary`, `rust_shared_library`, `rust_static_library`, and `rust_test`.

## Problem

When a platform label comes from the main repository (no repo name), `str(label)` produces `//platforms:foo` instead of `@//platforms:foo`. Bazel's `//command_line_option:platforms` setting requires the canonical form with `@`, so the transition silently selects the wrong platform or fails.

This affects anyone using the `platform` attribute on Rust rules with a label defined in the main repository.

Note: as mentioned in https://github.com/bazelbuild/rules_rust/pull/3997#discussion_r3156712697, this only affects builds that use `--noincompatible_unambiguous_label_stringification`.

## Fix

Extract a `_resolve_platform` helper that adds the `@` prefix when `attr.platform.repo_name` is empty, and apply it consistently to all four rule transitions. The original patch only fixed `rust_binary`; this PR fixes all four for completeness.

---

> **Note:** This PR was largely AI-generated using Claude Code, with human review and guidance throughout.