### PR TITLE
Consume cc deps with PIC when rustc emits PIE binaries

### DIFF
--- a/rust/private/pic_utils.bzl
+++ b/rust/private/pic_utils.bzl
@@ -1,0 +1,223 @@
+"""Utilities related to Position Independent Code/Executables (PIC/PIE)"""
+
+_NON_PIE_OS_KEYWORDS = [
+    "windows",
+    "uefi",
+    "vxworks",
+    "solaris",
+    "illumos",
+    "helenos",
+    "cygwin",
+    "l4re",
+    "lynxos178",
+    "aix",
+    "cuda",
+]
+
+_NON_PIE_ARCH_PREFIXES = [
+    "wasm",
+    "xtensa",
+    "nvptx",
+    "amdgcn",
+    "msp430",
+    "avr",
+]
+
+_NON_PIE_ENV_KEYWORDS = [
+    "nuttx",
+    "espidf",
+    "rtems",
+    "xous",
+    "zkvm",
+    "qurt",
+    "psp",
+    "psx",
+    "vita",
+    "3ds",
+    "vex",
+]
+
+def parse_rustc_version(version_semver):
+    """Convert a parsed semver struct into the (major, minor, patch) tuple used for version comparisons.
+
+    A `None` input (channel labels like "nightly"/"beta" and unset versions
+    don't parse as semver) returns a sentinel representing "latest", since
+    nightly and beta are always at or ahead of the most recent stable release.
+
+    Args:
+        version_semver: A semver struct from `rust/private/semver.bzl`, typically
+            `toolchain.version_semver`, or `None`.
+
+    Returns:
+        A (major, minor, patch) tuple of ints.
+    """
+    if not version_semver:
+        return (999, 0, 0)
+    return (version_semver.major, version_semver.minor, version_semver.patch)
+
+def produces_pie_binaries(
+        target_triple,
+        rust_version):
+    """Returns True if rustc links binaries as Position Independent Executables.
+
+    The truth table here is a port of the per-target `position_independent_executables`
+    field that rustc sets in its target specs. The constants and special cases
+    below were derived from analyzing
+    https://github.com/rust-lang/rust/tree/1.95.0/compiler/rustc_target/src/spec/base
+    across Rust 1.0.0-1.95.0.
+
+    ## When to update
+
+    Add or revise an entry here whenever any of the following happens upstream:
+
+    - A new Rust release flips `position_independent_executables` on or off for
+      some target (most commonly via a base spec like `linux_musl_base.rs`).
+    - A new target triple is stabilized.
+    - rustc's PIE default itself changes (rare, but happens — e.g. the bpf
+      targets gained PIE in 1.75.0).
+
+    A divergence here typically shows up as a link error: rustc-emitted PIC/PIE
+    objects mixed with non-PIE intermediate rlibs (or vice versa).
+
+    ## How to perform the analysis
+
+    rustc target specs live under `compiler/rustc_target/src/spec/`. Each
+    triple has a `targets/<triple>.rs` that returns a `Target` whose `options`
+    field is usually built from one of the shared bases under `spec/base/`
+    (e.g. `linux_gnu_base.rs`, `apple_base.rs`, `freebsd_base.rs`).
+
+    The decision tree for a given triple is:
+
+    1. Open `compiler/rustc_target/src/spec/targets/<triple>.rs` and follow
+       which `base::*` it calls into.
+    2. In that base file, look for `position_independent_executables: true`
+       (or the field being overridden back to `false` after the base sets it).
+       Some triples override the base's value directly in their own
+       `targets/<triple>.rs` — check there too.
+    3. To find the Rust release where the value changed, `git log -p -S
+       'position_independent_executables' compiler/rustc_target/src/spec/`
+       in a rust-lang/rust checkout and cross-reference the commit's first
+       containing release tag (e.g. `git tag --contains <sha> | sort -V | head -1`).
+    4. Cross-check with the `arm-linux-androideabi`, `x86_64-unknown-haiku`,
+       and `nto` entries below — those are the existing examples of
+       version-gated PIE flips and are the right shape to copy.
+
+    Three buckets cover the bulk of the matrix without per-triple cases; only
+    add a special case here when a triple is genuinely an outlier:
+
+    - **`_NON_PIE_OS_KEYWORDS`** — operating systems whose base spec sets
+      PIE off. Matched against any `-` separated component of the triple
+      (i.e. exact-segment match). Add an entry if a *new OS* lands and its
+      base spec sets `position_independent_executables: false` (or omits it,
+      since the default is false).
+    - **`_NON_PIE_ARCH_PREFIXES`** — architectures whose base spec sets PIE
+      off. Matched as a prefix of the first triple component (the arch),
+      because variants like `wasm32`/`wasm64` and `nvptx64` share a base.
+    - **`_NON_PIE_ENV_KEYWORDS`** — embedded/environment markers whose base
+      spec sets PIE off. Substring match against the full triple, because
+      these often appear concatenated with the OS (e.g. `nuttx` in
+      `aarch64-nuttx-elf`).
+
+    Args:
+        target_triple: A parsed target triple struct (see `rust/platform/triple.bzl`),
+            typically `toolchain.target_triple`. Provides `arch`, `vendor`, `system`,
+            `abi`, and `str` fields.
+        rust_version: (major, minor, patch) tuple, e.g. (1, 93, 0).
+
+    Returns:
+        True if rustc will pass -pie to the linker for this target.
+    """
+    if target_triple.vendor == "apple":
+        return True
+
+    version = parse_rustc_version(rust_version)
+
+    if target_triple.system == "none":
+        if target_triple.arch in ("bpfeb", "bpfel"):
+            return version >= (1, 75, 0)
+        if target_triple.str == "x86_64-unknown-none":
+            return True
+        return False
+
+    if target_triple.system in _NON_PIE_OS_KEYWORDS:
+        return False
+
+    for prefix in _NON_PIE_ARCH_PREFIXES:
+        if target_triple.arch.startswith(prefix):
+            return False
+
+    # Env keywords use substring match against the full triple string because
+    # they sometimes appear in 4+-segment triples (e.g. "rtems" in
+    # "armv7-unknown-trappist-rtems-eabihf") that don't land cleanly in any
+    # single struct field.
+    for keyword in _NON_PIE_ENV_KEYWORDS:
+        if keyword in target_triple.str:
+            return False
+    if "solid" in target_triple.str:
+        return False
+
+    if target_triple.str == "i686-unknown-haiku":
+        return False
+    if target_triple.vendor == "unikraft":
+        return False
+
+    if target_triple.str == "x86_64-unknown-haiku":
+        return version >= (1, 29, 0)
+    if target_triple.str == "arm-linux-androideabi":
+        return version >= (1, 1, 0)
+
+    if target_triple.abi == "musl" and target_triple.system == "linux":
+        if target_triple.arch.startswith("mips"):
+            return True
+        return version >= (1, 21, 0)
+    if target_triple.system == "freebsd":
+        return version >= (1, 8, 0)
+    if target_triple.system == "hermit":
+        return version >= (1, 40, 0)
+    if target_triple.system == "redox":
+        return version >= (1, 38, 0)
+    if target_triple.system == "nto":
+        return version >= (1, 75, 0)
+
+    return True
+
+def should_use_pic(
+        *,
+        cc_toolchain,
+        feature_configuration,
+        crate_type,
+        compilation_mode,
+        toolchain):
+    """Whether or not [PIC][pic] should be enabled
+
+    [pic]: https://en.wikipedia.org/wiki/Position-independent_code
+
+    Args:
+        cc_toolchain (CcToolchainInfo): The current `cc_toolchain`.
+        feature_configuration (FeatureConfiguration): Feature configuration to be queried.
+        crate_type (str): A Rust target's crate type.
+        compilation_mode: The compilation mode.
+        toolchain (rust_toolchain): The current `rust_toolchain`, used to derive
+            the target triple and rustc version for PIE detection.
+
+    Returns:
+        bool: Whether or not [PIC][pic] should be enabled.
+    """
+
+    # We use the same logic to select between `pic` and `nopic` outputs as the C++ rules:
+    # - For shared libraries - we use `pic`. This covers `dylib`, `cdylib` and `proc-macro` crate types.
+    # - In `fastbuild` and `dbg` mode we use `pic` by default.
+    # - In `opt` mode we use `nopic` outputs to build binaries.
+    if cc_toolchain and crate_type in ("cdylib", "dylib", "proc-macro"):
+        return cc_toolchain.needs_pic_for_dynamic_libraries(feature_configuration = feature_configuration)
+    elif compilation_mode in ("fastbuild", "dbg"):
+        return True
+
+    # In opt mode, rustc links executables with -pie on most platforms.
+    # Any CC objects linked into a PIE binary must be PIC, including those
+    # embedded in intermediate rlibs, so this applies to all crate types.
+    # target_triple is None when a custom target JSON spec is used.
+    if toolchain.target_triple:
+        if produces_pie_binaries(toolchain.target_triple, toolchain.version_semver):
+            return True
+    return False

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -27,6 +27,10 @@ load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(":common.bzl", "rust_common")
 load(":lto.bzl", "construct_lto_arguments")
 load(
+    ":pic_utils.bzl",
+    "should_use_pic",
+)
+load(
     ":providers.bzl",
     "AllocatorLibrariesImplInfo",
     "AllocatorLibrariesInfo",
@@ -156,219 +160,6 @@ def _are_linkstamps_supported(feature_configuration):
     return (cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "linkstamps") and
             # Is Bazel recent enough to support Starlark linkstamps?
             hasattr(cc_common, "register_linkstamp_compile_action"))
