### PR TITLE
docs: fix generated rules doc links

### DIFF
--- a/docs/rust_clippy.vm
+++ b/docs/rust_clippy.vm
@@ -19,7 +19,7 @@ build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build --output_groups=+clippy_checks
 ```
 
-This will enable clippy on all [Rust targets](./defs.md).
+This will enable clippy on all [Rust targets](./rust.md).
 
 Note that targets tagged with `no-clippy` will not perform clippy checks
 

--- a/docs/src/rules.md
+++ b/docs/src/rules.md
@@ -1,6 +1,6 @@
 # Rules
 
-- [defs](defs.md): standard rust rules for building and testing libraries and binaries.
+- [rust](rust.md): standard rust rules for building and testing libraries and binaries.
 - [rustdoc](rust_doc.md): rules for generating and testing rust documentation.
 - [clippy](rust_clippy.md): rules for running [clippy](https://github.com/rust-lang/rust-clippy#readme).
 - [rustfmt](rust_fmt.md): rules for running [rustfmt](https://github.com/rust-lang/rustfmt#readme).


### PR DESCRIPTION
## Summary
- Fix the `rules` docs link from the missing `defs.md` page to the generated `rust.md` page.
- Fix the same stale `defs.md` reference in the clippy docs template.

Fixes #3791.

## Validation
- `rg -n "defs\.md" docs/src docs/*.vm` returns no matches.
- `git diff --check` passes.
- `bazelisk build //docs:book` was not run because `bazelisk`/`bazel` is not installed in this environment.
