### PR TITLE
rust_analyzer: fix target exclusions in gen_rust_project

### DIFF
--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -94,7 +94,22 @@ pub fn get_crate_specs(
 ) -> anyhow::Result<BTreeSet<CrateSpec>> {
     log::info!("running bazel aquery...");
     log::debug!("Get crate specs with targets: {:?}", targets);
-    let target_pattern = format!("deps({})", targets.join("+"));
+    let target_pattern = format!(
+        "deps({})",
+        targets
+            .iter()
+            .map(|t| {
+                if let Some(stripped) = t.strip_prefix('-') {
+                    format!(" - {stripped}")
+                } else {
+                    format!(" + {t}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("")
+            .trim_start_matches(" + ")
+            .to_owned()
+    );
 
     let mut aquery_command = bazel_command(bazel, Some(workspace), Some(output_base));
     aquery_command

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -112,6 +112,7 @@ fn generate_crate_info(
             "--aspects={rules_rust}//rust:defs.bzl%rust_analyzer_aspect"
         ))
         .arg("--output_groups=rust_analyzer_crate_spec,rust_generated_srcs,rust_analyzer_proc_macro_dylib,rust_analyzer_src")
+        .arg("--")
         .args(targets)
         .output()?;
 


### PR DESCRIPTION
`gen_rust_project` did not support target exclusion patterns (e.g. `-//util/process_wrapper/...`). Two bugs:

1. **`lib.rs`**: `bazel build` received exclusion patterns before the end-of-options marker `--`, so Bazel rejected them as unknown flags.
2. **`aquery.rs`**: the `deps()` expression was constructed by joining all targets with `+` (e.g. `deps(//util/...+-//util/process_wrapper/...)`), which is invalid aquery syntax. Exclusions need to use ` - ` instead.

**Before (main), fails at `bazel build`:**
```
$ bazel run @rules_rust//tools/rust_analyzer:gen_rust_project -- -- //util/... -//util/process_wrapper/...
ERROR: Invalid options syntax: -//util/process_wrapper/...
Note: Negative target patterns can only appear after the end of options marker ('--').
Error: bazel build failed: (exit status: 2)
```

**After (this branch), full round-trip succeeds:**
```
$ bazel run @rules_rust//tools/rust_analyzer:gen_rust_project -- -- //util/... -//util/process_wrapper/...
INFO: running bazel build...
INFO: bazel build finished
INFO: running bazel aquery...
INFO: bazel aquery finished; parsing spec files...
# rust-project.json written with action_args, collect_coverage, label, workspace_status
# (process_wrapper excluded as expected)
```