### PR TITLE
Fix failing test in rolling bazel version

### DIFF
--- a/test/unit/common.bzl
+++ b/test/unit/common.bzl
@@ -52,6 +52,18 @@ def assert_argv_contains_prefix_not(env, action, prefix):
                 ),
             )
 
+def assert_argv_contains_prefix_then_digit(env, action, prefix):
+    for found_flag in action.argv:
+        if found_flag.startswith(prefix) and len(found_flag) > len(prefix) and found_flag[len(prefix)].isdigit():
+            return
+    unittest.fail(
+        env,
+        "Expected an arg with prefix '{prefix}' followed by a digit in {args}".format(
+            prefix = prefix,
+            args = action.argv,
+        ),
+    )
+
 def assert_action_mnemonic(env, action, mnemonic):
     if not action.mnemonic == mnemonic:
         unittest.fail(

--- a/test/unit/crate_name/crate_name_test.bzl
+++ b/test/unit/crate_name/crate_name_test.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "analysistest")
 load("//rust:defs.bzl", "rust_binary", "rust_library", "rust_shared_library", "rust_static_library", "rust_test", "rust_test_suite")
-load("//test/unit:common.bzl", "assert_argv_contains", "assert_argv_contains_prefix_not")
+load("//test/unit:common.bzl", "assert_argv_contains", "assert_argv_contains_prefix_not", "assert_argv_contains_prefix_then_digit")
 
 def _default_crate_name_library_test_impl(ctx):
     env = analysistest.begin(ctx)
@@ -58,8 +58,8 @@ def _slib_library_name_test_impl(ctx):
     """
     env = analysistest.begin(ctx)
     tut = analysistest.target_under_test(env)
-    assert_argv_contains(env, tut.actions[0], "--codegen=metadata=-2102077805")
-    assert_argv_contains(env, tut.actions[0], "--codegen=extra-filename=-2102077805")
+    assert_argv_contains_prefix_then_digit(env, tut.actions[0], "--codegen=metadata=-")
+    assert_argv_contains_prefix_then_digit(env, tut.actions[0], "--codegen=extra-filename=-")
     return analysistest.end(env)
 
 def _no_extra_filename_test_impl(ctx):


### PR DESCRIPTION
My assumption is that the hashing algorithm changed in some way in the rolling Bazel version. I don't think we need to test the exact value, just that it's a numeric hash.