### PR TITLE
Restore `crate_universe/extension.bzl` shim with a deprecation warning

### DIFF
--- a/crate_universe/extension.bzl
+++ b/crate_universe/extension.bzl
@@ -1,0 +1,11 @@
+"""Deprecated, use `:extensions.bzl`."""
+
+load(":extensions.bzl", _crate = "crate")
+
+# buildifier: disable=print
+print(
+    "\nWARNING: @rules_rust//crate_universe:extension.bzl is deprecated and will be removed in a future release. " +
+    "Load `crate` from @rules_rust//crate_universe:extensions.bzl instead.",
+)
+
+crate = _crate


### PR DESCRIPTION
#4005 removed `crate_universe/extension.bzl`, the deprecated re-export of `crate_universe/extensions.bzl`, as part of dropping WORKSPACE support.

Downstream projects may still load `crate` from that path via `use_extension`, so any build that resolves `rules_rust` 0.71.0 with such a module in its graph fails.
`protobuf` 35.1, the newest release on BCR, is one such module.

Restore the shim and print a deprecation warning at load time, giving downstream modules a short window to migrate to `extensions.bzl`, e.g.:
- protocolbuffers/protobuf#28226.

Closes #4111.