### PR TITLE
Pass `--respect-source-config` to `cargo vendor`

### DIFF
--- a/crate_universe/src/metadata.rs
+++ b/crate_universe/src/metadata.rs
@@ -256,6 +256,10 @@ impl VendorGenerator {
             .arg("--locked")
             .arg("--versioned-dirs")
             .arg(output_dir)
+            // Without this flag `cargo vendor` ignores `[source]` replacement
+            // in `.cargo/config.toml`, so it bypasses any configured registry
+            // proxy and connects directly to index.crates.io.
+            .arg("--respect-source-config")
             .env("RUSTC", &self.rustc_bin)
             .output()
             .with_context(|| {


### PR DESCRIPTION
## Summary

Pass `--respect-source-config` to `cargo vendor`.

## Problem

Without this flag, `cargo vendor` ignores `[source]` replacement configured in `.cargo/config.toml`. This means any configured registry proxy is silently bypassed, and `cargo vendor` connects directly to `index.crates.io`. This breaks vendoring in environments that require a proxy, such as air-gapped networks or behind corporate firewalls.

## Fix

Add `--respect-source-config` to the `cargo vendor` invocation in `VendorGenerator`.

---

> **Note:** This PR was largely AI-generated using Claude Code, with human review and guidance throughout.