### PR TITLE
Prefix execroot-relative file arguments with pwd

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -207,12 +207,39 @@ def _pwd_flags_resource_dir(args):
     """Prefix execroot-relative paths in -resource-dir arguments with ${pwd}."""
     return _prefix_pwd_to_flag(args, ["-resource-dir=", "-resource-dir"])
 
+_DIRECT_LIB_EXTENSIONS = (".a", ".o", ".so", ".dylib")
+
+def _pwd_flags_direct_libs(args):
+    """Prefix execroot-relative object/library file arguments with ${pwd}.
+
+    Handles bare object and library file paths passed directly to the linker
+    without any associated flag (e.g. a positional path to
+    libclang_rt.builtins.a, or a positional .o/.so/.dylib). These are emitted
+    by some cc toolchains (e.g. hermetic LLVM passing the compiler-rt builtins
+    archive as a positional input) and would otherwise stay execroot-relative
+    and fail to resolve from the build script's working directory.
+
+    Args:
+        args (list): List of tool arguments.
+
+    Returns:
+        list: The modified argument list with relative object/library file
+            paths prefixed with ${pwd}.
+    """
+    res = []
+    for arg in args:
+        if not arg.startswith("-") and not paths.is_absolute(arg) and arg.endswith(_DIRECT_LIB_EXTENSIONS):
+            res.append("${{pwd}}/{}".format(arg))
+        else:
+            res.append(arg)
+    return res
+
 def _pwd_paths(args):
     """Prefix execroot-relative paths with ${pwd}."""
     return _prefix_pwd_to_paths(args)
 
 def _pwd_flags(args):
-    return _pwd_flags_fsanitize_ignorelist(_pwd_flags_isystem(_pwd_flags_L(_pwd_flags_B(_pwd_flags_resource_dir(_pwd_flags_sysroot(args))))))
+    return _pwd_flags_direct_libs(_pwd_flags_fsanitize_ignorelist(_pwd_flags_isystem(_pwd_flags_L(_pwd_flags_B(_pwd_flags_resource_dir(_pwd_flags_sysroot(args)))))))
 
 def _feature_enabled(ctx, feature_name, default = False):
     """Check if a feature is enabled.

--- a/cargo/tests/cargo_build_script/cc_args_and_env/BUILD.bazel
+++ b/cargo/tests/cargo_build_script/cc_args_and_env/BUILD.bazel
@@ -2,6 +2,8 @@ load(
     "cc_args_and_env_test.bzl",
     "bindir_absolute_test",
     "bindir_relative_test",
+    "direct_libs_absolute_test",
+    "direct_libs_relative_test",
     "fsanitize_ignorelist_absolute_test",
     "fsanitize_ignorelist_relative_test",
     "include_absolute_test",
@@ -58,3 +60,7 @@ include_relative_test(name = "include_relative_test")
 include_absolute_test(name = "include_absolute_test")
 
 include_mixed_test(name = "include_mixed_test")
+
+direct_libs_relative_test(name = "direct_libs_relative_test")
+
+direct_libs_absolute_test(name = "direct_libs_absolute_test")

--- a/cargo/tests/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
+++ b/cargo/tests/cargo_build_script/cc_args_and_env/cc_args_and_env_test.bzl
@@ -565,3 +565,25 @@ def include_mixed_test(name):
             "//conditions:default": "/test/absolute/include:${pwd}/test/relative/path",
         }),
     )
+
+def direct_libs_relative_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = ["bazel-out/bin/compiler-rt/libclang_rt.builtins.static.a", "test/relative/obj.o", "test/relative/libfoo.so", "test/relative/libbar.dylib", "some_unrelated_arg"],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = ["${pwd}/bazel-out/bin/compiler-rt/libclang_rt.builtins.static.a", "${pwd}/test/relative/obj.o", "${pwd}/test/relative/libfoo.so", "${pwd}/test/relative/libbar.dylib", "some_unrelated_arg"],
+    )
+
+def direct_libs_absolute_test(name):
+    cargo_build_script_with_extra_cc_compile_flags(
+        name = "%s/cargo_build_script" % name,
+        extra_cc_compile_flags = ["/test/absolute/libclang_rt.builtins.static.a", "/test/absolute/obj.o", "/test/absolute/libfoo.so", "/test/absolute/libbar.dylib", "some_unrelated_arg"],
+    )
+    cc_args_and_env_analysis_test(
+        name = name,
+        target_under_test = "%s/cargo_build_script" % name,
+        expected_cflags = ["/test/absolute/libclang_rt.builtins.static.a", "/test/absolute/obj.o", "/test/absolute/libfoo.so", "/test/absolute/libbar.dylib", "some_unrelated_arg"],
+    )


### PR DESCRIPTION
Prefix execroot-relative bare positional file args with pwd in cargo build scripts. This is already done for `-L`, `-isystem`, `--sysroot`, etc but not for bare positional arguments like `bazel-out/bin/compiler-rt/libclang_rt.builtins.static.a`.

This problem arised when compiling `aws-lc-sys` with [hermetic-llvm](https://github.com/hermeticbuild/hermetic-llvm), see https://github.com/hermeticbuild/hermetic-llvm/issues/405

A minimal working example to reproduce is created in https://github.com/martin4861/mwe-bootstrapped-rust-clang_rt.builtins.static:
```
clang: error: no such file or directory:
'bazel-out/darwin_arm64-fastbuild-ST-bdec89fd5d65/bin/external/llvm++llvm_source+compiler-rt/clang_rt.builtins.static_/libclang_rt.builtins.static.a'
```