-
-_NON_PIE_OS_KEYWORDS = [
-    "windows",
-    "uefi",
-    "vxworks",
-    "solaris",
-    "illumos",
-    "helenos",
-    "cygwin",
-    "l4re",
-    "lynxos178",
-    "aix",
-    "cuda",
-]
-
-_NON_PIE_ARCH_PREFIXES = [
-    "wasm",
-    "xtensa",
-    "nvptx",
-    "amdgcn",
-    "msp430",
-    "avr",
-]
-
-_NON_PIE_ENV_KEYWORDS = [
-    "nuttx",
-    "espidf",
-    "rtems",
-    "xous",
-    "zkvm",
-    "qurt",
-    "psp",
-    "psx",
-    "vita",
-    "3ds",
-    "vex",
-]
-
-def parse_rustc_version(version_semver):
-    """Convert a parsed semver struct into the (major, minor, patch) tuple used for version comparisons.
-
-    A `None` input (channel labels like "nightly"/"beta" and unset versions
-    don't parse as semver) returns a sentinel representing "latest", since
-    nightly and beta are always at or ahead of the most recent stable release.
-
-    Args:
-        version_semver: A semver struct from `rust/private/semver.bzl`, typically
-            `toolchain.version_semver`, or `None`.
-
-    Returns:
-        A (major, minor, patch) tuple of ints.
-    """
-    if not version_semver:
-        return (999, 0, 0)
-    return (version_semver.major, version_semver.minor, version_semver.patch)
-
-def produces_pie_binaries(target_triple, rust_version):
-    """Returns True if rustc links binaries as Position Independent Executables.
-
-    The truth table here is a port of the per-target `position_independent_executables`
-    field that rustc sets in its target specs. The constants and special cases
-    below were derived from analyzing
-    https://github.com/rust-lang/rust/tree/1.95.0/compiler/rustc_target/src/spec/base
-    across Rust 1.0.0-1.95.0.
-
-    ## When to update
-
-    Add or revise an entry here whenever any of the following happens upstream:
-
-    - A new Rust release flips `position_independent_executables` on or off for
-      some target (most commonly via a base spec like `linux_musl_base.rs`).
-    - A new target triple is stabilized.
-    - rustc's PIE default itself changes (rare, but happens — e.g. the bpf
-      targets gained PIE in 1.75.0).
-
-    A divergence here typically shows up as a link error: rustc-emitted PIC/PIE
-    objects mixed with non-PIE intermediate rlibs (or vice versa).
-
-    ## How to perform the analysis
-
-    rustc target specs live under `compiler/rustc_target/src/spec/`. Each
-    triple has a `targets/<triple>.rs` that returns a `Target` whose `options`
-    field is usually built from one of the shared bases under `spec/base/`
-    (e.g. `linux_gnu_base.rs`, `apple_base.rs`, `freebsd_base.rs`).
-
-    The decision tree for a given triple is:
-
-    1. Open `compiler/rustc_target/src/spec/targets/<triple>.rs` and follow
-       which `base::*` it calls into.
-    2. In that base file, look for `position_independent_executables: true`
-       (or the field being overridden back to `false` after the base sets it).
-       Some triples override the base's value directly in their own
-       `targets/<triple>.rs` — check there too.
-    3. To find the Rust release where the value changed, `git log -p -S
-       'position_independent_executables' compiler/rustc_target/src/spec/`
-       in a rust-lang/rust checkout and cross-reference the commit's first
-       containing release tag (e.g. `git tag --contains <sha> | sort -V | head -1`).
-    4. Cross-check with the `arm-linux-androideabi`, `x86_64-unknown-haiku`,
-       and `nto` entries below — those are the existing examples of
-       version-gated PIE flips and are the right shape to copy.
-
-    Three buckets cover the bulk of the matrix without per-triple cases; only
-    add a special case here when a triple is genuinely an outlier:
-
-    - **`_NON_PIE_OS_KEYWORDS`** — operating systems whose base spec sets
-      PIE off. Matched against any `-` separated component of the triple
-      (i.e. exact-segment match). Add an entry if a *new OS* lands and its
-      base spec sets `position_independent_executables: false` (or omits it,
-      since the default is false).
-    - **`_NON_PIE_ARCH_PREFIXES`** — architectures whose base spec sets PIE
-      off. Matched as a prefix of the first triple component (the arch),
-      because variants like `wasm32`/`wasm64` and `nvptx64` share a base.
-    - **`_NON_PIE_ENV_KEYWORDS`** — embedded/environment markers whose base
-      spec sets PIE off. Substring match against the full triple, because
-      these often appear concatenated with the OS (e.g. `nuttx` in
-      `aarch64-nuttx-elf`).
-
-    Args:
-        target_triple: A parsed target triple struct (see `rust/platform/triple.bzl`),
-            typically `toolchain.target_triple`. Provides `arch`, `vendor`, `system`,
-            `abi`, and `str` fields.
-        rust_version: (major, minor, patch) tuple, e.g. (1, 93, 0).
-
-    Returns:
-        True if rustc will pass -pie to the linker for this target.
-    """
-    if target_triple.vendor == "apple":
-        return True
-
-    if target_triple.system == "none":
-        if target_triple.arch in ("bpfeb", "bpfel"):
-            return rust_version >= (1, 75, 0)
-        if target_triple.str == "x86_64-unknown-none":
-            return True
-        return False
-
-    if target_triple.system in _NON_PIE_OS_KEYWORDS:
-        return False
-
-    for prefix in _NON_PIE_ARCH_PREFIXES:
-        if target_triple.arch.startswith(prefix):
-            return False
-
-    # Env keywords use substring match against the full triple string because
-    # they sometimes appear in 4+-segment triples (e.g. "rtems" in
-    # "armv7-unknown-trappist-rtems-eabihf") that don't land cleanly in any
-    # single struct field.
-    for keyword in _NON_PIE_ENV_KEYWORDS:
-        if keyword in target_triple.str:
-            return False
-    if "solid" in target_triple.str:
-        return False
-
-    if target_triple.str == "i686-unknown-haiku":
-        return False
-    if target_triple.vendor == "unikraft":
-        return False
-
-    if target_triple.str == "x86_64-unknown-haiku":
-        return rust_version >= (1, 29, 0)
-    if target_triple.str == "arm-linux-androideabi":
-        return rust_version >= (1, 1, 0)
-
-    if target_triple.abi == "musl" and target_triple.system == "linux":
-        if target_triple.arch.startswith("mips"):
-            return True
-        return rust_version >= (1, 21, 0)
-    if target_triple.system == "freebsd":
-        return rust_version >= (1, 8, 0)
-    if target_triple.system == "hermit":
-        return rust_version >= (1, 40, 0)
-    if target_triple.system == "redox":
-        return rust_version >= (1, 38, 0)
-    if target_triple.system == "nto":
-        return rust_version >= (1, 75, 0)
-
-    return True
-
-def _should_use_pic(cc_toolchain, feature_configuration, crate_type, compilation_mode, toolchain):
-    """Whether or not [PIC][pic] should be enabled
-
-    [pic]: https://en.wikipedia.org/wiki/Position-independent_code
-
-    Args:
-        cc_toolchain (CcToolchainInfo): The current `cc_toolchain`.
-        feature_configuration (FeatureConfiguration): Feature configuration to be queried.
-        crate_type (str): A Rust target's crate type.
-        compilation_mode: The compilation mode.
-        toolchain (rust_toolchain): The current `rust_toolchain`, used to derive
-            the target triple and rustc version for PIE detection.
-
-    Returns:
-        bool: Whether or not [PIC][pic] should be enabled.
-    """
-
-    # We use the same logic to select between `pic` and `nopic` outputs as the C++ rules:
-    # - For shared libraries - we use `pic`. This covers `dylib`, `cdylib` and `proc-macro` crate types.
-    # - In `fastbuild` and `dbg` mode we use `pic` by default.
-    # - In `opt` mode we use `nopic` outputs to build binaries.
-    if cc_toolchain and crate_type in ("cdylib", "dylib", "proc-macro"):
-        return cc_toolchain.needs_pic_for_dynamic_libraries(feature_configuration = feature_configuration)
-    elif compilation_mode in ("fastbuild", "dbg"):
-        return True
-
-    # In opt mode, rustc links executables with -pie on most platforms.
-    # Any CC objects linked into a PIE binary must be PIC, including those
-    # embedded in intermediate rlibs, so this applies to all crate types.
-    # target_triple is None when a custom target JSON spec is used.
-    if toolchain.target_triple:
-        rust_version = parse_rustc_version(toolchain.version_semver)
-        if produces_pie_binaries(toolchain.target_triple, rust_version):
-            return True
-    return False
 
 def _is_proc_macro(crate_info):
     return "proc-macro" in (crate_info.type, crate_info.wrapped_crate_type)
