### PR TITLE
Stop removing AR from macOS env

### DIFF
--- a/cargo/private/cargo_build_script_runner/bin.rs
+++ b/cargo/private/cargo_build_script_runner/bin.rs
@@ -136,19 +136,7 @@ fn run_buildrs() -> Result<(), String> {
     }
 
     if let Some(ar_path) = env::var_os("AR") {
-        // The default OSX toolchain uses libtool as ar_executable not ar.
-        // This doesn't work when used as $AR, so simply don't set it - tools will probably fall back to
-        // /usr/bin/ar which is probably good enough.
-        let file_name = Path::new(&ar_path)
-            .file_name()
-            .ok_or_else(|| "Failed while getting file name".to_string())?
-            .to_string_lossy();
-        if file_name.contains("libtool") {
-            command.env_remove("AR");
-            command.env_remove("ARFLAGS");
-        } else {
-            command.env("AR", exec_root.join(ar_path));
-        }
+        command.env("AR", exec_root.join(ar_path));
     }
 
     // replace env vars with a ${pwd} prefix with the exec_root


### PR DESCRIPTION
With https://github.com/bazelbuild/apple_support/pull/601 we make our
libtool wrapper normalize ar arguments so we can handle this case and
still produce hermetic archives (which Apple's ar does not)
