### PR TITLE
Support `--incompatible_exclude_starlark_flags_from_exec_config`.

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2879,6 +2879,7 @@ extra_exec_rustc_flags = rule(
         "These flags only apply to the exec configuration (proc-macros, cargo_build_script, etc)."
     ),
     implementation = _extra_exec_rustc_flags_impl,
+    attrs = {"scope": attr.string(default = "universal")},
     build_setting = config.string_list(flag = True),
 )
 
@@ -2904,6 +2905,7 @@ extra_exec_rustc_flag = rule(
         "Multiple uses are accumulated and appended after the extra_exec_rustc_flags."
     ),
     implementation = _extra_exec_rustc_flag_impl,
+    attrs = {"scope": attr.string(default = "universal")},
     build_setting = config.string_list(flag = True, repeatable = True),
 )
 

--- a/rust/settings/settings.bzl
+++ b/rust/settings/settings.bzl
@@ -110,6 +110,7 @@ def pipelined_compilation():
     """
     bool_flag(
         name = "pipelined_compilation",
+        scope = "universal",
         build_setting_default = False,
     )
 
@@ -487,6 +488,7 @@ def extra_exec_rustc_flags():
     """
     _extra_exec_rustc_flags(
         name = "extra_exec_rustc_flags",
+        scope = "universal",
         build_setting_default = [],
     )
 
@@ -498,6 +500,7 @@ def extra_exec_rustc_flag():
     """
     _extra_exec_rustc_flag(
         name = "extra_exec_rustc_flag",
+        scope = "universal",
         build_setting_default = [],
     )
 
@@ -554,5 +557,6 @@ def collect_cfgs():
     """
     bool_flag(
         name = "collect_cfgs",
+        scope = "universal",
         build_setting_default = False,
     )

--- a/rust/toolchain/channel/BUILD.bazel
+++ b/rust/toolchain/channel/BUILD.bazel
@@ -3,6 +3,7 @@ load(":channel.bzl", "rust_toolchain_channel_flag")
 rust_toolchain_channel_flag(
     name = "channel",
     build_setting_default = "stable",
+    scope = "universal",
     visibility = ["//visibility:public"],
 )
 

--- a/rust/toolchain/channel/channel.bzl
+++ b/rust/toolchain/channel/channel.bzl
@@ -24,6 +24,7 @@ def _rust_toolchain_channel_flag_impl(ctx):
 rust_toolchain_channel_flag = rule(
     doc = "A build setting which represents the Rust toolchain channel. The allowed values are {}".format(_CHANNELS),
     implementation = _rust_toolchain_channel_flag_impl,
+    attrs = {"scope": attr.string(default = "universal")},
     build_setting = config.string(
         flag = True,
     ),


### PR DESCRIPTION
This change adds `scope = "universal"` to some settings that need to be preserved in exec config.