### PR TITLE
Make setup authorative over rust-analyzer paths

### DIFF
--- a/docs/src/rust_analyzer.md
+++ b/docs/src/rust_analyzer.md
@@ -1,233 +1,27 @@
 # Rust Analyzer
 
-[rust-analyzer](https://rust-analyzer.github.io/) needs a project model to do its job.
-For [non-Cargo projects](https://rust-analyzer.github.io/manual.html#non-cargo-based-projects),
-that comes from [project auto-discovery](https://rust-analyzer.github.io/manual.html#rust-analyzer.workspace.discoverConfig):
-rust-analyzer invokes a build-system-specific command and reads the project description
-from its stdout. `rules_rust` provides that command (`discover_bazel_rust_project`) and
-a one-shot installer (`setup`) that wires it up for you.
+`rules_rust` ships a one-shot installer that configures
+[rust-analyzer](https://rust-analyzer.github.io/) to use the project's Bazel
+toolchain. After setup, rust-analyzer, the proc-macro server, and rustfmt
+all come from Bazel — no host Rust install required.
 
-Performance is good enough on large monorepos: the discover binary reads the per-crate
-spec files Bazel's already producing via the [Build Event Protocol][bep] (no separate
-`bazel aquery` round-trip), and the assembled project JSON is memoized in a local
-content-addressed cache.
+## Quick start
 
-[bep]: https://bazel.build/remote/bep
+Pick your editor below. Each runs the same `setup` tool with a different
+subcommand — `setup` is re-runnable any time.
 
-## Quick start (VSCode)
+### VSCode
 
-Two steps from a clean checkout to a working IDE:
-
-1. Install the [rust-analyzer extension](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).
-2. Write the `.vscode/settings.json` keys that wire everything together:
-   ```
+1. Install the
+   [rust-analyzer extension](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).
+2. ```
    bazel run @rules_rust//tools/rust_analyzer:setup -- vscode
    ```
+3. Reload the VSCode window.
 
-Reload the VSCode window. rust-analyzer will run the Bazel-bundled LSP server, discover
-the project on the fly via `discover_bazel_rust_project`, run on-save flycheck via
-`flycheck`, and auto-reload when any of the watched BUILD files change.
-
-`setup` is the one entry point for every editor — `vscode`, `neovim`, `helix`, `print`
-are subcommands; see [Editors other than VSCode](#editors-other-than-vscode) below for
-the other three. The shared flags (`--workspace`, `--output-user-root`,
-`--skip-proc-macro-server`, `--skip-rustfmt`) accept on any subcommand.
-
-`setup vscode` writes two artifacts:
-
-- Managed keys in `.vscode/settings.json`:
-  `rust-analyzer.workspace.discoverConfig`, `rust-analyzer.server.path`,
-  `rust-analyzer.procMacro.server`, `rust-analyzer.rustfmt.overrideCommand`,
-  `rust-analyzer.files.excludeDirs` (auto-populated with every immediate
-  subdirectory that contains a `Cargo.toml`, so rust-analyzer doesn't load
-  those as parallel cargo workspaces in addition to the discoverConfig
-  project), and matching `files.exclude` / `files.watcherExclude` /
-  `search.exclude` entries for the Bazel convenience symlinks. User keys are
-  preserved on re-runs.
-- Five small launcher scripts under `.vscode/.rules_rust_analyzer/`
-  (`rust_analyzer`, `rust_analyzer_proc_macro_srv`, `rustfmt`, `flycheck`,
-  `discover_bazel_rust_project`; `.sh` on POSIX, `.bat` on Windows). The
-  launchers — not `bazel-bin/` — are what the LSP / proc-macro /
-  rustfmt / discover / flycheck settings point at, so `bazel clean` doesn't
-  break the IDE: if the underlying wrapper binary is missing, the next launch
-  rebuilds it on demand; otherwise the launcher exec's it directly without
-  touching Bazel at all. That fast path matters because **Bazel serializes
-  commands per output_base** — wrapping every LSP / discover / format call
-  in `bazel run` would deadlock the IDE behind any concurrent
-  `bazel build` / CI run.
-
-With all keys wired up, **users do not need a host rust install**: rust-analyzer,
-proc-macro-srv, and rustfmt all come from the Bazel toolchain. `editor.formatOnSave`
-calls rust-analyzer's LSP formatting request, which spawns the rustfmt launcher,
-which exec's the Bazel-built rustfmt wrapper.
-
-Re-run `setup vscode` any time. Flags:
-
-- `--dry-run` previews the settings JSON. (vscode subcommand only)
-- `--replace` starts from scratch. (vscode subcommand only)
-- `--skip-proc-macro-server` leaves the proc-macro key alone.
-- `--skip-rustfmt` leaves the formatter key alone (use the host rustfmt instead).
-- `--output-user-root <abs-path>` overrides where the flycheck wrapper's
-  dedicated Bazel server lives (its `--output_user_root`). Default:
-  `${HOME}/.vscode-server/.rules_rust_analyzer/output_user_root` when that
-  directory exists (remote-SSH / Codespaces), else
-  `${HOME}/.vscode/.rules_rust_analyzer/output_user_root`. Required on
-  Windows for any non-trivial workspace: Bazel's path-length budget plus
-  the deepest `external/+...//bin/...` paths it generates can blow MAX_PATH;
-  point this at something short like `C:\ra-ob` or `D:\bzl\ra`.
-- `--per-package-workspaces` opts into rust-analyzer's per-package
-  workspace switching. Off by default — the whole workspace gets indexed
-  as one project, which is the simpler / less surprising default and
-  what most users want. Turn it on for monorepos where indexing the
-  whole graph hurts LSP responsiveness; the trade-off is that
-  rust-analyzer reloads (and re-runs discover) every time you jump to a
-  file in a different package, AND that dependents of the package you're
-  working on aren't indexed.
-
-### What you get in the editor
-
-- **`▶ Run Tests`** codelens on every `#[cfg(test)] mod ...` (runs all
-  tests in the module via `bazel test`).
-- **`▶ Run Test`** codelens on every individual `#[test]` function (runs
-  exactly that test via `bazel test --test_arg=--exact --test_arg=<id>`).
-- **On-save squiggles** from rustc diagnostics, via the flycheck wrapper.
-- **Format-on-save** via the Bazel-toolchain rustfmt.
-- **Workspace reload** when any watched BUILD / MODULE.bazel file changes.
-
-### Debugging
-
-The `▶ Debug` codelens that VSCode displays next to `#[test]` functions
-**does not work** with this setup, and we can't fix it from the
-rules_rust side. The VSCode rust-analyzer extension's debug handler
-([`editors/code/src/debug.ts`][ra-debug] in upstream) hard-bails on
-shell runnables — it only knows how to debug crates whose runnable is
-shaped as a cargo invocation, because it shells out to cargo with
-`--message-format=json --no-run` to discover the test binary path.
-Bazel projects emit shell runnables (`bazel test ...`), so the extension
-silently returns `undefined` and no debug session starts. Lifting this
-would need a PR upstream to teach the extension how to extract a binary
-path from a shell runnable.
-
-**The supported debug path is `.vscode/launch.json` + F5**, via the
-[`gen_launch_json` tool][gen-launch-json] this repository ships:
-
-```
-bazel run @rules_rust//tools/vscode:gen_launch_json
-```
-
-It queries Bazel for every `rust_binary` / `rust_test` target in the
-workspace and writes a `.vscode/launch.json` where each entry uses
-CodeLLDB's `targetCreateCommands` with a Python script that runs
-`bazel run --compilation_mode=dbg --strip=never --run_under=...
-<target>` to build + extract the binary path, then attaches LLDB. Pure
-Bazel invocation under the hood; works for any target without
-custom config. Re-run when targets change. Install
-[CodeLLDB][codelldb] (or `lldb-dap` / `vscode-lldb`) first.
-
-Caveat: per-target only, not per-`#[test]`-fn. Once a debug session is
-attached, set a breakpoint in the test you care about and re-run the
-target — libtest's test selection happens inside the binary, so a single
-launch config covers every test in the target.
-
-[ra-debug]: https://github.com/rust-lang/rust-analyzer/blob/master/editors/code/src/debug.ts
-[gen-launch-json]: https://github.com/bazelbuild/rules_rust/blob/main/tools/vscode/src/bin/gen_launch_json.rs
-[codelldb]: https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb
-
-## On-save diagnostics (flycheck)
-
-The assembled `rust-project.json` wires a `flycheck` runnable that
-rust-analyzer invokes whenever a file is saved. The runnable points at the
-flycheck launcher script (`.vscode/.rules_rust_analyzer/flycheck.sh` on
-POSIX, `.bat` on Windows), which exec's the `flycheck` wrapper binary —
-`setup` writes both.
-
-The wrapper runs `bazel build` on the saved file's owning crate with
-`error_format=json` and `--keep_going`, harvests every action's
-stderr from the build's Build Event Protocol stream, filters for rustc
-JSON messages, and streams them to stdout for rust-analyzer to render
-as inline diagnostics.
-
-The wrapper uses a **dedicated `--output_user_root`** (the path baked into
-the flycheck launcher at `setup` time; see `--output-user-root`
-above) so its `error_format=json` / `rustc_output_diagnostics=true` flags
-don't thrash the user's primary `bazel build` analysis cache. The two
-Bazel servers — yours and the flycheck one — are fully isolated.
-
-Failed actions are deliberately supported: rustc still emits its
-diagnostics to stderr before exiting non-zero, and BEP captures that
-stderr regardless of action outcome. The wrapper forwards Bazel's exit
-code so rust-analyzer can distinguish "build succeeded with no errors"
-from "build tool itself broke" (e.g. a BUILD-file syntax error).
-
-Downstream targets of a failed action don't get rebuilt — `--keep_going`
-lets other *independent* targets in the graph continue, but anything
-that depends on the failed crate is skipped. The user sees diagnostics
-on the broken crate; the cascade further down the graph is invisible
-until they fix the root cause and save again. This matches cargo's
-flycheck behavior (a `cargo check` that fails on `foo` doesn't go on to
-check `foo`'s dependents either) and is what users expect.
-
-No `rust-analyzer.check.overrideCommand` configuration is needed —
-flycheck is on by default.
-
-## Bazel-provided rust-analyzer
-
-The registered `rust_analyzer_toolchain` ships the rust-analyzer binary and
-proc-macro server matched to the toolchain's rustc/sysroot. Pointing your
-editor at those binaries — instead of the rust-analyzer extension's bundled
-copy — guarantees the LSP behavior agrees with `bazel build` and avoids
-proc-macro ABI mismatches.
-
-Two stable wrapper targets are provided:
-
-```
-bazel build @rules_rust//tools/rust_analyzer:rust_analyzer
-bazel build @rules_rust//tools/rust_analyzer:rust_analyzer_proc_macro_srv
-```
-
-VSCode users should NOT point `server.path` directly at `bazel-bin/...` —
-`bazel clean` would silently break the LSP until the next manual rebuild.
-**Use `setup` (see Quick Start above) instead.** It writes a launcher
-script at `.vscode/.rules_rust_analyzer/rust_analyzer.sh` that exec's the
-wrapper if it's already built and rebuilds it on demand if not, so the IDE
-keeps working across `bazel clean`s.
-
-For editors `setup` doesn't target, the same launcher pattern is the
-right shape. A minimal `rust_analyzer.sh`:
-
-```sh
-#!/bin/sh
-set -e
-WORKSPACE="$(cd "$(dirname "$0")/.." && pwd)"
-WRAPPER="$WORKSPACE/bazel-bin/tools/rust_analyzer/rust_analyzer"
-if [ ! -x "$WRAPPER" ]; then
-    cd "$WORKSPACE" && bazel build @rules_rust//tools/rust_analyzer:rust_analyzer >&2
-fi
-# rust-analyzer is itself a rules_rust binary when it spawns us — strip its
-# RUNFILES_* env so our wrapper resolves its OWN runfiles via argv[0].
-unset RUNFILES_DIR RUNFILES_MANIFEST_FILE
-exec "$WRAPPER" "$@"
-```
-
-Point your editor's `server.path` at that script. Setting `server.path` alone is
-usually sufficient because rust-analyzer uses itself as the proc-macro server
-when no explicit one is configured — the separate `rust_analyzer_proc_macro_srv`
-wrapper is only needed when an editor pins a different rust-analyzer version and
-you want the proc-macro ABI to track the Bazel rustc.
-
-## Editors other than VSCode
-
-Each non-VSCode IDE has its own subcommand. The subcommand:
-
-1. Installs the launcher scripts at an IDE-appropriate location (no
-   `.vscode/` references for non-VSCode editors).
-2. Prints a ready-to-paste config snippet to stdout with the launcher
-   paths baked in.
-
-You paste the snippet into the editor's config file. The launchers are
-self-contained — re-running setup updates them with current workspace /
-output-user-root paths but doesn't change the snippet shape, so the
-config in your editor file keeps working unless paths actually move.
+Existing user keys in `.vscode/settings.json` are preserved on re-runs.
+Pass `--dry-run` to preview the JSON without writing it; `--replace` to
+overwrite all managed keys (destroys user keys).
 
 ### Neovim
 
@@ -235,42 +29,11 @@ config in your editor file keeps working unless paths actually move.
 bazel run @rules_rust//tools/rust_analyzer:setup -- neovim
 ```
 
-Installs launchers under `<workspace>/.rules_rust_analyzer/` and prints
-an `nvim-lspconfig` Lua snippet to stdout. Pipe it into your config or
-copy-paste:
+Prints an `nvim-lspconfig` Lua snippet to stdout. Paste it into your
+`init.lua` (or pipe to a file you `require`). Restart Neovim.
 
-```
-bazel run @rules_rust//tools/rust_analyzer:setup -- neovim > /tmp/ra.lua
-```
-
-The snippet looks like:
-
-```lua
-require("lspconfig").rust_analyzer.setup({
-  cmd = { "/abs/workspace/.rules_rust_analyzer/rust_analyzer.sh" },
-  settings = {
-    ["rust-analyzer"] = {
-      workspace = {
-        discoverConfig = {
-          command = { "/abs/workspace/.rules_rust_analyzer/discover_bazel_rust_project.sh", "{arg}" },
-          progressLabel = "rules_rust",
-          filesToWatch = { "BUILD", "BUILD.bazel", "MODULE.bazel", "WORKSPACE", "WORKSPACE.bazel" },
-        },
-      },
-      procMacro = { server = "/abs/workspace/.rules_rust_analyzer/rust_analyzer_proc_macro_srv.sh" },
-      rustfmt = { overrideCommand = { "/abs/workspace/.rules_rust_analyzer/rustfmt.sh" } },
-      files = { excludeDirs = { "cargo", "crate_universe" } },
-      lens = { enable = true },
-    },
-  },
-})
-```
-
-Drop into your `init.lua` (or a plugin module). Absolute paths are
-baked at install time — re-run `setup neovim` if the workspace moves.
-
-For users on [`rustaceanvim`](https://github.com/mrcjkb/rustaceanvim)
-instead: pass the same `cmd` and `settings` table via its `server`
+For [`rustaceanvim`](https://github.com/mrcjkb/rustaceanvim) users:
+pass the printed `cmd` and `settings` table through its `server`
 option (`vim.g.rustaceanvim = { server = { cmd = ..., settings = ... } }`).
 
 ### Helix
@@ -279,123 +42,102 @@ option (`vim.g.rustaceanvim = { server = { cmd = ..., settings = ... } }`).
 bazel run @rules_rust//tools/rust_analyzer:setup -- helix
 ```
 
-Installs launchers under `<workspace>/.helix/.rules_rust_analyzer/`
-(Helix already conventionally uses `.helix/` for per-project config) and
-prints a `languages.toml` snippet for you to paste into
-`<workspace>/.helix/languages.toml`:
+Prints a `languages.toml` snippet. Paste it into
+`<workspace>/.helix/languages.toml`. Restart Helix.
 
-```toml
-[language-server.rust-analyzer]
-command = "/abs/workspace/.helix/.rules_rust_analyzer/rust_analyzer.sh"
-
-[language-server.rust-analyzer.config.rust-analyzer.workspace.discoverConfig]
-command = ["/abs/workspace/.helix/.rules_rust_analyzer/discover_bazel_rust_project.sh", "{arg}"]
-progressLabel = "rules_rust"
-filesToWatch = ["BUILD", "BUILD.bazel", "MODULE.bazel", "WORKSPACE", "WORKSPACE.bazel"]
-# ...etc
-```
-
-### Vim (classic) and other JSON-config LSP clients
+### Other editors (`coc.nvim`, `vim-lsp`, ALE, etc.)
 
 ```
 bazel run @rules_rust//tools/rust_analyzer:setup -- print
 ```
 
-Installs launchers under `<workspace>/.rules_rust_analyzer/` and prints
-a generic JSON snippet using the `rust-analyzer.*` keys VSCode uses —
-[`coc.nvim`](https://github.com/neoclide/coc.nvim) reads the same
-namespace via `coc-settings.json` (open with `:CocConfig`); `vim-lsp` /
-`ALE` / `LanguageClient-neovim` settings are configured in plugin-
-specific ways but accept the same keys. Paste the snippet into the
-relevant settings file:
+Prints a generic JSON snippet using the `rust-analyzer.*` keys VSCode
+uses. `coc.nvim` reads them via `coc-settings.json` (open with
+`:CocConfig`); `vim-lsp` / ALE / `LanguageClient-neovim` accept the
+same keys via plugin-specific config files.
 
-```json
-{
-  "rust-analyzer.server.path": "/abs/workspace/.rules_rust_analyzer/rust_analyzer.sh",
-  "rust-analyzer.workspace.discoverConfig": {
-    "command": ["/abs/workspace/.rules_rust_analyzer/discover_bazel_rust_project.sh", "{arg}"],
-    "progressLabel": "rules_rust",
-    "filesToWatch": ["BUILD", "BUILD.bazel", "MODULE.bazel", "WORKSPACE", "WORKSPACE.bazel"]
-  },
-  "rust-analyzer.procMacro.server": "/abs/workspace/.rules_rust_analyzer/rust_analyzer_proc_macro_srv.sh",
-  "rust-analyzer.rustfmt.overrideCommand": ["/abs/workspace/.rules_rust_analyzer/rustfmt.sh"],
-  "rust-analyzer.files.excludeDirs": ["cargo", "crate_universe"],
-  "rust-analyzer.lens.enable": true
-}
+## Flags
+
+Re-runnable at any time. All flags work on any subcommand.
+
+| Flag | Effect |
+|---|---|
+| `--skip-proc-macro-server` | Don't manage the proc-macro key. |
+| `--skip-rustfmt` | Don't manage the formatter key (use host rustfmt). |
+| `--output-user-root <abs-path>` | `--output_user_root` for flycheck's dedicated Bazel server. Required on Windows for non-trivial workspaces (MAX_PATH). |
+| `--cache-dir <abs-path>` | Where discover writes its merged-JSON cache. |
+| `--per-package-workspaces` | Opt in to per-package workspace splitting (see below). |
+
+VSCode subcommand also accepts `--dry-run` (preview JSON without writing) and
+`--replace` (overwrite all managed keys, destroying user keys).
+
+## What you get
+
+- **`▶ Run Tests` / `▶ Run Test`** codelens on every `#[cfg(test)] mod` and
+  individual `#[test]`.
+- **On-save squiggles** from rustc diagnostics. Matches `cargo check` —
+  errors anywhere in the dep graph surface at their actual file paths.
+- **Format-on-save** via the Bazel-toolchain rustfmt.
+- **Workspace reload** on watched `BUILD` / `MODULE.bazel` changes.
+
+## Troubleshooting
+
+### Stale or wrong project model
+
+Discovery memoizes the assembled `rust-project.json` in a local cache
+keyed on every input. If the IDE shows symbols / deps that don't match
+what `bazel build` actually produces — and re-running discovery
+(restart rust-analyzer, or save a `BUILD` file) doesn't fix it — nuke
+the cache and try again:
+
+```
+rm -rf <workspace>/<editor-dir>/.rules_rust_analyzer/cache
 ```
 
-## How it works
+Where `<editor-dir>` is `.vscode` for VSCode, `.helix` for Helix, or
+empty for Neovim / `print` (cache sits at `<workspace>/.rules_rust_analyzer/cache`).
 
-### Project model
+If you passed `--cache-dir` at setup time, the cache is wherever you
+pointed it instead.
 
-The discover binary reads each Bazel rust target's per-crate spec file
-(produced by `rust_analyzer_aspect` as a side effect of `bazel build`),
-consolidates duplicates, absolutizes the `__WORKSPACE__` / `__EXEC_ROOT__`
-/ `__OUTPUT_BASE__` templates, and streams a JSON document with the shape
-rust-analyzer expects to stdout. The document is the in-memory equivalent
-of the `rust-project.json` file rust-analyzer would read from disk in the
-manual-config flow.
+The cache survives `bazel clean` by design (it lives in the workspace,
+not the Bazel output base) so a full Bazel rebuild won't invalidate
+stale entries — that's what the manual `rm -rf` is for.
 
-### Crate model (cycles, lib/test pairs)
+### Diagnostics stopped appearing
 
-Each Bazel rust target produces exactly one rust-analyzer crate, keyed by
-the target's label. A `rust_library(name = "lib")` and its
-`rust_test(name = "lib_test", crate = ":lib")` show up as **two** distinct
-crates that share a `root_module` — exactly how cargo models a lib and its
-integrated tests. They are not merged into one crate with a union of deps.
+Check `<workspace>/.rules_rust_analyzer/flycheck.log` — the on-save
+wrapper appends one line per internal failure.
 
-This eliminates the only way Bazel-built projects could exhibit "cycles"
-in the rust-analyzer graph: the previous heuristic keyed crates by
-`root_module` path, so the lib and test specs would merge, and the test's
-test-only deps would end up on the merged "lib" crate. When two packages'
-test-only deps reached back into each other's libs, the merged graph
-contained a cycle that Bazel's own build graph never had. Project loading
-would then fail with `"Failed to make progress on building crate
-dependency graph"` and rust-analyzer would show nothing.
+## Workspace splitting
 
-Under the label-keyed scheme this can't happen — the test crate carries
-its own deps directly, no merge is performed, and the assembly step
-tolerates forward references, missing deps, and even genuine cycles by
-silently dropping unresolvable edges instead of bailing out.
-
-### Performance
-
-Auto-discovery uses Bazel's [Build Event Protocol][bep] to learn the paths of the per-crate spec
-files produced by `rust_analyzer_aspect` — a side-effect of the `bazel build` that's already
-running, so there's no separate `bazel aquery` round-trip. Discovery only includes spec files
-that the **current** build's action graph actually produced; stale `*.rust_analyzer_crate_spec.json`
-files left behind in `bazel-out/` by deleted targets or no-longer-reachable configurations are
-correctly ignored.
-
-The assembled `rust-project.json` is then memoized in a content-addressed local cache under
-`<workspace>/.vscode/.rules_rust_analyzer/cache/`. The key includes the contents of every
-input spec, a version constant that's bumped whenever the assembled JSON shape changes, the
-toolchain info, and the bazel/workspace/execution-root paths, so the cache is only served
-when every input matches byte-for-byte. Living under `.vscode/` (not the Bazel output base)
-means it survives `bazel clean` — but clearing it is a single `rm -rf
-.vscode/.rules_rust_analyzer/cache/` if a hand-edit ever leaves it inconsistent.
-
-In practice, a warm-cache discovery on a large workspace runs in the time it takes Bazel to
-report its action-cache hits — typically a few seconds.
-
-### Workspace splitting
-
-By default, `setup` configures rust-analyzer to treat the whole
-project as a single workspace — simpler to reason about, no surprise
-context switches when you jump between files. The discover command is
-invoked with just the launcher path and no per-file argument.
+By default the whole project is treated as a single workspace.
 
 For monorepos where indexing the whole graph is too slow, pass
-`--per-package-workspaces` to setup. That appends `"{arg}"` to the
-discover command array; rust-analyzer fills it with the path of the
-file you opened, and discover scopes the project to that file's package
-+ deps. rust-analyzer reloads (and re-runs discover) whenever you jump
-to a file in a different package.
+`--per-package-workspaces`. Discover then scopes to the saved file's
+package + deps; rust-analyzer reloads when you jump to a different
+package. Caveat: _dependents_ of the package you're working on aren't
+indexed, so "find usages" can miss callers in other packages.
 
-Caveat of per-package mode: _dependents_ of the package you're working
-on are not indexed and won't be tracked by `rust-analyzer`. If you go
-fix a callee, then re-open a caller in a different package, the caller's
-view of the callee is whatever the caller's own discover saw.
+Switch any time by re-running `setup` with or without the flag.
 
-You can switch modes any time by re-running `setup vscode` (or your
-editor's subcommand) with or without `--per-package-workspaces`.
+## Debugging
+
+The `▶ Debug` codelens VSCode renders next to `#[test]` functions
+**does not work** — the VSCode rust-analyzer extension's debug handler
+only supports cargo-shaped runnables, and Bazel projects emit shell
+runnables. Lifting this needs an upstream PR.
+
+The supported debug path is `.vscode/launch.json` + F5:
+
+```
+bazel run @rules_rust//tools/vscode:gen_launch_json
+```
+
+Writes a per-target launch config that uses CodeLLDB's
+`targetCreateCommands` to build with `--compilation_mode=dbg
+--strip=never` and attach LLDB. Install
+[CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
+first. Set a breakpoint inside the test you care about and re-run the
+target — libtest selects tests inside the binary, so one launch config
+covers every test in the target.

--- a/tools/rust_analyzer/bin/setup.rs
+++ b/tools/rust_analyzer/bin/setup.rs
@@ -117,6 +117,14 @@ const OUTPUT_USER_ROOT_PLACEHOLDER: &str = "__RULES_RUST_RA_OUTPUT_USER_ROOT__";
 /// contain this placeholder — nothing else touches the cache.
 const CACHE_DIR_PLACEHOLDER: &str = "__RULES_RUST_RA_CACHE_DIR__";
 
+/// Baked at install time with the editor-specific launcher dir setup
+/// wrote launchers into. discover reads it (via `$RULES_RUST_RA_LAUNCHER_DIR`)
+/// and uses it to materialize the flycheck runnable's `program` path in
+/// the assembled rust-project.json. Only the discover launcher
+/// templates contain this placeholder — the other launchers don't
+/// publish runnables.
+const LAUNCHER_DIR_PLACEHOLDER: &str = "__RULES_RUST_RA_LAUNCHER_DIR__";
+
 // ---------------------------------------------------------------------------
 // Launcher flavor (POSIX vs Windows)
 // ---------------------------------------------------------------------------
@@ -190,9 +198,11 @@ struct Cli {
 
     /// `--output_user_root` to bake into the flycheck launcher (the
     /// dedicated Bazel server for on-save diagnostics, isolated from the
-    /// user's primary `bazel build`). Picks a HOME-rooted default when
-    /// unset — see [`default_output_user_root`]. Required on Windows for
-    /// any non-trivial workspace: Bazel's path-length budget vs MAX_PATH.
+    /// user's primary `bazel build`). Defaults to
+    /// `<launcher-dir>/output_user_root`, i.e. nested inside the
+    /// editor-specific subdir setup writes launchers to. Required on
+    /// Windows for any non-trivial workspace: Bazel's path-length
+    /// budget vs MAX_PATH.
     #[arg(long, global = true)]
     output_user_root: Option<Utf8PathBuf>,
 
@@ -271,14 +281,22 @@ fn main() -> Result<()> {
     } = Cli::parse();
 
     let workspace = workspace.unwrap_or_else(|| Utf8PathBuf::from("."));
-    let output_user_root = output_user_root.unwrap_or_else(|| default_output_user_root(&workspace));
-    let cache_dir = cache_dir.unwrap_or_else(|| default_cache_dir(&workspace));
+    let launcher_dir = launcher_dir_for(&workspace, &ide);
+    // Default cache + output_user_root sit alongside the launcher
+    // scripts so they share the editor's chosen home (vscode lives
+    // under `.vscode/.rules_rust_analyzer/`, helix under
+    // `.helix/.rules_rust_analyzer/`, neovim/print under the
+    // workspace-root `.rules_rust_analyzer/`). CLI flags override.
+    let output_user_root =
+        output_user_root.unwrap_or_else(|| launcher_dir.join("output_user_root"));
+    let cache_dir = cache_dir.unwrap_or_else(|| launcher_dir.join("cache"));
     let flavor = LauncherFlavor::detect();
     info!("Using --output_user_root = {output_user_root}");
     info!("Using --cache-dir = {cache_dir}");
 
     let ctx = SetupCtx {
         workspace,
+        launcher_dir,
         output_user_root,
         cache_dir,
         flavor,
@@ -296,10 +314,13 @@ fn main() -> Result<()> {
 }
 
 /// Shared state computed once at startup and threaded through every
-/// per-IDE runner. Keeping this in one struct avoids passing the same 5
-/// arguments to every helper function.
+/// per-IDE runner.
 struct SetupCtx {
     workspace: Utf8PathBuf,
+    /// Editor-specific dir setup writes launcher scripts into. Defaults
+    /// for cache_dir / output_user_root sit alongside it unless the
+    /// user passed CLI overrides.
+    launcher_dir: Utf8PathBuf,
     output_user_root: Utf8PathBuf,
     cache_dir: Utf8PathBuf,
     flavor: LauncherFlavor,
@@ -336,13 +357,9 @@ fn run_vscode(ctx: &SetupCtx, args: VscodeArgs) -> Result<()> {
     } else {
         ctx.workspace.join(&args.output)
     };
-    let vscode_dir = output_path
-        .parent()
-        .map(|p| p.to_owned())
-        .unwrap_or_else(|| ctx.workspace.join(".vscode"));
-    let launcher_dir = vscode_dir.join(LAUNCHER_SUBDIR);
+    let launcher_dir = &ctx.launcher_dir;
 
-    let managed = vscode_managed_keys(ctx, &launcher_dir);
+    let managed = vscode_managed_keys(ctx, launcher_dir);
     let key_count = managed.len();
 
     let merged = if args.replace {
@@ -362,7 +379,7 @@ fn run_vscode(ctx: &SetupCtx, args: VscodeArgs) -> Result<()> {
     }
 
     write_settings(output_path.as_std_path(), &merged)?;
-    write_all_launchers(ctx, &launcher_dir)?;
+    write_all_launchers(ctx, launcher_dir)?;
 
     info!(
         "{} {} key(s) in {} (+ {:?} launcher scripts in {})",
@@ -380,11 +397,9 @@ fn run_vscode(ctx: &SetupCtx, args: VscodeArgs) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn run_neovim(ctx: &SetupCtx) -> Result<()> {
-    // Neovim has no canonical per-project dotdir — drop launchers at the
-    // workspace root in `.rules_rust_analyzer/`.
-    let launcher_dir = ctx.workspace.join(LAUNCHER_SUBDIR);
-    write_all_launchers(ctx, &launcher_dir)?;
-    let snippet = generate_neovim_lua(ctx, &launcher_dir);
+    let launcher_dir = &ctx.launcher_dir;
+    write_all_launchers(ctx, launcher_dir)?;
+    let snippet = generate_neovim_lua(ctx, launcher_dir);
     print_snippet_with_banner("Add this to your init.lua (nvim-lspconfig):", &snippet);
     info!(
         "Wrote {} launcher script(s) to {}",
@@ -399,11 +414,9 @@ fn run_neovim(ctx: &SetupCtx) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn run_helix(ctx: &SetupCtx) -> Result<()> {
-    // Helix already conventionally uses `.helix/` for per-project config
-    // (`.helix/languages.toml` etc.), so nest the launchers there.
-    let launcher_dir = ctx.workspace.join(".helix").join(LAUNCHER_SUBDIR);
-    write_all_launchers(ctx, &launcher_dir)?;
-    let snippet = generate_helix_toml(ctx, &launcher_dir);
+    let launcher_dir = &ctx.launcher_dir;
+    write_all_launchers(ctx, launcher_dir)?;
+    let snippet = generate_helix_toml(ctx, launcher_dir);
     print_snippet_with_banner(
         "Add this to .helix/languages.toml at the workspace root:",
         &snippet,
@@ -421,9 +434,9 @@ fn run_helix(ctx: &SetupCtx) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn run_print(ctx: &SetupCtx) -> Result<()> {
-    let launcher_dir = ctx.workspace.join(LAUNCHER_SUBDIR);
-    write_all_launchers(ctx, &launcher_dir)?;
-    let snippet = generate_settings_json(ctx, &launcher_dir);
+    let launcher_dir = &ctx.launcher_dir;
+    write_all_launchers(ctx, launcher_dir)?;
+    let snippet = generate_settings_json(ctx, launcher_dir);
     print_snippet_with_banner(
         "Add this to your editor's rust-analyzer settings (coc-settings.json, etc.):",
         &snippet,
@@ -461,6 +474,7 @@ fn launcher_filename(basename: &str, flavor: LauncherFlavor) -> String {
     format!("{basename}.{}", flavor.extension())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_launcher(
     dir: &Utf8Path,
     basename: &str,
@@ -479,6 +493,9 @@ fn write_launcher(
         workspace_root.as_str(),
         output_user_root.as_str(),
         cache_dir.as_str(),
+        // The launcher's own directory is also the launcher_dir the
+        // flycheck runnable should point at — they're always the same.
+        dir.as_str(),
     );
     fs::write(&path, body).with_context(|| format!("writing launcher {path}"))?;
     if flavor == LauncherFlavor::Posix {
@@ -498,9 +515,10 @@ fn write_launcher(
 }
 
 /// Substitute the launcher template placeholders. `WORKSPACE_ROOT_PLACEHOLDER`
-/// is present in every template; `OUTPUT_USER_ROOT_PLACEHOLDER` only in the
-/// flycheck templates; `CACHE_DIR_PLACEHOLDER` only in the discover templates.
-/// `replace` is a no-op when a placeholder is absent, so a single function
+/// is present in every template; `OUTPUT_USER_ROOT_PLACEHOLDER` only in
+/// the flycheck templates; `CACHE_DIR_PLACEHOLDER` and
+/// `LAUNCHER_DIR_PLACEHOLDER` only in the discover templates. `replace`
+/// is a no-op when a placeholder is absent, so a single function
 /// handles every template.
 ///
 /// All substituted paths are normalized to forward slashes — see
@@ -510,6 +528,7 @@ fn bake_placeholders(
     workspace_root: &str,
     output_user_root: &str,
     cache_dir: &str,
+    launcher_dir: &str,
 ) -> String {
     template
         .replace(
@@ -521,6 +540,7 @@ fn bake_placeholders(
             &to_forward_slashes(output_user_root),
         )
         .replace(CACHE_DIR_PLACEHOLDER, &to_forward_slashes(cache_dir))
+        .replace(LAUNCHER_DIR_PLACEHOLDER, &to_forward_slashes(launcher_dir))
 }
 
 /// Normalize backslashes to forward slashes. Applied to every path we
@@ -549,70 +569,33 @@ fn to_forward_slashes(path: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// Output_user_root default + HOME resolution
+// Editor-relative defaults
 // ---------------------------------------------------------------------------
 
-/// Pick where the dedicated rules_rust Bazel server should live when the
-/// user didn't pass `--output-user-root` explicitly.
-///
-/// Default search order:
-///   1. `${HOME}/.vscode-server/.rules_rust_analyzer/output_user_root` —
-///      preferred when that directory exists, which is the signal that
-///      we're running inside VSCode Remote-SSH / Codespaces / WSL on the
-///      remote side.
-///   2. `${HOME}/.vscode/.rules_rust_analyzer/output_user_root` — the
-///      local-VSCode case. `.vscode/` is created lazily on first run.
-///   3. `<workspace>/.vscode/.rules_rust_analyzer/output_user_root` —
-///      fallback when neither `HOME` nor `USERPROFILE` is set (CI shells,
-///      bare containers). Workspace-local means it loses the per-user
-///      cache-sharing property but at least keeps the shim from
-///      exploding.
-///
-/// Per-workspace isolation is handled by Bazel itself: under
-/// `--output_user_root`, Bazel hashes the workspace path into a subdir,
-/// so multiple workspaces pointing at the same root each get their own
-/// server / cache and never collide.
-///
-/// The default still uses `.vscode-server` / `.vscode` even for non-VSCode
-/// IDEs — those directories are simply convenient HOME-relative places to
-/// stash a Bazel output root, and they already get gitignored on most
-/// machines. Override with `--output-user-root` if you'd rather keep it
-/// elsewhere.
-fn default_output_user_root(workspace: &Utf8Path) -> Utf8PathBuf {
-    if let Some(home) = home_dir() {
-        let server = home.join(".vscode-server");
-        if server.is_dir() {
-            return server.join(".rules_rust_analyzer").join("output_user_root");
+/// Resolve the launcher directory for a given IDE subcommand. Setup is
+/// authoritative over launcher/cache/output_user_root placement; every
+/// downstream default is computed by appending to whatever this
+/// returns.
+fn launcher_dir_for(workspace: &Utf8Path, ide: &IdeCmd) -> Utf8PathBuf {
+    match ide {
+        IdeCmd::Vscode(args) => {
+            let output_path = if args.output.is_absolute() {
+                args.output.clone()
+            } else {
+                workspace.join(&args.output)
+            };
+            output_path
+                .parent()
+                .map(|p| p.to_owned())
+                .unwrap_or_else(|| workspace.join(".vscode"))
+                .join(LAUNCHER_SUBDIR)
         }
-        return home
-            .join(".vscode")
-            .join(".rules_rust_analyzer")
-            .join("output_user_root");
+        IdeCmd::Helix => workspace.join(".helix").join(LAUNCHER_SUBDIR),
+        // Neovim has no canonical per-project dotdir; print covers
+        // editor-agnostic JSON-config LSP clients. Both land at the
+        // workspace root.
+        IdeCmd::Neovim | IdeCmd::Print => workspace.join(LAUNCHER_SUBDIR),
     }
-    workspace
-        .join(".vscode")
-        .join(".rules_rust_analyzer")
-        .join("output_user_root")
-}
-
-/// Default merge-cache directory: workspace-local
-/// `.rules_rust_analyzer/cache/`. Mirrored from `cache::CACHE_DIR_REL`
-/// (we don't depend on `gen_rust_project_lib` here just for that one
-/// constant — it's small enough to duplicate, and a test catches any
-/// drift if either side moves).
-fn default_cache_dir(workspace: &Utf8Path) -> Utf8PathBuf {
-    workspace.join(".rules_rust_analyzer").join("cache")
-}
-
-/// Cross-platform user home. Reads `HOME` on POSIX-y systems and
-/// `USERPROFILE` on Windows — the same two variables `dirs::home_dir`
-/// consults, without taking the dep.
-fn home_dir() -> Option<Utf8PathBuf> {
-    let var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
-    std::env::var(var)
-        .ok()
-        .filter(|s| !s.is_empty())
-        .map(Utf8PathBuf::from)
 }
 
 // ---------------------------------------------------------------------------
@@ -1199,11 +1182,10 @@ mod tests {
         let workspace = Utf8PathBuf::from("/ws");
         let launcher_dir = workspace.join(".vscode").join(LAUNCHER_SUBDIR);
         let ctx = SetupCtx {
-            cache_dir: default_cache_dir(&workspace),
             workspace,
-            output_user_root: Utf8PathBuf::from(
-                "/home/u/.vscode/.rules_rust_analyzer/output_user_root",
-            ),
+            output_user_root: launcher_dir.join("output_user_root"),
+            cache_dir: launcher_dir.join("cache"),
+            launcher_dir: launcher_dir.clone(),
             flavor: LauncherFlavor::Posix,
             skip_proc_macro_server: false,
             skip_rustfmt: false,
@@ -1421,15 +1403,23 @@ mod tests {
     }
 
     #[test]
-    fn bake_placeholders_substitutes_all_three_placeholders() {
-        let template = "WS=\"__WORKSPACE_ROOT__\"\nOUR=\"__RULES_RUST_RA_OUTPUT_USER_ROOT__\"\nCACHE=\"__RULES_RUST_RA_CACHE_DIR__\"\n";
-        let baked = bake_placeholders(template, "/abs/ws", "/home/u/out", "/abs/ws/cache");
+    fn bake_placeholders_substitutes_all_four_placeholders() {
+        let template = "WS=\"__WORKSPACE_ROOT__\"\nOUR=\"__RULES_RUST_RA_OUTPUT_USER_ROOT__\"\nCACHE=\"__RULES_RUST_RA_CACHE_DIR__\"\nLDIR=\"__RULES_RUST_RA_LAUNCHER_DIR__\"\n";
+        let baked = bake_placeholders(
+            template,
+            "/abs/ws",
+            "/home/u/out",
+            "/abs/ws/cache",
+            "/abs/ws/.vscode/.rules_rust_analyzer",
+        );
         assert!(baked.contains("WS=\"/abs/ws\""));
         assert!(baked.contains("OUR=\"/home/u/out\""));
         assert!(baked.contains("CACHE=\"/abs/ws/cache\""));
+        assert!(baked.contains("LDIR=\"/abs/ws/.vscode/.rules_rust_analyzer\""));
         assert!(!baked.contains(WORKSPACE_ROOT_PLACEHOLDER));
         assert!(!baked.contains(OUTPUT_USER_ROOT_PLACEHOLDER));
         assert!(!baked.contains(CACHE_DIR_PLACEHOLDER));
+        assert!(!baked.contains(LAUNCHER_DIR_PLACEHOLDER));
     }
 
     #[test]
@@ -1453,6 +1443,31 @@ mod tests {
             assert!(
                 !body.contains(CACHE_DIR_PLACEHOLDER),
                 "{name} unexpectedly contains the cache-dir placeholder"
+            );
+        }
+    }
+
+    #[test]
+    fn launcher_dir_placeholder_is_present_only_in_discover_launchers() {
+        // Discover bakes the editor-specific launcher dir so the flycheck
+        // runnable it materializes in rust-project.json points at the
+        // right path. Other launchers don't publish runnables and must
+        // not contain the placeholder.
+        assert!(DISCOVER_LAUNCHER_SH.contains(LAUNCHER_DIR_PLACEHOLDER));
+        assert!(DISCOVER_LAUNCHER_BAT.contains(LAUNCHER_DIR_PLACEHOLDER));
+        for (name, body) in [
+            ("ra.sh", RA_LAUNCHER_SH),
+            ("ra.bat", RA_LAUNCHER_BAT),
+            ("pms.sh", PMS_LAUNCHER_SH),
+            ("pms.bat", PMS_LAUNCHER_BAT),
+            ("rustfmt.sh", RUSTFMT_LAUNCHER_SH),
+            ("rustfmt.bat", RUSTFMT_LAUNCHER_BAT),
+            ("flycheck.sh", FLYCHECK_LAUNCHER_SH),
+            ("flycheck.bat", FLYCHECK_LAUNCHER_BAT),
+        ] {
+            assert!(
+                !body.contains(LAUNCHER_DIR_PLACEHOLDER),
+                "{name} unexpectedly contains the launcher-dir placeholder"
             );
         }
     }
@@ -1510,32 +1525,46 @@ mod tests {
     }
 
     #[test]
-    fn default_output_user_root_falls_back_to_workspace_without_home() {
-        // Isolate from the test runner's real HOME / USERPROFILE so the
-        // fallback branch is actually exercised. We restore both because
-        // other tests in this binary may rely on them.
-        let saved_home = std::env::var("HOME").ok();
-        let saved_userprofile = std::env::var("USERPROFILE").ok();
-        // SAFETY: tests are single-threaded with --test-threads=1 in
-        // Bazel's default rust_test config, so env mutation is fine.
-        unsafe {
-            std::env::remove_var("HOME");
-            std::env::remove_var("USERPROFILE");
-        }
+    fn launcher_dir_for_picks_editor_specific_subdir() {
         let ws = Utf8PathBuf::from("/workspace");
-        let resolved = default_output_user_root(&ws);
         assert_eq!(
-            resolved,
-            Utf8PathBuf::from("/workspace/.vscode/.rules_rust_analyzer/output_user_root"),
+            launcher_dir_for(
+                &ws,
+                &IdeCmd::Vscode(VscodeArgs {
+                    output: Utf8PathBuf::from(".vscode/settings.json"),
+                    dry_run: false,
+                    replace: false,
+                }),
+            ),
+            Utf8PathBuf::from("/workspace/.vscode/.rules_rust_analyzer"),
         );
-        unsafe {
-            if let Some(v) = saved_home {
-                std::env::set_var("HOME", v);
-            }
-            if let Some(v) = saved_userprofile {
-                std::env::set_var("USERPROFILE", v);
-            }
-        }
+        assert_eq!(
+            launcher_dir_for(&ws, &IdeCmd::Helix),
+            Utf8PathBuf::from("/workspace/.helix/.rules_rust_analyzer"),
+        );
+        assert_eq!(
+            launcher_dir_for(&ws, &IdeCmd::Neovim),
+            Utf8PathBuf::from("/workspace/.rules_rust_analyzer"),
+        );
+        assert_eq!(
+            launcher_dir_for(&ws, &IdeCmd::Print),
+            Utf8PathBuf::from("/workspace/.rules_rust_analyzer"),
+        );
+    }
+
+    #[test]
+    fn launcher_dir_for_vscode_honors_custom_output() {
+        let ws = Utf8PathBuf::from("/workspace");
+        // Custom output path → launcher dir sits alongside it.
+        let custom = IdeCmd::Vscode(VscodeArgs {
+            output: Utf8PathBuf::from(".custom/conf.json"),
+            dry_run: false,
+            replace: false,
+        });
+        assert_eq!(
+            launcher_dir_for(&ws, &custom),
+            Utf8PathBuf::from("/workspace/.custom/.rules_rust_analyzer"),
+        );
     }
 
     #[test]

--- a/tools/rust_analyzer/cache.rs
+++ b/tools/rust_analyzer/cache.rs
@@ -46,12 +46,14 @@ const CACHE_SCHEMA_VERSION: u32 = 0;
 ///
 /// `spec_contents` should already be sorted by spec path so the key is
 /// independent of file-system enumeration order.
+#[allow(clippy::too_many_arguments)]
 pub fn compute_key(
     spec_contents: &[(Utf8PathBuf, String)],
     toolchain_info: &str,
     bazel: &Utf8Path,
     workspace: &Utf8Path,
     execution_root: &Utf8Path,
+    launcher_dir: &str,
 ) -> String {
     let mut hasher = DefaultHasher::new();
     CACHE_SCHEMA_VERSION.hash(&mut hasher);
@@ -59,12 +61,25 @@ pub fn compute_key(
     workspace.as_str().hash(&mut hasher);
     execution_root.as_str().hash(&mut hasher);
     toolchain_info.hash(&mut hasher);
+    // Hashed because `flycheck_launcher_path` in `rust_project.rs` reads
+    // `$RULES_RUST_RA_LAUNCHER_DIR` to bake an absolute path into the
+    // assembled JSON. If we left this out, switching editors
+    // (vscode→neovim→helix) on the same workspace would silently serve
+    // the previously-cached editor's launcher path.
+    launcher_dir.hash(&mut hasher);
     for (path, content) in spec_contents {
         path.as_str().hash(&mut hasher);
         content.hash(&mut hasher);
     }
     format!("{:016x}", hasher.finish())
 }
+
+/// Env var setup bakes into the discover launcher carrying the editor-
+/// specific directory where launchers live. Consumed by both
+/// `compute_key` (cache shard) and `rust_project::flycheck_launcher_path`
+/// (path embedded in the assembled JSON). Reading it once at the call
+/// site keeps both readers consistent.
+pub const LAUNCHER_DIR_ENV_VAR: &str = "RULES_RUST_RA_LAUNCHER_DIR";
 
 /// Env var that overrides the cache directory location. `setup` bakes the
 /// resolved path into the discover launcher (`export RULES_RUST_RA_CACHE_DIR=...`)
@@ -74,7 +89,13 @@ const CACHE_DIR_ENV_VAR: &str = "RULES_RUST_RA_CACHE_DIR";
 
 /// Resolve the cache directory. `$RULES_RUST_RA_CACHE_DIR` wins if set;
 /// otherwise we fall back to `<workspace>/.rules_rust_analyzer/cache`.
-/// Callers can use this directly when they want to list / nuke entries.
+///
+/// `setup` is authoritative over the actual location — it bakes the
+/// resolved path (editor-specific or `--cache-dir`-overridden) into the
+/// discover launcher's `$RULES_RUST_RA_CACHE_DIR` env. This fallback
+/// only fires when discover is invoked outside the launcher (e.g.
+/// direct exec for debugging); the workspace-local default keeps that
+/// case from depending on per-user state.
 pub fn cache_dir(workspace: &Utf8Path) -> Utf8PathBuf {
     if let Ok(s) = std::env::var(CACHE_DIR_ENV_VAR) {
         if !s.is_empty() {
@@ -145,8 +166,8 @@ mod tests {
                 String::from("{\"id\":\"b\"}"),
             ),
         ];
-        let k1 = compute_key(&specs, toolchain, bazel, ws, er);
-        let k2 = compute_key(&specs, toolchain, bazel, ws, er);
+        let k1 = compute_key(&specs, toolchain, bazel, ws, er, "");
+        let k2 = compute_key(&specs, toolchain, bazel, ws, er, "");
         assert_eq!(k1, k2);
     }
 
@@ -159,8 +180,8 @@ mod tests {
         let base = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         let mutated = vec![(Utf8PathBuf::from("a.json"), "b".to_string())];
         assert_ne!(
-            compute_key(&base, toolchain, bazel, ws, er),
-            compute_key(&mutated, toolchain, bazel, ws, er)
+            compute_key(&base, toolchain, bazel, ws, er, ""),
+            compute_key(&mutated, toolchain, bazel, ws, er, "")
         );
     }
 
@@ -171,8 +192,8 @@ mod tests {
         let er = Utf8Path::new("/er");
         let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         assert_ne!(
-            compute_key(&specs, "{\"sysroot\":\"a\"}", bazel, ws, er),
-            compute_key(&specs, "{\"sysroot\":\"b\"}", bazel, ws, er),
+            compute_key(&specs, "{\"sysroot\":\"a\"}", bazel, ws, er, ""),
+            compute_key(&specs, "{\"sysroot\":\"b\"}", bazel, ws, er, ""),
         );
     }
 
@@ -182,8 +203,38 @@ mod tests {
         let er = Utf8Path::new("/er");
         let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         assert_ne!(
-            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws1"), er),
-            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws2"), er),
+            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws1"), er, ""),
+            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws2"), er, ""),
+        );
+    }
+
+    #[test]
+    fn compute_key_changes_with_launcher_dir() {
+        // Editor switch on the same workspace must invalidate the
+        // cache, otherwise the assembled rust-project.json would still
+        // contain the previously-cached launcher path (see comment in
+        // `compute_key`).
+        let bazel = Utf8Path::new("/usr/bin/bazel");
+        let ws = Utf8Path::new("/ws");
+        let er = Utf8Path::new("/er");
+        let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
+        assert_ne!(
+            compute_key(
+                &specs,
+                "{}",
+                bazel,
+                ws,
+                er,
+                "/ws/.vscode/.rules_rust_analyzer"
+            ),
+            compute_key(
+                &specs,
+                "{}",
+                bazel,
+                ws,
+                er,
+                "/ws/.helix/.rules_rust_analyzer"
+            ),
         );
     }
 }

--- a/tools/rust_analyzer/data/launcher_discover_bazel_rust_project.bat
+++ b/tools/rust_analyzer/data/launcher_discover_bazel_rust_project.bat
@@ -6,6 +6,7 @@
 setlocal
 
 set "RULES_RUST_RA_CACHE_DIR=__RULES_RUST_RA_CACHE_DIR__"
+set "RULES_RUST_RA_LAUNCHER_DIR=__RULES_RUST_RA_LAUNCHER_DIR__"
 
 set "WORKSPACE=__WORKSPACE_ROOT__"
 set "WRAPPER=%WORKSPACE%\bazel-bin\tools\rust_analyzer\discover_bazel_rust_project.exe"

--- a/tools/rust_analyzer/data/launcher_discover_bazel_rust_project.sh
+++ b/tools/rust_analyzer/data/launcher_discover_bazel_rust_project.sh
@@ -19,6 +19,13 @@ set -e
 # is workspace-local `.rules_rust_analyzer/cache/`.
 export RULES_RUST_RA_CACHE_DIR="__RULES_RUST_RA_CACHE_DIR__"
 
+# Baked at install time so the flycheck runnable that discover
+# materializes into rust-project.json points at the editor-specific
+# launcher dir (`.vscode/.rules_rust_analyzer/`, `.helix/...`, or
+# `<workspace>/.rules_rust_analyzer/`). Without this, every editor
+# would share a hardcoded `.vscode/` path that breaks non-vscode users.
+export RULES_RUST_RA_LAUNCHER_DIR="__RULES_RUST_RA_LAUNCHER_DIR__"
+
 WORKSPACE="__WORKSPACE_ROOT__"
 WRAPPER="$WORKSPACE/bazel-bin/tools/rust_analyzer/discover_bazel_rust_project"
 

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -69,12 +69,14 @@ pub fn generate_rust_project(
     // consolidate/assemble step on a miss.
     let spec_contents = read_specs(&spec_paths)?;
 
+    let launcher_dir = std::env::var(cache::LAUNCHER_DIR_ENV_VAR).unwrap_or_default();
     let cache_key = cache::compute_key(
         &spec_contents,
         &toolchain_info_raw,
         bazel,
         workspace,
         execution_root,
+        &launcher_dir,
     );
     if let Some(bytes) = cache::get(workspace, &cache_key)? {
         match serde_json::from_slice::<RustProject>(&bytes) {

--- a/tools/rust_analyzer/rust_project.rs
+++ b/tools/rust_analyzer/rust_project.rs
@@ -278,20 +278,32 @@ pub enum RunnableKind {
     TestMod,
 }
 
-/// Workspace-relative path of the flycheck launcher script that
-/// `setup_vscode` writes. The path itself is platform-dependent (`.sh` on
-/// POSIX, `.bat` on Windows) but the directory layout is fixed and shared
-/// with `bin/setup_vscode.rs` — keep them in sync.
+/// Absolute path of the flycheck launcher script that `setup` writes.
+///
+/// `setup` bakes the editor-specific launcher dir into the discover
+/// launcher as `$RULES_RUST_RA_LAUNCHER_DIR`; we read it here so the
+/// flycheck runnable embedded in `rust-project.json` points at the
+/// right per-editor path (`.vscode/.rules_rust_analyzer/`,
+/// `.helix/.rules_rust_analyzer/`, or `<workspace>/.rules_rust_analyzer/`).
+///
+/// When the env var is unset (discover invoked outside the
+/// setup-generated launcher — direct exec for debugging, or a config
+/// that predates setup) we fall back to `<workspace>/.rules_rust_analyzer/`,
+/// the editor-agnostic default. The fallback is only "right" for
+/// neovim/print users; vscode/helix users who bypass the launcher will
+/// get a stale path, which matches every other fallback in this code.
 fn flycheck_launcher_path(workspace: &Utf8Path) -> Utf8PathBuf {
     let filename = if cfg!(windows) {
         "flycheck.bat"
     } else {
         "flycheck.sh"
     };
-    workspace
-        .join(".vscode")
-        .join(".rules_rust_analyzer")
-        .join(filename)
+    let launcher_dir = std::env::var("RULES_RUST_RA_LAUNCHER_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(Utf8PathBuf::from)
+        .unwrap_or_else(|| workspace.join(".rules_rust_analyzer"));
+    launcher_dir.join(filename)
 }
 
 /// Findings from inspecting the consolidated `CrateSpec` set for problems


### PR DESCRIPTION
This change adds control over the launchers and cache dir through the rust-analyzer setup tool so users don't see mystery files appear in their checkout when they don't want.