### PR TITLE
Add `RUST_COVERAGE_IGNORE_REGEX` for configurable coverage filtering

### DIFF
--- a/util/collect_coverage/collect_coverage.rs
+++ b/util/collect_coverage/collect_coverage.rs
@@ -190,7 +190,20 @@ fn main() {
         .arg("-instr-profile")
         .arg(&profdata_file)
         .arg("-ignore-filename-regex=.*external/.+")
-        .arg("-ignore-filename-regex=/tmp/.+")
+        .arg("-ignore-filename-regex=/tmp/.+");
+
+    // Allow additional ignore patterns via RUST_COVERAGE_IGNORE_REGEX env var
+    // (comma-separated list of regexes passed to llvm-cov -ignore-filename-regex).
+    if let Ok(extra) = env::var("RUST_COVERAGE_IGNORE_REGEX") {
+        for pattern in extra.split(',') {
+            let pattern = pattern.trim();
+            if !pattern.is_empty() {
+                llvm_cov_cmd.arg(format!("-ignore-filename-regex={}", pattern));
+            }
+        }
+    }
+
+    llvm_cov_cmd
         .arg(format!("-path-equivalence=.,{}", execroot.display()))
         .arg(test_binary)
         .stdout(process::Stdio::piped())


### PR DESCRIPTION
## Summary

Add `RUST_COVERAGE_IGNORE_REGEX` environment variable for configurable `llvm-cov export` filtering.

## Problem

The `collect_coverage.rs` script hardcodes two `-ignore-filename-regex` patterns (`.*external/.+` and `/tmp/.+`) passed to `llvm-cov export`. Projects often need additional filters — for example, to exclude vendored C/C++ code or generated files — but there's no way to add them without patching the script.

## Fix

Read an optional `RUST_COVERAGE_IGNORE_REGEX` environment variable: a comma-separated list of additional regex patterns passed as `-ignore-filename-regex` arguments to `llvm-cov`. The existing hardcoded patterns are preserved as defaults.

Users can set this via `--test_env` in `.bazelrc`:

```
coverage --test_env=RUST_COVERAGE_IGNORE_REGEX=.*vendor/.*,^/rustc/
```

---

> **Note:** This PR was largely AI-generated using Claude Code, with human review and guidance throughout.