### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: needs-triage
+assignees: ''
+type: Bug
+
+---
+
+**Description**
+A clear and concise description of what the bug is, including:
+- what's the current (wrong) behavior?
+- what's the expected behavior?
+
+**Reproduction steps**
+Detailed instructions to reproduce your issue, including what your build configurations look like, what commands you run, etc. Providing a stand-alone minimal repo that reproduces your problem is ideal.
+
+**Additional context**
+Any other information that might help understand the issue: logs, screenshots, etc.
+
+**Impact**
+Describe the impact of the issue (e.g. if there's a workaround, or whether this blocks updating to a newer rules_rust version).
+
+**Bazel and rules_rust version**
+Please specify what version of bazel and rules_rust version you were using when you encountered the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+type: Feature
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or logs/screenshots about the feature request here.


### PR DESCRIPTION
This is based on @scentini's "rules_rust contributor guidelines" draft document. Instead of adding a "Type" section for bug/feature request/... I have created separate templates.

- The bug template is similar to what's described in the document
- The feature request template is pretty much Github's default feature request template. It seems like a reasonable starting point but I'm happy to make any changes you'd like to see.