### PR TITLE
Pass --config skip_children=true to rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,1 @@
 # rustfmt options: https://rust-lang.github.io/rustfmt/
-
-# Skipping children allows rustfmt to run on crates with
-# generated source files. Without this formatting will
-# fail with: `failed to resolve mod ${MOD}`.
-skip_children = true

--- a/docs/rust_fmt.vm
+++ b/docs/rust_fmt.vm
@@ -38,14 +38,6 @@ file is used whenever `rustfmt` is run:
 ```text
 build --@rules_rust//rust/settings:rustfmt.toml=//:rustfmt.toml
 ```
-#[[
-### Tips
-]]#
-
-Any target which uses Bazel generated sources will cause the `@rules_rust//tools/rustfmt` tool to fail with
-``failed to resolve mod `MOD` ``. To avoid failures, [`skip_children = true`](https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=skip_chil#skip_children)
-is recommended to be set in the workspace's `rustfmt.toml` file which allows rustfmt to run on these targets
-without failing.
 
 [rustfmt]: https://github.com/rust-lang/rustfmt#readme
 [rsg]: https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md

--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -86,6 +86,7 @@ def _perform_check(edition, srcs, ctx):
     args.add(rustfmt_toolchain.rustfmt)
     args.add("--config-path", config)
     args.add("--edition", edition)
+    args.add("--config", "skip_children=true")
     args.add("--check")
     args.add_all(srcs)
 

--- a/rust/settings/.rustfmt.toml
+++ b/rust/settings/.rustfmt.toml
@@ -1,6 +1,1 @@
 # rustfmt options: https://rust-lang.github.io/rustfmt/
-
-# Skipping children allows rustfmt to run on crates with
-# generated source files. Without this formatting will
-# fail with: `failed to resolve mod ${MOD}`.
-skip_children = true

--- a/test/rustfmt/test_rustfmt.toml
+++ b/test/rustfmt/test_rustfmt.toml
@@ -1,8 +1,3 @@
 # rustfmt options: https://rust-lang.github.io/rustfmt/
 
-# Skipping children allows rustfmt to run on crates with
-# generated source files. Without this formatting will
-# fail with: `failed to resolve mod ${MOD}`.
-skip_children = true
-
 reorder_imports = false

--- a/tools/rustfmt/src/bin/test_main.rs
+++ b/tools/rustfmt/src/bin/test_main.rs
@@ -29,6 +29,8 @@ fn run_rustfmt(options: &Config) {
             .arg(&manifest.edition)
             .arg("--config-path")
             .arg(&options.rustfmt_config.config)
+            .arg("--config")
+            .arg("skip_children=true")
             .args(&manifest.sources)
             .status()
             .expect("Failed to run rustfmt");

--- a/tools/rustfmt/src/main.rs
+++ b/tools/rustfmt/src/main.rs
@@ -151,6 +151,8 @@ fn apply_rustfmt(options: &Config, editions_and_targets: &HashMap<String, Vec<St
             .arg(edition)
             .arg("--config-path")
             .arg(&options.rustfmt_config.config)
+            .arg("--config")
+            .arg("skip_children=true")
             .args(sources)
             .status()
             .expect("Failed to run rustfmt");


### PR DESCRIPTION
The rustfmt.toml `skip_children` workaround is a no-op on stable rustfmt. Instead, we pass it as a --config flag, which seems to be honored.

Fixes #4022