### PR TITLE
Fix static link failures when cc_library linkopts precede later archives

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -2472,8 +2472,19 @@ def portable_link_flags(
 
     return []
 
-def _add_user_link_flags(ret, linker_input):
-    ret.extend(["--codegen=link-arg={}".format(flag) for flag in linker_input.user_link_flags])
+def _add_user_link_flags(make_link_flags_args):
+    linker_input = make_link_flags_args[0]
+    return ["--codegen=link-arg={}".format(flag) for flag in linker_input.user_link_flags]
+
+def _add_user_link_flags_windows(make_link_flags_args):
+    # Windows toolchains can inherit POSIX defaults like -pthread from C deps,
+    # which fails to link with the MinGW/LLD toolchain. Drop them here.
+    linker_input = make_link_flags_args[0]
+    return [
+        "--codegen=link-arg={}".format(flag)
+        for flag in linker_input.user_link_flags
+        if flag not in ("-pthread", "-lpthread")
+    ]
 
 def _make_link_flags_windows(make_link_flags_args, flavor_msvc, use_direct_driver):
     linker_input, use_pic, ambiguous_libs, include_link_flags = make_link_flags_args
@@ -2493,12 +2504,6 @@ def _make_link_flags_windows(make_link_flags_args, flavor_msvc, use_direct_drive
             get_lib_name = get_lib_name_for_windows if flavor_msvc else get_lib_name_default
             ret.extend(portable_link_flags(lib, use_pic, ambiguous_libs, get_lib_name, flavor_msvc = flavor_msvc))
 
-    # Windows toolchains can inherit POSIX defaults like -pthread from C deps,
-    # which fails to link with the MinGW/LLD toolchain. Drop them here.
-    for flag in linker_input.user_link_flags:
-        if flag in ("-pthread", "-lpthread"):
-            continue
-        ret.append("--codegen=link-arg={}".format(flag))
     return ret
 
 def _make_link_flags_windows_msvc(make_link_flags_args, use_direct_driver):
@@ -2519,7 +2524,6 @@ def _make_link_flags_darwin(make_link_flags_args, use_direct_driver):
             ])
         elif include_link_flags:
             ret.extend(portable_link_flags(lib, use_pic, ambiguous_libs, get_lib_name_default, for_darwin = True))
-    _add_user_link_flags(ret, linker_input)
     return ret
 
 def _make_link_flags_default(make_link_flags_args, use_direct_driver):
@@ -2535,7 +2539,6 @@ def _make_link_flags_default(make_link_flags_args, use_direct_driver):
             ])
         elif include_link_flags:
             ret.extend(portable_link_flags(lib, use_pic, ambiguous_libs, get_lib_name_default))
-    _add_user_link_flags(ret, linker_input)
     return ret
 
 def _make_link_flags_default_indirect(make_link_flags_args):
@@ -2576,8 +2579,10 @@ def _get_make_link_flag_funcs(target_os, target_abi, use_direct_link_driver):
         tuple:
             - callable: The function for producing link args.
             - callable: The function for formatting link library names.
