### PR TITLE
Add rust-analyzer clippy end-to-end test

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -400,6 +400,7 @@ tasks:
       - "//tools/rust_analyzer:discover_bazel_rust_project"
       - "//test/rust_analyzer:rust_analyzer_test"
       - "//test/rust_analyzer:partial_failure_test"
+      - "//test/rust_analyzer:flycheck_clippy_test"
   ide_integration_tests_macos:
     name: IDE VSCode Tests
     platform: macos_arm64
@@ -410,6 +411,7 @@ tasks:
       - "//tools/rust_analyzer:discover_bazel_rust_project"
       - "//test/rust_analyzer:rust_analyzer_test"
       - "//test/rust_analyzer:partial_failure_test"
+      - "//test/rust_analyzer:flycheck_clippy_test"
   ide_integration_tests_windows:
     name: IDE VSCode Tests
     platform: windows

--- a/test/rust_analyzer/BUILD.bazel
+++ b/test/rust_analyzer/BUILD.bazel
@@ -10,3 +10,8 @@ sh_binary(
     name = "partial_failure_test",
     srcs = ["partial_failure_test_runner.sh"],
 )
+
+sh_binary(
+    name = "flycheck_clippy_test",
+    srcs = ["flycheck_clippy_test_runner.sh"],
+)

