### PR TITLE
crate_universe: emit build_script_env_files on rendered cargo_build_script targets

### DIFF
--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -641,6 +641,12 @@ impl Renderer {
                     .unwrap_or_default(),
                 platforms,
             ),
+            build_script_env_files: SelectSet::new(
+                attrs
+                    .map(|attrs| attrs.build_script_env_files.clone())
+                    .unwrap_or_default(),
+                platforms,
+            ),
             rustc_flags: SelectList::new(
                 // In most cases, warnings in 3rd party crates are not
                 // interesting as they're out of the control of consumers. The

--- a/crate_universe/src/utils/starlark.rs
+++ b/crate_universe/src/utils/starlark.rs
@@ -98,6 +98,8 @@ pub(crate) struct CargoBuildScript {
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) build_script_env: SelectDict<String, String>,
+    #[serde(skip_serializing_if = "SelectSet::is_empty")]
+    pub(crate) build_script_env_files: SelectSet<String>,
     #[serde(skip_serializing_if = "Data::is_empty")]
     pub(crate) compile_data: Data,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]


### PR DESCRIPTION
Fixes #4037. Reproducer: https://github.com/ashi009/rules-rust-4037-repro.

## Problem

#3632 added a `build_script_env_files` attribute to `cargo_build_script`, threaded it through `BuildScriptAttributes`, and inserted `":cargo_toml_env_vars"` into it when `generate_cargo_toml_env_vars = True`:

https://github.com/bazelbuild/rules_rust/blob/56176ea1722d7b457a6c431d1a6a24e75767b7b8/crate_universe/src/rendering.rs#L386-L394

But the `CargoBuildScript` starlark struct in `crate_universe/src/utils/starlark.rs` — the one whose `#[derive(Serialize)]` emits `cargo_build_script(...)` into the rendered BUILD.bazel — was not updated to include a `build_script_env_files` field. Serde drops the value on the way out, so the rendered output looks like:

```python
cargo_build_script(
    name = "_bs",
    ...
    rustc_env_files = [":cargo_toml_env_vars"],
    # build_script_env_files = [":cargo_toml_env_vars"]  ← missing
    ...
)
```

`rustc_env_files` sets env when **compiling** `build.rs` (so `env!(...)` works). `build_script_env_files` sets env when **executing** the compiled binary (so `env::var(...)` works). The `built` crate uses `env::var("CARGO_PKG_AUTHORS")` at execution time, so anything depending on `built` (e.g. `rav1e`) panics:

```
thread 'main' panicked at .../built-0.7.7/src/environment.rs:54:9:
Missing expected environment variable "CARGO_PKG_AUTHORS"
```

#3632's regression test (`test_data/build_script_env_files/`) exercises a hand-written `cargo_build_script(build_script_env_files = [...])`, which works fine because the user writes the field directly. The crate_universe rendering path was never covered, so the gap went unnoticed.

## Fix

Add `build_script_env_files` to `CargoBuildScript` and populate it from `attrs.build_script_env_files` in `make_cargo_build_script`, mirroring the existing `rustc_env_files` plumbing. No new attributes — the rule, macro, and context struct already support it.

## Verification

Repro: https://github.com/ashi009/rules-rust-4037-repro (tiny workspace with `rav1e = "0.7.1"`).

- Without this PR: `bazel build @crates//:rav1e` panics with the `CARGO_PKG_AUTHORS` error above.
- With this PR (cargo-bazel built from this branch via `CARGO_BAZEL_GENERATOR_URL`): build succeeds. Generated `BUILD.rav1e-0.7.1.bazel` emits `build_script_env_files = [":cargo_toml_env_vars"]` on the `cargo_build_script` target.

Tested against Bazel 7.7.1, macOS arm64.