@@ -909,7 +700,13 @@ def collect_inputs(
         linker_depset = cc_toolchain.linker_files()
     compilation_mode = ctx.var["COMPILATION_MODE"]
 
-    use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_info.type, compilation_mode, toolchain)
+    use_pic = should_use_pic(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        crate_type = crate_info.type,
+        compilation_mode = compilation_mode,
+        toolchain = toolchain,
+    )
 
     # Pass linker inputs only for linking-like actions, not for example where
     # the output is rlib. This avoids quadratic behavior where transitive noncrates are
@@ -1441,7 +1238,13 @@ def construct_arguments(
         compilation_mode = ctx.var["COMPILATION_MODE"]
         if toolchain.target_arch not in ("wasm32", "wasm64"):
             if output_dir:
-                use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_info.type, compilation_mode, toolchain)
+                use_pic = should_use_pic(
+                    cc_toolchain = cc_toolchain,
+                    feature_configuration = feature_configuration,
+                    crate_type = crate_info.type,
+                    compilation_mode = compilation_mode,
+                    toolchain = toolchain,
+                )
                 rpaths = _compute_rpaths(toolchain, output_dir, dep_info, use_pic)
             else:
                 rpaths = depset()
@@ -2825,7 +2628,13 @@ def _add_native_link_flags(
     if crate_type in ["lib", "rlib"]:
         return
 
-    use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_type, compilation_mode, toolchain)
+    use_pic = should_use_pic(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        crate_type = crate_type,
+        compilation_mode = compilation_mode,
+        toolchain = toolchain,
+    )
 
     make_link_flags, get_lib_name = _get_make_link_flag_funcs(
         target_os = toolchain.target_os,

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -157,7 +157,184 @@ def _are_linkstamps_supported(feature_configuration):
             # Is Bazel recent enough to support Starlark linkstamps?
             hasattr(cc_common, "register_linkstamp_compile_action"))
 
-def _should_use_pic(cc_toolchain, feature_configuration, crate_type, compilation_mode):
+_NON_PIE_OS_KEYWORDS = [
+    "windows",
+    "uefi",
+    "vxworks",
+    "solaris",
+    "illumos",
+    "helenos",
+    "cygwin",
+    "l4re",
+    "lynxos178",
+    "aix",
+    "cuda",
+]
+
+_NON_PIE_ARCH_PREFIXES = [
+    "wasm",
+    "xtensa",
+    "nvptx",
+    "amdgcn",
+    "msp430",
+    "avr",
+]
+
+_NON_PIE_ENV_KEYWORDS = [
+    "nuttx",
+    "espidf",
+    "rtems",
+    "xous",
+    "zkvm",
+    "qurt",
+    "psp",
+    "psx",
+    "vita",
+    "3ds",
+    "vex",
+]
+
+def parse_rustc_version(version_semver):
+    """Convert a parsed semver struct into the (major, minor, patch) tuple used for version comparisons.
+
+    A `None` input (channel labels like "nightly"/"beta" and unset versions
+    don't parse as semver) returns a sentinel representing "latest", since
+    nightly and beta are always at or ahead of the most recent stable release.
+
+    Args:
+        version_semver: A semver struct from `rust/private/semver.bzl`, typically
+            `toolchain.version_semver`, or `None`.
+
+    Returns:
+        A (major, minor, patch) tuple of ints.
+    """
+    if not version_semver:
+        return (999, 0, 0)
+    return (version_semver.major, version_semver.minor, version_semver.patch)
+
+def produces_pie_binaries(target_triple, rust_version):
+    """Returns True if rustc links binaries as Position Independent Executables.
+
+    The truth table here is a port of the per-target `position_independent_executables`
+    field that rustc sets in its target specs. The constants and special cases
+    below were derived from analyzing
+    https://github.com/rust-lang/rust/tree/1.95.0/compiler/rustc_target/src/spec/base
+    across Rust 1.0.0-1.95.0.
+
+    ## When to update
+
+    Add or revise an entry here whenever any of the following happens upstream:
+
+    - A new Rust release flips `position_independent_executables` on or off for
+      some target (most commonly via a base spec like `linux_musl_base.rs`).
+    - A new target triple is stabilized.
+    - rustc's PIE default itself changes (rare, but happens — e.g. the bpf
+      targets gained PIE in 1.75.0).
+
+    A divergence here typically shows up as a link error: rustc-emitted PIC/PIE
+    objects mixed with non-PIE intermediate rlibs (or vice versa).
+
+    ## How to perform the analysis
+
+    rustc target specs live under `compiler/rustc_target/src/spec/`. Each
+    triple has a `targets/<triple>.rs` that returns a `Target` whose `options`
+    field is usually built from one of the shared bases under `spec/base/`
+    (e.g. `linux_gnu_base.rs`, `apple_base.rs`, `freebsd_base.rs`).
+
+    The decision tree for a given triple is:
+
+    1. Open `compiler/rustc_target/src/spec/targets/<triple>.rs` and follow
+       which `base::*` it calls into.
+    2. In that base file, look for `position_independent_executables: true`
+       (or the field being overridden back to `false` after the base sets it).
+       Some triples override the base's value directly in their own
+       `targets/<triple>.rs` — check there too.
+    3. To find the Rust release where the value changed, `git log -p -S
+       'position_independent_executables' compiler/rustc_target/src/spec/`
+       in a rust-lang/rust checkout and cross-reference the commit's first
+       containing release tag (e.g. `git tag --contains <sha> | sort -V | head -1`).
+    4. Cross-check with the `arm-linux-androideabi`, `x86_64-unknown-haiku`,
+       and `nto` entries below — those are the existing examples of
+       version-gated PIE flips and are the right shape to copy.
+
+    Three buckets cover the bulk of the matrix without per-triple cases; only
+    add a special case here when a triple is genuinely an outlier:
+
+    - **`_NON_PIE_OS_KEYWORDS`** — operating systems whose base spec sets
+      PIE off. Matched against any `-` separated component of the triple
+      (i.e. exact-segment match). Add an entry if a *new OS* lands and its
+      base spec sets `position_independent_executables: false` (or omits it,
+      since the default is false).
+    - **`_NON_PIE_ARCH_PREFIXES`** — architectures whose base spec sets PIE
+      off. Matched as a prefix of the first triple component (the arch),
+      because variants like `wasm32`/`wasm64` and `nvptx64` share a base.
+    - **`_NON_PIE_ENV_KEYWORDS`** — embedded/environment markers whose base
+      spec sets PIE off. Substring match against the full triple, because
+      these often appear concatenated with the OS (e.g. `nuttx` in
+      `aarch64-nuttx-elf`).
+
+    Args:
+        target_triple: A parsed target triple struct (see `rust/platform/triple.bzl`),
+            typically `toolchain.target_triple`. Provides `arch`, `vendor`, `system`,
+            `abi`, and `str` fields.
+        rust_version: (major, minor, patch) tuple, e.g. (1, 93, 0).
+
+    Returns:
+        True if rustc will pass -pie to the linker for this target.
+    """
+    if target_triple.vendor == "apple":
+        return True
+
+    if target_triple.system == "none":
+        if target_triple.arch in ("bpfeb", "bpfel"):
+            return rust_version >= (1, 75, 0)
+        if target_triple.str == "x86_64-unknown-none":
+            return True
+        return False
+
+    if target_triple.system in _NON_PIE_OS_KEYWORDS:
+        return False
+
+    for prefix in _NON_PIE_ARCH_PREFIXES:
+        if target_triple.arch.startswith(prefix):
+            return False
+
+    # Env keywords use substring match against the full triple string because
+    # they sometimes appear in 4+-segment triples (e.g. "rtems" in
+    # "armv7-unknown-trappist-rtems-eabihf") that don't land cleanly in any
+    # single struct field.
+    for keyword in _NON_PIE_ENV_KEYWORDS:
+        if keyword in target_triple.str:
+            return False
+    if "solid" in target_triple.str:
+        return False
+
+    if target_triple.str == "i686-unknown-haiku":
+        return False
+    if target_triple.vendor == "unikraft":
+        return False
+
+    if target_triple.str == "x86_64-unknown-haiku":
+        return rust_version >= (1, 29, 0)
+    if target_triple.str == "arm-linux-androideabi":
+        return rust_version >= (1, 1, 0)
+
+    if target_triple.abi == "musl" and target_triple.system == "linux":
+        if target_triple.arch.startswith("mips"):
+            return True
+        return rust_version >= (1, 21, 0)
+    if target_triple.system == "freebsd":
+        return rust_version >= (1, 8, 0)
+    if target_triple.system == "hermit":
+        return rust_version >= (1, 40, 0)
+    if target_triple.system == "redox":
+        return rust_version >= (1, 38, 0)
+    if target_triple.system == "nto":
+        return rust_version >= (1, 75, 0)
+
+    return True
+
+def _should_use_pic(cc_toolchain, feature_configuration, crate_type, compilation_mode, toolchain):
     """Whether or not [PIC][pic] should be enabled
 
     [pic]: https://en.wikipedia.org/wiki/Position-independent_code
@@ -167,6 +344,8 @@ def _should_use_pic(cc_toolchain, feature_configuration, crate_type, compilation
         feature_configuration (FeatureConfiguration): Feature configuration to be queried.
         crate_type (str): A Rust target's crate type.
         compilation_mode: The compilation mode.
+        toolchain (rust_toolchain): The current `rust_toolchain`, used to derive
+            the target triple and rustc version for PIE detection.
 
     Returns:
         bool: Whether or not [PIC][pic] should be enabled.
@@ -180,6 +359,15 @@ def _should_use_pic(cc_toolchain, feature_configuration, crate_type, compilation
         return cc_toolchain.needs_pic_for_dynamic_libraries(feature_configuration = feature_configuration)
     elif compilation_mode in ("fastbuild", "dbg"):
         return True
+
+    # In opt mode, rustc links executables with -pie on most platforms.
+    # Any CC objects linked into a PIE binary must be PIC, including those
+    # embedded in intermediate rlibs, so this applies to all crate types.
+    # target_triple is None when a custom target JSON spec is used.
+    if toolchain.target_triple:
+        rust_version = parse_rustc_version(toolchain.version_semver)
+        if produces_pie_binaries(toolchain.target_triple, rust_version):
+            return True
     return False
 
 def _is_proc_macro(crate_info):
@@ -721,7 +909,7 @@ def collect_inputs(
         linker_depset = cc_toolchain.linker_files()
     compilation_mode = ctx.var["COMPILATION_MODE"]
 
-    use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_info.type, compilation_mode)
+    use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_info.type, compilation_mode, toolchain)
 
     # Pass linker inputs only for linking-like actions, not for example where
     # the output is rlib. This avoids quadratic behavior where transitive noncrates are
@@ -1253,7 +1441,7 @@ def construct_arguments(
         compilation_mode = ctx.var["COMPILATION_MODE"]
         if toolchain.target_arch not in ("wasm32", "wasm64"):
             if output_dir:
-                use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_info.type, compilation_mode)
+                use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_info.type, compilation_mode, toolchain)
                 rpaths = _compute_rpaths(toolchain, output_dir, dep_info, use_pic)
             else:
                 rpaths = depset()
@@ -2637,7 +2825,7 @@ def _add_native_link_flags(
     if crate_type in ["lib", "rlib"]:
         return
 
-    use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_type, compilation_mode)
+    use_pic = _should_use_pic(cc_toolchain, feature_configuration, crate_type, compilation_mode, toolchain)
 
     make_link_flags, get_lib_name = _get_make_link_flag_funcs(
         target_os = toolchain.target_os,

--- a/rust/private/semver.bzl
+++ b/rust/private/semver.bzl
@@ -3,31 +3,49 @@
 def semver(version):
     """Constructs a struct containing separated sections of a semantic version value.
 