--- a/test/rust_analyzer/flycheck_clippy_test_runner.sh
+++ b/test/rust_analyzer/flycheck_clippy_test_runner.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# End-to-end test for the setup → discover → flycheck pipeline with
+# clippy enabled. Stands up a workspace with a `rust_library` whose
+# source triggers a clippy-only lint, runs `setup --clippy`, runs
+# discovery, invokes flycheck the way rust-analyzer would on save,
+# and checks that a clippy diagnostic ends up in flycheck's output.
+#
+# Regression coverage for two contract failures:
+#   1. `assemble_rust_project` baking a flag into the runnable command
+#      that flycheck's CLI doesn't accept — the bug pattern that shipped
+#      the initial clippy support: `--clippy` was prepended to the
+#      runnable but flycheck's Args struct never learned about it.
+#   2. `bin/flycheck.rs` silently ignoring the per-user `clippy=true`
+#      preference in `user_config.json` — the fallback path that keeps
+#      the runnable command byte-identical across users.
+
+set -euo pipefail
+
+if [[ -z "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then
+    >&2 echo "This script should be run under Bazel"
+    exit 1
+fi
+
+workspace="$(mktemp -d -t rules_rust_ra_flycheck_clippy-XXXXXXXXXX)"
+
+cat >"${workspace}/MODULE.bazel" <<EOF
+module(name = "rules_rust_ra_flycheck_clippy", version = "0.0.0")
+bazel_dep(name = "rules_rust", version = "0.0.0")
+local_path_override(
+    module_name = "rules_rust",
+    path = "${BUILD_WORKSPACE_DIRECTORY}",
+)
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+use_repo(rust, "rust_toolchains")
+register_toolchains("@rust_toolchains//:all")
+EOF
+
+if [[ -f "${BUILD_WORKSPACE_DIRECTORY}/.bazelversion" ]]; then
+    cp "${BUILD_WORKSPACE_DIRECTORY}/.bazelversion" "${workspace}/.bazelversion"
+fi
+
+# `assert!(true)` triggers `clippy::assertions_on_constants` (warn by
+# default) without triggering any rustc warning — a clean signal that a
+# clippy diagnostic reached flycheck's output.
+cat >"${workspace}/lib.rs" <<'EOF'
+pub fn check_it() {
+    assert!(true);
+}
+EOF
+
+cat >"${workspace}/BUILD.bazel" <<'EOF'
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+rust_library(
+    name = "clippy_target",
+    srcs = ["lib.rs"],
+    edition = "2021",
+)
+EOF
+
+cd "${workspace}"
+
+fail() {
+    >&2 echo "FAIL: $1"
+    for f in discovery.json flycheck.out flycheck.err; do
+        if [[ -f "${f}" ]]; then
+            >&2 echo "--- ${f} ---"
+            >&2 cat "${f}"
+        fi
+    done
+    exit 1
+}
+
+echo "Installing setup binaries with --clippy..."
+bazel run @rules_rust//tools/rust_analyzer:setup -- --clippy neovim >/dev/null
+
+launcher_dir="${workspace}/.rules_rust_analyzer"
+[[ -f "${launcher_dir}/flycheck.exe" ]] || fail "flycheck.exe not installed at ${launcher_dir}"
+[[ -f "${launcher_dir}/user_config.json" ]] || fail "user_config.json not written by setup"
+grep -q '"clippy": *true' "${launcher_dir}/user_config.json" || \
+    fail "user_config.json did not record clippy=true"
+
+# Discover self-locates via `dirname(current_exe())` when invoked from
+# an install directory, but here we're running the bazel-bin copy —
+# publish the launcher dir explicitly so `flycheck_launcher_path`
+# resolves to the install we just wrote.
+export RULES_RUST_RA_LAUNCHER_DIR="${launcher_dir}"
+
+echo "Running discovery..."
+bazel run @rules_rust//tools/rust_analyzer:discover_bazel_rust_project >discovery.json || true
+
+# Regression #1: discovery must NOT bake `--clippy` (or any per-user
+# preference) into the runnable command. The runnable is shared across
+# developers and must stay byte-identical regardless of who ran discover.
+if grep -q '"--clippy"' discovery.json; then
+    fail "'--clippy' leaked into the discovery output — the runnable command should be user-agnostic"
+fi
+
+grep -q '"kind":"finished"' discovery.json || fail "discovery did not finish"
+
+# Invoke flycheck as rust-analyzer would on save. The runnable's exact
+# arg shape is verified by the `flycheck_runnable_uses_positional_args_only`
+# unit test in `rust_project.rs`; this test just needs the two
+# positional args in place so we can prove the user_config → aspect
+# path fires. `BUILD_WORKSPACE_DIRECTORY` is overridden because the
+# outer `bazel run` for this test leaks its own value (this repo's
+# root).
+echo "Invoking flycheck as rust-analyzer would..."
+BUILD_WORKSPACE_DIRECTORY="${workspace}" \
+    "${launcher_dir}/flycheck.exe" "//:clippy_target" "${workspace}/lib.rs" \
+    >flycheck.out 2>flycheck.err || true
+
+# Regression #2: with clippy enabled in user_config, flycheck must
+# actually invoke the clippy aspect (proven by the lint firing). The
+# diagnostic surfaces via stdout (JSON from `.clippy.diagnostics` when
+# the action succeeds) or stderr (bazel's rendered output when
+# `-D warnings` fails the build hard) — check both.
+if ! grep -q "assertions_on_constants\|assertions-on-constants" flycheck.out flycheck.err; then
+    fail "no clippy diagnostic in flycheck output — the user_config → aspect path is broken"
+fi
+
+echo "PASS: discovery emitted a user-agnostic runnable that flycheck accepts, and clippy diagnostics reached the output"
+
+bazel clean --expunge --async >/dev/null 2>&1 || true
+cd /
+rm -rf "${workspace}"

--- a/tools/rust_analyzer/bin/discover_rust_project.rs
+++ b/tools/rust_analyzer/bin/discover_rust_project.rs
@@ -46,10 +46,11 @@ fn project_discovery() -> anyhow::Result<DiscoverProject<'static>> {
     // `discoverConfig.command` is intentionally identical for every
     // developer — clippy and per-package-workspaces toggles live in
     // `<launcher_dir>/user_config.json` (see `user_config.rs`).
+    // Clippy is consulted per-save inside `bin/flycheck.rs` and does
+    // not need to be threaded through discovery.
     let user = user_config::load(&install_dir()?);
     log::info!(
-        "user config: clippy={} per_package_workspaces={}",
-        user.clippy,
+        "user config: per_package_workspaces={}",
         user.per_package_workspaces
     );
 
@@ -89,7 +90,6 @@ fn project_discovery() -> anyhow::Result<DiscoverProject<'static>> {
         &bazel_args,
         rules_rust_name,
         &[targets],
-        user.clippy,
     )?;
 
     Ok(DiscoverProject::Finished { buildfile, project })

--- a/tools/rust_analyzer/bin/flycheck.rs
+++ b/tools/rust_analyzer/bin/flycheck.rs
@@ -48,9 +48,7 @@ struct Args {
     bazel: Utf8PathBuf,
 
     /// Bazel `--output_user_root` for the flycheck server. Overrides
-    /// the default (`<install_dir>/output_user_root`, derived from
-    /// `current_exe()`). Useful on Windows where MAX_PATH limits make
-    /// the in-launcher-dir default impractical.
+    /// the default (see [`default_output_user_root`]).
     #[clap(long)]
     output_user_root: Option<Utf8PathBuf>,
 }
@@ -75,23 +73,28 @@ fn run() -> Result<u8> {
     let bep_path = temp_dir.join(format!("flycheck_bep_{}.json", std::process::id()));
     let _bep_cleanup = scopeguard(bep_path.clone());
 
-    // Dedicated `--output_user_root` for the inner `bazel build` so
-    // its `--error_format=json` / `--rustc_output_diagnostics=true`
-    // don't thrash the user's primary Bazel server's analysis cache.
-    // CLI override exists for Windows MAX_PATH cases where the
-    // sibling default is too long.
-    let output_user_root = match args.output_user_root.clone() {
-        Some(p) => p,
-        None => gen_rust_project_lib::install_dir()?.join("output_user_root"),
-    };
-    std::fs::create_dir_all(&output_user_root)
-        .with_context(|| format!("creating output_user_root {output_user_root}"))?;
-
     // Per-user preferences live in `<launcher_dir>/user_config.json`.
     // Clippy mode is a per-user opt-in there — the shared discover
     // command doesn't decide it — so we consult the config on every
     // save rather than baking the choice into flycheck's argv.
     let user = user_config::load(&install_dir()?);
+
+    // Dedicated `--output_user_root` for the inner `bazel build` so
+    // its `--error_format=json` / `--rustc_output_diagnostics=true`
+    // don't thrash the user's primary Bazel server's analysis cache.
+    // Precedence: CLI flag > user_config > platform default. The
+    // default lives next to Bazel's own output roots (~/.cache/bazel
+    // on Linux) — not inside the workspace, which Bazel 8+ rejects
+    // for repo_contents_cache.
+    let output_user_root = match args.output_user_root.clone() {
+        Some(p) => p,
+        None => match user.output_user_root.clone() {
+            Some(p) => p,
+            None => default_output_user_root(&workspace)?,
+        },
+    };
+    std::fs::create_dir_all(&output_user_root)
+        .with_context(|| format!("creating output_user_root {output_user_root}"))?;
 
     // Assemble the bazel command. Clippy mode adds the aspect and
     // its diagnostics output group on top of the base build flags.
@@ -252,6 +255,53 @@ fn workspace_dir() -> Result<Utf8PathBuf> {
     }
     let cwd = env::current_dir().context("current_dir")?;
     Utf8PathBuf::try_from(cwd).context("current_dir was not valid UTF-8")
+}
+
+/// Default location for flycheck's dedicated `--output_user_root`,
+/// sitting next to Bazel's own user cache root
+/// (`~/.cache/bazel/_bazel_<user>/…` on Linux, `~/Library/Caches/bazel/…`
+/// on macOS). Living outside the workspace matters on Bazel 8+, which
+/// errors when a repo_contents_cache falls inside the main repo — the
+/// old default (`<launcher_dir>/output_user_root`) always did.
+///
+/// A per-workspace subdirectory (hashed workspace path) keeps two
+/// projects from sharing a flycheck server.
+fn default_output_user_root(workspace: &Utf8Path) -> Result<Utf8PathBuf> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    workspace.as_str().hash(&mut hasher);
+    let workspace_hash = format!("{:016x}", hasher.finish());
+
+    let cache_root = user_cache_dir()?.join("bazel").join("rules_rust_flycheck");
+    Ok(cache_root.join(workspace_hash))
+}
+
+/// Best-effort platform cache dir. Uses `$XDG_CACHE_HOME` when set;
+/// otherwise `~/.cache` on Linux, `~/Library/Caches` on macOS,
+/// `%LOCALAPPDATA%` on Windows.
+fn user_cache_dir() -> Result<Utf8PathBuf> {
+    if let Ok(dir) = env::var("XDG_CACHE_HOME") {
+        if !dir.is_empty() {
+            return Ok(Utf8PathBuf::from(dir));
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let home = env::var("HOME").context("HOME not set")?;
+        Ok(Utf8PathBuf::from(home).join("Library").join("Caches"))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let dir = env::var("LOCALAPPDATA").context("LOCALAPPDATA not set")?;
+        Ok(Utf8PathBuf::from(dir))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let home = env::var("HOME").context("HOME not set")?;
+        Ok(Utf8PathBuf::from(home).join(".cache"))
+    }
 }
 
 /// Query `bazel info execution_root` against the flycheck server (same

--- a/tools/rust_analyzer/bin/gen_rust_project.rs
+++ b/tools/rust_analyzer/bin/gen_rust_project.rs
@@ -30,7 +30,6 @@ fn write_rust_project() -> anyhow::Result<()> {
         &bazel_args,
         rules_rust_name,
         &targets,
-        false,
     )?;
 
     let rust_project_path = &workspace.join("rust-project.json");

--- a/tools/rust_analyzer/bin/setup.rs
+++ b/tools/rust_analyzer/bin/setup.rs
@@ -166,6 +166,16 @@ struct Cli {
     #[arg(long, global = true)]
     clean: bool,
 
+    /// Persist a per-user override for flycheck's inner Bazel
+    /// `--output_user_root`. Writes the path into
+    /// `<launcher_dir>/user_config.json` so it survives future setup
+    /// runs without touching the shared committed settings file.
+    /// The `--output_user_root` flag on the flycheck binary still
+    /// wins over this. To clear, delete the `output_user_root` key
+    /// from `user_config.json` by hand.
+    #[arg(long, global = true, value_name = "PATH")]
+    output_user_root: Option<Utf8PathBuf>,
+
     #[command(subcommand)]
     ide: IdeCmd,
 }
@@ -259,8 +269,9 @@ fn apply_user_config_edits(
     launcher_dir: &Utf8Path,
     clippy: Option<bool>,
     per_package_workspaces: Option<bool>,
+    output_user_root: Option<Utf8PathBuf>,
 ) -> Result<()> {
-    if clippy.is_none() && per_package_workspaces.is_none() {
+    if clippy.is_none() && per_package_workspaces.is_none() && output_user_root.is_none() {
         return Ok(());
     }
     let mut config = user_config::load(launcher_dir);
@@ -270,10 +281,13 @@ fn apply_user_config_edits(
     if let Some(v) = per_package_workspaces {
         config.per_package_workspaces = v;
     }
+    if let Some(v) = output_user_root {
+        config.output_user_root = Some(v);
+    }
     user_config::save(launcher_dir, &config)?;
     info!(
-        "user_config: clippy={} per_package_workspaces={}",
-        config.clippy, config.per_package_workspaces
+        "user_config: clippy={} per_package_workspaces={} output_user_root={:?}",
+        config.clippy, config.per_package_workspaces, config.output_user_root
     );
     Ok(())
 }
@@ -289,6 +303,7 @@ fn main() -> Result<()> {
         clippy,
         no_clippy,
         clean,
+        output_user_root,
         ide,
     } = Cli::parse();
 
@@ -333,7 +348,7 @@ fn main() -> Result<()> {
     // and the per-IDE runners themselves see a consistent on-disk
     // state, and running `setup --clippy` with no IDE change still
     // takes effect.
-    apply_user_config_edits(&launcher_dir, pending_clippy, pending_ppw)?;
+    apply_user_config_edits(&launcher_dir, pending_clippy, pending_ppw, output_user_root)?;
 
     let ctx = SetupCtx {
         launcher_dir,
@@ -1407,11 +1422,12 @@ mod tests {
             &user_config::UserConfig {
                 clippy: false,
                 per_package_workspaces: true,
+                output_user_root: Some(Utf8PathBuf::from("/existing/root")),
             },
         )
         .unwrap();
 
-        apply_user_config_edits(&launcher_dir, Some(true), None).unwrap();
+        apply_user_config_edits(&launcher_dir, Some(true), None, None).unwrap();
 
         let loaded = user_config::load(&launcher_dir);
         assert!(loaded.clippy, "--clippy must land in the file");
@@ -1419,6 +1435,30 @@ mod tests {
             loaded.per_package_workspaces,
             "unnamed fields must be preserved: got {loaded:?}",
         );
+        assert_eq!(
+            loaded.output_user_root,
+            Some(Utf8PathBuf::from("/existing/root")),
+            "unnamed fields must be preserved: got {loaded:?}",
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn apply_user_config_edits_persists_output_user_root() {
+        // `setup --output-user-root /some/path` writes the path into
+        // the launcher-dir user_config, so flycheck picks it up on
+        // future saves without any committed-file change.
+        let dir = std::env::temp_dir().join(format!("setup_uc_our_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let launcher_dir = Utf8PathBuf::try_from(dir.clone()).unwrap();
+        let path = Utf8PathBuf::from("/custom/flycheck/root");
+
+        apply_user_config_edits(&launcher_dir, None, None, Some(path.clone())).unwrap();
+
+        let loaded = user_config::load(&launcher_dir);
+        assert_eq!(loaded.output_user_root, Some(path));
+        assert!(!loaded.clippy, "unrelated fields must stay default");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1432,7 +1472,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let launcher_dir = Utf8PathBuf::try_from(dir.clone()).unwrap();
 
-        apply_user_config_edits(&launcher_dir, None, None).unwrap();
+        apply_user_config_edits(&launcher_dir, None, None, None).unwrap();
 
         assert!(!launcher_dir
             .join(user_config::USER_CONFIG_FILENAME)

--- a/tools/rust_analyzer/cache.rs
+++ b/tools/rust_analyzer/cache.rs
@@ -43,7 +43,7 @@ const CACHE_DIR_REL_PREFIX: &str = ".rules_rust_analyzer";
 /// unchanged workspace would keep serving JSON assembled by an older
 /// version of the assembler. See the explanatory comment on
 /// `compute_key` for the incident that motivated this.
-const CACHE_SCHEMA_VERSION: u32 = 0;
+const CACHE_SCHEMA_VERSION: u32 = 1;
 
 /// Compute the cache key for an assembled rust-project.json from the raw
 /// spec contents plus every auxiliary input the assembler bakes into its
@@ -53,7 +53,6 @@ const CACHE_SCHEMA_VERSION: u32 = 0;
 ///
 /// `spec_contents` should already be sorted by spec path so the key is
 /// independent of file-system enumeration order.
-#[allow(clippy::too_many_arguments)]
 pub fn compute_key(
     spec_contents: &[(Utf8PathBuf, String)],
     toolchain_info: &str,
@@ -61,7 +60,6 @@ pub fn compute_key(
     workspace: &Utf8Path,
     execution_root: &Utf8Path,
     launcher_dir: &str,
-    clippy: bool,
 ) -> String {
     let mut hasher = DefaultHasher::new();
     CACHE_SCHEMA_VERSION.hash(&mut hasher);
@@ -75,11 +73,6 @@ pub fn compute_key(
     // (vscode→neovim→helix) on the same workspace would silently serve
     // the previously-cached editor's launcher path.
     launcher_dir.hash(&mut hasher);
-    // The Flycheck Runnable's args differ between build-mode and clippy-mode
-    // (`--clippy` prepended). Without this bit in the key, a cached
-    // build-mode project would be served to a clippy-mode setup (or vice
-    // versa) and rust-analyzer would silently keep running the wrong flow.
-    clippy.hash(&mut hasher);
     for (path, content) in spec_contents {
         path.as_str().hash(&mut hasher);
         content.hash(&mut hasher);
@@ -178,8 +171,8 @@ mod tests {
                 String::from("{\"id\":\"b\"}"),
             ),
         ];
-        let k1 = compute_key(&specs, toolchain, bazel, ws, er, "", false);
-        let k2 = compute_key(&specs, toolchain, bazel, ws, er, "", false);
+        let k1 = compute_key(&specs, toolchain, bazel, ws, er, "");
+        let k2 = compute_key(&specs, toolchain, bazel, ws, er, "");
         assert_eq!(k1, k2);
     }
 
@@ -192,8 +185,8 @@ mod tests {
         let base = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         let mutated = vec![(Utf8PathBuf::from("a.json"), "b".to_string())];
         assert_ne!(
-            compute_key(&base, toolchain, bazel, ws, er, "", false),
-            compute_key(&mutated, toolchain, bazel, ws, er, "", false)
+            compute_key(&base, toolchain, bazel, ws, er, ""),
+            compute_key(&mutated, toolchain, bazel, ws, er, "")
         );
     }
 
@@ -204,8 +197,8 @@ mod tests {
         let er = Utf8Path::new("/er");
         let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         assert_ne!(
-            compute_key(&specs, "{\"sysroot\":\"a\"}", bazel, ws, er, "", false),
-            compute_key(&specs, "{\"sysroot\":\"b\"}", bazel, ws, er, "", false),
+            compute_key(&specs, "{\"sysroot\":\"a\"}", bazel, ws, er, ""),
+            compute_key(&specs, "{\"sysroot\":\"b\"}", bazel, ws, er, ""),
         );
     }
 
@@ -215,8 +208,8 @@ mod tests {
         let er = Utf8Path::new("/er");
         let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
         assert_ne!(
-            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws1"), er, "", false),
-            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws2"), er, "", false),
+            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws1"), er, ""),
+            compute_key(&specs, "{}", bazel, Utf8Path::new("/ws2"), er, ""),
         );
     }
 
@@ -238,7 +231,6 @@ mod tests {
                 ws,
                 er,
                 "/ws/.vscode/.rules_rust_analyzer",
-                false,
             ),
             compute_key(
                 &specs,
@@ -247,24 +239,7 @@ mod tests {
                 ws,
                 er,
                 "/ws/.helix/.rules_rust_analyzer",
-                false,
             ),
-        );
-    }
-
-    #[test]
-    fn compute_key_changes_with_clippy() {
-        // The flycheck runnable's args differ between clippy and
-        // non-clippy setups — the cache key must distinguish them so a
-        // build-mode cached project can't be served to a clippy-mode
-        // setup (or vice versa).
-        let bazel = Utf8Path::new("/usr/bin/bazel");
-        let ws = Utf8Path::new("/ws");
-        let er = Utf8Path::new("/er");
-        let specs = vec![(Utf8PathBuf::from("a.json"), "a".to_string())];
-        assert_ne!(
-            compute_key(&specs, "{}", bazel, ws, er, "", false),
-            compute_key(&specs, "{}", bazel, ws, er, "", true),
         );
     }
 }

--- a/tools/rust_analyzer/lib.rs
+++ b/tools/rust_analyzer/lib.rs
@@ -69,7 +69,6 @@ pub fn generate_rust_project(
     bazel_args: &[String],
     rules_rust_name: &str,
     targets: &[String],
-    clippy: bool,
 ) -> anyhow::Result<RustProject> {
     // Materialize per-crate spec files via the aspect, with Bazel emitting BEP
     // so we can discover them as a side-effect of the build. This replaces a
@@ -126,7 +125,6 @@ pub fn generate_rust_project(
         workspace,
         execution_root,
         &launcher_dir,
-        clippy,
     );
     if let Some(bytes) = cache::get(workspace, &cache_key)? {
         match serde_json::from_slice::<RustProject>(&bytes) {
@@ -151,13 +149,8 @@ pub fn generate_rust_project(
     let crate_specs =
         parse_and_consolidate(&spec_contents, output_base, workspace, execution_root)?;
 
-    let project = rust_project::assemble_rust_project(
-        bazel,
-        workspace,
-        toolchain_info,
-        &crate_specs,
-        clippy,
-    )?;
+    let project =
+        rust_project::assemble_rust_project(bazel, workspace, toolchain_info, &crate_specs)?;
 
     // Surface dep-graph problems the assembler had to paper over (missing
     // deps, cycles). Each becomes a log::warn (visible as a progress event

--- a/tools/rust_analyzer/rust_project.rs
+++ b/tools/rust_analyzer/rust_project.rs
@@ -478,22 +478,8 @@ pub fn assemble_rust_project(
     workspace: &Utf8Path,
     toolchain_info: ToolchainInfo,
     crate_specs: &BTreeSet<CrateSpec>,
-    clippy: bool,
 ) -> anyhow::Result<RustProject> {
     let emit_test_mod = supports_test_mod(&toolchain_info.version);
-
-    // The flycheck launcher forwards positional args verbatim to the
-    // flycheck binary. `--clippy` opts into concatenating clippy JSON
-    // alongside rustc's — see `bin/flycheck.rs`. Order matters: clap
-    // treats leading `--foo` before positionals as flags, and putting
-    // it before `{label}` keeps the `--` clean when the label needs
-    // shell-escaping.
-    let mut flycheck_args = Vec::new();
-    if clippy {
-        flycheck_args.push("--clippy".to_owned());
-    }
-    flycheck_args.push("{label}".to_owned());
-    flycheck_args.push("{saved_file}".to_owned());
 
     let mut runnables = vec![
         Runnable {
@@ -507,10 +493,13 @@ pub fn assemble_rust_project(
         // binary spawns `bazel build` for that label with rustc
         // diagnostics enabled, harvests the resulting .rustc-output
         // files via BEP, and streams their JSON to stdout for
-        // rust-analyzer to parse into squiggles.
+        // rust-analyzer to parse into squiggles. Args stay user-
+        // agnostic; per-user preferences (clippy, ...) live in
+        // `<launcher_dir>/user_config.json` and are read by
+        // `bin/flycheck.rs` on each save.
         Runnable {
             program: flycheck_launcher_path(workspace).to_string(),
-            args: flycheck_args,
+            args: vec!["{label}".to_owned(), "{saved_file}".to_owned()],
             cwd: workspace.to_owned(),
             kind: RunnableKind::Flycheck,
         },
@@ -705,7 +694,6 @@ mod tests {
                 is_test: false,
                 build: None,
             }]),
-            false,
         )
         .expect("expect success");
 
@@ -780,7 +768,6 @@ mod tests {
                     build: None,
                 },
             ]),
-            false,
         )
         .expect("expect success");
 
@@ -832,7 +819,6 @@ mod tests {
                 version: String::new(),
             },
             &BTreeSet::from([spec("ID-a", &["ID-b"]), spec("ID-b", &["ID-a"])]),
-            false,
         )
         .expect("cycle must not fail assembly");
 
@@ -866,7 +852,6 @@ mod tests {
                 version: String::new(),
             },
             &BTreeSet::from([spec("ID-a", &["ID-nonexistent"])]),
-            false,
         )
         .expect("missing dep must not fail assembly");
 
@@ -874,8 +859,13 @@ mod tests {
         assert_eq!(project.crates[0].deps.len(), 0);
     }
 
+    /// The runnable command must be byte-identical across users regardless
+    /// of clippy preference — flycheck reads its own per-user opt-in from
+    /// `user_config.json` on each save. If this ever regresses to
+    /// per-user command args, the CLI contract with `bin/flycheck.rs`
+    /// silently breaks (clap rejects unknown flags at runtime).
     #[test]
-    fn flycheck_runnable_gets_clippy_flag_when_enabled() {
+    fn flycheck_runnable_uses_positional_args_only() {
         let project = assemble_rust_project(
             Utf8Path::new("bazel"),
             Utf8Path::new("workspace"),
@@ -885,40 +875,6 @@ mod tests {
                 version: String::new(),
             },
             &BTreeSet::from([spec("ID-a", &[])]),
-            true,
-        )
-        .expect("expect success");
-
-        // Under clippy mode the Flycheck runnable prepends `--clippy`
-        // ahead of the `{label}` / `{saved_file}` positional args so
-        // the flycheck binary switches to clippy-aspect mode.
-        let flycheck = project
-            .runnables
-            .iter()
-            .find(|r| matches!(r.kind, RunnableKind::Flycheck))
-            .expect("flycheck runnable must exist");
-        assert_eq!(
-            flycheck.args,
-            vec![
-                "--clippy".to_owned(),
-                "{label}".to_owned(),
-                "{saved_file}".to_owned()
-            ],
-        );
-    }
-
-    #[test]
-    fn flycheck_runnable_omits_clippy_flag_by_default() {
-        let project = assemble_rust_project(
-            Utf8Path::new("bazel"),
-            Utf8Path::new("workspace"),
-            ToolchainInfo {
-                sysroot: "sysroot".to_owned().into(),
-                sysroot_src: "sysroot_src".to_owned().into(),
-                version: String::new(),
-            },
-            &BTreeSet::from([spec("ID-a", &[])]),
-            false,
         )
         .expect("expect success");
 

--- a/tools/rust_analyzer/user_config.rs
+++ b/tools/rust_analyzer/user_config.rs
@@ -19,7 +19,7 @@
 use std::fs;
 
 use anyhow::{Context, Result};
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Serialize};
 
 /// Filename inside `<launcher_dir>` that holds the per-user config.
@@ -36,6 +36,15 @@ pub struct UserConfig {
     /// re-emitting the whole workspace. See the `--per-package-workspaces`
     /// docs in `bin/setup.rs`.
     pub per_package_workspaces: bool,
+
+    /// Override for flycheck's inner `--output_user_root`. Escape
+    /// hatch for platform-specific concerns (Windows MAX_PATH, atypical
+    /// cache layouts) — `None` lets `bin/flycheck.rs` pick a per-
+    /// workspace directory next to Bazel's normal cache. The
+    /// `--output_user_root` CLI flag on flycheck still wins over this
+    /// for one-off overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_user_root: Option<Utf8PathBuf>,
 }
 
 /// Read `<launcher_dir>/user_config.json`. Missing → defaults;
@@ -112,10 +121,27 @@ mod tests {
         let original = UserConfig {
             clippy: true,
             per_package_workspaces: true,
+            output_user_root: Some(Utf8PathBuf::from("/tmp/custom_flycheck_root")),
         };
         save(&dir, &original).unwrap();
         let loaded = load(&dir);
         assert_eq!(loaded, original);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn absent_output_user_root_stays_none() {
+        // `skip_serializing_if` keeps the key out of the file so the
+        // default JSON stays minimal. Round-tripping a `None` produces
+        // a file with no `output_user_root` field.
+        let dir = tmp_dir("absent_output_user_root");
+        save(&dir, &UserConfig::default()).unwrap();
+        let text = fs::read_to_string(dir.join(USER_CONFIG_FILENAME)).unwrap();
+        assert!(
+            !text.contains("output_user_root"),
+            "unset field should be omitted, got:\n{}",
+            text,
+        );
         let _ = fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
This revealed cli discrepancies in flycheck and bad assumptions about the placement of `output_user_root` for Bazel versions less than 9.