### PR TITLE
Fix rust_doc_test linking with native libraries

### DIFF
--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -651,6 +651,7 @@ def collect_inputs(
         stamp = False,
         force_depend_on_objects = False,
         experimental_use_cc_common_link = False,
+        include_linker_inputs = False,
         include_link_flags = True):
     """Gather's the inputs and required input information for a rustc action
 
@@ -673,6 +674,7 @@ def collect_inputs(
             metadata, even for libraries. This is used in rustdoc tests.
         experimental_use_cc_common_link (bool, optional): Whether rules_rust uses cc_common.link to link
             rust binaries.
+        include_linker_inputs (bool, optional): Whether to include linker inputs in transitive dependencies.
         include_link_flags (bool, optional): Whether to include flags like `-l` that instruct the linker to search for a library.
 
     Returns:
@@ -713,7 +715,7 @@ def collect_inputs(
     # flattened on each transitive rust_library dependency.
     libs_from_linker_inputs = []
     ambiguous_libs = {}
-    if crate_info.type not in ("lib", "rlib"):
+    if crate_info.type not in ("lib", "rlib") or include_linker_inputs:
         linker_inputs = dep_info.transitive_noncrates.to_list()
         ambiguous_libs = _disambiguate_libs(ctx.actions, toolchain, crate_info, dep_info, use_pic)
         libs_from_linker_inputs = _collect_libs_from_linker_inputs(linker_inputs, use_pic) + [
@@ -2625,8 +2627,6 @@ def _add_native_link_flags(
         use_direct_link_driver (bool): Whether the linker is a direct driver (e.g. `ld`, `wasm-ld`) vs a wrapper (e.g. `clang`, `gcc`).
         include_link_flags (bool, optional): Whether to include flags like `-l` that instruct the linker to search for a library.
     """
