### PR TITLE
fix: declare rustfmt aspect action toolchain

### DIFF
--- a/rust/private/rustfmt.bzl
+++ b/rust/private/rustfmt.bzl
@@ -98,6 +98,7 @@ def _perform_check(edition, srcs, ctx):
         arguments = [args],
         mnemonic = "Rustfmt",
         progress_message = "Rustfmt %{label}",
+        toolchain = Label("//rust/rustfmt:toolchain_type"),
     )
 
     return marker


### PR DESCRIPTION
The --incompatible_auto_exec_groups flag requires Starlark actions to declare whether their executable/tools come from an action toolchain. This is not a Bazel default today, but it is exposed through strict preset configurations and is intended to catch rules that rely on implicit action toolchain inference.

rustfmt_aspect runs rustfmt from rules_rust's rustfmt toolchain, but the formatting action does not declare that action toolchain. Declare the matching rustfmt toolchain so the action's toolchain behavior is explicit without changing its inputs or execution model.