### PR TITLE
fix(cargo_build_script): keep real OUT_DIR path in cross-crate dep-env

### DIFF
--- a/cargo/private/cargo_build_script_runner/lib.rs
+++ b/cargo/private/cargo_build_script_runner/lib.rs
@@ -183,6 +183,26 @@ impl BuildScriptOutput {
         exec_root: &str,
         out_dir: &str,
     ) -> String {
+        // `out_dir` is intentionally NOT rewritten to the generic `${out_dir}`
+        // token here (unlike the env file produced by `outputs_to_env`).
+        //
+        // A dep-env file is consumed by a *dependent* crate's build-script
+        // runner (`bin.rs`), which only substitutes `${pwd}` and has no notion
+        // of *this* crate's `out_dir`. A `${out_dir}` token would therefore
+        // survive unresolved in the dependent's environment (e.g. leaving
+        // `DEP_LZ4_INCLUDE=${pwd}/${out_dir}/include`), breaking C/C++ includes
+        // that consume `DEP_<LINKS>_INCLUDE`. This is the same transitive-
+        // consumption case that `redact_flags` handles with per-build-script
+        // tokens plus `--subst` entries; the dep-env path has no such resolution
+        // on the consuming side, so emit the real path instead.
+        //
+        // The producing crate's `out_dir` tree is provided to the dependent
+        // build-script action as an input at this same exec-root-relative path,
+        // so emitting the real path with only the exec root tokenized
+        // (`${pwd}/<out_dir>/…`) resolves correctly there. Build-script actions
+        // do not advertise `supports-path-mapping`, so `--experimental_output_paths=strip`
+        // never rewrites that path out from under the literal value.
+        let _ = out_dir;
         let prefix = format!("DEP_{}_", crate_links.replace('-', "_").to_uppercase());
         outputs
             .iter()
@@ -191,7 +211,7 @@ impl BuildScriptOutput {
                     Some(format!(
                         "{}{}",
                         prefix,
-                        Self::escape_for_serializing(Self::redact_paths(env, exec_root, out_dir))
+                        Self::escape_for_serializing(Self::redact_exec_root(env, exec_root))
                     ))
                 } else {
                     None
@@ -475,6 +495,56 @@ cargo::rustc-env=BAR=/abs/exec_root/elsewhere/file.rs
                 "bazel-out/cfg/bin/_bs.out_dir",
             ),
             "FOO=${pwd}/${out_dir}/op.rs\nBAR=${pwd}/elsewhere/file.rs"
+        );
+    }
+
+    /// Counterpart to [`out_dir_in_env_value_is_redacted_to_substitution_token`]:
+    /// a `links` crate's `cargo::metadata` (or legacy `cargo:<key>`) value that
+    /// points into its own `OUT_DIR` must be written to the cross-crate dep-env
+    /// file using the real exec-root-relative `out_dir` path, with only the exec
+    /// root tokenized as `${pwd}`. It must NOT be rewritten to the generic
+    /// `${out_dir}` token: a dep-env file is consumed by a *dependent* crate's
+    /// build-script runner, which only resolves `${pwd}` and would otherwise
+    /// leave `${out_dir}` unresolved — breaking, for example, `DEP_LZ4_INCLUDE`
+    /// for a crate like `librocksdb-sys`.
+    #[test]
+    fn dep_env_out_dir_is_preserved_not_tokenized() {
+        let buff = Cursor::new(
+            "cargo::metadata=include=/abs/exec_root/bazel-out/cfg/bin/ext/lz4-sys_bs.out_dir/include\n",
+        );
+        let reader = BufReader::new(buff);
+        let result = BuildScriptOutput::outputs_from_reader(reader, true);
+        assert_eq!(
+            BuildScriptOutput::outputs_to_dep_env(
+                &result,
+                "lz4",
+                "/abs/exec_root",
+                "bazel-out/cfg/bin/ext/lz4-sys_bs.out_dir",
+            ),
+            "DEP_LZ4_INCLUDE=${pwd}/bazel-out/cfg/bin/ext/lz4-sys_bs.out_dir/include".to_owned()
+        );
+    }
+
+    /// Windows variant of [`dep_env_out_dir_is_preserved_not_tokenized`].
+    /// `redact_exec_root` rewrites a backslash-separated exec root to `${pwd}`
+    /// and preserves the rest of the (backslashed) out_dir-relative path
+    /// verbatim — no `${out_dir}` token.
+    #[test]
+    fn dep_env_out_dir_is_preserved_not_tokenized_windows() {
+        let buff = Cursor::new(
+            "cargo::metadata=include=C:\\exec_root\\bazel-out\\x64_windows-fastbuild\\bin\\ext\\lz4-sys_bs.out_dir\\include\n",
+        );
+        let reader = BufReader::new(buff);
+        let result = BuildScriptOutput::outputs_from_reader(reader, true);
+        assert_eq!(
+            BuildScriptOutput::outputs_to_dep_env(
+                &result,
+                "lz4",
+                "C:\\exec_root",
+                "bazel-out\\x64_windows-fastbuild\\bin\\ext\\lz4-sys_bs.out_dir",
+            ),
+            "DEP_LZ4_INCLUDE=${pwd}\\bazel-out\\x64_windows-fastbuild\\bin\\ext\\lz4-sys_bs.out_dir\\include"
+                .to_owned()
         );
     }
 

