### PR TITLE
Add support for build script runfiles

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -246,16 +246,13 @@ def _rlocationpath(file, workspace_name):
 def _create_runfiles_dir(ctx, script, data_runfiles, retain_list):
     """Create a runfiles directory to represent `CARGO_MANIFEST_DIR`.
 
+    Merges runfiles from both the script binary and the data runfiles target,
+    filtering out the fake executable from the data runfiles.
+
     Due to the inability to forcibly generate runfiles directories for use as inputs
     to actions, this function creates a custom runfiles directory that can more
     consistently be relied upon as an input. For more details see:
     https://github.com/bazelbuild/bazel/issues/15486
-
-    Merges runfiles from both the script binary and the data runfiles target,
-    filtering out the fake executable from the data runfiles.
-
-    If runfiles directories can ever be more directly treated as an input this function
-    can be retired.
 
     Args:
         ctx (ctx): The rule's context object
@@ -507,7 +504,6 @@ def _cargo_build_script_impl(ctx):
 
     tools = depset(
         direct = [
-            script,
             ctx.executable._cargo_build_script_runner,
         ] + fallback_tools + ([toolchain.target_json] if toolchain.target_json else []),
         transitive = script_data + toolchain_tools,
@@ -593,7 +589,10 @@ def _cargo_build_script_impl(ctx):
             dep_env_out,
             runfiles_dir,
         ] + extra_output,
-        tools = tools,
+        tools = [
+            ctx.attr.script[DefaultInfo].files_to_run,
+            tools,
+        ],
         inputs = depset(build_script_inputs, transitive = [runfiles_inputs]),
         mnemonic = "CargoBuildScriptRun",
         progress_message = "Running Cargo build script {}".format(pkg_name),

--- a/cargo/private/cargo_build_script_runner/bin.rs
+++ b/cargo/private/cargo_build_script_runner/bin.rs
@@ -87,7 +87,8 @@ fn run_buildrs() -> Result<(), String> {
 
     let working_directory = resolve_rundir(&rundir, &exec_root, &manifest_dir)?;
 
-    let mut command = Command::new(exec_root.join(progname));
+    let script_path = exec_root.join(&progname);
+    let mut command = Command::new(&script_path);
     command
         .current_dir(&working_directory)
         .envs(target_env_vars)
@@ -95,6 +96,15 @@ fn run_buildrs() -> Result<(), String> {
         .env("CARGO_MANIFEST_DIR", manifest_dir)
         .env("RUSTC", rustc)
         .env("RUST_BACKTRACE", "full");
+
+    // The script binary may have a `<script>.runfiles/` tree or a
+    // `<script>.runfiles_manifest` file materialized next to it by Bazel
+    // (because the script was passed as a `FilesToRunProvider`). Expose
+    // whichever exists so the runfiles library can locate the script's
+    // runfiles (tools). Data files of `cargo_build_script` are intentionally
+    // NOT in this tree — they must be looked up relative to
+    // `CARGO_MANIFEST_DIR`.
+    set_script_runfiles_env(&script_path, &mut command);
 
     for dep_env_path in input_dep_env_paths.iter() {
         if let Ok(contents) = read_to_string(dep_env_path) {
@@ -311,6 +321,39 @@ fn should_symlink_exec_root() -> bool {
     env::var("RULES_RUST_SYMLINK_EXEC_ROOT")
         .map(|s| s == "1")
         .unwrap_or(false)
+}
+
+/// Locate the runfiles materialized for `script_path` and expose them to the
+/// build script via the appropriate env var.
+///
+/// Bazel materializes runfiles for a `FilesToRunProvider` tool either as a
+/// `<script>.runfiles/` directory tree, a `<script>.runfiles_manifest` file,
+/// or both. Both are checked; if neither is present, no env var is set and
+/// the runfiles library falls back to its own heuristics (e.g. argv[0]).
+///
+/// `RUNFILES_MANIFEST_FILE` inherited from the parent process is cleared so
+/// it doesn't shadow what we're exposing.
+fn set_script_runfiles_env(script_path: &Path, command: &mut Command) {
+    command.env_remove("RUNFILES_MANIFEST_FILE");
+    command.env_remove("RUNFILES_DIR");
+
+    let Some(file_name) = script_path.file_name() else {
+        return;
+    };
+
+    let mut runfiles_dir_name = file_name.to_owned();
+    runfiles_dir_name.push(".runfiles");
+    let runfiles_dir = script_path.with_file_name(&runfiles_dir_name);
+    if runfiles_dir.is_dir() {
+        command.env("RUNFILES_DIR", &runfiles_dir);
+    }
+
+    let mut runfiles_manifest_name = file_name.to_owned();
+    runfiles_manifest_name.push(".runfiles_manifest");
+    let runfiles_manifest = script_path.with_file_name(&runfiles_manifest_name);
+    if runfiles_manifest.is_file() {
+        command.env("RUNFILES_MANIFEST_FILE", &runfiles_manifest);
+    }
 }
 
 /// Create a symlink from `link` to `original` if `link` doesn't already exist.

--- a/cargo/private/cargo_build_script_runner/cargo_manifest_dir.rs
+++ b/cargo/private/cargo_build_script_runner/cargo_manifest_dir.rs
@@ -139,6 +139,7 @@ impl RunfilesMaker {
             .next()
             .unwrap_or_else(|| panic!("Not enough arguments provided."))
             .split(',')
+            .filter(|s| !s.is_empty())
             .map(|s| s.to_owned())
             .collect::<BTreeSet<String>>();
         let runfiles = args

--- a/cargo/tests/cargo_build_script/runfiles/BUILD.bazel
+++ b/cargo/tests/cargo_build_script/runfiles/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//cargo:defs.bzl", "cargo_build_script")
+load("//rust:defs.bzl", "rust_test")
+
+# A "tool" file that becomes `data` on the rust_binary backing the build
+# script. The build script should be able to locate it via the runfiles
+# library (RUNFILES_DIR).
+write_file(
+    name = "tool_txt",
+    out = "tool.txt",
+    content = ["this is a tool, locatable via the runfiles library"],
+)
+
+# A "data" file that lives in CARGO_MANIFEST_DIR. The build script must NOT
+# be able to locate it via the runfiles library; it should be looked up
+# relative to CARGO_MANIFEST_DIR like a normal source file.
+write_file(
+    name = "data_txt",
+    out = "data.txt",
+    content = ["this is data, locatable only via CARGO_MANIFEST_DIR"],
+)
+
+cargo_build_script(
+    name = "build_rs",
+    srcs = ["build.rs"],
+    build_script_env = {
+        "DATA_RLOCATION": "$(rlocationpath :data.txt)",
+        "TOOL_RLOCATION": "$(rlocationpath :tool.txt)",
+    },
+    data = [":data.txt"],
+    edition = "2021",
+    tools = [":tool.txt"],
+    deps = ["//rust/runfiles"],
+)
+
+rust_test(
+    name = "test",
+    srcs = ["test.rs"],
+    edition = "2021",
+    deps = [":build_rs"],
+)

--- a/cargo/tests/cargo_build_script/runfiles/build.rs
+++ b/cargo/tests/cargo_build_script/runfiles/build.rs
@@ -1,0 +1,52 @@
+//! A Cargo build script binary used in unit tests for the Bazel
+//! `cargo_build_script` rule.
+//!
+//! Asserts that:
+//!   1. Tools (which are `data` of the underlying `rust_binary`) are locatable
+//!      via the runfiles library (RUNFILES_DIR).
+//!   2. Data (which is `data` of `cargo_build_script`) is NOT locatable via
+//!      the runfiles library.
+//!   3. Data IS locatable relative to `CARGO_MANIFEST_DIR`, like a normal
+//!      source file alongside `build.rs`.
+
+fn main() {
+    let r = runfiles::Runfiles::create().expect(
+        "Build scripts should be able to construct a Runfiles object — \
+         RUNFILES_DIR or RUNFILES_MANIFEST_FILE must be exposed by the build script runner",
+    );
+
+    let tool_rlocation =
+        std::env::var("TOOL_RLOCATION").expect("TOOL_RLOCATION env var should be set");
+    let tool_path = r.rlocation(&tool_rlocation).unwrap_or_else(|| {
+        panic!(
+            "Tool must be locatable via the runfiles library (rlocation: {})",
+            tool_rlocation,
+        )
+    });
+    assert!(
+        tool_path.exists(),
+        "Tool must exist at the path returned by the runfiles library: {}",
+        tool_path.display(),
+    );
+
+    let data_rlocation =
+        std::env::var("DATA_RLOCATION").expect("DATA_RLOCATION env var should be set");
+    let data_via_runfiles = r.rlocation(&data_rlocation);
+    if let Some(path) = data_via_runfiles {
+        assert!(
+            !path.exists(),
+            "Data must NOT be locatable via the runfiles library, but found it at {} (rlocation: {})",
+            path.display(),
+            data_rlocation,
+        );
+    }
+
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set");
+    let data_in_manifest = std::path::Path::new(&manifest_dir).join("data.txt");
+    assert!(
+        data_in_manifest.exists(),
+        "Data must be locatable relative to CARGO_MANIFEST_DIR at {}",
+        data_in_manifest.display(),
+    );
+}

--- a/cargo/tests/cargo_build_script/runfiles/test.rs
+++ b/cargo/tests/cargo_build_script/runfiles/test.rs
@@ -1,0 +1,6 @@
+//! Triggers execution of the `build.rs` build script. The build script
+//! itself contains the assertions; if any fail the action fails and this
+//! test fails to build.
+
+#[test]
+fn build_script_ran() {}


### PR DESCRIPTION
This change restores support for runfiles in `cargo_build_script.script`. There exists one limitation where only `cargo_build_script.tools` can be located via runfiles. Any `cargo_build_script.data` files should be located relative to the `CARGO_MANIFEST_DIR` env var. This is required as there is no existing interface for merging exec (tools) and target (data) runfiles.

closes https://github.com/bazelbuild/rules_rust/pull/4064