### PR TITLE
Add extensions_bindgen_ios task in CI to verify iOS cross-compilation

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1140,6 +1140,15 @@ tasks:
       - "//..."
     test_targets:
       - "//..."
+  extensions_bindgen_ios:
+    platform: macos_arm64
+    name: Extensions Bindgen iOS
+    working_directory: extensions/bindgen
+    build_flags:
+      - "--cpu=ios_sim_arm64"
+      - "--apple_platform_type=ios"
+    build_targets:
+      - "//..."
   # # TODO: https://github.com/bazelbuild/rules_rust/issues/2009
   # # The bindgen rules are currently broken on windows
   # extensions_bindgen_windows:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1145,7 +1145,7 @@ tasks:
     name: Extensions Bindgen iOS
     working_directory: extensions/bindgen
     build_flags:
-      - "--cpu=ios_sim_arm64"
+      - "--cpu=ios_arm64"
       - "--apple_platform_type=ios"
     build_targets:
       - "//..."

--- a/extensions/bindgen/test/integration/BUILD.bazel
+++ b/extensions/bindgen/test/integration/BUILD.bazel
@@ -24,3 +24,25 @@ rust_test(
     name = "simple_test",
     crate = ":simple_example",
 )
+
+rust_bindgen_library(
+    name = "std_headers_bindgen",
+    bindgen_flags = [
+        "--allowlist-function=get_random_value",
+    ],
+    cc_lib = "//test/integration/std_headers",
+    edition = "2021",
+    header = "//test/integration/std_headers:std_headers.h",
+)
+
+rust_binary(
+    name = "std_headers_example",
+    srcs = ["main_std_headers.rs"],
+    edition = "2021",
+    deps = [":std_headers_bindgen"],
+)
+
+rust_test(
+    name = "std_headers_test",
+    crate = ":std_headers_example",
+)

--- a/extensions/bindgen/test/integration/main_std_headers.rs
+++ b/extensions/bindgen/test/integration/main_std_headers.rs
@@ -1,0 +1,17 @@
+//! rust_bindgen_library example consumer with stdlib headers
+
+fn get_random_value() -> i64 {
+    unsafe { std_headers_bindgen::get_random_value() }
+}
+
+fn main() {
+    println!("The value is {}!", get_random_value(),);
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn do_the_test() {
+        assert_eq!(42, super::get_random_value());
+    }
+}

--- a/extensions/bindgen/test/integration/std_headers/BUILD.bazel
+++ b/extensions/bindgen/test/integration/std_headers/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+exports_files(
+    [
+        "std_headers.h",
+    ],
+    visibility = ["//test/integration:__pkg__"],
+)
+
+cc_library(
+    name = "std_headers",
+    srcs = ["std_headers.cc"],
+    hdrs = ["std_headers.h"],
+    visibility = ["//test/integration:__pkg__"],
+)

--- a/extensions/bindgen/test/integration/std_headers/std_headers.cc
+++ b/extensions/bindgen/test/integration/std_headers/std_headers.cc
@@ -1,0 +1,7 @@
+#include "std_headers.h"
+
+int64_t get_random_value() {
+    // Use a stdlib function to ensure it's not optimized away and stdlib is
+    // linked
+    return abs(-42);
+}

--- a/extensions/bindgen/test/integration/std_headers/std_headers.h
+++ b/extensions/bindgen/test/integration/std_headers/std_headers.h
@@ -1,0 +1,15 @@
+#ifndef __STD_HEADERS_H_INCLUDE__
+#define __STD_HEADERS_H_INCLUDE__
+
+#ifdef __cplusplus
+#define EXTERN_C extern "C"
+#else
+#define EXTERN_C
+#endif
+
+#include <stdint.h>
+#include <stdlib.h>
+
+EXTERN_C int64_t get_random_value();
+
+#endif


### PR DESCRIPTION
Bindgen is failing to generate bindings for the iOS platform in google3 due to extra Apple-specific Clang flags that are not currently allowlisted by the bindgen implementation.

Adding the iOS task to the upstream CI will help catch any cross-compilation failures early.