--- a/test/cargo_build_script/metadata_dep_env/BUILD.bazel
+++ b/test/cargo_build_script/metadata_dep_env/BUILD.bazel
@@ -35,3 +35,10 @@ rust_test(
     edition = "2021",
     deps = [":consumer_build_rs"],
 )
+
+rust_test(
+    name = "metadata_dep_env_include_test",
+    srcs = ["include_test.rs"],
+    edition = "2021",
+    deps = [":consumer_build_rs"],
+)

--- a/test/cargo_build_script/metadata_dep_env/consumer_build.rs
+++ b/test/cargo_build_script/metadata_dep_env/consumer_build.rs
@@ -13,6 +13,20 @@ fn main() {
         "unexpected DEP_PRODUCER_LEGACY_VERSION_1_10_0 value"
     );
 
+    // `DEP_PRODUCER_INCLUDE` points into the producer crate's `OUT_DIR`.
+    // It must reach this dependent build script as a fully resolved, existing
+    // path. Before the fix it arrived with the producer's `OUT_DIR` rewritten
+    // to the literal, unresolved `${out_dir}` token (e.g.
+    // `<execroot>/${out_dir}/include`), so the directory did not exist.
+    let include = std::env::var("DEP_PRODUCER_INCLUDE")
+        .expect("DEP_PRODUCER_INCLUDE should be set by producer build script");
+    let resolved = !include.contains("${out_dir}")
+        && std::path::Path::new(&include).join("marker.h").is_file();
+    println!(
+        "cargo:rustc-env=METADATA_INCLUDE_RESOLVED={}",
+        if resolved { "1" } else { "0" }
+    );
+
     println!("cargo:rustc-env=METADATA_MODERN_VALUE={modern}");
     println!("cargo:rustc-env=METADATA_LEGACY_VALUE={legacy}");
 }

--- a/test/cargo_build_script/metadata_dep_env/include_test.rs
+++ b/test/cargo_build_script/metadata_dep_env/include_test.rs
@@ -1,0 +1,9 @@
+/// A `DEP_<LINKS>_INCLUDE` value that points into the producing crate's
+/// `OUT_DIR` must reach the dependent's build script as a fully resolved,
+/// existing path. Previously the producing crate's `OUT_DIR` was rewritten to
+/// the literal `${out_dir}` token, which the dependent build-script runner
+/// never resolves, so C/C++ includes such as `lz4.h` could not be found.
+#[test]
+fn include_path_dep_env_is_resolved() {
+    assert_eq!(env!("METADATA_INCLUDE_RESOLVED"), "1");
+}

