### PR TITLE
Tolerate partial build failures during rust-analyzer discovery

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -399,6 +399,7 @@ tasks:
       - "//tools/rust_analyzer:gen_rust_project"
       - "//tools/rust_analyzer:discover_bazel_rust_project"
       - "//test/rust_analyzer:rust_analyzer_test"
+      - "//test/rust_analyzer:partial_failure_test"
   ide_integration_tests_macos:
     name: IDE VSCode Tests
     platform: macos_arm64
@@ -408,6 +409,7 @@ tasks:
       - "//tools/rust_analyzer:gen_rust_project"
       - "//tools/rust_analyzer:discover_bazel_rust_project"
       - "//test/rust_analyzer:rust_analyzer_test"
+      - "//test/rust_analyzer:partial_failure_test"
   ide_integration_tests_windows:
     name: IDE VSCode Tests
     platform: windows

--- a/test/rust_analyzer/BUILD.bazel
+++ b/test/rust_analyzer/BUILD.bazel
@@ -5,3 +5,8 @@ sh_binary(
     srcs = ["rust_analyzer_test_runner.sh"],
     args = [package_name()],
 )
+
+sh_binary(
+    name = "partial_failure_test",
+    srcs = ["partial_failure_test_runner.sh"],
+)

--- a/test/rust_analyzer/partial_failure_test_runner.sh
+++ b/test/rust_analyzer/partial_failure_test_runner.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# End-to-end test that discovery still produces a project when part of
+# the workspace is broken. Stands up a workspace with one good
+# `rust_library` and one target that fails analysis, runs
+# `discover_bazel_rust_project`, and checks the good crate is still
+# discovered. See `--keep_going` in tools/rust_analyzer/lib.rs.
+
+set -euo pipefail
+
+if [[ -z "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then
+    >&2 echo "This script should be run under Bazel"
+    exit 1
+fi
+
+workspace="$(mktemp -d -t rules_rust_ra_partial-XXXXXXXXXX)"
+
+cat >"${workspace}/MODULE.bazel" <<EOF
+module(name = "rules_rust_ra_partial", version = "0.0.0")
+bazel_dep(name = "rules_rust", version = "0.0.0")
+local_path_override(
+    module_name = "rules_rust",
+    path = "${BUILD_WORKSPACE_DIRECTORY}",
+)
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+use_repo(rust, "rust_toolchains")
+register_toolchains("@rust_toolchains//:all")
+EOF
+
+if [[ -f "${BUILD_WORKSPACE_DIRECTORY}/.bazelversion" ]]; then
+    cp "${BUILD_WORKSPACE_DIRECTORY}/.bazelversion" "${workspace}/.bazelversion"
+fi
+
+echo "pub fn good() {}" >"${workspace}/lib.rs"
+
+cat >"${workspace}/BUILD.bazel" <<EOF
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+rust_library(
+    name = "good",
+    srcs = ["lib.rs"],
+    edition = "2021",
+)
+
+# Fails analysis: depends on a target that does not exist.
+rust_library(
+    name = "bad",
+    srcs = ["lib.rs"],
+    edition = "2021",
+    deps = [":does_not_exist"],
+)
+EOF
+
+cd "${workspace}"
+
+fail() {
+    >&2 echo "FAIL: $1"
+    >&2 echo "--- discovery.json ---"
+    >&2 cat discovery.json
+    exit 1
+}
+
+# The workspace must actually fail to build, or the checks below are
+# vacuous.
+if bazel build //... >/dev/null 2>&1; then
+    >&2 echo "FAIL: expected '//...' to fail to build"
+    exit 1
+fi
+
+echo "Running discovery against the half-broken workspace..."
+bazel run @rules_rust//tools/rust_analyzer:discover_bazel_rust_project >discovery.json || true
+
+grep -q '"kind":"error"' discovery.json && fail "discovery returned an error instead of a partial project"
+grep -q '"kind":"finished"' discovery.json || fail "discovery did not finish"
+grep -q '"display_name":"good"' discovery.json || fail "the good crate is missing from the project"
+grep -q '"display_name":"bad"' discovery.json && fail "the bad crate should have been skipped but is present"
+
+echo "PASS: discovery produced a project with 'good' and without 'bad'"
+
+bazel clean --expunge --async >/dev/null 2>&1 || true
+cd /
+rm -rf "${workspace}"

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -76,7 +76,7 @@ pub fn generate_rust_project(
     let bep_file = output_base.join(format!("rules_rust_ra_bep_{}.json", std::process::id()));
     let _bep_cleanup = BepCleanup(bep_file.clone());
 
-    generate_crate_info(
+    let build = generate_crate_info(
         bazel,
         output_base,
         workspace,
@@ -87,8 +87,24 @@ pub fn generate_rust_project(
         &bep_file,
     )?;
 
-    let spec_paths =
-        bep::parse_spec_paths(&bep_file).with_context(|| format!("parsing BEP file {bep_file}"))?;
+    let spec_paths = match bep::parse_spec_paths(&bep_file) {
+        Ok(paths) => paths,
+        // A failed build often means a missing or partial BEP file; surface
+        // the build error rather than the downstream parse error.
+        Err(_) if !build.success => {
+            bail!(
+                "bazel build failed and produced no usable output:\n{}",
+                build.stderr
+            )
+        }
+        Err(e) => return Err(e).with_context(|| format!("parsing BEP file {bep_file}")),
+    };
+    if assess_discovery(build.success, spec_paths.len(), &build.stderr)? {
+        log::warn!(
+            "some targets failed to build; the rust-analyzer project may be \
+             incomplete. Run `bazel build //...` to see the errors."
+        );
+    }
     log::info!("discovered {} crate spec files via BEP", spec_paths.len());
 
     // Toolchain-info JSON is embedded at compile time — see
@@ -244,6 +260,13 @@ pub fn bazel_info(
     Ok(info_map)
 }
 
+/// Result of the discovery build. With `--keep_going` a non-`success` exit
+/// isn't fatal — the caller proceeds if the BEP still yielded specs.
+struct DiscoveryBuild {
+    success: bool,
+    stderr: String,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn generate_crate_info(
     bazel: &Utf8Path,
@@ -254,7 +277,7 @@ fn generate_crate_info(
     rules_rust: &str,
     targets: &[String],
     bep_file: &Utf8Path,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<DiscoveryBuild> {
     log::info!("running bazel build with BEP discovery...");
     log::debug!("Building rust_analyzer_crate_spec files for {:?}", targets);
 
@@ -262,6 +285,9 @@ fn generate_crate_info(
         .args(bazel_startup_options)
         .arg("build")
         .args(bazel_args)
+        // Don't let one broken target abort discovery for the whole
+        // workspace; the caller decides if the partial result is usable.
+        .arg("--keep_going")
         .arg("--norun_validations")
         .arg("--remote_download_all")
         .arg(format!(
@@ -275,15 +301,25 @@ fn generate_crate_info(
         .args(targets)
         .output()?;
 
-    if !output.status.success() {
-        let status = output.status;
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("bazel build failed: ({status})\n{stderr}");
+    let success = output.status.success();
+    if success {
+        log::info!("bazel build finished");
     }
 
-    log::info!("bazel build finished");
+    Ok(DiscoveryBuild {
+        success,
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
 
-    Ok(())
+/// `Ok(true)` = usable but some targets failed (caller warns); `Ok(false)` =
+/// clean; `Err` = nothing usable was produced.
+fn assess_discovery(success: bool, spec_count: usize, stderr: &str) -> anyhow::Result<bool> {
+    match (success, spec_count) {
+        (true, _) => Ok(false),
+        (false, 0) => bail!("bazel build failed and produced no crate specs:\n{stderr}"),
+        (false, _) => Ok(true),
+    }
 }
 
 fn bazel_command(
@@ -389,5 +425,29 @@ mod tests {
         assert_eq!(dir_to_bazel_package(""), "");
         // Mixed (defense in depth).
         assert_eq!(dir_to_bazel_package(r"a/b\c/d"), "a/b/c/d");
+    }
+
+    #[test]
+    fn assess_discovery_clean_build_is_complete() {
+        // Success → never incomplete, regardless of spec count.
+        assert_eq!(assess_discovery(true, 0, "").unwrap(), false);
+        assert_eq!(assess_discovery(true, 42, "").unwrap(), false);
+    }
+
+    #[test]
+    fn assess_discovery_partial_failure_is_usable_but_incomplete() {
+        // Some targets failed but specs were produced (e.g. an unrelated
+        // broken target in a large monorepo) → proceed, but flag incomplete.
+        assert_eq!(assess_discovery(false, 2712, "boom").unwrap(), true);
+    }
+
+    #[test]
+    fn assess_discovery_total_failure_errors() {
+        // Failed build with nothing usable → fatal, and the message carries
+        // the captured stderr so the user sees the real cause.
+        let err = assess_discovery(false, 0, "the real bazel error")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("the real bazel error"), "got: {err}");
     }
 }


### PR DESCRIPTION
`discover_bazel_rust_project` builds the rust-analyzer aspect over the whole workspace and bailed on any non-zero Bazel exit. In a large monorepo a single broken target (e.g. an unrelated, unmaintained one) aborted the build, leaving rust-analyzer with no Bazel project model. It then silently falls back to a Cargo workspace, which breaks proc-macro expansion (toolchain ABI mismatch) and materializes a stray `target/`.

Pass `--keep_going` so Bazel keeps building the rest of the graph, and treat the result as usable when the BEP still yielded crate specs: proceed with a `log::warn` that the project may be incomplete, and only fail when zero specs were produced. This mirrors `flycheck`'s existing exit-code handling.

Add an end-to-end test that stands up a workspace with one good `rust_library` and one target that fails analysis, then checks discovery still returns a project containing the good crate. Unit tests cover the `assess_discovery` decision.

Written with Claude, but I believe I understand what is going on.