### PR TITLE
Fix `rustfmt` silently skipping symlinked sources

### DIFF
--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -47,7 +47,19 @@ def _find_rustfmtable_srcs(crate_info, aspect_ctx = None):
             if tag.replace("-", "_").lower() in ignore_tags:
                 return []
 
-    # Filter out any generated files
+    # Filter out generated files, but recover hand-written sources that were
+    # symlinked into bazel-out by transform_sources() (which happens when any
+    # compile_data entry is generated). Return the original source File objects
+    # so that exec_path and short_path remain correct for manifests and runfiles.
+    if aspect_ctx and hasattr(aspect_ctx.rule.attr, "srcs"):
+        original_srcs = []
+        for target in aspect_ctx.rule.attr.srcs:
+            for f in target.files.to_list():
+                if f.is_source:
+                    original_srcs.append(f)
+        if original_srcs:
+            return original_srcs
+
     srcs = [src for src in crate_info.srcs.to_list() if src.is_source]
 
     return srcs
@@ -219,7 +231,7 @@ def _rustfmt_test_impl(ctx):
     )
 
     crate_infos = [_get_rustfmt_ready_crate_info(target) for target in ctx.attr.targets]
-    srcs = [depset(_find_rustfmtable_srcs(crate_info)) for crate_info in crate_infos if crate_info]
+    srcs = [crate_info.srcs for crate_info in crate_infos if crate_info]
 
     # Some targets may be included in tests but tagged as "no-format". In this
     # case, there will be no manifest.

--- a/test/rustfmt/rustfmt_failure_tester.sh
+++ b/test/rustfmt/rustfmt_failure_tester.sh
@@ -86,7 +86,6 @@ EOF
     check_build_result $TEST_OK ${variant}_formatted_2015_test
     check_build_result $TEST_OK ${variant}_formatted_2018_test
     check_build_result $TEST_OK ${variant}_generated_test
-    check_build_result $TEST_FAILED ${variant}_compile_data_generated_test
   done
 
   # Format a specific target
@@ -100,7 +99,6 @@ EOF
     check_build_result $TEST_OK ${variant}_formatted_2015_test
     check_build_result $TEST_OK ${variant}_formatted_2018_test
     check_build_result $TEST_OK ${variant}_generated_test
-    check_build_result $TEST_OK ${variant}_compile_data_generated_test
   done
 
   # Format all targets

--- a/test/rustfmt/rustfmt_failure_tester.sh
+++ b/test/rustfmt/rustfmt_failure_tester.sh
@@ -86,6 +86,7 @@ EOF
     check_build_result $TEST_OK ${variant}_formatted_2015_test
     check_build_result $TEST_OK ${variant}_formatted_2018_test
     check_build_result $TEST_OK ${variant}_generated_test
+    check_build_result $TEST_FAILED ${variant}_compile_data_generated_test
   done
 
   # Format a specific target
@@ -99,6 +100,7 @@ EOF
     check_build_result $TEST_OK ${variant}_formatted_2015_test
     check_build_result $TEST_OK ${variant}_formatted_2018_test
     check_build_result $TEST_OK ${variant}_generated_test
+    check_build_result $TEST_OK ${variant}_compile_data_generated_test
   done
 
   # Format all targets

--- a/test/rustfmt/rustfmt_integration_test_suite.bzl
+++ b/test/rustfmt/rustfmt_integration_test_suite.bzl
@@ -1,5 +1,6 @@
 """Test definitions for rustfmt test rules"""
 
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load(
     "@rules_rust//rust:defs.bzl",
     "rust_binary",
@@ -101,12 +102,36 @@ def rustfmt_integration_test_suite(name, **kwargs):
             targets = [":{}_generated".format(variant)],
         )
 
+        #
+        # Test targets with generated compile_data (triggers transform_sources
+        # to symlink hand-written sources into bazel-out)
+        #
+        write_file(
+            name = "{}_compile_data_gen".format(variant),
+            out = "{}_generated_data.txt".format(variant),
+            content = ["generated"],
+        )
+
+        rust_rule(
+            name = "{}_compile_data_generated".format(variant),
+            srcs = ["srcs/compile_data_generated/lib.rs"],
+            compile_data = [":{}_compile_data_gen".format(variant)],
+            edition = "2021",
+        )
+
+        rustfmt_test(
+            name = "{}_compile_data_generated_test".format(variant),
+            tags = ["manual"],
+            targets = [":{}_compile_data_generated".format(variant)],
+        )
+
         tests.extend([
             "{}_formatted_2015_test".format(variant),
             "{}_formatted_2018_test".format(variant),
             "{}_unformatted_2015_test".format(variant),
             "{}_unformatted_2018_test".format(variant),
             "{}_generated_test".format(variant),
+            "{}_compile_data_generated_test".format(variant),
         ])
 
     native.test_suite(

--- a/test/rustfmt/rustfmt_integration_test_suite.bzl
+++ b/test/rustfmt/rustfmt_integration_test_suite.bzl
@@ -121,7 +121,6 @@ def rustfmt_integration_test_suite(name, **kwargs):
 
         rustfmt_test(
             name = "{}_compile_data_generated_test".format(variant),
-            tags = ["manual"],
             targets = [":{}_compile_data_generated".format(variant)],
         )
 
@@ -131,6 +130,7 @@ def rustfmt_integration_test_suite(name, **kwargs):
             "{}_unformatted_2015_test".format(variant),
             "{}_unformatted_2018_test".format(variant),
             "{}_generated_test".format(variant),
+            "{}_compile_data_generated_test".format(variant),
         ])
 
     native.test_suite(

--- a/test/rustfmt/rustfmt_integration_test_suite.bzl
+++ b/test/rustfmt/rustfmt_integration_test_suite.bzl
@@ -131,7 +131,6 @@ def rustfmt_integration_test_suite(name, **kwargs):
             "{}_unformatted_2015_test".format(variant),
             "{}_unformatted_2018_test".format(variant),
             "{}_generated_test".format(variant),
-            "{}_compile_data_generated_test".format(variant),
         ])
 
     native.test_suite(

--- a/test/rustfmt/srcs/compile_data_generated/lib.rs
+++ b/test/rustfmt/srcs/compile_data_generated/lib.rs
@@ -1,0 +1,6 @@
+pub fn main()
+{
+    println!(
+        "compile_data_generated"
+    );
+}

--- a/test/rustfmt/srcs/compile_data_generated/lib.rs
+++ b/test/rustfmt/srcs/compile_data_generated/lib.rs
@@ -1,6 +1,3 @@
-pub fn main()
-{
-    println!(
-        "compile_data_generated"
-    );
+pub fn main() {
+    println!("compile_data_generated");
 }


### PR DESCRIPTION
## Summary

Fix `rustfmt_test` and `rustfmt_aspect` silently skipping hand-written sources that were symlinked by `transform_sources()`.

## Problem

When any `compile_data` entry is a generated file, `transform_sources()` symlinks all source files into `bazel-out`. After symlinking, `is_source` returns `False` for these files, so `_find_rustfmtable_srcs` filters them all out. The result is that rustfmt silently does nothing — no error, no formatting check.

## Fix

When the aspect context is available, recover original source `File` objects from the rule's `srcs` attribute (which still references the pre-symlink originals). This preserves correct `exec_path` and `short_path` for manifests and runfiles.

Also use `crate_info.srcs` directly in `_rustfmt_test_impl` to include all sources.

---

> **Note:** This PR was largely AI-generated using Claude Code, with human review and guidance throughout.