### PR TITLE
Order rust lints before clippy lints to allow ignoring unknown lints

### DIFF
--- a/rust/private/clippy.bzl
+++ b/rust/private/clippy.bzl
@@ -134,11 +134,11 @@ def rust_clippy_action(ctx, clippy_executable, process_wrapper, crate_info, conf
     lint_files = []
     if hasattr(ctx.rule.attr, "lint_config") and ctx.rule.attr.lint_config:
         clippy_flags = clippy_flags + \
-                       ctx.rule.attr.lint_config[LintsInfo].clippy_lint_flags + \
-                       ctx.rule.attr.lint_config[LintsInfo].rustc_lint_flags
+                       ctx.rule.attr.lint_config[LintsInfo].rustc_lint_flags + \
+                       ctx.rule.attr.lint_config[LintsInfo].clippy_lint_flags
         lint_files = lint_files + \
-                     ctx.rule.attr.lint_config[LintsInfo].clippy_lint_files + \
-                     ctx.rule.attr.lint_config[LintsInfo].rustc_lint_files
+                     ctx.rule.attr.lint_config[LintsInfo].rustc_lint_files + \
+                     ctx.rule.attr.lint_config[LintsInfo].clippy_lint_files
 
     compile_inputs, out_dir, build_env_files, build_flags_files, linkstamp_outs, ambiguous_libs = collect_inputs(
         ctx,


### PR DESCRIPTION
When updating the Rust toolchain in a quickly moving repository, it can be difficult to atomically fix all the lints and update the toolchain in a single commit. It can be helpful to:

* land a patch that adds the flags `-Aunknown_lints -Aclippy::useless_borrows_in_formatting`. Rust needs them in that order, otherwise it will error out.
* land the toolchain update.
* clean up the remaining lint failures.

Unfortunately before this patch rules_rust would emit the clippy lints first, then the rustc lints, so we couldn't use this pattern. This patch reverses the order and fixes this issue.