### PR TITLE
Fix RBE jobs

### DIFF
--- a/extensions/bindgen/private/internal_extensions.bzl
+++ b/extensions/bindgen/private/internal_extensions.bzl
@@ -7,7 +7,7 @@ def _rust_ext_dev_impl(module_ctx):
 
     rbe_preconfig(
         name = "buildkite_config",
-        toolchain = "ubuntu1804-bazel-java11",
+        toolchain = "ubuntu2404",
     )
 
     deps.append(struct(repo = "buildkite_config"))

--- a/extensions/mdbook/private/internal_extensions.bzl
+++ b/extensions/mdbook/private/internal_extensions.bzl
@@ -7,7 +7,7 @@ def _rust_ext_dev_impl(module_ctx):
 
     rbe_preconfig(
         name = "buildkite_config",
-        toolchain = "ubuntu1804-bazel-java11",
+        toolchain = "ubuntu2404",
     )
 
     deps.append(struct(repo = "buildkite_config"))

--- a/extensions/prost/private/internal_extensions.bzl
+++ b/extensions/prost/private/internal_extensions.bzl
@@ -7,7 +7,7 @@ def _rust_ext_dev_impl(module_ctx):
 
     rbe_preconfig(
         name = "buildkite_config",
-        toolchain = "ubuntu2204",
+        toolchain = "ubuntu2404",
     )
 
     deps.append(struct(repo = "buildkite_config"))

--- a/extensions/pyo3/private/internal_extensions_dev.bzl
+++ b/extensions/pyo3/private/internal_extensions_dev.bzl
@@ -7,7 +7,7 @@ def _rust_ext_dev_impl(module_ctx):
 
     rbe_preconfig(
         name = "buildkite_config",
-        toolchain = "ubuntu1804-bazel-java11",
+        toolchain = "ubuntu2404",
     )
 
     deps.append(struct(repo = "buildkite_config"))

--- a/extensions/wasm_bindgen/private/internal_extensions.bzl
+++ b/extensions/wasm_bindgen/private/internal_extensions.bzl
@@ -7,7 +7,7 @@ def _rust_ext_dev_impl(module_ctx):
 
     rbe_preconfig(
         name = "buildkite_config",
-        toolchain = "ubuntu1804-bazel-java11",
+        toolchain = "ubuntu2404",
     )
 
     deps.append(struct(repo = "buildkite_config"))

--- a/test/test_extensions.bzl
+++ b/test/test_extensions.bzl
@@ -10,7 +10,7 @@ def _rust_test_impl(module_ctx):
 
     rbe_preconfig(
         name = "buildkite_config",
-        toolchain = "ubuntu1804-bazel-java11",
+        toolchain = "ubuntu2404",
     )
 
     deps.append(struct(repo = "buildkite_config"))


### PR DESCRIPTION
Hopefully this fixes this error we're now seeing on jobs.
```
(17:55:08) ERROR: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/external/bazel_ci_rules+/rbe_repo.bzl:64:13: An error occurred during the fetch of repository '+rust_test+buildkite_config':
   Traceback (most recent call last):
	File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/external/bazel_ci_rules+/rbe_repo.bzl", line 64, column 13, in _rbe_preconfig_impl
		fail("\nrbe_preconfig: Unsupported toolchain '{}' (Values: {}).\n".format(toolchain_name, _available_toolchain_names(manifest)))
Error in fail:
rbe_preconfig: Unsupported toolchain 'ubuntu1804-bazel-java11' (Values: 'ubuntu2404').
(17:55:08) ERROR: com.google.devtools.build.lib.packages.RepositoryFetchException: no such package '@@+rust_test+buildkite_config//config':
rbe_preconfig: Unsupported toolchain 'ubuntu1804-bazel-java11' (Values: 'ubuntu2404').
```