--- a/test/cargo_build_script/metadata_dep_env/producer_build.rs
+++ b/test/cargo_build_script/metadata_dep_env/producer_build.rs
@@ -1,5 +1,19 @@
+use std::fs;
+use std::path::PathBuf;
+
 fn main() {
     println!("cargo::metadata=modern_version_1_10_0=1");
     // Legacy (pre-1.77-compatible) syntax where unknown cargo:KEY is treated as metadata.
     println!("cargo:legacy_version_1_10_0=2");
+
+    // Expose an `OUT_DIR`-relative include directory through the
+    // `links`/metadata convention, exactly as a `-sys` crate does with
+    // `cargo:include=$OUT_DIR/include`. The dependent build script must
+    // receive this through `DEP_PRODUCER_INCLUDE` as a fully resolved path
+    // that actually exists — not a literal `${out_dir}` token.
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR set by rules_rust"));
+    let include = out_dir.join("include");
+    fs::create_dir_all(&include).expect("create include dir");
+    fs::write(include.join("marker.h"), "/* marker */\n").expect("write marker header");
+    println!("cargo:include={}", include.display());
 }


### PR DESCRIPTION
## Summary

Fixes #4103.

A `links` (`-sys`) crate whose build script exposes an `OUT_DIR`-relative path through the metadata convention (`cargo:include=$OUT_DIR/include`) propagated `DEP_<LINKS>_INCLUDE` to a **dependent** build script with the producing crate's `OUT_DIR` rewritten to the literal, unresolved `${out_dir}` token — e.g. the dependent saw `DEP_LZ4_INCLUDE=<execroot>/${out_dir}/include`, which does not exist, so `librocksdb-sys` could not find `lz4.h`.

This is a regression from #4011 (`experimental_output_paths`, refined by #4050), which introduced the `${out_dir}` tokenization of build-script outputs. It is on `main` only — the latest release `0.70.0` predates #4011 and is unaffected.

## Root cause

`outputs_to_dep_env` redacted values with `redact_paths`, rewriting the producing crate's `out_dir` to the generic `${out_dir}` token. That token is only resolved by `process_wrapper`'s `--out-dir` for the crate that **directly owns** the build script. A `.depenv` file is instead consumed by a **dependent** crate's build-script runner (`bin.rs`), which only substitutes `${pwd}` and has no `${out_dir}` binding for *another* crate's out_dir — so the token survives unresolved.

This is the same transitive-consumption scenario `redact_flags` was written for (per-build-script tokens plus matching `--subst` entries added on the Starlark side). The dep-env path was left on the generic-token codepath, which has no resolution mechanism on the consuming side.

## Fix

`outputs_to_dep_env` now redacts only the exec root (`${pwd}`) and keeps the producing crate's real `out_dir`-relative path. Safe because:

- the consumer (`bin.rs`) already resolves `${pwd}`;
- the producing crate's `out_dir` tree is already a declared input of the dependent build-script action at that same exec-root-relative path;
- build-script actions do not advertise `supports-path-mapping`, so `--experimental_output_paths=strip` never rewrites the literal path;
- the producing crate's own `.env` file (`outputs_to_env`) still uses `${out_dir}`, so path-mapping cache-shareability for the owning target is unchanged.

## Tests

- **Unit** (`cargo/private/cargo_build_script_runner`): `dep_env_out_dir_is_preserved_not_tokenized` and a Windows variant assert the dep-env keeps the real path with only `${pwd}` tokenized.
- **End-to-end** (`test/cargo_build_script/metadata_dep_env`): the producer now exposes an `OUT_DIR`-relative `include/` via `cargo:include=`, and `include_test.rs` asserts the dependent build script receives a resolved, existing path (red before the fix, green after).

Reported downstream as hermeticbuild/rules_rs#163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