+    Parses per [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html):
+    `MAJOR.MINOR.PATCH[-PRE-RELEASE][+BUILD-METADATA]`.
+
     Args:
         version (str): The semver value.
 
     Returns:
         struct:
-            - major (int): The semver's major component. E.g. `1` from `1.2.3`
-            - minor (int): The semver's minor component. E.g. `2` from `1.2.3`
-            - patch (int): The semver's patch component. E.g. `3` from `1.2.3`
-            - pre (optional str): The semver's pre component. E.g. `rc4` from `1.2.3-rc4` or None if absent.
+            - major (int): The semver's major component. E.g. `1` from `1.2.3`.
+            - minor (int): The semver's minor component. E.g. `2` from `1.2.3`.
+            - patch (int): The semver's patch component. E.g. `3` from `1.2.3`.
+            - pre (optional str): The semver's pre-release identifier. E.g. `rc4`
+              from `1.2.3-rc4`, `beta.1` from `1.0.0-beta.1+exp.sha`. `None` when
+              no `-` is present.
+            - build (optional str): The semver's build metadata identifier. E.g.
+              `exp.sha.5114f85` from `1.0.0-beta+exp.sha.5114f85`. `None` when no
+              `+` is present.
             - str (str): The full string value of the semver.
     """
-    parts = version.split(".", 2)
-    if len(parts) < 3:
-        fail("Unexpected number of parts for semver value: {}".format(version))
 
-    major = parts[0]
-    minor = parts[1]
-    patch, split, pre = parts[2].partition("-")
-    if not split:
+    # Build metadata is everything after the first `+`. Per the spec, `+` cannot
+    # appear inside MAJOR.MINOR.PATCH or the pre-release identifier, so this is
+    # always a clean split.
+    core, plus, build = version.partition("+")
+    if not plus:
+        build = None
+
+    # Pre-release is everything after the first `-` in the core. Multiple dashes
+    # are allowed in the pre-release identifier itself (e.g. `1.2.3-alpha-test`),
+    # so we only split on the first one.
+    main, dash, pre = core.partition("-")
+    if not dash:
         pre = None
 
+    parts = main.split(".")
+    if len(parts) != 3:
+        fail("Unexpected number of parts for semver value: {}".format(version))
+
     return struct(
-        major = int(major),
-        minor = int(minor),
-        patch = int(patch),
+        major = int(parts[0]),
+        minor = int(parts[1]),
+        patch = int(parts[2]),
         pre = pre,
+        build = build,
         str = version,
     )

--- a/rust/toolchain.bzl
+++ b/rust/toolchain.bzl
@@ -23,6 +23,7 @@ load(
     _current_rustfmt_toolchain = "current_rustfmt_toolchain",
     _rustfmt_toolchain = "rustfmt_toolchain",
 )
+load("//rust/private:semver.bzl", "semver")
 load(
     "//rust/private:utils.bzl",
     "deduplicate",
@@ -370,6 +371,18 @@ def _experimental_use_cc_common_link(ctx):
 def _require_explicit_unstable_features(ctx):
     return ctx.attr.require_explicit_unstable_features[BuildSettingInfo].value
 
+_DIGITS = "0123456789"
+
+def _is_semver_string(version):
+    """Whether `version` looks like a `MAJOR.MINOR.PATCH[-pre][+build]` semver string.
+
+    The `rust_toolchain.version` attribute also accepts channel labels like
+    `"nightly"` or `"beta"` (and is sometimes the empty string), neither of
+    which are valid input for `semver()`. This filter exists so we can populate
+    `version_semver` opportunistically.
+    """
+    return version != "" and version[0] in _DIGITS
+
 def _expand_flags(ctx, attr_name, targets, make_variables):
     targets = deduplicate(targets)
     expanded_flags = []
@@ -584,6 +597,11 @@ def _rust_toolchain_impl(ctx):
     if cc_toolchain and cc_toolchain.all_files:
         all_files_depsets.append(cc_toolchain.all_files)
 
+    # Parse the version string once so downstream rules can branch on the
+    # semver components without re-parsing. `None` for empty or non-semver
+    # values (e.g. unset, or channel labels like "nightly" without a version).
+    version_semver = semver(ctx.attr.version) if _is_semver_string(ctx.attr.version) else None
+
     toolchain = platform_common.ToolchainInfo(
         all_files = depset(transitive = all_files_depsets),
         binary_ext = ctx.attr.binary_ext,
@@ -633,6 +651,7 @@ def _rust_toolchain_impl(ctx):
         target_abi = target_abi,
         target_triple = target_triple,
         version = ctx.attr.version,
+        version_semver = version_semver,
         require_explicit_unstable_features = _require_explicit_unstable_features(ctx),
 
         # Experimental and incompatible flags

--- a/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
+++ b/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
@@ -27,11 +27,27 @@ def _dependency_linkopts_are_propagated_test_impl(ctx):
     tut = analysistest.target_under_test(env)
     link_action = [action for action in tut.actions if action.mnemonic == "Rustc"][0]
 
+    pic_suffix = _get_pic_suffix(ctx)
+
     # Expect a library's own linkopts to come after the flags we create to link them.
     # This is required, because linkopts are ordered and the linker will only apply later ones when resolving symbols required for earlier ones.
     # This means that if one of our transitive deps has a linkopt like `-lfoo`, the dep will see the symbols of foo at link time.
-    _assert_contains_in_order(env, link_action.argv, ["-lstatic=foo_with_linkopts", "-Clink-arg=-lfoo_with_linkopts", "--codegen=link-arg=-L/doesnotexist"])
+    _assert_contains_in_order(env, link_action.argv, [
+        "-lstatic=foo_with_linkopts{}".format(pic_suffix),
+        "-Clink-arg=-lfoo_with_linkopts{}".format(pic_suffix),
+        "--codegen=link-arg=-L/doesnotexist",
+    ])
     return analysistest.end(env)
+
+def _get_pic_suffix(ctx):
+    # cc_library only produces .pic.a artifacts on linux-ish platforms in opt mode
+    # (mac/win produce a single variant regardless of mode). Mirrors the same logic
+    # in native_deps_test.bzl.
+    if ctx.target_platform_has_constraint(ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]):
+        return ""
+    if ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]):
+        return ""
+    return ".pic" if ctx.var["COMPILATION_MODE"] == "opt" else ""
 
 def _assert_contains_input(env, inputs, name):
     for input in inputs.to_list():
@@ -70,6 +86,10 @@ shared_lib_is_propagated_test = analysistest.make(
 
 dependency_linkopts_are_propagated_test = analysistest.make(
     _dependency_linkopts_are_propagated_test_impl,
+    attrs = {
+        "_macos_constraint": attr.label(default = Label("@platforms//os:macos")),
+        "_windows_constraint": attr.label(default = Label("@platforms//os:windows")),
+    },
 )
 
 def _linker_inputs_propagation_test():

--- a/test/unit/native_deps/native_action_inputs_test.bzl
+++ b/test/unit/native_deps/native_action_inputs_test.bzl
@@ -5,7 +5,6 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load(
     "//rust:defs.bzl",
     "rust_binary",
-    "rust_common",
     "rust_library",
     "rust_proc_macro",
     "rust_shared_library",
@@ -13,17 +12,13 @@ load(
 )
 load("//test/unit:common.bzl", "assert_action_mnemonic")
 
-def _get_crate_info(target):
-    return target[rust_common.crate_info] if rust_common.crate_info in target else target[rust_common.test_crate_info].crate
-
 def _native_action_inputs_present_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
     action = tut.actions[0]
     assert_action_mnemonic(env, action, "Rustc")
     inputs = action.inputs.to_list()
-    for_shared_library = _get_crate_info(tut).type in ("dylib", "cdylib", "proc-macro")
-    lib_name = _native_dep_lib_name(ctx, for_shared_library)
+    lib_name = _native_dep_lib_name(ctx)
 
     asserts.true(
         env,
@@ -40,10 +35,9 @@ def _native_action_inputs_not_present_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
     action = tut.actions[0]
-    for_shared_library = _get_crate_info(tut).type in ("dylib", "cdylib", "proc-macro")
     assert_action_mnemonic(env, action, "Rustc")
     inputs = action.inputs.to_list()
-    lib_name = _native_dep_lib_name(ctx, for_shared_library)
+    lib_name = _native_dep_lib_name(ctx)
 
     asserts.false(
         env,
@@ -53,7 +47,7 @@ def _native_action_inputs_not_present_test_impl(ctx):
 
     return analysistest.end(env)
 
-def _native_dep_lib_name(ctx, for_shared_library):
+def _native_dep_lib_name(ctx):
     compilation_mode = ctx.var["COMPILATION_MODE"]
     if ctx.target_platform_has_constraint(
         ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
@@ -64,7 +58,7 @@ def _native_dep_lib_name(ctx, for_shared_library):
     ):
         pic_suffix = ""
     else:
-        pic_suffix = ".pic" if compilation_mode == "opt" and for_shared_library else ""
+        pic_suffix = ".pic" if compilation_mode == "opt" else ""
     return "libbar{}.a".format(pic_suffix)
 
 def _has_action_input(name, inputs):

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -132,16 +132,18 @@ def _staticlib_has_native_libs_test_impl(ctx):
     tut = analysistest.target_under_test(env)
     action = tut.actions[0]
     toolchain = _get_toolchain(ctx)
+    compilation_mode = ctx.var["COMPILATION_MODE"]
+    pic_suffix = _get_pic_suffix(ctx, compilation_mode)
     assert_argv_contains_prefix_suffix(env, action, "-Lnative=", "/native_deps")
     assert_argv_contains(env, action, "--crate-type=staticlib")
-    assert_argv_contains(env, action, "-lstatic=native_dep")
+    assert_argv_contains(env, action, "-lstatic=native_dep{}".format(pic_suffix))
     if toolchain.target_os == "windows":
         if toolchain.target_triple.abi == "msvc":
             native_link_arg = "-Clink-arg=native_dep.lib"
         else:
             native_link_arg = "-Clink-arg=-lnative_dep.lib"
     else:
-        native_link_arg = "-Clink-arg=-lnative_dep"
+        native_link_arg = "-Clink-arg=-lnative_dep{}".format(pic_suffix)
     assert_argv_contains(env, action, native_link_arg)
     assert_argv_contains_prefix(env, action, "--codegen=linker=")
     return analysistest.end(env)
@@ -172,15 +174,17 @@ def _bin_has_native_libs_test_impl(ctx):
     tut = analysistest.target_under_test(env)
     action = tut.actions[0]
     toolchain = _get_toolchain(ctx)
+    compilation_mode = ctx.var["COMPILATION_MODE"]
+    pic_suffix = _get_pic_suffix(ctx, compilation_mode)
     assert_argv_contains_prefix_suffix(env, action, "-Lnative=", "/native_deps")
-    assert_argv_contains(env, action, "-lstatic=native_dep")
+    assert_argv_contains(env, action, "-lstatic=native_dep{}".format(pic_suffix))
     if toolchain.target_os == "windows":
         if toolchain.target_triple.abi == "msvc":
             native_link_arg = "-Clink-arg=native_dep.lib"
         else:
             native_link_arg = "-Clink-arg=-lnative_dep.lib"
     else:
-        native_link_arg = "-Clink-arg=-lnative_dep"
+        native_link_arg = "-Clink-arg=-lnative_dep{}".format(pic_suffix)
     assert_argv_contains(env, action, native_link_arg)
     assert_argv_contains_prefix(env, action, "--codegen=linker=")
     return analysistest.end(env)
@@ -214,22 +218,25 @@ def _bin_has_native_dep_and_alwayslink_test_impl(ctx, use_cc_linker):
     # Validate bin_dir structure (ignoring ST-{hash} suffix from config transitions)
     _assert_bin_dir_structure(env, ctx, bin_dir, toolchain)
 
+    compilation_mode = ctx.var["COMPILATION_MODE"]
+    pic_suffix = _get_pic_suffix(ctx, compilation_mode)
+
     if toolchain.target_os in ["macos", "darwin"]:
         if use_cc_linker:
             # When using CC linker, args are passed with -Wl, prefix as separate arguments
             want = [
-                "-lstatic=native_dep",
-                "-lnative_dep",
+                "-lstatic=native_dep{}".format(pic_suffix),
+                "-lnative_dep{}".format(pic_suffix),
                 "-Wl,-force_load",
-                "-Wl,{}/test/unit/native_deps/libalwayslink.lo".format(bin_dir),
+                "-Wl,{}/test/unit/native_deps/libalwayslink{}.lo".format(bin_dir, pic_suffix),
             ]
         else:
             # When using rust-lld directly, args are passed without prefix as separate arguments
             want = [
-                "-lstatic=native_dep",
-                "-lnative_dep",
+                "-lstatic=native_dep{}".format(pic_suffix),
+                "-lnative_dep{}".format(pic_suffix),
                 "-force_load",
-                "{}/test/unit/native_deps/libalwayslink.lo".format(bin_dir),
+                "{}/test/unit/native_deps/libalwayslink{}.lo".format(bin_dir, pic_suffix),
             ]
         assert_list_contains_adjacent_elements(env, link_args, want)
     elif toolchain.target_os == "windows":
@@ -257,25 +264,25 @@ def _bin_has_native_dep_and_alwayslink_test_impl(ctx, use_cc_linker):
             ]
     elif toolchain.target_arch == "s390x":
         want = [
-            "-lstatic=native_dep",
+            "-lstatic=native_dep{}".format(pic_suffix),
             "link-arg=-Wl,--whole-archive",
-            "link-arg={}/test/unit/native_deps/libalwayslink.lo".format(bin_dir),
+            "link-arg={}/test/unit/native_deps/libalwayslink{}.lo".format(bin_dir, pic_suffix),
             "link-arg=-Wl,--no-whole-archive",
         ]
     elif use_cc_linker:
         want = [
-            "-lstatic=native_dep",
-            "-lnative_dep",
+            "-lstatic=native_dep{}".format(pic_suffix),
+            "-lnative_dep{}".format(pic_suffix),
             "-Wl,--whole-archive",
-            "{}/test/unit/native_deps/libalwayslink.lo".format(bin_dir),
+            "{}/test/unit/native_deps/libalwayslink{}.lo".format(bin_dir, pic_suffix),
             "-Wl,--no-whole-archive",
         ]
     else:
         want = [
-            "-lstatic=native_dep",
-            "-lnative_dep",
+            "-lstatic=native_dep{}".format(pic_suffix),
+            "-lnative_dep{}".format(pic_suffix),
             "--whole-archive",
-            "{}/test/unit/native_deps/libalwayslink.lo".format(bin_dir),
+            "{}/test/unit/native_deps/libalwayslink{}.lo".format(bin_dir, pic_suffix),
             "--no-whole-archive",
         ]
     assert_list_contains_adjacent_elements(env, link_args, want)

--- a/test/unit/proc_macro/leaks_deps/proc_macro_does_not_leak_deps.bzl
+++ b/test/unit/proc_macro/leaks_deps/proc_macro_does_not_leak_deps.bzl
@@ -35,7 +35,8 @@ def _proc_macro_does_not_leak_deps_impl(ctx):
         else:
             native_deps = [arg for arg in rustc_action.argv if arg == "-Clink-arg=-lnative.lib"]
     else:
-        native_deps = [arg for arg in rustc_action.argv if arg == "-Clink-arg=-lnative"]
+        pic_suffix = ".pic" if ctx.var["COMPILATION_MODE"] == "opt" and toolchain.target_os not in ("darwin", "macos") else ""
+        native_deps = [arg for arg in rustc_action.argv if arg == "-Clink-arg=-lnative{}".format(pic_suffix)]
     asserts.equals(env, 1, len(native_deps))
 
     return analysistest.end(env)

--- a/test/unit/rustc_pie/BUILD.bazel
+++ b/test/unit/rustc_pie/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":rustc_pie_test.bzl", "rustc_pie_test_suite")
+
+rustc_pie_test_suite(name = "rustc_pie_test_suite")

--- a/test/unit/rustc_pie/rustc_pie_test.bzl
+++ b/test/unit/rustc_pie/rustc_pie_test.bzl
@@ -5,7 +5,7 @@ load("//rust/platform:triple.bzl", "triple")
 
 # buildifier: disable=bzl-visibility
 load(
-    "//rust/private:rustc.bzl",
+    "//rust/private:pic_utils.bzl",
     "parse_rustc_version",
     "produces_pie_binaries",
 )
@@ -13,7 +13,7 @@ load(
 # buildifier: disable=bzl-visibility
 load("//rust/private:semver.bzl", "semver")
 
-_LATEST = (999, 0, 0)
+_LATEST = semver("999.0.0")
 
 def _parse_rustc_version_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -32,7 +32,11 @@ def _parse_rustc_version_test_impl(ctx):
     # `None` (what `rust_toolchain.version_semver` is when the toolchain's
     # version is empty or a channel label like "nightly"/"beta") falls back to
     # the "latest" sentinel.
-    asserts.equals(env, _LATEST, parse_rustc_version(None))
+    asserts.equals(
+        env,
+        (_LATEST.major, _LATEST.minor, _LATEST.patch),
+        parse_rustc_version(None),
+    )
 
     return unittest.end(env)
 
@@ -85,9 +89,9 @@ def _produces_pie_binaries_none_targets_test_impl(ctx):
     env = unittest.begin(ctx)
 
     # bpf is PIE starting at 1.75.0.
-    asserts.equals(env, False, produces_pie_binaries(triple("bpfeb-unknown-none"), (1, 74, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("bpfeb-unknown-none"), (1, 75, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("bpfel-unknown-none"), (1, 75, 0)))
+    asserts.equals(env, False, produces_pie_binaries(triple("bpfeb-unknown-none"), semver("1.74.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("bpfeb-unknown-none"), semver("1.75.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("bpfel-unknown-none"), semver("1.75.0")))
 
     # x86_64-unknown-none is always PIE.
     asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-none"), _LATEST))
@@ -103,31 +107,31 @@ def _produces_pie_binaries_version_thresholds_test_impl(ctx):
     env = unittest.begin(ctx)
 
     # x86_64-unknown-haiku: PIE starting at 1.29.0.
-    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-haiku"), (1, 28, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-haiku"), (1, 29, 0)))
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-haiku"), semver("1.28.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-haiku"), semver("1.29.0")))
 
     # i686-unknown-haiku is always non-PIE.
     asserts.equals(env, False, produces_pie_binaries(triple("i686-unknown-haiku"), _LATEST))
 
     # arm-linux-androideabi: PIE starting at 1.1.0.
-    asserts.equals(env, False, produces_pie_binaries(triple("arm-linux-androideabi"), (1, 0, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("arm-linux-androideabi"), (1, 1, 0)))
+    asserts.equals(env, False, produces_pie_binaries(triple("arm-linux-androideabi"), semver("1.0.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("arm-linux-androideabi"), semver("1.1.0")))
 
     # freebsd: PIE starting at 1.8.0.
-    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-freebsd"), (1, 7, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-freebsd"), (1, 8, 0)))
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-freebsd"), semver("1.7.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-freebsd"), semver("1.8.0")))
 
     # hermit: PIE starting at 1.40.0.
-    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-hermit"), (1, 39, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-hermit"), (1, 40, 0)))
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-hermit"), semver("1.39.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-hermit"), semver("1.40.0")))
 
     # redox: PIE starting at 1.38.0.
-    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-redox"), (1, 37, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-redox"), (1, 38, 0)))
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-redox"), semver("1.37.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-redox"), semver("1.38.0")))
 
     # nto (QNX): PIE starting at 1.75.0.
-    asserts.equals(env, False, produces_pie_binaries(triple("aarch64-unknown-nto-qnx710"), (1, 74, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("aarch64-unknown-nto-qnx710"), (1, 75, 0)))
+    asserts.equals(env, False, produces_pie_binaries(triple("aarch64-unknown-nto-qnx710"), semver("1.74.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("aarch64-unknown-nto-qnx710"), semver("1.75.0")))
 
     return unittest.end(env)
 
@@ -135,14 +139,14 @@ def _produces_pie_binaries_musl_test_impl(ctx):
     env = unittest.begin(ctx)
 
     # Standard musl: PIE starting at 1.21.0.
-    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-linux-musl"), (1, 20, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-linux-musl"), (1, 21, 0)))
-    asserts.equals(env, False, produces_pie_binaries(triple("aarch64-unknown-linux-musl"), (1, 20, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("aarch64-unknown-linux-musl"), (1, 21, 0)))
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-linux-musl"), semver("1.20.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-linux-musl"), semver("1.21.0")))
+    asserts.equals(env, False, produces_pie_binaries(triple("aarch64-unknown-linux-musl"), semver("1.20.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("aarch64-unknown-linux-musl"), semver("1.21.0")))
 
     # mips-musl is PIE at any version.
-    asserts.equals(env, True, produces_pie_binaries(triple("mips-unknown-linux-musl"), (1, 0, 0)))
-    asserts.equals(env, True, produces_pie_binaries(triple("mipsel-unknown-linux-musl"), (1, 0, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("mips-unknown-linux-musl"), semver("1.0.0")))
+    asserts.equals(env, True, produces_pie_binaries(triple("mipsel-unknown-linux-musl"), semver("1.0.0")))
 
     # unikraft is always non-PIE.
     asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unikraft-linux-musl"), _LATEST))
@@ -161,11 +165,30 @@ def rustc_pie_test_suite(name):
     Args:
         name (str): Name of the test suite.
     """