-    if crate_type in ["lib", "rlib"]:
-        return
 
     use_pic = should_use_pic(
         cc_toolchain = cc_toolchain,

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -15,9 +15,18 @@
 """Rules for generating documentation with `rustdoc` for Bazel built crates"""
 
 load("//rust/private:common.bzl", "rust_common")
+load("//rust/private:pic_utils.bzl", "should_use_pic")
 load("//rust/private:providers.bzl", "LintsInfo")
 load("//rust/private:rustc.bzl", "collect_deps", "collect_inputs", "construct_arguments")
-load("//rust/private:utils.bzl", "dedent", "find_cc_toolchain", "find_toolchain")
+load(
+    "//rust/private:utils.bzl",
+    "dedent",
+    "find_cc_toolchain",
+    "find_toolchain",
+    "get_lib_name_default",
+    "get_lib_name_for_windows",
+    "get_preferred_artifact",
+)
 
 def _strip_crate_info_output(crate_info):
     """Set the CrateInfo.output to None for a given CrateInfo provider.
@@ -122,6 +131,7 @@ def rustdoc_compile_action(
         build_info = build_info,
         lint_files = lint_files,
         force_depend_on_objects = force_depend_on_objects,
+        include_linker_inputs = is_test or force_depend_on_objects,
         include_link_flags = False,
     )
 
@@ -130,6 +140,32 @@ def rustdoc_compile_action(
     # of the rustc functionality in `construct_arguments` to avoid generating
     # arguments expecting to do so.
     rustdoc_crate_info = _strip_crate_info_output(crate_info)
+
+    # rustdoc does not understand linker flags like -lstatic that
+    # `include_link_flags` generates. So we manually build flags that only apply
+    # to rustdoc.
+    if is_test or force_depend_on_objects:
+        compilation_mode = ctx.var["COMPILATION_MODE"]
+        use_pic = should_use_pic(
+            cc_toolchain = cc_toolchain,
+            feature_configuration = feature_configuration,
+            crate_type = crate_info.type,
+            compilation_mode = compilation_mode,
+            toolchain = toolchain,
+        )
+        for_windows = toolchain.target_abi == "msvc"
+        get_lib_name = get_lib_name_for_windows if for_windows else get_lib_name_default
+        for dep in dep_info.transitive_noncrates.to_list():
+            for lib in dep.libraries:
+                if not (lib.static_library or lib.pic_static_library):
+                    continue
+                arg = get_lib_name(get_preferred_artifact(lib, use_pic))
+                if not for_windows:
+                    arg = "-l" + arg
+                if type(rustdoc_flags) == "Args":
+                    rustdoc_flags.add("-Clink-arg=%s" % arg)
+                else:
+                    rustdoc_flags.append("-Clink-arg=%s" % arg)
 
     args, env = construct_arguments(
         ctx = ctx,

--- a/rust/private/rustdoc_test.bzl
+++ b/rust/private/rustdoc_test.bzl
@@ -20,6 +20,15 @@ load("//rust/private:providers.bzl", "CrateInfo")
 load("//rust/private:rustdoc.bzl", "rustdoc_compile_action")
 load("//rust/private:utils.bzl", "dedent", "find_toolchain", "transform_deps")
 
+def _collect_library_roots(roots, deps):
+    for dep in deps.to_list():
+        for lib in dep.libraries:
+            for artifact in [lib.static_library, lib.pic_static_library]:
+                if artifact:
+                    roots.append(artifact.root.path)
+        for input in dep.additional_inputs:
+            roots.append(input.root.path)
+
 def _construct_writer_arguments(ctx, test_runner, opt_test_params, action, crate_info):
     """Construct arguments and environment variables specific to `rustdoc_test_writer`.
 
@@ -64,29 +73,23 @@ def _construct_writer_arguments(ctx, test_runner, opt_test_params, action, crate
 
     # Collect and dedupe all of the file roots in a list before appending
     # them to args to prevent generating a large amount of identical args
-    roots = []
-    root = crate_info.output.root.path
-    if not root in roots:
-        roots.append(root)
+    roots = [crate_info.output.root.path]
     for dep in crate_info.deps.to_list() + crate_info.proc_macro_deps.to_list():
         dep_crate_info = getattr(dep, "crate_info", None)
         dep_dep_info = getattr(dep, "dep_info", None)
+        dep_cc_info = getattr(dep, "cc_info", None)
         if dep_crate_info:
-            root = dep_crate_info.output.root.path
-            if not root in roots:
-                roots.append(root)
+            roots.append(dep_crate_info.output.root.path)
         if dep_dep_info:
             for direct_dep in dep_dep_info.direct_crates.to_list():
-                root = direct_dep.dep.output.root.path
-                if not root in roots:
-                    roots.append(root)
+                roots.append(direct_dep.dep.output.root.path)
             for transitive_dep in dep_dep_info.transitive_crates.to_list():
-                root = transitive_dep.output.root.path
-                if not root in roots:
-                    roots.append(root)
+                roots.append(transitive_dep.output.root.path)
+            _collect_library_roots(roots, dep_dep_info.transitive_noncrates)
+        if dep_cc_info:
+            _collect_library_roots(roots, dep_cc_info.linking_context.linker_inputs)
 
-    for root in roots:
-        writer_args.add("--strip_substring={}/".format(root))
+    writer_args.add_all(roots, format_each = "--strip_substring=%s/", uniquify = True)
 
     # Indicate that the rustdoc_test args are over.
     writer_args.add("--")

--- a/test/unit/rustdoc/rustdoc.cc
+++ b/test/unit/rustdoc/rustdoc.cc
@@ -1,0 +1,3 @@
+#include "test/unit/rustdoc/rustdoc.h"
+
+int rustdoc_native_dep() { return 42; }

--- a/test/unit/rustdoc/rustdoc.h
+++ b/test/unit/rustdoc/rustdoc.h
@@ -1,0 +1,1 @@
+extern "C" int rustdoc_native_dep();

--- a/test/unit/rustdoc/rustdoc_depends_on_native.rs
+++ b/test/unit/rustdoc/rustdoc_depends_on_native.rs
@@ -1,0 +1,7 @@
+/// Calls into a Rust dependency that links a native library.
+/// ```
+/// assert_eq!(lib_nodep_with_cc::native_answer(), 42);
+/// ```
+pub fn answer() -> u32 {
+    lib_nodep_with_cc::native_answer()
+}

--- a/test/unit/rustdoc/rustdoc_nodep_lib.rs
+++ b/test/unit/rustdoc/rustdoc_nodep_lib.rs
@@ -7,6 +7,11 @@ make_answer!();
 #[cfg(feature = "with_build_script")]
 pub const CONST: &str = env!("CONST");
 
+#[cfg(feature = "with_cc")]
+extern "C" {
+    fn rustdoc_native_dep() -> u32;
+}
+
 /// The answer to the ultimate question
 /// ```
 /// fn answer() -> u32 { 42 }
@@ -15,6 +20,11 @@ pub const CONST: &str = env!("CONST");
 #[cfg(not(feature = "with_proc_macro"))]
 pub fn answer() -> u32 {
     42
+}
+
+#[cfg(feature = "with_cc")]
+pub fn native_answer() -> u32 {
+    unsafe { rustdoc_native_dep() }
 }
 
 #[cfg(test)]

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -3,7 +3,15 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//cargo:defs.bzl", "cargo_build_script")
-load("//rust:defs.bzl", "rust_binary", "rust_doc", "rust_doc_test", "rust_library", "rust_proc_macro", "rust_test")
+load(
+    "//rust:defs.bzl",
+    "rust_binary",
+    "rust_doc",
+    "rust_doc_test",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
 load(
     "//test/unit:common.bzl",
     "assert_action_mnemonic",
@@ -154,6 +162,24 @@ def _rustdoc_with_json_error_format_test_impl(ctx):
 
     return analysistest.end(env)
 
+def _rustdoc_test_uses_cc_library_native_lib_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    tut = analysistest.target_under_test(env)
+    action = tut.actions[0]
+
+    asserts.true(
+        env,
+        action.mnemonic in ["RustdocTestWriter", "RustdocTestCompile"],
+        "Expected RustdocTestWriter or RustdocTestCompile, got {}".format(action.mnemonic),
+    )
+    asserts.true(
+        env,
+        "-Clink-arg=-lrustdoc_cc_library" in action.argv or "-Clink-arg=-lrustdoc_cc_library.pic" in action.argv,
+        "Expected {} to contain a rustdoc_cc_library native link arg".format(action.argv),
+    )
+
+    return analysistest.end(env)
+
 rustdoc_for_lib_test = analysistest.make(_rustdoc_for_lib_test_impl)
 rustdoc_for_bin_test = analysistest.make(_rustdoc_for_bin_test_impl)
 rustdoc_for_bin_with_cc_lib_test = analysistest.make(_rustdoc_for_bin_with_cc_lib_test_impl)
@@ -168,6 +194,7 @@ rustdoc_zip_output_test = analysistest.make(_rustdoc_zip_output_test_impl)
 rustdoc_with_json_error_format_test = analysistest.make(_rustdoc_with_json_error_format_test_impl, config_settings = {
     str(Label("//rust/settings:error_format")): "json",
 })
+rustdoc_test_uses_cc_library_native_lib_test = analysistest.make(_rustdoc_test_uses_cc_library_native_lib_test_impl)
 
 def _target_maker(rule_fn, name, rustdoc_deps = [], rustdoc_proc_macro_deps = [], **kwargs):
     rule_fn(
@@ -329,6 +356,20 @@ def _define_targets():
         deps = [":lib_nodep_with_cc"],
     )
 
+    cc_library(
+        name = "rustdoc_cc_library",
+        hdrs = ["rustdoc.h"],
+        srcs = ["rustdoc.cc"],
+    )
+
+    _target_maker(
+        rust_library,
+        name = "lib_with_cc_library",
+        srcs = ["rustdoc_nodep_lib.rs"],
+        crate_features = ["with_cc"],
+        deps = [":rustdoc_cc_library"],
+    )
+
     cargo_build_script(
         name = "lib_build_script",
         srcs = ["rustdoc_build.rs"],
@@ -446,6 +487,11 @@ def rustdoc_test_suite(name):
         target_under_test = ":lib_doc",
     )
 
+    rustdoc_test_uses_cc_library_native_lib_test(
+        name = "rustdoc_test_uses_cc_library_native_lib_test",
+        target_under_test = ":lib_with_cc_library_doctest",
+    )
+
     native.filegroup(
         name = "lib_doc_zip",
         srcs = [":lib_doc.zip"],
@@ -469,6 +515,7 @@ def rustdoc_test_suite(name):
             ":rustdoc_for_lib_with_cc_lib_test",
             ":rustdoc_with_args_test",
             ":rustdoc_with_json_error_format_test",
+            ":rustdoc_test_uses_cc_library_native_lib_test",
             ":rustdoc_zip_output_test",
         ],
     )

--- a/test/unit/rustdoc/rustdoc_unit_test.bzl
+++ b/test/unit/rustdoc/rustdoc_unit_test.bzl
@@ -322,6 +322,13 @@ def _define_targets():
         deps = [":cc_lib"],
     )
 
+    _target_maker(
+        rust_library,
+        name = "lib_depends_on_native",
+        srcs = ["rustdoc_depends_on_native.rs"],
+        deps = [":lib_nodep_with_cc"],
+    )
+
     cargo_build_script(
         name = "lib_build_script",
         srcs = ["rustdoc_build.rs"],


### PR DESCRIPTION
rust_doc_test does not propagate native libraries into the final test command. This appears to only affect native libraries built by bazel rather than ones linked into crates by build.rs. This change only works with static libraries - dynamic libraries are much more complex.

For example, using the jemalloc bazel module in tikv-jemalloc-sys.

* Add -Clink-arg for all transitive non-crates
* Add include_linker_inputs to collect all linker inputs
* Collect linker roots from all libraries and additional inputs