### PR TITLE
Add `link_deps` crate_universe annotation

### DIFF
--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -1397,6 +1397,9 @@ _ANNOTATION_SELECT_ATTRS = {
     "deps": _relative_label_list(
         doc = "A list of labels to add to a crate's `rust_library::deps` attribute.",
     ),
+    "link_deps": _relative_label_list(
+        doc = "A list of labels to add to a crate's `rust_library::link_deps` attribute.",
+    ),
     "proc_macro_deps": _relative_label_list(
         doc = "A list of labels to add to a crate's `rust_library::proc_macro_deps` attribute.",
     ),

--- a/crate_universe/extensions.bzl
+++ b/crate_universe/extensions.bzl
@@ -540,6 +540,7 @@ def _generate_hub_and_spokes(
         lockfile,
         skip_cargo_lockfile_overwrite,
         strip_internal_dependencies_from_cargo_lockfile,
+        is_root,
         cargo_lockfile = None,
         manifests = {},
         packages = {}):
@@ -561,6 +562,12 @@ def _generate_hub_and_spokes(
             Bazel only requires external dependencies to be present in the lockfile.
             By removing internal dependencies, the lockfile changes less frequently which reduces merge conflicts
             in other lockfiles where the cargo lockfile's sha is stored.
+        is_root (bool): Whether the module owning this extension call is the workspace's root module.
+            For non-root (transitive) modules the lockfile is trusted as-is — the digest check is
+            skipped and repinning is never attempted, because the digest can legitimately differ
+            across rust / cargo / rules_rust versions between the producing module and the consumer,
+            and the producer's lockfile typically lives in a read-only bzlmod cache that can't be
+            repinned anyway.
         cargo_lockfile (path): Path to Cargo.lock, if we have one.
         manifests (dict): The set of Cargo.toml manifests that apply to this closure, if any, keyed by path.
         packages (dict): The set of extra cargo crate tags that apply to this closure, if any, keyed by package name.
@@ -604,15 +611,27 @@ def _generate_hub_and_spokes(
     # TODO: Repins should never be allowed if the lockfile is not within
     # https://github.com/bazelbuild/rules_rust/issues/1738
 
-    # Determine whether or not to repin dependencies
-    repin = not lockfile or determine_repin(
-        repository_ctx = module_ctx,
-        repository_name = cfg.name,
-        cargo_bazel_fn = cargo_bazel_fn,
-        lockfile_path = lockfile,
-        config = config_file,
-        splicing_manifest = splicing_manifest,
-    )
+    # Determine whether or not to repin dependencies. Transitive (non-root)
+    # modules are taken as-is: the digest check would fail across rust /
+    # cargo / rules_rust version differences between the producing module
+    # and the consumer, and the producer's lockfile typically lives in a
+    # read-only bzlmod cache so repinning isn't an option anyway.
+    if not is_root:
+        if not lockfile:
+            fail(("crate_universe extension call `{}` is in a non-root module " +
+                  "but has no lockfile. Transitive crate_universe repositories " +
+                  "must ship a `lockfile = ...` because repinning is not " +
+                  "supported across module boundaries.").format(cfg.name))
+        repin = False
+    else:
+        repin = not lockfile or determine_repin(
+            repository_ctx = module_ctx,
+            repository_name = cfg.name,
+            cargo_bazel_fn = cargo_bazel_fn,
+            lockfile_path = lockfile,
+            config = config_file,
+            splicing_manifest = splicing_manifest,
+        )
 
     # The workspace root when one is explicitly provided.
     # buildifier: disable=canonical-repository
@@ -1178,6 +1197,7 @@ def _crate_impl(module_ctx):
                 packages = packages,
                 skip_cargo_lockfile_overwrite = cfg.skip_cargo_lockfile_overwrite,
                 strip_internal_dependencies_from_cargo_lockfile = cfg.strip_internal_dependencies_from_cargo_lockfile,
+                is_root = mod.is_root,
             )
 
             # Watch cfg.lockfile AFTER generation. The generator may modify it during

--- a/crate_universe/private/crate.bzl
+++ b/crate_universe/private/crate.bzl
@@ -110,6 +110,7 @@ def _annotation(
         data = None,
         data_glob = None,
         deps = None,
+        link_deps = None,
         extra_aliased_targets = None,
         gen_binaries = None,
         disable_pipelining = False,
@@ -160,6 +161,7 @@ def _annotation(
         data (list, optional): A list of labels to add to a crate's `rust_library::data` attribute.
         data_glob (list, optional): A list of glob patterns to add to a crate's `rust_library::data` attribute.
         deps (list, optional): A list of labels to add to a crate's `rust_library::deps` attribute.
+        link_deps (list, optional): A list of labels to add to a crate's `rust_library::link_deps` attribute.
         extra_aliased_targets (dict, optional): A list of targets to add to the generated aliases in the root
             crate_universe repository.
         gen_binaries (list or bool, optional): As a list, the subset of the crate's bins that should get `rust_binary`
@@ -222,6 +224,7 @@ def _annotation(
             data = _stringify_list(data),
             data_glob = data_glob,
             deps = _stringify_list(deps),
+            link_deps = _stringify_list(link_deps),
             extra_aliased_targets = extra_aliased_targets,
             gen_binaries = gen_binaries,
             disable_pipelining = disable_pipelining,

--- a/crate_universe/src/config.rs
+++ b/crate_universe/src/config.rs
@@ -282,6 +282,10 @@ pub(crate) struct CrateAnnotations {
     /// [proc_macro_deps](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-proc_macro_deps) attribute.
     pub(crate) proc_macro_deps: Option<Select<BTreeSet<Label>>>,
 
+    /// Additional data to pass to
+    /// [link_deps](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-link_deps) attribute.
+    pub(crate) link_deps: Option<Select<BTreeSet<Label>>>,
+
     /// Additional data to pass to  the target's
     /// [crate_features](https://bazelbuild.github.io/rules_rust/defs.html#rust_library-crate_features) attribute.
     pub(crate) crate_features: Option<Select<BTreeSet<String>>>,
@@ -446,6 +450,7 @@ impl Add for CrateAnnotations {
             gen_build_script: self.gen_build_script.or(rhs.gen_build_script),
             deps: select_merge(self.deps, rhs.deps),
             proc_macro_deps: select_merge(self.proc_macro_deps, rhs.proc_macro_deps),
+            link_deps: select_merge(self.link_deps, rhs.link_deps),
             crate_features: select_merge(self.crate_features, rhs.crate_features),
             data: select_merge(self.data, rhs.data),
             data_glob: joined_extra_member!(self.data_glob, rhs.data_glob, BTreeSet::new, BTreeSet::extend),
@@ -511,6 +516,7 @@ pub(crate) struct AnnotationsProvidedByPackage {
     pub(crate) data: Option<Select<BTreeSet<Label>>>,
     pub(crate) data_glob: Option<BTreeSet<String>>,
     pub(crate) deps: Option<Select<BTreeSet<Label>>>,
+    pub(crate) link_deps: Option<Select<BTreeSet<Label>>>,
     pub(crate) compile_data: Option<Select<BTreeSet<Label>>>,
     pub(crate) compile_data_glob: Option<BTreeSet<String>>,
     pub(crate) compile_data_glob_excludes: Option<BTreeSet<String>>,
@@ -535,6 +541,7 @@ impl CrateAnnotations {
             data,
             data_glob,
             deps,
+            link_deps,
             compile_data,
             compile_data_glob,
             compile_data_glob_excludes,
@@ -567,6 +574,7 @@ impl CrateAnnotations {
         default(&mut self.data, data);
         default(&mut self.data_glob, data_glob);
         default(&mut self.deps, deps);
+        default(&mut self.link_deps, link_deps);
         default(&mut self.compile_data, compile_data);
         default(&mut self.compile_data_glob, compile_data_glob);
         default(

--- a/crate_universe/src/config/label_injection.rs
+++ b/crate_universe/src/config/label_injection.rs
@@ -43,6 +43,8 @@ use std::collections::BTreeMap;
 use anyhow::{bail, Result};
 use serde_json::{Map, Value};
 
+use crate::utils::starlark::is_repo_name_byte;
+
 /// Walk `config.annotations` and:
 ///
 ///   * strip each annotation's `label_injections` field (so typed
@@ -160,10 +162,95 @@ fn rewrite(value: &mut Value, mapping: &BTreeMap<String, String>) {
 fn replace_all(input: &str, mapping: &BTreeMap<String, String>) -> String {
     let mut out = input.to_owned();
     for (canonical, apparent) in mapping {
-        if out.contains(apparent.as_str()) {
-            out = out.replace(apparent.as_str(), canonical.as_str());
-        }
+        out = replace_at_label_boundary(&out, apparent, canonical);
     }
+    out
+}
+
+/// Replace `apparent` with `canonical` in `input`, but only at label-prefix
+/// boundaries — i.e., where `apparent` is not preceded by another `@` and is
+/// not followed by another repo-name character (or `@`).
+///
+/// Plain `str::replace` is wrong for two reasons that combine catastrophically:
+///
+///   1. `sanitize_label_injections` partitions on `//`, so a user-written
+///      apparent of `@//pkg:tgt` reduces to a one-character apparent `@`.
+///      Naive replace would rewrite every `@` in every string, including the
+///      leading `@@` on already-canonical labels in the same Context (e.g.
+///      from `override_target_lib`'s `attr.label` resolution), producing
+///      `@@@@…` and failing the next `Label::from_str` on JSON roundtrip.
+///
+///   2. Even with a well-formed apparent like `@curl`, the substring also
+///      appears at position 1 of the canonical `@@curl+v8.0.0`, so any
+///      already-canonical occurrence in the same Context would be partially
+///      mangled to `@@@curl+v8.0.0+v8.0.0`.
+///
+/// Anchoring on `//` alone would fix (1) and (2) for `@curl//:tgt`, but break
+/// `$(execpath @curl)` — Bazel's location-expansion shorthand for the bare
+/// repo, which never carries a `//`. So we anchor on a label-boundary instead:
+///
+///   * Skip if the character before the match is `@` — that's the inside of
+///     a canonical `@@…` prefix, not a label boundary.
+///   * Skip if the character after the match is a repo-name char (alphanum,
+///     `_`, `-`, `.`, `+`, `~`) or `@` — that means the match is a prefix of
+///     a longer repo name (`@curl` inside `@curlx` or `@curl+v8`), or the
+///     run-up to a canonical `@@`.
+///
+/// One more wrinkle: when the apparent occurs in **bare-shorthand** position
+/// (no `//` follows), Bazel re-expands the bare form to `<repo>//:<repo>` at
+/// resolution time. The repo name in the canonical includes Bazel's `+`
+/// suffix (e.g. `native_lib+`), but the target that actually exists in the
+/// canonical repo's BUILD file is the user's original target name (e.g.
+/// `native_lib`). So substituting `@native_lib` → `@@native_lib+` for a
+/// bare-shorthand occurrence yields `@@native_lib+` which Bazel re-expands
+/// to `@@native_lib+//:native_lib+` — a target that doesn't exist. The
+/// bare-shorthand case is rewritten with an explicit
+/// `<canonical>//:<apparent_target>` to preserve the apparent target name
+/// (which always matches the apparent repo name and equals what the repo's
+/// BUILD file actually defines).
+fn replace_at_label_boundary(input: &str, apparent: &str, canonical: &str) -> String {
+    debug_assert!(
+        !apparent.is_empty(),
+        "empty apparents are filtered by `into_mapping`",
+    );
+    // Fast path: skip the per-match scan (and the output allocation) when the
+    // apparent doesn't occur at all. Mappings often have several entries and
+    // most Context strings won't reference most of them.
+    if !input.contains(apparent) {
+        return input.to_owned();
+    }
+    // The bare-shorthand target preserved on bare matches. `apparent` is
+    // usually `@<name>`, in which case `strip_prefix('@')` yields the
+    // bare repo name; for the degenerate `apparent = "@"` (which arises
+    // from a user-written `label_injections` value of `@//pkg:tgt` —
+    // see `does_not_mangle_at_signs_outside_repo_boundary`), the strip
+    // yields `""`, and the bare-shorthand emission below skips itself.
+    let apparent_target = apparent.strip_prefix('@').unwrap_or(apparent);
+
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut last_end = 0;
+    for (start, _) in input.match_indices(apparent) {
+        if start > 0 && bytes[start - 1] == b'@' {
+            continue;
+        }
+        let after = start + apparent.len();
+        if matches!(bytes.get(after), Some(&n) if n == b'@' || is_repo_name_byte(n)) {
+            continue;
+        }
+        out.push_str(&input[last_end..start]);
+        out.push_str(canonical);
+        // Bare-shorthand expansion: when the apparent isn't followed by `//`,
+        // re-emit the apparent target name explicitly. See the doc comment.
+        // Skip when the apparent has no name (`@` alone): there's no target
+        // to derive, and emitting `<canonical>//:` would be malformed.
+        if !input[after..].starts_with("//") && !apparent_target.is_empty() {
+            out.push_str("//:");
+            out.push_str(apparent_target);
+        }
+        last_end = after;
+    }
+    out.push_str(&input[last_end..]);
     out
 }
 
@@ -175,7 +262,10 @@ mod tests {
     // `{canonical_repo_prefix: apparent_repo_prefix}` (the Label coercion is
     // where Starlark resolves apparent -> canonical for the current session).
     // Substitution here rewrites apparent -> canonical.
+    use std::str::FromStr;
+
     use super::*;
+    use crate::utils::starlark::Label;
     use serde_json::json;
 
     // ---- extract_global_mapping ----
@@ -414,6 +504,205 @@ mod tests {
                     }
                 }
             }),
+        );
+    }
+
+    #[test]
+    fn does_not_mangle_at_signs_outside_repo_boundary() {
+        // Regression: `sanitize_label_injections` partitions on `//` and so
+        // reduces an apparent value of `@//pkg:target` (a label in the root
+        // module, written with the explicit-apparent `@//` prefix) to just
+        // `@`. A naive `str::replace` would then rewrite every `@` in the
+        // Context — including the leading `@@` of already-canonical labels —
+        // producing invalid strings like `@@@@rules_rust++crate+crate_index//:heapless`
+        // that fail to parse on the JSON roundtrip back into Context.
+        let mut v = json!({
+            "override_targets": {
+                "lib": "@@rules_rust++crate+crate_index//:heapless"
+            },
+            "deps": ["@//pkg:tgt"]
+        });
+        let mapping = BTreeMap::from([("@@".to_owned(), "@".to_owned())]);
+        apply_mapping_to_value(&mut v, &mapping);
+        assert_eq!(
+            v,
+            json!({
+                "override_targets": {
+                    "lib": "@@rules_rust++crate+crate_index//:heapless"
+                },
+                "deps": ["@@//pkg:tgt"]
+            }),
+            "anchored substitution must rewrite `@//pkg:tgt` but leave the \
+             unrelated `@@…//:` canonical untouched",
+        );
+    }
+
+    #[test]
+    fn substitutes_bare_repo_shorthand_in_location_expansion() {
+        // `$(execpath @curl)` is Bazel's location-expansion shorthand for
+        // `@curl//:curl` (no `//` separator). The label-boundary anchor must
+        // still rewrite the `@curl` in this position, and must emit the
+        // EXPLICIT canonical form `@@curl+v8.0.0//:curl` rather than the bare
+        // `@@curl+v8.0.0` — Bazel would re-expand the bare canonical to
+        // `@@curl+v8.0.0//:curl+v8.0.0` whose target name doesn't exist
+        // (see `expands_bare_repo_shorthand_to_apparent_target` below for
+        // the same shape in `deps`). The same mapping must NOT match
+        // `@curl` at position 1 of an already-canonical `@@curl+v8.0.0//:curl`
+        // (preceded by `@`), and must NOT match the prefix of a longer repo
+        // name like `@curlx//:foo`.
+        let mut v = json!({
+            "build_script_env": {
+                "common": {
+                    "CURL_BIN": "$(execpath @curl)",
+                    "CURL_LIB": "$(execpath @curl//:lib)",
+                }
+            },
+            "deps": [
+                "@curl",
+                "@curl//:curl",
+                "@@curl+v8.0.0//:curl",
+                "@curlx//:foo",
+            ]
+        });
+        let mapping = BTreeMap::from([("@@curl+v8.0.0".to_owned(), "@curl".to_owned())]);
+        apply_mapping_to_value(&mut v, &mapping);
+        assert_eq!(
+            v,
+            json!({
+                "build_script_env": {
+                    "common": {
+                        "CURL_BIN": "$(execpath @@curl+v8.0.0//:curl)",
+                        "CURL_LIB": "$(execpath @@curl+v8.0.0//:lib)",
+                    }
+                },
+                "deps": [
+                    "@@curl+v8.0.0//:curl",
+                    "@@curl+v8.0.0//:curl",
+                    "@@curl+v8.0.0//:curl",
+                    "@curlx//:foo",
+                ]
+            }),
+        );
+    }
+
+    #[test]
+    fn does_not_corrupt_canonical_when_apparent_is_its_prefix() {
+        // Direct regression for the field-reported failure
+        // `Failed to parse label from string: @@@rules_rust_pyo3++//:current_pyo3_toolchain`.
+        //
+        // Setup: `bazel_dep(name = "rules_rust_pyo3", version = "0.71.0")`
+        // resolves to canonical `@@rules_rust_pyo3+`. The annotation has
+        // `label_injections = {"@rules_rust_pyo3//...": "@rules_rust_pyo3//..."}`
+        // so the sanitized mapping is `{"@@rules_rust_pyo3+": "@rules_rust_pyo3"}`.
+        //
+        // The annotation also references the same target in two shapes that
+        // coexist in the same Context:
+        //
+        //   * `build_script_data` is `attr.string_list`-typed, preserved
+        //     verbatim — value is the apparent `@rules_rust_pyo3//:…`.
+        //   * `build_script_toolchains` is `attr.label_list`-typed, so
+        //     Bazel resolves each entry to a Label and the JSON we receive
+        //     already has the canonical form `@@rules_rust_pyo3+//:…`.
+        //
+        // The boundary-blind `str::replace` shipped in 0.71.0 found the
+        // apparent at position 1 of the already-canonical string and
+        // produced `@@@rules_rust_pyo3++//:current_pyo3_toolchain` — three
+        // `@`s and the canonical's trailing `+` glued onto the input's `+`.
+        // The downstream `serde_json::from_value` then tried to parse it as
+        // a `Label` and surfaced the user-visible error.
+        let mut v = json!({
+            "build_script_data": [
+                "@rules_rust_pyo3//:current_pyo3_toolchain"
+            ],
+            "build_script_toolchains": [
+                "@@rules_rust_pyo3+//:current_pyo3_toolchain"
+            ],
+        });
+        let mapping = BTreeMap::from([(
+            "@@rules_rust_pyo3+".to_owned(),
+            "@rules_rust_pyo3".to_owned(),
+        )]);
+        apply_mapping_to_value(&mut v, &mapping);
+        assert_eq!(
+            v,
+            json!({
+                "build_script_data": [
+                    "@@rules_rust_pyo3+//:current_pyo3_toolchain"
+                ],
+                "build_script_toolchains": [
+                    "@@rules_rust_pyo3+//:current_pyo3_toolchain"
+                ],
+            }),
+            "apparent in the apparent-form field must rewrite to canonical; \
+             the already-canonical field must be left untouched",
+        );
+
+        // Tie the test directly to the user-visible failure mode: every
+        // string in the rewritten Value must parse back as a `Label`. The
+        // 0.71.0 bug surfaced inside `Context::apply_label_injection_mapping`'s
+        // `serde_json::from_value` roundtrip, which uses exactly this
+        // parser. If anyone reintroduces the substitution bug, this
+        // assertion fails with the same `Failed to parse label from string:
+        // @@@…` text that was reported in the field.
+        for arr_key in ["build_script_data", "build_script_toolchains"] {
+            for s in v[arr_key].as_array().unwrap() {
+                Label::from_str(s.as_str().unwrap()).unwrap_or_else(|e| {
+                    panic!("rewritten value {s} must parse as Label, got: {e:#}")
+                });
+            }
+        }
+    }
+
+    #[test]
+    fn expands_bare_repo_shorthand_to_apparent_target() {
+        // Regression for the bare-shorthand-in-`deps` failure:
+        // `no such target '@@native_lib+//:native_lib+': target 'native_lib+' not declared`.
+        //
+        // Setup: a `bazel_dep(name = "native_lib", ...)` resolves to
+        // canonical `@@native_lib+`. The annotation is:
+        //
+        //     crate.annotation(
+        //         crate = "some-sys",
+        //         label_injections = {"@native_lib": "@native_lib"},
+        //         deps = ["@native_lib"],
+        //     )
+        //
+        // Sanitized mapping: `{"@@native_lib+": "@native_lib"}`. The
+        // `"@native_lib"` in `deps` is Bazel's bare-shorthand form for
+        // `@native_lib//:native_lib`.
+        //
+        // The fix must not substitute that to just `@@native_lib+` — Bazel
+        // would then re-expand the bare canonical to
+        // `@@native_lib+//:native_lib+`, and the target name `native_lib+`
+        // doesn't exist in the canonical repo's BUILD file (which defines
+        // `native_lib`, because `+` is part of the canonical-repo-name
+        // suffix, not the user's target name). The substitution must emit
+        // the explicit `@@native_lib+//:native_lib` form, preserving the
+        // apparent target name.
+        let mut v = json!({
+            "deps": ["@native_lib"],
+        });
+        let mapping = BTreeMap::from([("@@native_lib+".to_owned(), "@native_lib".to_owned())]);
+        apply_mapping_to_value(&mut v, &mapping);
+        assert_eq!(
+            v,
+            json!({
+                "deps": ["@@native_lib+//:native_lib"],
+            }),
+        );
+
+        // The rewritten label must round-trip through `Label::from_str` —
+        // i.e. it must be syntactically valid — and crucially must have
+        // target name `native_lib` (the user's intended target), not the
+        // canonical-name suffix `native_lib+` (which is what Bazel would
+        // derive from a bare canonical re-expansion).
+        let parsed =
+            Label::from_str(v["deps"][0].as_str().unwrap()).expect("rewritten label must parse");
+        assert_eq!(
+            parsed.target(),
+            "native_lib",
+            "explicit `//:native_lib` target preserves the apparent target name; \
+             the canonical-derived target `native_lib+` would not exist in the BUILD file",
         );
     }
 }

--- a/crate_universe/src/context/crate_context.rs
+++ b/crate_universe/src/context/crate_context.rs
@@ -133,6 +133,9 @@ pub(crate) struct CommonAttributes {
     pub(crate) extra_proc_macro_deps: Select<BTreeSet<Label>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
+    pub(crate) extra_link_deps: Select<BTreeSet<Label>>,
+
+    #[serde(skip_serializing_if = "Select::is_empty")]
     pub(crate) proc_macro_deps_dev: Select<BTreeSet<CrateDependency>>,
 
     #[serde(skip_serializing_if = "Select::is_empty")]
@@ -167,6 +170,7 @@ impl Default for CommonAttributes {
             linker_script: Default::default(),
             proc_macro_deps: Default::default(),
             extra_proc_macro_deps: Default::default(),
+            extra_link_deps: Default::default(),
             proc_macro_deps_dev: Default::default(),
             rustc_env: Default::default(),
             rustc_env_files: Default::default(),
@@ -589,6 +593,12 @@ impl CrateContext {
             if let Some(extra) = &crate_extra.proc_macro_deps {
                 self.common_attrs.extra_proc_macro_deps =
                     Select::merge(self.common_attrs.extra_proc_macro_deps, extra.clone());
+            }
+
+            // Link deps
+            if let Some(extra) = &crate_extra.link_deps {
+                self.common_attrs.extra_link_deps =
+                    Select::merge(self.common_attrs.extra_link_deps, extra.clone());
             }
 
             // Compile data

--- a/crate_universe/src/lockfile.rs
+++ b/crate_universe/src/lockfile.rs
@@ -305,7 +305,7 @@ mod test {
         );
 
         assert_eq!(
-            Digest("76d987edaa3f6a281133997c7d31a657acfaeb639585d9e8c629996c1fcb94af".to_owned()),
+            Digest("c395b0c5bed8470775b13399a6e8ec43af4abd4aa104ebc81297a286e449fc23".to_owned()),
             digest,
         );
     }

--- a/crate_universe/src/rendering.rs
+++ b/crate_universe/src/rendering.rs
@@ -860,6 +860,7 @@ impl Renderer {
                 ),
                 platforms,
             ),
+            link_deps: SelectSet::new(krate.common_attrs.extra_link_deps.clone(), platforms),
             aliases: SelectDict::new(self.make_aliases(krate, false, false), platforms),
             common: self.make_common_attrs(platforms, krate, target)?,
             disable_pipelining: krate.disable_pipelining,
@@ -901,6 +902,7 @@ impl Renderer {
             name: format!("{}__bin", target.crate_name),
             deps: SelectSet::new(deps, platforms),
             proc_macro_deps: SelectSet::new(proc_macro_deps, platforms),
+            link_deps: SelectSet::new(krate.common_attrs.extra_link_deps.clone(), platforms),
             aliases: SelectDict::new(self.make_aliases(krate, false, false), platforms),
             common: self.make_common_attrs(platforms, krate, target)?,
         })

--- a/crate_universe/src/utils/starlark.rs
+++ b/crate_universe/src/utils/starlark.rs
@@ -173,6 +173,8 @@ pub(crate) struct RustLibrary {
     pub(crate) deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
     pub(crate) proc_macro_deps: SelectSet<Label>,
+    #[serde(skip_serializing_if = "SelectSet::is_empty")]
+    pub(crate) link_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]
@@ -188,6 +190,8 @@ pub(crate) struct RustBinary {
     pub(crate) deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectSet::is_empty")]
     pub(crate) proc_macro_deps: SelectSet<Label>,
+    #[serde(skip_serializing_if = "SelectSet::is_empty")]
+    pub(crate) link_deps: SelectSet<Label>,
     #[serde(skip_serializing_if = "SelectDict::is_empty")]
     pub(crate) aliases: SelectDict<Label, String>,
     #[serde(flatten)]

--- a/crate_universe/src/utils/starlark/label.rs
+++ b/crate_universe/src/utils/starlark/label.rs
@@ -59,13 +59,28 @@ impl Label {
     }
 }
 
+/// Returns true if `b` is a byte that may appear inside a Bazel repository name.
+///
+/// Mirrors the repository-name character class used by the label-parsing regex
+/// in [`Label::from_str`] (`[\w\d\-_\.+~]`). Kept here as the single source of
+/// truth so the byte-level callers (e.g. `label_injection::replace_at_label_boundary`)
+/// stay in sync with the regex.
+///
+/// TODO: Disallow `~` once support for Bazel 7.2 is dropped (see the matching
+/// TODO in `Label::from_str`).
+pub(crate) fn is_repo_name_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'+' | b'~')
+}
+
 impl FromStr for Label {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         static RE: OnceCell<Regex> = OnceCell::new();
         let re = RE.get_or_try_init(|| {
-            // TODO: Disallow `~` in repository names once support for Bazel 7.2 is dropped.
+            // TODO: Disallow `~` in repository names once support for Bazel 7.2
+            // is dropped. Keep the character class in sync with
+            // [`is_repo_name_byte`] above.
             Regex::new(r"^(@@?[\w\d\-_\.+~]*)?(//)?([\w\d\-_\./+]+)?(:([\+\w\d\-_\./]+))?$")
         });
 

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_alias_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "dc5592c894451a5b97d276a4984335797d87b99bf1143e906bd88c3dd3aa89e3",
+  "checksum": "2f45aea8c226ac75b52dca8050d9ba9982d9aba1af627d5f21d54755b6c987e3",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_alias_annotation_opt.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b089bd015a3a47c22898be62a0576348c1bd0992b824e9acf08ec5ec751559e6",
+  "checksum": "e0966af5103b839a9deec4a57835e936379725c4be159c7928c410555c49c03e",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_custom_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0cee05c9c64cda4438f787789c3c7388e27245744e5fdf9163590af2e57ab37d",
+  "checksum": "68e3d8dbd0c591c5d3ca6d6feb7ec46d3abf2af2416eff8a522a6b33eb8e096c",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_dbg_annotation_fastbuild.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d5c6453edb27136829f58d571992b9473d58e5fdeec28cdad4788d179e4897b3",
+  "checksum": "a880a406c24b0d853a792b6adf049e7c667bdeea95f89ee2c6a3ce19b362b8b7",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_alias.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "22277f89d71a79b58124ed33d78760ebf25c7bc7acf4043ad11ff64d20c3b299",
+  "checksum": "262ef1a76ee66370b4f7263b7367cc17aa8fbf92107710540f0341782f9eb8d5",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_dbg.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "93f3fd2205973bb9abbb43e24d84ad8813f759d977e6b8d6603fd90bbec339b1",
+  "checksum": "1581e2ac2c2c7be5a63c80df1ddde7b8085b5c0f1026616a0c1e29c0c6bb8698",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
+++ b/crate_universe/tests/integration/alias_rule/cargo-bazel-lock_global_opt_annotation_none.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "6c61458576b699ef8fbdd8aeea6ebcb61af5b71628c29c961f6179f8102a3c48",
+  "checksum": "5384dbc1dbe6c8ff3c4e6270d17df87bc8d73ed7aae57e0437b0559243733d54",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/crate_universe/tests/integration/cargo_aliases/cargo-bazel-lock.json
+++ b/crate_universe/tests/integration/cargo_aliases/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "c98e8d58a1ed506727fa93c25269ab9f021db6e23cb16b3d737e022a2ed7397f",
+  "checksum": "65fec64878a3cc023079f1eadafdfbf0af87ff789065eaa3297c1715b99a965f",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",

--- a/crate_universe/tests/integration/complicated_dependencies/cargo-bazel-lock.json
+++ b/crate_universe/tests/integration/complicated_dependencies/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "1d5ff7e09f8bf0e418bf1dd443ef8b97418379888c4dda28f447fab831c5044c",
+  "checksum": "05d31c113a1fd51c63b1d955abfdb2adcb9912684e091c63f3aca7f9cf9f633e",
   "crates": {
     "bitflags 2.11.1": {
       "name": "bitflags",

--- a/crate_universe/tests/integration/multi_package/cargo-bazel-lock.json
+++ b/crate_universe/tests/integration/multi_package/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3d5564c82ea84672e436824818f47b6aacf37913df5fc59603ba051710ce89cb",
+  "checksum": "52be38ed52d27532597340917506e2518284019c686cb5095ae926b6860092f7",
   "crates": {
     "aho-corasick 0.7.20": {
       "name": "aho-corasick",

--- a/crate_universe/tests/integration/override_target/cargo-bazel-lock.json
+++ b/crate_universe/tests/integration/override_target/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "406f2d3f073f2c34def1bb1f49020aa1e919b03c1d6f5a5dff78bfa6aff74097",
+  "checksum": "b60853bcb0d67833011bc4abbd329e22ef803e3474ce95990408bc2f201c5079",
   "crates": {
     "direct-cargo-bazel-deps 0.0.1": {
       "name": "direct-cargo-bazel-deps",

--- a/examples/cross_compile_nix/bazel/cargo/cargo-bazel-lock.json
+++ b/examples/cross_compile_nix/bazel/cargo/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "77f9a5851f87791d4af5583054fdf62296df9786d36a3f2f43431f8da0eac10a",
+  "checksum": "a23b22aefd7365ca7ab07c191225d503fd233fea9f60ef1751ff66369777549d",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",


### PR DESCRIPTION
https://github.com/bazelbuild/rules_rust/pull/4024 now adds noisy prints that users have no way to handle when using crate_universe. This change adds annotations so the prints can be actioned.