-    unittest.suite(
-        name,
-        parse_rustc_version_test,
-        produces_pie_binaries_always_test,
-        produces_pie_binaries_none_targets_test,
-        produces_pie_binaries_version_thresholds_test,
-        produces_pie_binaries_musl_test,
+
+    parse_rustc_version_test(
+        name = "parse_rustc_version_test",
+    )
+    produces_pie_binaries_always_test(
+        name = "produces_pie_binaries_always_test",
+    )
+    produces_pie_binaries_none_targets_test(
+        name = "produces_pie_binaries_none_targets_test",
+    )
+    produces_pie_binaries_version_thresholds_test(
+        name = "produces_pie_binaries_version_thresholds_test",
+    )
+    produces_pie_binaries_musl_test(
+        name = "produces_pie_binaries_musl_test",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":parse_rustc_version_test",
+            ":produces_pie_binaries_always_test",
+            ":produces_pie_binaries_none_targets_test",
+            ":produces_pie_binaries_version_thresholds_test",
+            ":produces_pie_binaries_musl_test",
+        ],
     )

--- a/test/unit/rustc_pie/rustc_pie_test.bzl
+++ b/test/unit/rustc_pie/rustc_pie_test.bzl
@@ -1,0 +1,171 @@
+"""Unit tests for the PIE detection helpers in rustc.bzl."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//rust/platform:triple.bzl", "triple")
+
+# buildifier: disable=bzl-visibility
+load(
+    "//rust/private:rustc.bzl",
+    "parse_rustc_version",
+    "produces_pie_binaries",
+)
+
+# buildifier: disable=bzl-visibility
+load("//rust/private:semver.bzl", "semver")
+
+_LATEST = (999, 0, 0)
+
+def _parse_rustc_version_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # A parsed semver struct collapses to its (major, minor, patch) tuple.
+    asserts.equals(env, (1, 94, 1), parse_rustc_version(semver("1.94.1")))
+    asserts.equals(env, (1, 0, 0), parse_rustc_version(semver("1.0.0")))
+    asserts.equals(env, (10, 20, 30), parse_rustc_version(semver("10.20.30")))
+
+    # Pre-release and build metadata don't affect the tuple — comparisons
+    # operate on the (major, minor, patch) prefix only.
+    asserts.equals(env, (1, 87, 0), parse_rustc_version(semver("1.87.0-nightly")))
+    asserts.equals(env, (1, 87, 0), parse_rustc_version(semver("1.87.0-beta.1")))
+    asserts.equals(env, (1, 0, 0), parse_rustc_version(semver("1.0.0+exp.sha")))
+
+    # `None` (what `rust_toolchain.version_semver` is when the toolchain's
+    # version is empty or a channel label like "nightly"/"beta") falls back to
+    # the "latest" sentinel.
+    asserts.equals(env, _LATEST, parse_rustc_version(None))
+
+    return unittest.end(env)
+
+def _produces_pie_binaries_always_test_impl(ctx):
+    env = unittest.begin(ctx)
+    v = _LATEST
+
+    # Apple platforms are always PIE.
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-apple-darwin"), v))
+    asserts.equals(env, True, produces_pie_binaries(triple("aarch64-apple-darwin"), v))
+    asserts.equals(env, True, produces_pie_binaries(triple("aarch64-apple-ios"), v))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-apple-tvos"), v))
+
+    # Default linux-gnu falls through to True.
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-linux-gnu"), v))
+    asserts.equals(env, True, produces_pie_binaries(triple("aarch64-unknown-linux-gnu"), v))
+
+    # OS keywords that disable PIE.
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-pc-windows-msvc"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-uefi"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("powerpc-wrs-vxworks"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-pc-solaris"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-illumos"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-pc-cygwin"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("powerpc64-ibm-aix"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("nvptx64-nvidia-cuda"), v))
+
+    # Arch prefixes that disable PIE.
+    asserts.equals(env, False, produces_pie_binaries(triple("wasm32-unknown-unknown"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("xtensa-esp32-none-elf"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("msp430-none-elf"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("avr-unknown-gnu-atmega328"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("amdgcn-amd-amdhsa"), v))
+
+    # Env keywords that disable PIE.
+    asserts.equals(env, False, produces_pie_binaries(triple("riscv32imc-unknown-nuttx-elf"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("riscv32imc-esp-espidf"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("armv7-unknown-trappist-rtems-eabihf"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("riscv32im-risc0-zkvm-elf"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("mipsel-sony-psp"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("armv7-sony-vita-newlibeabihf"), v))
+    asserts.equals(env, False, produces_pie_binaries(triple("armv6k-nintendo-3ds"), v))
+
+    # `solid` substring match.
+    asserts.equals(env, False, produces_pie_binaries(triple("aarch64-kmc-solid_asp3"), v))
+
+    return unittest.end(env)
+
+def _produces_pie_binaries_none_targets_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # bpf is PIE starting at 1.75.0.
+    asserts.equals(env, False, produces_pie_binaries(triple("bpfeb-unknown-none"), (1, 74, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("bpfeb-unknown-none"), (1, 75, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("bpfel-unknown-none"), (1, 75, 0)))
+
+    # x86_64-unknown-none is always PIE.
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-none"), _LATEST))
+
+    # Other bare-metal `none` targets are not PIE.
+    asserts.equals(env, False, produces_pie_binaries(triple("aarch64-unknown-none"), _LATEST))
+    asserts.equals(env, False, produces_pie_binaries(triple("thumbv7m-none-eabi"), _LATEST))
+    asserts.equals(env, False, produces_pie_binaries(triple("riscv32i-unknown-none-elf"), _LATEST))
+
+    return unittest.end(env)
+
+def _produces_pie_binaries_version_thresholds_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # x86_64-unknown-haiku: PIE starting at 1.29.0.
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-haiku"), (1, 28, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-haiku"), (1, 29, 0)))
+
+    # i686-unknown-haiku is always non-PIE.
+    asserts.equals(env, False, produces_pie_binaries(triple("i686-unknown-haiku"), _LATEST))
+
+    # arm-linux-androideabi: PIE starting at 1.1.0.
+    asserts.equals(env, False, produces_pie_binaries(triple("arm-linux-androideabi"), (1, 0, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("arm-linux-androideabi"), (1, 1, 0)))
+
+    # freebsd: PIE starting at 1.8.0.
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-freebsd"), (1, 7, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-freebsd"), (1, 8, 0)))
+
+    # hermit: PIE starting at 1.40.0.
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-hermit"), (1, 39, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-hermit"), (1, 40, 0)))
+
+    # redox: PIE starting at 1.38.0.
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-redox"), (1, 37, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-redox"), (1, 38, 0)))
+
+    # nto (QNX): PIE starting at 1.75.0.
+    asserts.equals(env, False, produces_pie_binaries(triple("aarch64-unknown-nto-qnx710"), (1, 74, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("aarch64-unknown-nto-qnx710"), (1, 75, 0)))
+
+    return unittest.end(env)
+
+def _produces_pie_binaries_musl_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Standard musl: PIE starting at 1.21.0.
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unknown-linux-musl"), (1, 20, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("x86_64-unknown-linux-musl"), (1, 21, 0)))
+    asserts.equals(env, False, produces_pie_binaries(triple("aarch64-unknown-linux-musl"), (1, 20, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("aarch64-unknown-linux-musl"), (1, 21, 0)))
+
+    # mips-musl is PIE at any version.
+    asserts.equals(env, True, produces_pie_binaries(triple("mips-unknown-linux-musl"), (1, 0, 0)))
+    asserts.equals(env, True, produces_pie_binaries(triple("mipsel-unknown-linux-musl"), (1, 0, 0)))
+
+    # unikraft is always non-PIE.
+    asserts.equals(env, False, produces_pie_binaries(triple("x86_64-unikraft-linux-musl"), _LATEST))
+
+    return unittest.end(env)
+
+parse_rustc_version_test = unittest.make(_parse_rustc_version_test_impl)
+produces_pie_binaries_always_test = unittest.make(_produces_pie_binaries_always_test_impl)
+produces_pie_binaries_none_targets_test = unittest.make(_produces_pie_binaries_none_targets_test_impl)
+produces_pie_binaries_version_thresholds_test = unittest.make(_produces_pie_binaries_version_thresholds_test_impl)
+produces_pie_binaries_musl_test = unittest.make(_produces_pie_binaries_musl_test_impl)
+
+def rustc_pie_test_suite(name):
+    """Entry-point macro called from the BUILD file.
+
+    Args:
+        name (str): Name of the test suite.
+    """
+    unittest.suite(
+        name,
+        parse_rustc_version_test,
+        produces_pie_binaries_always_test,
+        produces_pie_binaries_none_targets_test,
+        produces_pie_binaries_version_thresholds_test,
+        produces_pie_binaries_musl_test,
+    )

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -294,9 +294,14 @@ def _define_targets():
         hdrs = ["rustdoc.h"],
         srcs = ["rustdoc.cc"],
         deps = [":cc_lib"],
-        # This is not needed for :cc_lib, but it is needed in other
-        # circumstances to link in system libraries.
-        linkopts = ["-lcc_lib"],
+        # Exercises propagation of system-library `-l` linkopts. Picks a
+        # library guaranteed to exist on each platform so the `-l` flag
+        # resolves without depending on any cc_library artifact name (which
+        # would gain a `.pic` suffix when consumers request PIC).
+        linkopts = select({
+            "@platforms//os:windows": ["-luser32"],
+            "//conditions:default": ["-lm"],
+        }),
         linkstatic = True,
     )
 

--- a/test/unit/semver/semver_test.bzl
+++ b/test/unit/semver/semver_test.bzl
@@ -14,6 +14,7 @@ def _semver_basic_test_impl(ctx):
     asserts.equals(env, 2, result.minor)
     asserts.equals(env, 3, result.patch)
     asserts.equals(env, None, result.pre)
+    asserts.equals(env, None, result.build)
     asserts.equals(env, "1.2.3", result.str)
 
     # Test with zeros
@@ -22,6 +23,7 @@ def _semver_basic_test_impl(ctx):
     asserts.equals(env, 0, result.minor)
     asserts.equals(env, 0, result.patch)
     asserts.equals(env, None, result.pre)
+    asserts.equals(env, None, result.build)
     asserts.equals(env, "0.0.0", result.str)
 
     # Test larger version numbers
@@ -30,6 +32,7 @@ def _semver_basic_test_impl(ctx):
     asserts.equals(env, 20, result.minor)
     asserts.equals(env, 30, result.patch)
     asserts.equals(env, None, result.pre)
+    asserts.equals(env, None, result.build)
     asserts.equals(env, "10.20.30", result.str)
 
     return unittest.end(env)
@@ -43,6 +46,7 @@ def _semver_with_pre_test_impl(ctx):
     asserts.equals(env, 2, result.minor)
     asserts.equals(env, 3, result.patch)
     asserts.equals(env, "rc4", result.pre)
+    asserts.equals(env, None, result.build)
     asserts.equals(env, "1.2.3-rc4", result.str)
 
     # Test semver with alpha pre-release
@@ -51,14 +55,16 @@ def _semver_with_pre_test_impl(ctx):
     asserts.equals(env, 0, result.minor)
     asserts.equals(env, 0, result.patch)
     asserts.equals(env, "alpha", result.pre)
+    asserts.equals(env, None, result.build)
     asserts.equals(env, "2.0.0-alpha", result.str)
 
-    # Test semver with beta pre-release
+    # Test semver with beta pre-release with dot-separated identifier
     result = semver("1.5.0-beta.1")
     asserts.equals(env, 1, result.major)
     asserts.equals(env, 5, result.minor)
     asserts.equals(env, 0, result.patch)
     asserts.equals(env, "beta.1", result.pre)
+    asserts.equals(env, None, result.build)
     asserts.equals(env, "1.5.0-beta.1", result.str)
 
     # Test semver with nightly pre-release
@@ -67,29 +73,83 @@ def _semver_with_pre_test_impl(ctx):
     asserts.equals(env, 70, result.minor)
     asserts.equals(env, 0, result.patch)
     asserts.equals(env, "nightly", result.pre)
+    asserts.equals(env, None, result.build)
     asserts.equals(env, "1.70.0-nightly", result.str)
+
+    return unittest.end(env)
+
+def _semver_with_build_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Plain build metadata, no pre-release.
+    result = semver("1.0.0+20130313144700")
+    asserts.equals(env, 1, result.major)
+    asserts.equals(env, 0, result.minor)
+    asserts.equals(env, 0, result.patch)
+    asserts.equals(env, None, result.pre)
+    asserts.equals(env, "20130313144700", result.build)
+    asserts.equals(env, "1.0.0+20130313144700", result.str)
+
+    # Build metadata with dot-separated identifiers (a real semver 2.0 example).
+    result = semver("1.0.0+exp.sha.5114f85")
+    asserts.equals(env, 1, result.major)
+    asserts.equals(env, 0, result.minor)
+    asserts.equals(env, 0, result.patch)
+    asserts.equals(env, None, result.pre)
+    asserts.equals(env, "exp.sha.5114f85", result.build)
+
+    # Pre-release AND build metadata.
+    result = semver("1.0.0-beta+exp.sha.5114f85")
+    asserts.equals(env, 1, result.major)
+    asserts.equals(env, 0, result.minor)
+    asserts.equals(env, 0, result.patch)
+    asserts.equals(env, "beta", result.pre)
+    asserts.equals(env, "exp.sha.5114f85", result.build)
+    asserts.equals(env, "1.0.0-beta+exp.sha.5114f85", result.str)
+
+    # Dotted pre-release AND build metadata.
+    result = semver("1.2.3-rc.4+build.42")
+    asserts.equals(env, 1, result.major)
+    asserts.equals(env, 2, result.minor)
+    asserts.equals(env, 3, result.patch)
+    asserts.equals(env, "rc.4", result.pre)
+    asserts.equals(env, "build.42", result.build)
+
+    # Build metadata may itself contain `-` — only the first `+` is the
+    # separator; once we're in build metadata, `-` is just a content char.
+    result = semver("1.0.0+sha-abcdef")
+    asserts.equals(env, None, result.pre)
+    asserts.equals(env, "sha-abcdef", result.build)
 
     return unittest.end(env)
 
 def _semver_edge_cases_test_impl(ctx):
     env = unittest.begin(ctx)
 
-    # Test semver with empty pre-release (trailing dash)
-    # When there's a trailing dash, partition returns empty string for pre,
-    # but "pre or None" converts it to None
+    # Trailing dash: partition keeps an empty pre-release rather than None,
+    # since the `-` separator was present.
     result = semver("1.2.3-")
     asserts.equals(env, 1, result.major)
     asserts.equals(env, 2, result.minor)
     asserts.equals(env, 3, result.patch)
     asserts.equals(env, "", result.pre)
+    asserts.equals(env, None, result.build)
     asserts.equals(env, "1.2.3-", result.str)
 
-    # Test semver with multiple dashes in pre-release
+    # Trailing plus: similarly, empty build rather than None.
+    result = semver("1.2.3+")
+    asserts.equals(env, None, result.pre)
+    asserts.equals(env, "", result.build)
+    asserts.equals(env, "1.2.3+", result.str)
+
+    # Multiple dashes inside the pre-release: only the first `-` is the
+    # separator, so the rest are part of the pre-release identifier.
     result = semver("1.2.3-alpha-test")
     asserts.equals(env, 1, result.major)
     asserts.equals(env, 2, result.minor)
     asserts.equals(env, 3, result.patch)
     asserts.equals(env, "alpha-test", result.pre)
+    asserts.equals(env, None, result.build)
     asserts.equals(env, "1.2.3-alpha-test", result.str)
 
     return unittest.end(env)
@@ -97,30 +157,37 @@ def _semver_edge_cases_test_impl(ctx):
 def _semver_real_world_examples_test_impl(ctx):
     env = unittest.begin(ctx)
 
-    # Test real Rust version examples
-    result = semver("1.80.0")
-    asserts.equals(env, 1, result.major)
-    asserts.equals(env, 80, result.minor)
-    asserts.equals(env, 0, result.patch)
-    asserts.equals(env, None, result.pre)
-    asserts.equals(env, "1.80.0", result.str)
+    # A representative sample of versions we ship `rust_toolchain` against.
+    for version_str, expected_minor in [
+        ("1.54.0", 54),
+        ("1.70.0", 70),
+        ("1.80.0", 80),
+        ("1.87.0", 87),
+        ("1.94.1", 94),
+    ]:
+        result = semver(version_str)
+        asserts.equals(env, 1, result.major)
+        asserts.equals(env, expected_minor, result.minor)
+        asserts.equals(env, None, result.pre)
+        asserts.equals(env, None, result.build)
+        asserts.equals(env, version_str, result.str)
 
-    result = semver("1.70.0")
+    # Rust pre-release / nightly shapes that flow through `rust_toolchain`
+    # when the version embeds a channel marker rather than a `channel/date`
+    # tuple (which is handled separately, before `semver()` is called).
+    result = semver("1.87.0-nightly")
     asserts.equals(env, 1, result.major)
-    asserts.equals(env, 70, result.minor)
-    asserts.equals(env, 0, result.patch)
-    asserts.equals(env, None, result.pre)
+    asserts.equals(env, 87, result.minor)
+    asserts.equals(env, "nightly", result.pre)
 
-    result = semver("1.54.0")
-    asserts.equals(env, 1, result.major)
-    asserts.equals(env, 54, result.minor)
-    asserts.equals(env, 0, result.patch)
-    asserts.equals(env, None, result.pre)
+    result = semver("1.87.0-beta.1")
+    asserts.equals(env, "beta.1", result.pre)
 
     return unittest.end(env)
 
 semver_basic_test = unittest.make(_semver_basic_test_impl)
 semver_with_pre_test = unittest.make(_semver_with_pre_test_impl)
+semver_with_build_test = unittest.make(_semver_with_build_test_impl)
 semver_edge_cases_test = unittest.make(_semver_edge_cases_test_impl)
 semver_real_world_examples_test = unittest.make(_semver_real_world_examples_test_impl)
 
@@ -134,6 +201,7 @@ def semver_test_suite(name):
         name,
         semver_basic_test,
         semver_with_pre_test,
+        semver_with_build_test,
         semver_edge_cases_test,
         semver_real_world_examples_test,
     )


### PR DESCRIPTION
Today, rules_rust picks the PIC vs non-PIC variant of cc_library deps based only on the C++ toolchain, feature config, crate type, and compilation mode. But when rustc itself decides to emit a Position-Independent Executable (PIE) for a given target, the Rust objects need PIC-compatible cc deps - otherwise you get link errors from mixing PIE Rust objects with non-PIC C/C++ objects (the failure mode demonstrated by the existing test from commit https://github.com/bazelbuild/rules_rust/commit/70f8fb7814d1b2af7f2cb0c4bdfeebf3e2e47ff4 "Make native_deps test fail with pie").

This PR teaches Bazel when rustc will pass `-pie` to the linker by porting rustc's per-target `position_independent_executables` truth table into Starlark, then feeding that into the PIC selection.

Relates to #118 