### PR TITLE
Remove C Python headers from pyo3 build actions

### DIFF
--- a/extensions/pyo3/private/pyo3.bzl
+++ b/extensions/pyo3/private/pyo3.bzl
@@ -333,7 +333,6 @@ def pyo3_extension(
         data = data,
         deps = [
             Label("//private:current_rust_pyo3_toolchain"),
-            Label("@rules_python//python/cc:current_py_cc_headers"),
         ] + deps,
         edition = edition,
         proc_macro_deps = proc_macro_deps,


### PR DESCRIPTION
https://github.com/bazelbuild/rules_rust/pull/4024 introduced a warning for targets adding CC deps in `deps`. The warning calls out putting this in `link_deps` or `cc_deps`. The latter makes more sense here... but doesn't actually exist. However, I don't think this matters anyways, as I don't think it's needed (this works with an internal codebase).