+            - callable: The function for emitting cc_library user_link_flags.
     """
     get_lib_name = get_lib_name_default
+    add_user_link_flags = _add_user_link_flags
 
     if target_os == "windows":
         if target_abi == "msvc":
@@ -2585,12 +2590,13 @@ def _get_make_link_flag_funcs(target_os, target_abi, use_direct_link_driver):
             get_lib_name = get_lib_name_for_windows
         else:
             make_link_flags = _make_link_flags_windows_gnu_direct if use_direct_link_driver else _make_link_flags_windows_gnu_indirect
+        add_user_link_flags = _add_user_link_flags_windows
     elif target_os.startswith(("mac", "darwin", "ios")):
         make_link_flags = _make_link_flags_darwin_direct if use_direct_link_driver else _make_link_flags_darwin_indirect
     else:
         make_link_flags = _make_link_flags_default_direct if use_direct_link_driver else _make_link_flags_default_indirect
 
-    return (make_link_flags, get_lib_name)
+    return (make_link_flags, get_lib_name, add_user_link_flags)
 
 def _libraries_dirnames(make_link_flags_args):
     link_input, use_pic, _, _ = make_link_flags_args
@@ -2636,7 +2642,7 @@ def _add_native_link_flags(
         toolchain = toolchain,
     )
 
-    make_link_flags, get_lib_name = _get_make_link_flag_funcs(
+    make_link_flags, get_lib_name, add_user_link_flags = _get_make_link_flag_funcs(
         target_os = toolchain.target_os,
         target_abi = toolchain.target_abi,
         use_direct_link_driver = use_direct_link_driver,
@@ -2660,6 +2666,7 @@ def _add_native_link_flags(
         )
 
     args.add_all(make_link_flags_args, map_each = make_link_flags)
+    args.add_all(make_link_flags_args, map_each = add_user_link_flags)
 
     args.add_all(linkstamp_outs, format_each = "-Clink-args=%s")
 

--- a/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
+++ b/test/unit/linker_inputs_propagation/linker_inputs_propagation_test.bzl
@@ -26,17 +26,23 @@ def _dependency_linkopts_are_propagated_test_impl(ctx):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
     link_action = [action for action in tut.actions if action.mnemonic == "Rustc"][0]
+    argv = link_action.argv
 
     pic_suffix = _get_pic_suffix(ctx)
 
     # Expect a library's own linkopts to come after the flags we create to link them.
     # This is required, because linkopts are ordered and the linker will only apply later ones when resolving symbols required for earlier ones.
     # This means that if one of our transitive deps has a linkopt like `-lfoo`, the dep will see the symbols of foo at link time.
-    _assert_contains_in_order(env, link_action.argv, [
+    lfoo = "-Clink-arg=-lfoo_with_linkopts{}".format(pic_suffix)
+    _assert_contains_in_order(env, argv, [
         "-lstatic=foo_with_linkopts{}".format(pic_suffix),
-        "-Clink-arg=-lfoo_with_linkopts{}".format(pic_suffix),
-        "--codegen=link-arg=-L/doesnotexist",
+        lfoo,
     ])
+
+    # cc_library linkopts trail every native archive -l flag (not inline beside the first dep).
+    linkopt = "--codegen=link-arg=-L/doesnotexist"
+    asserts.true(env, linkopt in argv)
+    asserts.true(env, argv.index(linkopt) > argv.index(lfoo))
     return analysistest.end(env)
 
 def _get_pic_suffix(ctx):

--- a/test/unit/native_deps/native_deps_test.bzl
+++ b/test/unit/native_deps/native_deps_test.bzl
@@ -616,6 +616,62 @@ def _linkopts_test():
         target_under_test = ":linkopts_rust_bin",
     )
 
+def _cc_linkopts_trail_all_native_archives_test_impl(ctx):
+    """cc_library linkopts must trail every native archive -l flag.
+
+    rules_rust re-lists native archives after rlibs (section C). linkopts from
+    the first cc dep must not be emitted beside that dep only; they belong after
+    all archive -l flags.
+    """
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+    argv = tut.actions[0].argv
+
+    marker = "--codegen=link-arg=-Llinkopt_trailing_marker"
+    asserts.true(env, marker in argv)
+
+    last_archive_clink = -1
+    for i, arg in enumerate(argv):
+        if arg.startswith("-Clink-arg=-l") and "linkopt_trailing_marker" not in arg:
+            last_archive_clink = i
+
+    marker_idx = argv.index(marker)
+    asserts.true(
+        env,
+        marker_idx > last_archive_clink,
+        msg = "expected -Llinkopt_trailing_marker after the last native -Clink-arg=-l",
+    )
+    return analysistest.end(env)
+
+cc_linkopts_trail_all_native_archives_test = analysistest.make(
+    _cc_linkopts_trail_all_native_archives_test_impl,
+)
+
+def _cc_linkopts_trailing_test():
+    cc_library(
+        name = "trailing_native_dep_a",
+        srcs = ["native_dep.cc"],
+    )
+
+    cc_library(
+        name = "trailing_native_dep_b",
+        srcs = ["native_dep.cc"],
+        linkopts = ["-Llinkopt_trailing_marker"],
+        deps = [":trailing_native_dep_a"],
+    )
+
+    rust_binary(
+        name = "trailing_linkopts_bin",
+        srcs = ["bin_using_native_dep.rs"],
+        edition = "2018",
+        deps = [":trailing_native_dep_b"],
+    )
+
+    cc_linkopts_trail_all_native_archives_test(
+        name = "cc_linkopts_trail_all_native_archives_test",
+        target_under_test = ":trailing_linkopts_bin",
+    )
+
 def _check_additional_deps_test_impl(ctx, expect_additional_deps):
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
@@ -685,6 +741,7 @@ def native_deps_test_suite(name):
     """
     _native_dep_test()
     _linkopts_test()
+    _cc_linkopts_trailing_test()
     _additional_deps_test()
 
     native.test_suite(
@@ -694,6 +751,7 @@ def native_deps_test_suite(name):
             ":bin_has_native_dep_and_alwayslink_rust_linker_test",
             ":bin_has_native_dep_and_alwayslink_cc_linker_test",
             ":bin_has_native_libs_test",
+            ":cc_linkopts_trail_all_native_archives_test",
             ":cdylib_has_additional_deps_test",
             ":cdylib_has_native_dep_and_alwayslink_rust_linker_test",
             ":cdylib_has_native_dep_and_alwayslink_cc_linker_test",


### PR DESCRIPTION
rules_rust links native archives twice around rlibs. In the second pass, each cc_library's linkopts were emitted as `--codegen=link-arg=` right after that dep's own archives, not after every archive in the pass. Since static linkers resolve left-to-right, a linkopt on an early dep can be “spent,” and then later archives that still need the library it names get undefined references.

Example: rust_binary depends on cc_library B which depends on cc_library A. A uses `fstat` and states `linkopts = ["-lc"]`. -lc is applied while resolving A; B's archives still need libc but -lc has already been passed.

The fix is to emit CcInfo user_link_flags after all native archive flags in _add_native_link_flags, via add_user_link_flags from _get_make_link_flag_funcs.

This is not always reproducible; host gcc may not exhibit the issue because -lc is added again after the archive list, but custom linkers and -nodefaultlibs can expose it.