### PR TITLE
Strip whitespace from paths before prefixing ${pwd}

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -197,7 +197,7 @@ def _prefix_pwd_to_flag(args, flag_variations):
 
             # Check for concatenated form (flag with path)
             if arg.startswith(flag):
-                path = arg[len(flag):]
+                path = arg[len(flag):].strip()
 
                 # Don't prefix absolute paths
                 if paths.is_absolute(path):
@@ -208,8 +208,8 @@ def _prefix_pwd_to_flag(args, flag_variations):
                 break
 
             # Check for space-separated form (only for flags without '=' or ':')
-            if not flag.endswith("=") and not flag.endswith(":") and prefix_next_arg and not paths.is_absolute(arg):
-                res.append("${{pwd}}/{}".format(arg))
+            if not flag.endswith("=") and not flag.endswith(":") and prefix_next_arg and not paths.is_absolute(arg.strip()):
+                res.append("${{pwd}}/{}".format(arg.strip()))
                 handled = True
                 break
 
@@ -233,6 +233,7 @@ def _prefix_pwd_to_paths(args):
     """
     res = []
     for path in args:
+        path = path.strip()
         if not paths.is_absolute(path):
             res.append("${{pwd}}/{}".format(path))
         else:

--- a/cargo/tests/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/cargo/tests/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -519,8 +519,8 @@ def include_relative_test(name):
     cargo_build_script_with_extra_cc_compile_flags(
         name = "%s/cargo_build_script" % name,
         extra_include_paths = select({
-            "@platforms//os:windows": "test/relative/include;another/relative/path",
-            "//conditions:default": "test/relative/include:another/relative/path",
+            "@platforms//os:windows": "test/relative/include; another/relative/path",
+            "//conditions:default": "test/relative/include: another/relative/path",
         }),
     )
     cc_args_and_env_analysis_test(


### PR DESCRIPTION
Fixes #3992

This patch strips the relative paths before prefixing `${pwd}`. This also tweaks an existing test to test this situation.